### PR TITLE
Added help text color

### DIFF
--- a/src/scss/grommet-core/_base.color.scss
+++ b/src/scss/grommet-core/_base.color.scss
@@ -5,6 +5,7 @@ $brand-color-darker: darken($brand-color, 9%) !default;
 
 $text-color: #333 !default;
 $secondary-text-color: #777 !default;
+$help-text-color: #767676 !default;
 $hover-text-color: #000 !default;
 $placeholder-text-color: #aaa;
 $colored-text-color: rgba(255, 255, 255, 0.85); //#dbdbdb;

--- a/src/scss/grommet-core/_base.text.scss
+++ b/src/scss/grommet-core/_base.text.scss
@@ -88,6 +88,10 @@
     color: $secondary-text-color;
   }
 
+  .help {
+    color: $help-text-color;
+  }
+
   .error {
     color: map-get($brand-status-colors, critical);
   }


### PR DESCRIPTION
This change is to support help  text in drop down menu, the way we currently have in piano:
![image](https://cloud.githubusercontent.com/assets/13039669/13475254/aad55c44-e076-11e5-924f-db667442773e.png)