### PR TITLE
react-router context proptypes is changed from function to object

### DIFF
--- a/src/js/components/Layer.js
+++ b/src/js/components/Layer.js
@@ -100,7 +100,7 @@ LayerContents.propTypes = {
   ]),
   onClose: PropTypes.func,
   history: PropTypes.object,
-  router: PropTypes.func,
+  router: PropTypes.any,
   intl: PropTypes.object,
   a11yCloserTitle: PropTypes.string
 };
@@ -111,7 +111,7 @@ LayerContents.propTypes = {
 // whatever we find or have callers explicitly indicate which parts
 // of the context to transfer somehow.
 LayerContents.childContextTypes = {
-  router: PropTypes.func,
+  router: PropTypes.any,
   history: PropTypes.object,
   intl: PropTypes.object,
   store: PropTypes.object
@@ -223,7 +223,7 @@ Layer.propTypes = {
 };
 
 Layer.contextTypes = {
-  router: PropTypes.func,
+  router: PropTypes.any,
   history: PropTypes.object,
   intl: PropTypes.object,
   store: PropTypes.object

--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -205,7 +205,7 @@ MenuDrop.propTypes = {
   dropColorIndex: PropTypes.string,
   id: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
-  router: PropTypes.func,
+  router: PropTypes.any,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   ...Box.propTypes
 };
@@ -213,7 +213,7 @@ MenuDrop.propTypes = {
 MenuDrop.childContextTypes = {
   intl: PropTypes.object,
   history: PropTypes.object,
-  router: PropTypes.func
+  router: PropTypes.any
 };
 
 export default class Menu extends Component {
@@ -518,7 +518,7 @@ Menu.propTypes = {
 Menu.contextTypes = {
   intl: PropTypes.object,
   history: PropTypes.object,
-  router: PropTypes.func
+  router: PropTypes.any
 };
 
 Menu.defaultProps = {


### PR DESCRIPTION
Hello,
It seams that react router is now passing PropTypes.object trough context.
```
"grommet": "0.5.3",
"react-router": "2.0.0-rc5"
```
```
Error:
Warning: Failed Context Types: Invalid context `router` 
of type `object` supplied to `Layer`, expected `function`.
...
```
This is the problem for all grommet components that are defining proptypes router: PropTypes.func,
Opinion?
Cheers
