### PR TITLE
Fix HMR inline mode

### DIFF
--- a/src/utils/gulp/gulp-tasks-dev.js
+++ b/src/utils/gulp/gulp-tasks-dev.js
@@ -27,7 +27,11 @@ module.exports = function(gulp, options, webpackConfig, dist) {
 
     var devWebpackConfig = merge({}, webpackConfig, {
       entry: {
-        app: ['webpack/hot/dev-server', './' + options.mainJs]
+        app: [
+          'webpack-dev-server/client?http://localhost:8001',
+          'webpack/hot/dev-server',
+          './' + options.mainJs
+        ]
       },
 
       output: {

--- a/src/utils/gulp/gulp-tasks-dev.js
+++ b/src/utils/gulp/gulp-tasks-dev.js
@@ -28,7 +28,7 @@ module.exports = function(gulp, options, webpackConfig, dist) {
     var devWebpackConfig = merge({}, webpackConfig, {
       entry: {
         app: [
-          'webpack-dev-server/client?http://localhost:8001',
+          'webpack-dev-server/client?http://' + (options.devServerHost || 'localhost')  + ':' + (options.devServerPort || '8080'),
           'webpack/hot/dev-server',
           './' + options.mainJs
         ]


### PR DESCRIPTION
This will allow url changes in the app to reflect in the browsers url bar.
Hot Module Replacement will work without having to navigate to `http://<host>:<port>/webpack-dev-server/`. :smiley: 

[webpack-dev-server inline mode](https://webpack.github.io/docs/webpack-dev-server.html#inline-mode)
