### PR TITLE
Refactored table to be responsive

### DIFF
--- a/src/js/components/Table.js
+++ b/src/js/components/Table.js
@@ -1,13 +1,15 @@
 // (C) Copyright 2014-2015 Hewlett Packard Enterprise Development LP
 
 import React, { Component, PropTypes } from 'react';
+import classnames from 'classnames';
 import isEqual from 'lodash/lang/isEqual';
 import SpinningIcon from './icons/Spinning';
 import InfiniteScroll from '../utils/InfiniteScroll';
 import Selection from '../utils/Selection';
 
-const CLASS_ROOT = "table";
-const SELECTED_CLASS = CLASS_ROOT + "-row--selected";
+const CLASS_ROOT = 'table';
+const SELECTED_CLASS = `${CLASS_ROOT}-row--selected`;
+const MIN_CELL_WIDTH = 96;
 
 export default class Table extends Component {
 
@@ -16,6 +18,7 @@ export default class Table extends Component {
 
     this._onClick = this._onClick.bind(this);
     this._onResize = this._onResize.bind(this);
+    this._layout = this._layout.bind(this);
 
     if (props.selection) {
       console.warn('The "selection" property of Table has been deprecated.' +
@@ -24,30 +27,37 @@ export default class Table extends Component {
     }
     this.state = {
       selected: Selection.normalizeIndexes(props.selected || props.selection),
-      rebuildMirror: props.scrollable
+      rebuildMirror: props.scrollable,
+      small: false
     };
   }
 
   componentDidMount () {
     this._setSelection();
-    if (this.props.scrollable) {
+    if (this.props.scrollable && ! this.state.small) {
       this._buildMirror();
       this._alignMirror();
     }
     if (this.props.onMore) {
-      this._scroll = InfiniteScroll.startListeningForScroll(this.refs.more, this.props.onMore);
+      this._scroll = InfiniteScroll.startListeningForScroll(
+        this.refs.more, this.props.onMore
+      );
     }
+    this._adjustBodyCells();
     window.addEventListener('resize', this._onResize);
   }
 
   componentWillReceiveProps (nextProps) {
     if (this._scroll) {
       InfiniteScroll.stopListeningForScroll(this._scroll);
-      this._scroll = null;
+      this._scroll = undefined;
     }
-    if (nextProps.hasOwnProperty('selected') || nextProps.hasOwnProperty('selection')) {
+    if (nextProps.hasOwnProperty('selected') ||
+      nextProps.hasOwnProperty('selection')) {
       this.setState({
-        selected: Selection.normalizeIndexes(nextProps.selected || nextProps.selection)
+        selected: Selection.normalizeIndexes(
+          nextProps.selected || nextProps.selection
+        )
       });
     }
     this.setState({rebuildMirror: nextProps.scrollable});
@@ -57,16 +67,19 @@ export default class Table extends Component {
     if (! isEqual(this.state.selected, prevState.selected)) {
       this._setSelection();
     }
-    if (this.state.rebuildMirror) {
+    if (this.state.rebuildMirror && ! this.state.small) {
       this._buildMirror();
       this.setState({rebuildMirror: false});
     }
-    if (this.props.scrollable) {
+    if (this.props.scrollable && ! this.state.small) {
       this._alignMirror();
     }
     if (this.props.onMore && !this._scroll) {
-      this._scroll = InfiniteScroll.startListeningForScroll(this.refs.more, this.props.onMore);
+      this._scroll = InfiniteScroll.startListeningForScroll(
+        this.refs.more, this.props.onMore
+      );
     }
+    this._adjustBodyCells();
   }
 
   componentWillUnmount () {
@@ -120,35 +133,64 @@ export default class Table extends Component {
     }
   }
 
+  _adjustBodyCells () {
+    //adjust table body cells to have link to the header
+    //so that in responsive mode it displays the text as content in css
+    let headerCells = this.refs.table.querySelectorAll('thead th');
+    if (headerCells.length > 0) {
+      let rows = this.refs.table.querySelectorAll('tbody tr');
+
+      [].forEach.call(rows, (row) => {
+        [].forEach.call(row.cells, (cell, index) => {
+          cell.setAttribute('data-th', headerCells[index].innerText);
+        });
+      });
+    }
+  }
+
   _onResize () {
     this._alignMirror();
+    this._layout();
+  }
+
+  _layout () {
+    let availableSize = this.refs.container.offsetWidth;
+    let numberOfCells = this.refs.table.querySelectorAll('thead th').length;
+
+    if ((numberOfCells * MIN_CELL_WIDTH) > availableSize) {
+      this.setState({small: true});
+    } else {
+      this.setState({small: false});
+    }
   }
 
   _buildMirror () {
-    var tableElement = this.refs.table;
-    var cells = tableElement.querySelectorAll('thead tr th');
-    var mirrorElement = this.refs.mirror;
-    var mirrorRow = mirrorElement.querySelectorAll('thead tr')[0];
-    while (mirrorRow.hasChildNodes()) {
-      mirrorRow.removeChild(mirrorRow.lastChild);
-    }
-    for (var i = 0; i < cells.length; i++) {
-      mirrorRow.appendChild(cells[i].cloneNode(true));
+    let tableElement = this.refs.table;
+    let cells = tableElement.querySelectorAll('thead tr th');
+    let mirrorElement = this.refs.mirror;
+    if (mirrorElement) {
+      let mirrorRow = mirrorElement.querySelectorAll('thead tr')[0];
+      while (mirrorRow.hasChildNodes()) {
+        mirrorRow.removeChild(mirrorRow.lastChild);
+      }
+      for (let i = 0; i < cells.length; i++) {
+        mirrorRow.appendChild(cells[i].cloneNode(true));
+      }
     }
   }
 
   _alignMirror () {
     if (this.refs.mirror) {
-      var tableElement = this.refs.table;
-      var cells = tableElement.querySelectorAll('thead tr th');
-      var mirrorElement = this.refs.mirror;
-      var mirrorCells = mirrorElement.querySelectorAll('thead tr th');
+      let tableElement = this.refs.table;
+      let cells = tableElement.querySelectorAll('thead tr th');
+      let mirrorElement = this.refs.mirror;
+      let mirrorCells = mirrorElement.querySelectorAll('thead tr th');
 
-      var rect = tableElement.getBoundingClientRect();
+      let rect = tableElement.getBoundingClientRect();
       mirrorElement.style.width = '' + Math.floor(rect.right - rect.left) + 'px';
 
-      var height = 0;
-      for (var i = 0; i < cells.length; i++) {
+      let height = 0;
+      for (let i = 0; i < cells.length; i++) {
         rect = cells[i].getBoundingClientRect();
         mirrorCells[i].style.width = '' + Math.floor(rect.right - rect.left) + 'px';
         mirrorCells[i].style.height = '' + Math.floor(rect.bottom - rect.top) + 'px';
@@ -159,18 +201,17 @@ export default class Table extends Component {
   }
 
   render () {
-    var classes = [CLASS_ROOT];
-    if (this.props.selectable) {
-      classes.push(CLASS_ROOT + "--selectable");
-    }
-    if (this.props.scrollable) {
-      classes.push(CLASS_ROOT + "--scrollable");
-    }
-    if (this.props.className) {
-      classes.push(this.props.className);
-    }
+    let classes = classnames(
+      CLASS_ROOT,
+      this.props.className,
+      {
+        [`${CLASS_ROOT}--small`]: this.state.small,
+        [`${CLASS_ROOT}--selectable`]: this.props.selectable,
+        [`${CLASS_ROOT}--scrollable`]: this.props.scrollable
+      }
+    );
 
-    var mirror = null;
+    let mirror;
     if (this.props.scrollable) {
       mirror = (
         <table ref="mirror" className={CLASS_ROOT + "__mirror"}>
@@ -181,7 +222,7 @@ export default class Table extends Component {
       );
     }
 
-    var more = null;
+    let more;
     if (this.props.onMore) {
       more = (
         <div ref="more" className={CLASS_ROOT + "__more"}>
@@ -191,16 +232,16 @@ export default class Table extends Component {
     }
 
     return (
-      <div ref="container" className={classes.join(' ')}>
+      <div ref="container" className={classes}>
         {mirror}
-        <table ref="table" className={CLASS_ROOT + "__table"} onClick={this._onClick}>
+        <table ref="table" className={CLASS_ROOT + "__table"}
+          onClick={this._onClick}>
           {this.props.children}
         </table>
         {more}
       </div>
     );
   }
-
 }
 
 Table.propTypes = {

--- a/src/js/components/Table.js
+++ b/src/js/components/Table.js
@@ -9,6 +9,8 @@ import Selection from '../utils/Selection';
 
 const CLASS_ROOT = 'table';
 const SELECTED_CLASS = `${CLASS_ROOT}-row--selected`;
+// empirical number describing a minimum cell width for a
+// table to be presented in column-mode.
 const MIN_CELL_WIDTH = 96;
 
 export default class Table extends Component {
@@ -86,6 +88,7 @@ export default class Table extends Component {
     if (this._scroll) {
       InfiniteScroll.stopListeningForScroll(this._scroll);
     }
+    clearTimeout(this._resizeTimer);
     window.removeEventListener('resize', this._onResize);
   }
 
@@ -134,8 +137,10 @@ export default class Table extends Component {
   }
 
   _adjustBodyCells () {
-    //adjust table body cells to have link to the header
-    //so that in responsive mode it displays the text as content in css
+    // adjust table body cells to have link to the header
+    // so that in responsive mode it displays the text as content in css.
+    // IMPORTANT: non-text header cells, such as icon, are rendered as empty
+    // headers.
     let headerCells = this.refs.table.querySelectorAll('thead th');
     if (headerCells.length > 0) {
       let rows = this.refs.table.querySelectorAll('tbody tr');
@@ -149,11 +154,14 @@ export default class Table extends Component {
   }
 
   _onResize () {
-    this._alignMirror();
-    this._layout();
+    // debounce
+    clearTimeout(this._resizeTimer);
+    this._resizeTimer = setTimeout(this._layout, 50);
   }
 
   _layout () {
+    this._alignMirror();
+
     let availableSize = this.refs.container.offsetWidth;
     let numberOfCells = this.refs.table.querySelectorAll('thead th').length;
 
@@ -214,7 +222,7 @@ export default class Table extends Component {
     let mirror;
     if (this.props.scrollable) {
       mirror = (
-        <table ref="mirror" className={CLASS_ROOT + "__mirror"}>
+        <table ref="mirror" className={`${CLASS_ROOT}__mirror`}>
           <thead>
             <tr></tr>
           </thead>
@@ -225,7 +233,7 @@ export default class Table extends Component {
     let more;
     if (this.props.onMore) {
       more = (
-        <div ref="more" className={CLASS_ROOT + "__more"}>
+        <div ref="more" className={`${CLASS_ROOT}__more`}>
           <SpinningIcon />
         </div>
       );
@@ -234,7 +242,7 @@ export default class Table extends Component {
     return (
       <div ref="container" className={classes}>
         {mirror}
-        <table ref="table" className={CLASS_ROOT + "__table"}
+        <table ref="table" className={`${CLASS_ROOT}__table`}
           onClick={this._onClick}>
           {this.props.children}
         </table>

--- a/src/scss/grommet-core/_objects.table.scss
+++ b/src/scss/grommet-core/_objects.table.scss
@@ -11,7 +11,7 @@
 
     &:before {
       font-weight: 100;
-      @include inuit-font-size(18px);
+      @include inuit-font-size($control-font-size, $inuit-base-spacing-unit);
       content: attr(data-th);
       display: block;
 
@@ -121,10 +121,6 @@
         }
       }
     }
-  }
-
-  @include media-query(palm) {
-    @include small-table();
   }
 
   &--small {

--- a/src/scss/grommet-core/_objects.table.scss
+++ b/src/scss/grommet-core/_objects.table.scss
@@ -1,5 +1,34 @@
 // (C) Copyright 2014-2015 Hewlett Packard Enterprise Development LP
 
+@mixin small-table {
+
+  thead {
+    display: none;
+  }
+
+  td {
+    display: block;
+
+    &:before {
+      font-weight: 100;
+      @include inuit-font-size(18px);
+      content: attr(data-th);
+      display: block;
+
+      padding-right: halve($inuit-base-spacing-unit);
+    }
+  }
+
+  tr {
+    border-bottom: 1px solid $border-color;
+  }
+
+  td,
+  th {
+    padding-left: $inuit-base-spacing-unit;
+  }
+}
+
 .table {
 
   table {
@@ -29,7 +58,6 @@
   }
 
   &__mirror {
-
     position: absolute;
     top: 0px;
     left: 0px;
@@ -38,10 +66,6 @@
     > thead {
       position: fixed;
       background-color: $header-background-color;
-
-      @include media-query(palm) {
-        position: static;
-      }
     }
   }
 
@@ -52,6 +76,16 @@
 
   &--scrollable {
     position: relative;
+
+    .table__table {
+      thead {
+        visibility: hidden;
+      }
+
+      th {
+        border-bottom: none;
+      }
+    }
   }
 
   &--selectable {
@@ -87,5 +121,13 @@
         }
       }
     }
+  }
+
+  @include media-query(palm) {
+    @include small-table();
+  }
+
+  &--small {
+    @include small-table();
   }
 }


### PR DESCRIPTION
I'm proposing this PR to add responsive behavior for tables. This is what I've done:

  * Table is always responsive in mobile size.
  * Table is also responsive depending on how many columns has to be rendered in a given container.
     - To achieve that, I've set a `MIN_CELL_WIDTH` to 96 and I calculate if there is enough space for the amount of columns to be rendered in a given container. If the space is too short, the table is displayed in a responsive manner.
  * Hiding header text for scrollable tables as the text is already available in the mirror.

This is a regular Table (ferret example):

![screen shot 2016-02-04 at 2 19 32 pm](https://cloud.githubusercontent.com/assets/1207250/12831667/53550852-cb4a-11e5-953b-e6d3a48eb5fd.png)

This is the same table in responsive mode when the size of the window is still desktop, but there is not enough space for it to render the columns.

![screen shot 2016-02-04 at 2 20 38 pm](https://cloud.githubusercontent.com/assets/1207250/12831692/7b3fa138-cb4a-11e5-85ae-e7de3f5ee493.png)

 