### PR TITLE
Allowing for flexible linting, project based

### DIFF
--- a/src/utils/gulp/gulp-tasks-linters.js
+++ b/src/utils/gulp/gulp-tasks-linters.js
@@ -9,7 +9,7 @@ function scssLintExists() {
 
 module.exports = function(gulp, options) {
 
-  var scssLintPath = path.resolve(__dirname, 'scss-lint.yml');
+  var scssLintPath = options.scssLintPath || path.resolve(__dirname, 'scss-lint.yml');
   var esLintPath = path.resolve(__dirname, 'eslintrc');
   var customEslint = options.customEslintPath ?
     require(options.customEslintPath) : {};


### PR DESCRIPTION
- Allow user to specify path to utilize their own scss-lint.yml, on the property 'scssLintPath' in the gulpfile.

Signed-off-by: Derek Ahn <git.derek@gmail.com>