### PR TITLE
Fixing extraneous path nodes in document svgs

### DIFF
--- a/src/img/icons/document-pdf.svg
+++ b/src/img/icons/document-pdf.svg
@@ -9,9 +9,8 @@
 	<line fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" x1="32.5" y1="25" x2="26.5" y2="25"/>
 	<line fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" x1="27.5" y1="24" x2="27.5" y2="32"/>
 	<line fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" x1="31.5" y1="29" x2="26.5" y2="29"/>
-	<polyline fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" points="16.5,21 16.5,13 29.5002,13 34.5,17.9999 
+	<polyline fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" points="16.5,21 16.5,13 29.5002,13 34.5,17.9999
 		34.5,35 15.5,35 	"/>
 	<polyline fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" points="28.5,14 28.5,19 34.5,19 	"/>
-	<path fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" d="M27.5,19"/>
 </g>
 </svg>

--- a/src/img/icons/document-rtf.svg
+++ b/src/img/icons/document-rtf.svg
@@ -4,12 +4,10 @@
 	 viewBox="0 0 48 48" enable-background="new 0 0 48 48" xml:space="preserve">
 <g id="document-rtf">
 	<rect id="_x2E_svg_280_" x="0" y="0" fill="none" width="48" height="48"/>
-	<polyline fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" points="16.5,21 16.5,13 29.5002,13 34.5,17.9999 
+	<polyline fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" points="16.5,21 16.5,13 29.5002,13 34.5,17.9999
 		34.5,35 15.5,35 	"/>
 	<polyline fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" points="28.5,14 28.5,19 34.5,19 	"/>
-	<path fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" d="M27.5,19"/>
-	
-		<line fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" x1="12.5001" y1="25.0004" x2="12.5001" y2="32.0004"/>
+	<line fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" x1="12.5001" y1="25.0004" x2="12.5001" y2="32.0004"/>
 	<path fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" d="M14.5001,29.0004c1.1046,0,2-0.8954,2-2
 		s-0.8954-2-2-2h-2v4H14.5001z"/>
 	<polygon fill="#231F20" points="15.7461,32.0004 13.0438,28.2977 15.2342,28.2977 17.9562,32.0201 	"/>

--- a/src/img/icons/document-txt.svg
+++ b/src/img/icons/document-txt.svg
@@ -4,10 +4,9 @@
 	 viewBox="0 0 48 48" enable-background="new 0 0 48 48" xml:space="preserve">
 <g id="document-txt">
 	<rect id="_x2E_svg_274_" x="0" y="0" fill="none" width="48" height="48"/>
-	<polyline fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" points="16.4186,21 16.4186,13 29.4188,13 
+	<polyline fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" points="16.4186,21 16.4186,13 29.4188,13
 		34.4186,17.9999 34.4186,35 15.4186,35 	"/>
 	<polyline fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" points="28.4186,14 28.4186,19 34.4186,19 	"/>
-	<path fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" d="M27.4186,19"/>
 	<line fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" x1="17.4186" y1="25" x2="11.4186" y2="25"/>
 	<line fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" x1="14.4186" y1="24" x2="14.4186" y2="32"/>
 	<line fill="none" stroke="#231F20" stroke-width="2" stroke-miterlimit="10" x1="31.4186" y1="25" x2="25.4186" y2="25"/>


### PR DESCRIPTION
There is a weird phantom path that shows up in a few of the svgs that causes issues when trying to render as a font.  Because it causes an issue with unioning the paths, the font generates with inversions of the paths.