### PR TITLE
Fix Anchor component type error

### DIFF
--- a/src/js/components/Anchor.js
+++ b/src/js/components/Anchor.js
@@ -20,7 +20,7 @@ class Anchor extends Component {
       classes.push(this.props.className);
     }
     var children = React.Children.map(this.props.children, function (child) {
-      if (child.type && 'Icon' === child.type.name) {
+      if (child && child.type && 'Icon' === child.type.name) {
         return <span className={CLASS_ROOT + "__icon"}>{child}</span>;
       } else {
         return child;


### PR DESCRIPTION
Child can be null, which will cause an error `Uncaught TypeError: Cannot read property 'type' of null`. Screenshot attached below.

```javascript
// If the Anchor has spaces around {this.props.stuffNotHereYetWaitingForData}, it will cause child to be null
<Anchor href="#"> {this.props.stuffNotHereYetWaitingForData} </Anchor>
```

![screen shot 2015-12-21 at 2 23 48 pm](https://cloud.githubusercontent.com/assets/3210082/11946735/eaa1afe2-a801-11e5-9a91-c7ba6ef5696d.png)
