### PR TITLE
Typo in svg name

### DIFF
--- a/src/img/icons/cursor.svg
+++ b/src/img/icons/cursor.svg
@@ -2,9 +2,9 @@
 <!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="XMLID_121_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 48 48" enable-background="new 0 0 48 48" xml:space="preserve">
-<g id="cusror">
+<g id="cursor">
 	<rect id="_x2E_svg_193_" x="0" y="0" fill="none" width="48" height="48"/>
-	<polygon fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" points="32,26 18,13 18,32 22.3967,28.3361 
+	<polygon fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" points="32,26 18,13 18,32 22.3967,28.3361
 		25.1616,34.7876 28.8384,33.2124 26.0653,26.7418 	"/>
 </g>
 </svg>


### PR DESCRIPTION
Found another typo while working on the font icons.  Just submitting it back for correctness.  Will have a more meaningful contribution soon!