### PR TITLE
Issue 263: fix horizontal scrollbar on homepage

### DIFF
--- a/src/scss/grommet-core/_objects.article.scss
+++ b/src/scss/grommet-core/_objects.article.scss
@@ -7,6 +7,7 @@
     text-align: center;
     height: 100vh;
     width: 100vw;
+    max-width: 100%;
 
     > .article__controls {
       position: fixed;


### PR DESCRIPTION
Fixing https://github.com/grommet/grommet/issues/263 - `width: 100vw` incorrectly adds a horizontal scrollbar if a vertical scrollbar is present. Adding `max-width: 100%` fixes the issue.