### PR TITLE
Extended status icons to make use of the 'small' and 'large' properties as intended in _objects.icon.scss

### DIFF
--- a/src/js/components/icons/status/Disabled.js
+++ b/src/js/components/icons/status/Disabled.js
@@ -20,7 +20,7 @@ var Disabled = React.createClass({
   },
 
   render: function() {
-    var classes = [BASE_CLASS, CLASS_ROOT]
+    var classes = [BASE_CLASS, CLASS_ROOT];
     if (this.props.className) {
       classes.push(this.props.className);
     }

--- a/src/js/components/icons/status/ErrorStatus.js
+++ b/src/js/components/icons/status/ErrorStatus.js
@@ -20,7 +20,7 @@ var ErrorStatus = React.createClass({
   },
 
   render: function() {
-    var classes = [BASE_CLASS, CLASS_ROOT]
+    var classes = [BASE_CLASS, CLASS_ROOT];
     if (this.props.className) {
       classes.push(this.props.className);
     }

--- a/src/js/components/icons/status/Label.js
+++ b/src/js/components/icons/status/Label.js
@@ -20,7 +20,7 @@ var Label = React.createClass({
   },
 
   render: function() {
-    var classes = [BASE_CLASS, CLASS_ROOT]
+    var classes = [BASE_CLASS, CLASS_ROOT];
     if (this.props.className) {
       classes.push(this.props.className);
     }

--- a/src/js/components/icons/status/OK.js
+++ b/src/js/components/icons/status/OK.js
@@ -20,7 +20,7 @@ var OK = React.createClass({
   },
 
   render: function() {
-    var classes = [BASE_CLASS, CLASS_ROOT]
+    var classes = [BASE_CLASS, CLASS_ROOT];
     if (this.props.className) {
       classes.push(this.props.className);
     }

--- a/src/js/components/icons/status/Unknown.js
+++ b/src/js/components/icons/status/Unknown.js
@@ -20,7 +20,7 @@ var Unknown = React.createClass({
   },
 
   render: function() {
-    var classes = [BASE_CLASS, CLASS_ROOT]
+    var classes = [BASE_CLASS, CLASS_ROOT];
     if (this.props.className) {
       classes.push(this.props.className);
     }

--- a/src/js/components/icons/status/Warning.js
+++ b/src/js/components/icons/status/Warning.js
@@ -20,7 +20,7 @@ var Warning = React.createClass({
   },
 
   render: function() {
-    var classes = [BASE_CLASS, CLASS_ROOT]
+    var classes = [BASE_CLASS, CLASS_ROOT];
     if (this.props.className) {
       classes.push(this.props.className);
     }


### PR DESCRIPTION
Hi,

I have extended the status icon components to take care of the properties `small` and `large`.
The semantics are comparable to other components (e.g. Header). Furthermore my changes passed the tests (see screenshot below).

If you want me to change the semantics (e.g. exchanging the `classes` array for a string as it was before), I will do that.

Regards,

Tobias

![grommettestsscreenshot](https://cloud.githubusercontent.com/assets/6013423/7722502/40b504b2-fee1-11e4-8991-5958442974f0.PNG)

Signed-off-by: Tobias Kahse tobias.kahse@hp.com
