### PR TITLE
Fixing typos in icon svg filenames

### DIFF
--- a/src/img/icons/drive-cage.svg
+++ b/src/img/icons/drive-cage.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="XMLID_110_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 48 48" enable-background="new 0 0 48 48" xml:space="preserve">
-<g id="srive-cage">
+<g id="drive-cage">
 	<rect id="_x2E_svg_205_" x="0" y="0" fill="none" width="48" height="48"/>
 	<rect x="30" y="16" fill="#231F20" width="2" height="2"/>
 	<rect x="30" y="22" fill="#231F20" width="2" height="2"/>

--- a/src/img/icons/workshop.svg
+++ b/src/img/icons/workshop.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="XMLID_66_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 48 48" enable-background="new 0 0 48 48" xml:space="preserve">
-<g id="worksop">
+<g id="workshop">
 	<rect id="_x2E_svg_241_" x="0" y="0" fill="none" width="48" height="48"/>
 	<polyline fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" points="32,28 35,28 35,14 15,14 15,17 	"/>
 	<rect x="22" y="12" fill="#231F20" width="6" height="4"/>


### PR DESCRIPTION
I noticed these typos in my webfont output.  Figured I'd just submit them back corrected since I corrected them on my end as well.