### PR TITLE
"full" option for sidebar

### DIFF
--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -15,6 +15,7 @@ export default class Sidebar extends Component {
       {
         [`${CLASS_ROOT}--primary`]: this.props.primary,
         [`${CLASS_ROOT}--fixed`]: this.props.fixed,
+        [`${CLASS_ROOT}--full`]: this.props.full,
         [`${CLASS_ROOT}--${this.props.size}`]: this.props.size
       }
     );
@@ -33,10 +34,12 @@ Sidebar.propTypes = {
   fixed: PropTypes.bool,
   primary: PropTypes.bool, // Deprecated
   size: PropTypes.oneOf(['small', 'medium', 'large']),
+  full: PropTypes.bool,
   ...Box.propTypes
 };
 
 Sidebar.defaultProps = {
   direction: 'column',
-  primary: false
+  primary: false,
+  full: true
 };

--- a/src/scss/grommet-core/_objects.sidebar.scss
+++ b/src/scss/grommet-core/_objects.sidebar.scss
@@ -1,8 +1,6 @@
 // (C) Copyright 2014-2015 Hewlett Packard Enterprise Development LP
 
 .sidebar {
-  min-height: 100vh;
-
   @include media-query(palm) {
     max-width: 100%;
     width: 100vw;
@@ -42,5 +40,9 @@
     @include media-query(lap-and-up) {
       width: $sidebar-large-width;
     }
+  }
+
+  &--full {
+    min-height: 100vh;
   }
 }


### PR DESCRIPTION
Adds `full` option, for the `false` case in which someone may not want a full-height sidebar (such as a sidebar for a section in an article-type layout).