### PR TITLE
add anchor icon styles for small drop menu

### DIFF
--- a/src/scss/grommet-core/_objects.menu.scss
+++ b/src/scss/grommet-core/_objects.menu.scss
@@ -147,8 +147,22 @@
     }
   }
 
+  .anchor__icon {
+    padding-left: 0;
+    vertical-align: middle;
+  }
+
+  .anchor--reverse .anchor__icon {
+    padding-right: 0;
+  }
+
   &.menu__drop--small {
     @include inuit-font-size($small-menu-font-size);
+
+    .anchor__icon {
+      padding-top: 0;
+      padding-bottom: 0;
+    }
   }
 
   &.menu__drop--large {


### PR DESCRIPTION
Fix for issue #502. Vertically aligns icons in dropdown menu and removes extra left padding (or right padding if reversed)