### PR TITLE
Gulp tasks test

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,9 +89,14 @@ var opts = {
   },
   distPreprocess: ['generate-index-icons', 'dist-css'],
   scsslint: true,
-  testPaths: [
-    'test/**/*.js'
-  ]
+
+  test: {
+    paths: ['test/**/*.js'],
+    globPath: '**/src/**/spec.js',
+    // You may pass in a path or a custom config obj
+    pathToBabelRc: __dirname+'.bablercl'
+    // customBabelConfig: Object.assign({}, custom babelrc object)
+  }
 };
 
 require('./src/utils/gulp/gulp-tasks')(gulp, opts);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -92,9 +92,8 @@ var opts = {
 
   test: {
     paths: ['test/**/*.js'],
-    globPath: '**/src/**/spec.js',
     // You may pass in a path or a custom config obj
-    pathToBabelRc: __dirname+'.bablercl'
+    pathToBabelRc: __dirname+'/.babelrc'
     // customBabelConfig: Object.assign({}, custom babelrc object)
   }
 };

--- a/src/utils/gulp/gulp-tasks-test.js
+++ b/src/utils/gulp/gulp-tasks-test.js
@@ -20,7 +20,7 @@ module.exports = function(gulp, options) {
     }
   };
 
-  gulp.task('tests', function(done) {
+  gulp.task('test', function(done) {
     if (test.paths) {
       var jsxCoverage = require('gulp-jsx-coverage');
       var mocha = require('gulp-mocha');

--- a/src/utils/gulp/gulp-tasks-test.js
+++ b/src/utils/gulp/gulp-tasks-test.js
@@ -1,11 +1,15 @@
 var babel = require('gulp-babel');
 var glob = require('glob');
 var path = require('path');
+var merge = require('lodash/object/merge');
 
 module.exports = function(gulp, options) {
 
+  // caching refrence
+  var test = options.test;
+
   var jsxCoverageOptions = {
-    src: options.testPaths || [],
+    src: test.paths || [],
     istanbul: {
       coverageVariable: '__MY_TEST_COVERAGE__',
       exclude: /node_modules|test|icons|lib|index/
@@ -16,39 +20,48 @@ module.exports = function(gulp, options) {
     }
   };
 
-  gulp.task('test', function(done) {
-    if (options.testPaths) {
+  gulp.task('tests', function(done) {
+    if (test.paths) {
       var jsxCoverage = require('gulp-jsx-coverage');
       var mocha = require('gulp-mocha');
       var watch = require('gulp-watch');
       var argv = require('yargs').argv;
 
+      // customBabelRc object, or path to local babelrc
+      var customBabelConfig = test.customBabelConfig?
+        test.customBabelConfig :
+        typeof test.pathToBabelRc === 'string'?
+        JSON.parse(require('fs').readFileSync(test.pathToBabelRc, 'utf8')) :
+        {};
+
+      var babelConfig = merge({}, {
+        "presets": [ "es2015", "react" ],
+        "plugins": [
+          "transform-object-rest-spread",
+          "add-module-exports"
+        ]
+      }, customBabelConfig);
+
       jsxCoverage.initModuleLoaderHack(jsxCoverageOptions);
 
-      glob.sync('**src/js/**/*.js').forEach(function (file) {
+      glob.sync(test.globPath || '**src/js/**/*.js').forEach(function (file) {
         if (file.indexOf('lib') === -1 &&
           file.indexOf('icons') === -1) {
           require(path.resolve(file));
         }
       });
 
-      gulp.src(options.testPaths, {
+      gulp.src(test.paths, {
         read: false
-      }).pipe(babel({
-        "presets": [ "es2015", "react" ],
-        "plugins": [
-          "transform-object-rest-spread",
-          "add-module-exports"
-        ]
-      })).pipe(mocha({
+      }).pipe(babel(babelConfig)).pipe(mocha({
         reporter: 'spec'})).once('end', function() {
           if (argv.w) {
-            var watchFolders = options.testPaths.slice();
+            var watchFolders = test.paths.slice();
             options.jsAssets.forEach(function(jsAsset) {
               watchFolders.push(jsAsset);
             });
             watch(watchFolders, function() {
-              gulp.src(options.testPaths, {
+              gulp.src(test.paths, {
                 read: false
               }).pipe(mocha({
                 reporter: 'spec'


### PR DESCRIPTION
## Flexibility for test configs

Users may either pass in a path to their local babelrc, file, or pass in a custom object.
Refactored for all options to be encapsulated on the test property:

```js
test: {
  paths: [strings],
  globPath: string,
  pathToBabelRc: string,
  customBabelConfig: object
}
```

* If both a pathToBabelRc and a customBabelConfig, the customBabelConfig will trump.