### PR TITLE
Added media option to box.

### DIFF
--- a/docs/src/develop/components/BoxDoc.js
+++ b/docs/src/develop/components/BoxDoc.js
@@ -46,6 +46,8 @@ var BoxDoc = React.createClass({
             <dt><code>responsive   true|false</code></dt>
             <dd>Whether children laid out in a row direction should be
               switched to a column layout when the display area narrows.</dd>
+            <dt><code>media   lap-and-up|palm</code></dt>
+            <dd>Whether to show the box only for lap-and-up or palm size. Optional.</dd>
             <dt><code>separator   top|bottom|left|right</code></dt>
             <dd>Add a separator.</dd>
             <dt><code>tag          {"{text}"}</code></dt>
@@ -86,6 +88,15 @@ var BoxDoc = React.createClass({
           </div>
           <pre><code className="html">{"<Box direction=\"row\" align=\"center\" colorIndex=\"neutral-1\"\n  justify=\"between\" reverse={true} tag=\"aside\"> ..."}</code></pre>
 
+          <h3>Palm-only Box</h3>
+          <p>Set the browser size to mobile in order to see the box.</p>
+          <div className="example">
+            <Box colorIndex="neutral-2" direction="row" media="palm" align="center">
+              <div>first</div>
+              <div>second</div>
+            </Box>
+          </div>
+          <pre><code className="html">{"<Box colorIndex=\"neutral-2\" direction=\"row\" media=\"palm\" align=\"center\"> ..."}</code></pre>
         </section>
 
       </Article>

--- a/src/js/components/Box.js
+++ b/src/js/components/Box.js
@@ -26,6 +26,7 @@ var Box = React.createClass({
     ]),
     reverse: React.PropTypes.bool,
     responsive: React.PropTypes.bool,
+    media: React.PropTypes.string,
     separator: React.PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
     tag: React.PropTypes.string,
     textAlign: React.PropTypes.oneOf(['left', 'center', 'right']),
@@ -70,6 +71,7 @@ var Box = React.createClass({
     this._addPropertyClass(classes, CLASS_ROOT, 'pad');
     this._addPropertyClass(classes, CLASS_ROOT, 'separator');
     this._addPropertyClass(classes, CLASS_ROOT, 'textAlign', 'text-align');
+    this._addPropertyClass(classes, CLASS_ROOT, 'media');
 
     if (this.props.appCentered) {
       this._addPropertyClass(containerClasses, CLASS_ROOT + "__container", 'full');

--- a/src/scss/grommet-core/_objects.box.scss
+++ b/src/scss/grommet-core/_objects.box.scss
@@ -197,4 +197,18 @@
   &--flush {
     padding: 0px;
   }
+
+  &--media {
+    &-lap-and-up {
+      @include media-query(palm) {
+        display: none;
+      }
+    }
+
+    &-palm {
+      @include media-query(lap-and-up) {
+        display: none;
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR aims to add the media option to Box component. This means that the box now can be hidden/visible for specific breakpoints.

For example:

This box

```
<Box  media="palm"></Box>
```
Will only be visible for palm size devices.

Similarly, 

This box

```
<Box  media="lap-and-up"></Box>
```
Will only be visible for table-size and bigger.



