### PR TITLE
Updated Tag component to use Secondary button styles.

### DIFF
--- a/src/scss/grommet-core/_objects.tag.scss
+++ b/src/scss/grommet-core/_objects.tag.scss
@@ -1,11 +1,19 @@
 .tag {
-  background-color: $layer-overlay-background-color;
-  padding: $inuit-base-spacing-unit * 0.125 $inuit-base-spacing-unit * 0.25;
-  position: relative;
+  @include basic-button();
+  border-color: $button-secondary-color;
   margin: 0 halve($inuit-base-spacing-unit) halve($inuit-base-spacing-unit) 0;
+  position: relative;
+  opacity: 0.3;
 
-  .tag--label {
-    color: #fff;
+  a,
+  a:hover,
+  .anchor:hover:not(.anchor--disabled) {
+    color: $button-text-color;
     text-decoration: none;
+  }
+
+  &:hover {
+    box-shadow: 0px 0px 0px 2px $button-secondary-color;
+    opacity: 1;
   }
 }

--- a/src/scss/grommet-core/_objects.tag.scss
+++ b/src/scss/grommet-core/_objects.tag.scss
@@ -3,7 +3,7 @@
   border-color: $button-secondary-color;
   margin: 0 halve($inuit-base-spacing-unit) halve($inuit-base-spacing-unit) 0;
   position: relative;
-  opacity: 0.3;
+  opacity: 0.7;
 
   a,
   a:hover,


### PR DESCRIPTION
Please see this comment: https://github.com/grommet/grommet-docs/pull/13#issuecomment-174632811 for reference.

Here's what the Tag component looks like with the new styles:

![screen shot 2016-01-27 at 12 45 50 am](https://cloud.githubusercontent.com/assets/7669/12608497/5108af14-c491-11e5-90ea-87e0397209d0.png)

__Note__: "First" tag shows the hover state