### PR TITLE
layer flush, responsive tabs, hpe link text-decoration defaults

### DIFF
--- a/src/scss/grommet-core/_objects.layer.scss
+++ b/src/scss/grommet-core/_objects.layer.scss
@@ -54,6 +54,12 @@
   &--flush {
     .layer__container {
       padding: 0px;
+
+      @include media-query(palm) {
+        .box--full {
+          width: auto;
+        }
+      }
     }
   }
 

--- a/src/scss/grommet-core/_objects.layer.scss
+++ b/src/scss/grommet-core/_objects.layer.scss
@@ -55,10 +55,8 @@
     .layer__container {
       padding: 0px;
 
-      @include media-query(palm) {
-        .box--full {
-          width: auto;
-        }
+      .box--full {
+        width: auto;
       }
     }
   }

--- a/src/scss/grommet-core/_objects.tabs.scss
+++ b/src/scss/grommet-core/_objects.tabs.scss
@@ -31,6 +31,7 @@
       &.tabs--responsive {
         @include media-query(palm) {
           flex-direction: column;
+          text-align: center;
         }
       }
     }

--- a/src/scss/hpe/_hpe.defaults.scss
+++ b/src/scss/hpe/_hpe.defaults.scss
@@ -16,7 +16,7 @@ $brand-status-colors: (
 );
 $brand-link-color: inherit;
 $link-hover-color: #000;
-$brand-link-text-decoration: none;
+$brand-link-text-decoration: underline;
 $brand-grey-colors: (#333333, #3B3B3B, #434343, #666666);
 $brand-graph-colors: (
   lighten(#425563, 15%),

--- a/src/scss/hpe/_hpe.defaults.scss
+++ b/src/scss/hpe/_hpe.defaults.scss
@@ -16,7 +16,7 @@ $brand-status-colors: (
 );
 $brand-link-color: inherit;
 $link-hover-color: #000;
-$brand-link-text-decoration: underline;
+$brand-link-text-decoration: none;
 $brand-grey-colors: (#333333, #3B3B3B, #434343, #666666);
 $brand-graph-colors: (
   lighten(#425563, 15%),


### PR DESCRIPTION
- fixing bug with extra spacing in box for flush Layers
- centering responsive (column) tabs within their LI containers
- removing underline from HPE brand link defaults