### PR TITLE
layer + video bug fixes

### DIFF
--- a/src/js/components/Layer.js
+++ b/src/js/components/Layer.js
@@ -40,8 +40,9 @@ class LayerContents extends Component {
     };
 
     if (this.props.onClose) {
+      const layerParent = this.refs.container.parentNode;
       this._keyboardHandlers.esc = this.props.onClose;
-      document.addEventListener('click', this._onClick.bind(this));
+      layerParent.addEventListener('click', this._onClick.bind(this));
     }
 
     KeyboardAccelerators.startListeningToKeyboard(
@@ -62,17 +63,20 @@ class LayerContents extends Component {
   }
 
   componentWillUnmount () {
+    const layerParent = this.refs.container.parentNode;
+
     KeyboardAccelerators.stopListeningToKeyboard(
       this, this._keyboardHandlers
     );
 
     if (this.props.onClose) {
-      document.removeEventListener('click', this._onClick.bind(this));
+      layerParent.removeEventListener('click', this._onClick.bind(this));
     }
   }
 
   _onClick (event) {
     const layerContents = this.refs.container;
+
     if (layerContents && !layerContents.contains(event.target)) {
       this.props.onClose();
     }

--- a/src/js/components/Video.js
+++ b/src/js/components/Video.js
@@ -174,11 +174,12 @@ export default class Video extends Component {
           (seconds < 10 ? '0' + seconds : seconds);
         let currentProgress = this.state.progress;
         let nextChapter = chapters[Math.min(chapters.length - 1, index + 1)];
+        let lastChapter = chapters[chapters.length - 1];
 
         let timelineClasses = classnames(
           `${CLASS_ROOT}__timeline-chapter`,
           {
-            [`${CLASS_ROOT}__timeline-active`]: (currentProgress !== 0 && currentProgress >= chapter.time && currentProgress < nextChapter.time)
+            [`${CLASS_ROOT}__timeline-active`]: (currentProgress !== 0 && ((currentProgress >= chapter.time && currentProgress < nextChapter.time) || (index === chapters.length - 1 && currentProgress >= lastChapter.time)))
           }
         );
 
@@ -201,7 +202,9 @@ export default class Video extends Component {
 
     let progress;
     if (this.props.duration) {
-      let percent = Math.round((this.state.progress / this.props.duration) * 100);
+      // making sure percent is <= 100,
+      // so that progress bar does not extend beyond container width
+      let percent = Math.min((Math.round((this.state.progress / this.props.duration) * 100)), 100);
       progress = (
         <div className={`${CLASS_ROOT}__progress`}>
           <div className={`${CLASS_ROOT}__progress-meter`}

--- a/src/js/components/Video.js
+++ b/src/js/components/Video.js
@@ -45,9 +45,11 @@ export default class Video extends Component {
 
   _onPlaying () {
     let video = this.refs.video;
-    this._progressTimer = setInterval(function () {
-      this.setState({progress: this.state.progress + 0.5});
-    }.bind(this), 500);
+    if (!this._progressTimer) {
+      this._progressTimer = setInterval(function () {
+        this.setState({progress: this.state.progress + 0.5});
+      }.bind(this), 500);
+    }
     this.setState({ playing: true, progress: video.currentTime, ended: null });
   }
 


### PR DESCRIPTION
addresses issues:

* layer closing when clicking on drop options: https://github.com/grommet/grommet/issues/515
* layer closing when clicking on drop options (grommet-estories): https://github.com/grommet/grommet-estories/issues/145
* fixing video progress bar bug (endless, rapidly progressing progress bar, when clicking on chapter marker): https://github.com/grommet/grommet-estories/issues/153
* taking care of video edge cases: (1) progress bar sometimes is at 101% width, so setting cap to 100%, and (2) ensuring that very last chapter marker can be "active"/highlighted