### PR TITLE
Adds tinted versions of the "colorIndex" neutral colors.

### DIFF
--- a/src/scss/grommet-core/_objects.color-index.scss
+++ b/src/scss/grommet-core/_objects.color-index.scss
@@ -1,5 +1,13 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
+@function tint($color, $percent) {
+  @return mix(white, $color, $percent);
+}
+
+@function generateTint1($color) {
+  @return tint($color, 5%);
+}
+
 #{$dark-background-context} {
   color: $active-colored-text-color;
 }
@@ -15,9 +23,19 @@
     background-color: nth($brand-neutral-colors, $i);
   }
 
+  .background-color-index-neutral-#{$i}-tint-1,
+  .background-color-index-neutral-#{$i + length($brand-neutral-colors)} {
+    background-color: generateTint1(nth($brand-neutral-colors, $i));
+  }
+
   .background-color-index-neutral-#{$i}-a,
   .background-color-index-neutral-#{$i + length($brand-neutral-colors)}-a {
     background-color: rgba(nth($brand-neutral-colors, $i), 0.8);
+  }
+
+  .background-color-index-neutral-#{$i}-tint-1-a,
+  .background-color-index-neutral-#{$i + length($brand-neutral-colors)}-tint-1-a {
+    background-color: rgba(generateTint1(nth($brand-neutral-colors, $i)), 0.8);
   }
 
   .border-color-index-neutral-#{$i},
@@ -25,9 +43,19 @@
     border-color: nth($brand-neutral-colors, $i);
   }
 
+  .border-color-index-neutral-#{$i}-tint-1,
+  .border-color-index-neutral-#{$i + length($brand-neutral-colors)}-tint-1 {
+    border-color: generateTint1(nth($brand-neutral-colors, $i));
+  }
+
   .color-index-neutral-#{$i},
   .color-index-neutral-#{$i + length($brand-neutral-colors)} {
     color: nth($brand-neutral-colors, $i);
+  }
+
+  .color-index-neutral-#{$i}-tint-1,
+  .color-index-neutral-#{$i + length($brand-neutral-colors)}-tint-1 {
+    color: generateTint1(nth($brand-neutral-colors, $i));
   }
 }
 

--- a/src/scss/grommet-core/_objects.color-index.scss
+++ b/src/scss/grommet-core/_objects.color-index.scss
@@ -17,7 +17,6 @@
 }
 
 @for $i from 1 through length($brand-neutral-colors) {
-
   .background-color-index-neutral-#{$i},
   .background-color-index-neutral-#{$i + length($brand-neutral-colors)} {
     background-color: nth($brand-neutral-colors, $i);

--- a/src/scss/grommet-core/_objects.color-index.scss
+++ b/src/scss/grommet-core/_objects.color-index.scss
@@ -4,7 +4,7 @@
   @return mix(#ffffff, $color, $percent);
 }
 
-@function generate-tint-1($color) {
+@function generate-tint($color) {
   @return tint($color, 5%);
 }
 
@@ -22,9 +22,9 @@
     background-color: nth($brand-neutral-colors, $i);
   }
 
-  .background-color-index-neutral-#{$i}-tint-1,
+  .background-color-index-neutral-#{$i}-t,
   .background-color-index-neutral-#{$i + length($brand-neutral-colors)} {
-    background-color: generate-tint-1(nth($brand-neutral-colors, $i));
+    background-color: generate-tint(nth($brand-neutral-colors, $i));
   }
 
   .background-color-index-neutral-#{$i}-a,
@@ -37,9 +37,9 @@
     border-color: nth($brand-neutral-colors, $i);
   }
 
-  .border-color-index-neutral-#{$i}-tint-1,
-  .border-color-index-neutral-#{$i + length($brand-neutral-colors)}-tint-1 {
-    border-color: generate-tint-1(nth($brand-neutral-colors, $i));
+  .border-color-index-neutral-#{$i}-t,
+  .border-color-index-neutral-#{$i + length($brand-neutral-colors)}-t {
+    border-color: generate-tint(nth($brand-neutral-colors, $i));
   }
 
   .color-index-neutral-#{$i},
@@ -47,9 +47,9 @@
     color: nth($brand-neutral-colors, $i);
   }
 
-  .color-index-neutral-#{$i}-tint-1,
-  .color-index-neutral-#{$i + length($brand-neutral-colors)}-tint-1 {
-    color: generate-tint-1(nth($brand-neutral-colors, $i));
+  .color-index-neutral-#{$i}-t,
+  .color-index-neutral-#{$i + length($brand-neutral-colors)}-t {
+    color: generate-tint(nth($brand-neutral-colors, $i));
   }
 }
 

--- a/src/scss/grommet-core/_objects.color-index.scss
+++ b/src/scss/grommet-core/_objects.color-index.scss
@@ -23,7 +23,7 @@
   }
 
   .background-color-index-neutral-#{$i}-t,
-  .background-color-index-neutral-#{$i + length($brand-neutral-colors)} {
+  .background-color-index-neutral-#{$i + length($brand-neutral-colors)}-t {
     background-color: generate-tint(nth($brand-neutral-colors, $i));
   }
 
@@ -59,6 +59,11 @@
     background-color: nth($brand-accent-colors, $i);
   }
 
+  .background-color-index-accent-#{$i}-t,
+  .background-color-index-accent-#{$i + length($brand-accent-colors)}-t {
+    background-color: generate-tint(nth($brand-accent-colors, $i));
+  }
+
   .background-color-index-accent-#{$i}-a,
   .background-color-index-accent-#{$i + length($brand-accent-colors)}-a {
     background-color: rgba(nth($brand-accent-colors, $i), 0.8);
@@ -69,9 +74,19 @@
     border-color: nth($brand-accent-colors, $i);
   }
 
+  .border-color-index-accent-#{$i}-t,
+  .border-color-index-accent-#{$i + length($brand-accent-colors)}-t {
+    border-color: generate-tint(nth($brand-accent-colors, $i));
+  }
+
   .color-index-accent-#{$i},
   .color-index-accent-#{$i + length($brand-accent-colors)} {
     color: nth($brand-accent-colors, $i);
+  }
+
+  .color-index-accent-#{$i}-t,
+  .color-index-accent-#{$i + length($brand-accent-colors)}-t {
+    color: generate-tint(nth($brand-accent-colors, $i));
   }
 }
 

--- a/src/scss/grommet-core/_objects.color-index.scss
+++ b/src/scss/grommet-core/_objects.color-index.scss
@@ -1,10 +1,10 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
 @function tint($color, $percent) {
-  @return mix(white, $color, $percent);
+  @return mix(#ffffff, $color, $percent);
 }
 
-@function generateTint1($color) {
+@function generate-tint-1($color) {
   @return tint($color, 5%);
 }
 
@@ -24,7 +24,7 @@
 
   .background-color-index-neutral-#{$i}-tint-1,
   .background-color-index-neutral-#{$i + length($brand-neutral-colors)} {
-    background-color: generateTint1(nth($brand-neutral-colors, $i));
+    background-color: generate-tint-1(nth($brand-neutral-colors, $i));
   }
 
   .background-color-index-neutral-#{$i}-a,
@@ -34,7 +34,7 @@
 
   .background-color-index-neutral-#{$i}-tint-1-a,
   .background-color-index-neutral-#{$i + length($brand-neutral-colors)}-tint-1-a {
-    background-color: rgba(generateTint1(nth($brand-neutral-colors, $i)), 0.8);
+    background-color: rgba(generate-tint-1(nth($brand-neutral-colors, $i)), 0.8);
   }
 
   .border-color-index-neutral-#{$i},
@@ -44,7 +44,7 @@
 
   .border-color-index-neutral-#{$i}-tint-1,
   .border-color-index-neutral-#{$i + length($brand-neutral-colors)}-tint-1 {
-    border-color: generateTint1(nth($brand-neutral-colors, $i));
+    border-color: generate-tint-1(nth($brand-neutral-colors, $i));
   }
 
   .color-index-neutral-#{$i},
@@ -54,7 +54,7 @@
 
   .color-index-neutral-#{$i}-tint-1,
   .color-index-neutral-#{$i + length($brand-neutral-colors)}-tint-1 {
-    color: generateTint1(nth($brand-neutral-colors, $i));
+    color: generate-tint-1(nth($brand-neutral-colors, $i));
   }
 }
 

--- a/src/scss/grommet-core/_objects.color-index.scss
+++ b/src/scss/grommet-core/_objects.color-index.scss
@@ -32,11 +32,6 @@
     background-color: rgba(nth($brand-neutral-colors, $i), 0.8);
   }
 
-  .background-color-index-neutral-#{$i}-tint-1-a,
-  .background-color-index-neutral-#{$i + length($brand-neutral-colors)}-tint-1-a {
-    background-color: rgba(generate-tint-1(nth($brand-neutral-colors, $i)), 0.8);
-  }
-
   .border-color-index-neutral-#{$i},
   .border-color-index-neutral-#{$i + length($brand-neutral-colors)} {
     border-color: nth($brand-neutral-colors, $i);


### PR DESCRIPTION
![screen shot 2016-04-19 at 4 58 27 pm](https://cloud.githubusercontent.com/assets/7669/14659360/371b8206-0650-11e6-9bfc-d502a0a8b724.png)

I decided to go with appending the `-tint-1` for the colorIndex names so that in the future, we can add more tinted versions.

Let me know if I'm heading in the right direction with this, I can go ahead and add the tinted versions to the rest of the colors (accent, light, etc.).