### PR TITLE
Video Component

### DIFF
--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -279,5 +279,6 @@ Tiles.propTypes = {
 
 Tiles.defaultProps = {
   flush: true,
-  justify: 'start'
+  justify: 'start',
+  pad: 'small'
 };

--- a/src/js/components/Video.js
+++ b/src/js/components/Video.js
@@ -134,7 +134,10 @@ export default class Video extends Component {
       );
     }
 
-    var videoHeader;
+    var videoHeader = (
+      <Box>
+      </Box>
+    );
     if (this.props.videoHeader) {
       videoHeader = this.props.videoHeader;
       if (fullScreenButton) {
@@ -233,7 +236,7 @@ export default class Video extends Component {
             </Button>
             {title}
           </Box>
-          <Box pad="medium">
+          <Box>
           </Box>
         </Box>
         {timeline}

--- a/src/js/components/Video.js
+++ b/src/js/components/Video.js
@@ -135,8 +135,7 @@ export default class Video extends Component {
     }
 
     var videoHeader = (
-      <Box>
-      </Box>
+      <Box />
     );
 
     if (this.props.videoHeader) {
@@ -170,7 +169,6 @@ export default class Video extends Component {
         var time = Math.floor(chapter.time / 60) + ':' +
           (seconds < 10 ? '0' + seconds : seconds);
         var currentProgress = this.state.progress;
-        var previousChapter = chapters[Math.max(0, index - 1)];
         var nextChapter = chapters[Math.min(chapters.length - 1, index + 1)];
         var timelineClass = `${CLASS_ROOT}__timeline-chapter`;
         if (currentProgress !== 0) {
@@ -227,8 +225,7 @@ export default class Video extends Component {
             </Button>
             {title}
           </Box>
-          <Box>
-          </Box>
+          <Box />
         </Box>
         {timeline}
         {progress}

--- a/src/js/components/Video.js
+++ b/src/js/components/Video.js
@@ -138,18 +138,9 @@ export default class Video extends Component {
       <Box>
       </Box>
     );
+
     if (this.props.videoHeader) {
       videoHeader = this.props.videoHeader;
-      if (fullScreenButton) {
-        let videoHeaderChildren = videoHeader.props.children;
-        let iconBox = (
-          <Box direction="row" responsive={false}>
-            {fullScreenButton}
-            {videoHeaderChildren[0, videoHeaderChildren.length - 1]}
-          </Box>
-        );
-        videoHeaderChildren.splice(-1, 1, iconBox);
-      }
     } else if (fullScreenButton) {
       // fallback to only displaying full screen icon in header
       // if allowing fullscreen

--- a/src/js/components/Video.js
+++ b/src/js/components/Video.js
@@ -2,6 +2,7 @@
 
 import React, { Component, PropTypes } from 'react';
 import Button from './Button';
+import Box from './Box';
 import PlayIcon from './icons/base/Play';
 import PauseIcon from './icons/base/Pause';
 import RefreshIcon from './icons/base/Refresh';
@@ -110,9 +111,9 @@ export default class Video extends Component {
     if (this.props.title) {
       classes.push(`${CLASS_ROOT}--titled`);
       title = (
-        <div className={`${CLASS_ROOT}__title`}>
+        <Box align="center" justify="center" className={`${CLASS_ROOT}__title`}>
           {this.props.title}
-        </div>
+        </Box>
       );
     }
 
@@ -157,14 +158,16 @@ export default class Video extends Component {
         <video ref="video" poster={this.props.poster}>
           {this.props.children}
         </video>
-        <div className={`${CLASS_ROOT}__summary`}>
-          <Button className={`${CLASS_ROOT}__control`} plain={true}
-            primary={true}
-            onClick={this._onClickControl}>
-            {controlIcon}
-          </Button>
-          {title}
-        </div>
+        <Box pad="none" align="center" justify="center" className={`${CLASS_ROOT}__summary`}>
+          <Box pad="large" align="center" justify="center">
+            <Button className={`${CLASS_ROOT}__control`} plain={true}
+              primary={true}
+              onClick={this._onClickControl}>
+              {controlIcon}
+            </Button>
+            {title}
+          </Box>
+        </Box>
         {timeline}
         {progress}
       </div>

--- a/src/scss/grommet-core/_objects.tile.scss
+++ b/src/scss/grommet-core/_objects.tile.scss
@@ -2,7 +2,8 @@
 
 .tiles {
   width: 100%;
-  padding: halve($inuit-base-spacing-unit);
+
+  @include pad();
 
   &__container {
     display: flex;

--- a/src/scss/grommet-core/_objects.video.scss
+++ b/src/scss/grommet-core/_objects.video.scss
@@ -45,6 +45,12 @@
     padding: $inuit-base-spacing-unit;
   }
 
+  &--video-header {
+    .video__summary {
+      padding: 0;
+    }
+  }
+
   &__control.button--primary {
     flex: 0 0 auto;
     width: quadruple($inuit-base-spacing-unit);
@@ -70,7 +76,8 @@
     color: $colored-text-color;
     background-color: rgba(nth($brand-grey-colors, 1), 0.7);
 
-    &-chapter {
+    &-chapter,
+    &-chapter-current {
       position: absolute;
       height: 100%;
       padding-left: quarter($inuit-base-spacing-unit);
@@ -87,6 +94,11 @@
         display: block;
         @include inuit-font-size($label-font-size, $inuit-base-spacing-unit);
       }
+    }
+
+    &-chapter-current {
+      color: nth($brand-accent-colors, 2);
+      border-color: nth($brand-accent-colors, 2);
     }
   }
 
@@ -113,14 +125,18 @@
     }
   }
 
-  &--playing:not(.video--interacting) {
+  &--playing {
+    &:not(.video--interacting) {
+      .video__control,
+      .video__timeline,
+      .video__progress {
+        opacity: 0;
+        transition: opacity 1s;
+      }
+    }
 
-    .video__summary,
-    .video__timeline,
-    .video__progress {
-      opacity: 0;
-      transition: opacity 1s;
+    .video__title {
+      visibility: hidden;
     }
   }
-
 }

--- a/src/scss/grommet-core/_objects.video.scss
+++ b/src/scss/grommet-core/_objects.video.scss
@@ -37,12 +37,11 @@
 
   &__summary {
     position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    top: 0%;
+    width: 100%;
+    height: 100%;
     display: flex;
     align-items: center;
-    text-align: left;
     padding: $inuit-base-spacing-unit;
   }
 

--- a/src/scss/grommet-core/_objects.video.scss
+++ b/src/scss/grommet-core/_objects.video.scss
@@ -63,10 +63,6 @@
     }
   }
 
-  &__title {
-    margin-left: $inuit-base-spacing-unit;
-  }
-
   &__timeline {
     position: absolute;
     left: 0px;
@@ -97,8 +93,15 @@
     }
 
     &-chapter-current {
-      color: nth($brand-accent-colors, 2);
-      border-color: nth($brand-accent-colors, 2);
+      $brand-accent-color-index: 3;
+      @if ($brand-accent-color-index <= length($brand-accent-colors)) {
+        $chapter-current-color: nth($brand-accent-colors, $brand-accent-color-index);
+      }
+      @else {
+        $chapter-current-color: $brand-color;
+      }
+      color: $chapter-current-color;
+      border-color: $chapter-current-color;
     }
   }
 

--- a/src/scss/grommet-core/_objects.video.scss
+++ b/src/scss/grommet-core/_objects.video.scss
@@ -7,6 +7,10 @@
   @include media-query(palm) {
     max-width: 100%;
     width: 100vw;
+
+    &__title {
+      visibility: hidden;
+    }
   }
 
   @include media-query(lap-and-up) {

--- a/src/scss/grommet-core/_objects.video.scss
+++ b/src/scss/grommet-core/_objects.video.scss
@@ -41,7 +41,7 @@
 
   &__summary {
     position: absolute;
-    top: 0%;
+    top: 0;
     width: 100%;
     height: 100%;
     display: flex;
@@ -77,7 +77,7 @@
     background-color: rgba(nth($brand-grey-colors, 1), 0.7);
 
     &-chapter,
-    &-chapter-current {
+    &-active {
       position: absolute;
       height: 100%;
       padding-left: quarter($inuit-base-spacing-unit);
@@ -96,7 +96,7 @@
       }
     }
 
-    &-chapter-current {
+    &-active {
       $brand-accent-color-index: 3;
       @if ($brand-accent-color-index <= length($brand-accent-colors)) {
         $chapter-current-color: nth($brand-accent-colors, $brand-accent-color-index);

--- a/src/scss/grommet-core/_objects.video.scss
+++ b/src/scss/grommet-core/_objects.video.scss
@@ -100,8 +100,7 @@
       $brand-accent-color-index: 3;
       @if ($brand-accent-color-index <= length($brand-accent-colors)) {
         $chapter-current-color: nth($brand-accent-colors, $brand-accent-color-index);
-      }
-      @else {
+      } @else {
         $chapter-current-color: $brand-color;
       }
       color: $chapter-current-color;


### PR DESCRIPTION
Video component:
* so video summary background is full width/height and centered
* allow onClick prop, so clicking on control can do something else (e.g. open a layer with the video) instead of playing the video
* videoHeader prop (for instances where we want to use the video and header component together).
* highlighting current chapter on timeline in brand-accent-3 (if available, if not use brand-color).
* hiding video title when video is playing (on hover), and on small screens

Tile component:
* allow tiles to accept pad props (but still default to small pad)