### PR TITLE
Removes paddings which forces play button down

### DIFF
--- a/src/js/components/Video.js
+++ b/src/js/components/Video.js
@@ -217,7 +217,7 @@ export default class Video extends Component {
         </video>
         <Box pad="none" align="center" justify={videoSummaryJustify} className={`${CLASS_ROOT}__summary`}>
           {videoHeader}
-          <Box pad="large" align="center" justify="center">
+          <Box pad="none" align="center" justify="center">
             <Button className={`${CLASS_ROOT}__control`} plain={true}
               primary={true} onClick={onClickControl} 
               icon={controlIcon} a11yTitle={a11yControlButtonTitle} />


### PR DESCRIPTION
Fix for grommet-estories #100

Pull request removes padding which was forcing play button down. Tested in all major browsers to ensure that the rendered components looks the same and are similar to the mock ups in all of the different media query sizes.

signed-off-by: Kent Salcedo <kentsalcedo@webmocha.com>