### PR TITLE
Adds onClick prop to Brick component

### DIFF
--- a/src/js/components/Brick.js
+++ b/src/js/components/Brick.js
@@ -44,16 +44,16 @@ const Brick = props => {
     </div>
   );
 
-  if (props.href) {
+  if (props.href || props.onClick) {
     label = (
-      <Anchor href={props.href} className={`${CLASS_ROOT}--label`}>
+      <Anchor href={props.href} onClick={props.onClick} className={`${CLASS_ROOT}--label`}>
         <span>{props.label}</span>
       </Anchor>
     );
   }
 
   return (
-    <div className={classes} onClick={props.onClick}>
+    <div className={classes}>
       <div className={`${CLASS_ROOT}--content-wrapper`}>
         {props.children}
       </div>
@@ -66,6 +66,7 @@ Brick.propTypes = {
   colorIndex: PropTypes.string,
   href: PropTypes.string,
   label: PropTypes.string,
+  onClick: PropTypes.func,
   type: PropTypes.oneOf([TYPE_SMALL, TYPE_LARGE, TYPE_WIDE, TYPE_TALL])
 };
 


### PR DESCRIPTION
- Adds optional onClick prop to Brick component so users have the option to either pass in href or onClick.  This allows the user to route to another screen in a single-page app if they're using something such as React Router, or route the user to another page the traditional way if that's what they prefer.