### PR TITLE
Adds fix for issue #99 which creates a gap on the bottom of the backg…

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "classnames": "^2.2.3",
     "deep-assign": "^2.0.0",
+    "grommet-toolbox": "^0.1.0",
     "hammerjs": "2.0.1",
     "intl": "^1.0.0",
     "inuit-clearfix": "^0.2.1",
@@ -45,7 +46,6 @@
     "inuit-responsive-settings": "~0.1.2",
     "inuit-responsive-tools": "~0.1.1",
     "inuit-shared": "~0.1.5",
-    "grommet-toolbox": "^0.1.0",
     "markdown-to-jsx": "^2.0.0",
     "moment": "^2.8.3",
     "react": "^0.14.0",
@@ -60,6 +60,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "del": "^2.2.0",
+    "gulp-babel": "^6.1.2",
     "gulp-bump": "^1.0.0",
     "gulp-coveralls": "^0.1.4",
     "gulp-cssnano": "^2.1.1",

--- a/src/img/icons/social-email.svg
+++ b/src/img/icons/social-email.svg
@@ -4,7 +4,7 @@
     <title>mail-option-24</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none">
         <g id="mail-option-24" fill="#000000">
             <path d="M23,20 L23,6 L12,15 L1,6 L1,20 L23,20 Z M12,12 L22,4 L2,4 L12,12 Z" id="envelope"></path>
         </g>

--- a/src/img/icons/social-facebook.svg
+++ b/src/img/icons/social-facebook.svg
@@ -4,7 +4,7 @@
     <title>facebook-24</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none">
         <g id="facebook-24" fill="#000000">
             <path d="M14,23 L14,13 L17,13 L18,9 L14,9 L14,7 C14.1401313,5.424 15,5 16,5 L18,5 L18,1 C17.6553173,1.106 16.472035,1 15,1 C12,1 10,3 10,6 L10,9 L7,9 L7,13 L10,13 L10,23 L14,23 Z" id="Facebook"></path>
         </g>

--- a/src/img/icons/social-linkedin.svg
+++ b/src/img/icons/social-linkedin.svg
@@ -4,7 +4,7 @@
     <title>linkedin-24</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none">
         <g id="linkedin-24" fill="#000000">
             <path d="M22,23 L18,23 L18,17.0000002 C18,15.3255457 17.5,13 15,13 C12.5,13 12,15.1165094 12,17 L12,23.0000002 L8,23.0000002 L8,9 L12,9 L12,12 C12,12 13.5,9 17,9 C19.5,9 22,11 22,15.5 L22,23 Z M6,23 L2,23 L2,9.00000002 L6,9.00000002 L6,23 Z M4,7 C5.38071187,7 6.5,5.88071187 6.5,4.5 C6.5,3.11928813 5.38071187,2 4,2 C2.61928813,2 1.5,3.11928813 1.5,4.5 C1.5,5.88071187 2.61928813,7 4,7 Z" id="Linkedin"></path>
         </g>

--- a/src/img/icons/social-twitter.svg
+++ b/src/img/icons/social-twitter.svg
@@ -4,7 +4,7 @@
     <title>twiter-24</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none">
         <g id="twiter-24" fill="#000000">
             <path d="M22,5 C23,4 23,3 23,2 C22,3 21,4 20,4 C20,4 19,2 17,2 C13,2 12,4 12,8 C6,8 4.099,5.97949244 2,3 C0,5.97949243 2,9 3,10 C3,10 2,10 1,9 C1,11 2.661,13.5836965 5,14 C5,14 4,15 2,14 C2,16 5,18 7,18 C7,18 6,21 0,21 C2,22 5,22 8,22 C16.605,22 22,15 22,8 L22,7 C23,6 23.34,5.38067162 24,4 C23,5 22,5 22,5 Z" id="Twitter"></path>
         </g>

--- a/src/js/components/SocialShare.js
+++ b/src/js/components/SocialShare.js
@@ -14,6 +14,7 @@ export default class SocialShare extends Component {
 
     let socialIcon = undefined;
     let href = '';
+    let target = '_blank';
 
     const encodedLink = encodeURIComponent(link);
     const encodedTitle = encodeURIComponent(title);
@@ -34,10 +35,11 @@ export default class SocialShare extends Component {
     } else if (type === 'email') {
       socialIcon = <SocialEmailIcon />;
       href = `mailto:?subject=${encodedTitle}&body=${encodedText}%0D%0A${encodedLink}`;
+      target = '_self';
     }
 
     return (
-      <Anchor href={href} icon={socialIcon} target="_blank" />
+      <Anchor href={href} icon={socialIcon} target={target} />
     );
   }
 };

--- a/src/js/components/Value.js
+++ b/src/js/components/Value.js
@@ -67,7 +67,7 @@ Value.propTypes = {
   onClick: PropTypes.func,
   size: PropTypes.oneOf(['small', 'medium', 'large', 'xlarge']),
   trendIcon: PropTypes.node,
-  value: PropTypes.number.isRequired,
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   units: PropTypes.string
 };
 

--- a/src/scss/grommet-core/_objects.box.scss
+++ b/src/scss/grommet-core/_objects.box.scss
@@ -66,7 +66,6 @@
   min-height: 100vh;
   // min-height doesn't work for IE and vertical centering
   // https://connect.microsoft.com/IE/feedback/details/816293/ie11-flexbox-with-min-height-not-vertically-aligning-with-align-items-center
-  height: 100%;
 }
 
 .box--full-horizontal {


### PR DESCRIPTION
…round in firefox browser only. Removed `height: 100%` from scss as it has known issues to conflict with max-height in firefox. Tested in all supported browers and appears to fix gap in firefox, while not affecting the views of the other browsers signed-off-by: Kent Salcedo <kentsalcedo@webmocha.com>