### PR TITLE
adds fix for estories bug #100 - when modal opens in firefox in mobil…

### DIFF
--- a/src/scss/grommet-core/_objects.layer.scss
+++ b/src/scss/grommet-core/_objects.layer.scss
@@ -16,7 +16,9 @@
 
   @include media-query(palm) {
     &:not(.layer--hidden) + .app {
-      display: none;
+      visibility: hidden;
+      width: 0px;
+      height: 0px;
     }
   }
 


### PR DESCRIPTION
…e view and takes up full screen, upon closing the modal it would jump back to the first page. this bug was caused by how firefox renders elements with `display: none` so I adjusted the scss slightly to have the same outcome. Checked across all supported browers and in different browser sizes to ensure it renders and reponds as intended. signed-off-by: Kent Salcedo <kentsalcedo@webmocha.com>