### PR TITLE
menu component drop styles

### DIFF
--- a/src/scss/grommet-core/_objects.menu.scss
+++ b/src/scss/grommet-core/_objects.menu.scss
@@ -97,10 +97,12 @@
     display: block;
     text-decoration: none;
 
+    &.active,
     &:hover,
-    &:focus {
+    &:focus, {
       text-decoration: none;
       background-color: $hover-background-color;
+      color: $link-hover-color;
     }
   }
 

--- a/src/scss/grommet-core/_objects.menu.scss
+++ b/src/scss/grommet-core/_objects.menu.scss
@@ -99,7 +99,7 @@
 
     &.active,
     &:hover,
-    &:focus, {
+    &:focus {
       text-decoration: none;
       background-color: $hover-background-color;
       color: $link-hover-color;


### PR DESCRIPTION
updating Menu component's drop styles so active anchors have hover background color + text color (so active menu anchor is visible in apps where hover text colors are close to active text colors).