### PR TITLE
Meter fixes: remove total from inline legend (total: false), dark-background-context text colors

### DIFF
--- a/src/js/components/Meter.js
+++ b/src/js/components/Meter.js
@@ -379,17 +379,22 @@ export default class Meter extends Component {
     }
 
     let minMax = this._renderMinMax(classes);
-
     let activeValue = this._renderActiveValue();
-
     let legend;
     let a11yRole;
+
     if (this.props.legend || this.props.series) {
       a11yRole = 'tablist';
 
       if (this.props.legend) {
         if ('inline' !== this.props.legend.placement) {
           legend = this._renderLegend();
+        } else {
+          // Hide value (displaying total), if legend is inline
+          // and total is set to false
+          if (!(this.props.legend.total)) {
+            activeValue = null;
+          }
         }
         classes.push(`${CLASS_ROOT}--legend-${this.state.legendPlacement}`);
       }

--- a/src/scss/grommet-core/_objects.legend.scss
+++ b/src/scss/grommet-core/_objects.legend.scss
@@ -89,6 +89,10 @@
   }
 }
 
+#{$dark-background-context} .legend__item--active {
+  color: $active-colored-text-color;
+}
+
 .legend__total {
   margin-left: $inuit-base-spacing-unit;
 

--- a/src/scss/grommet-core/_objects.meter.scss
+++ b/src/scss/grommet-core/_objects.meter.scss
@@ -65,6 +65,10 @@ $meter-active-offset: round($inuit-base-spacing-unit * 1.5);
   &:focus {
     outline: $focus-border-color solid 1px;
   }
+
+  text {
+    fill: $secondary-text-color;
+  }
 }
 
 .meter__value {


### PR DESCRIPTION
Fixes the following issues:
* https://github.com/grommet/grommet/issues/400: font label contrast issue with background color (when legend is inline)
* https://github.com/grommet/grommet/issues/399: remove active value (displaying total) when total is false, and legend is inline
* fixing legend label/value hover colors so they don't disappear on dark-background-context colors