### PR TITLE
Fix for continuous tab cycle

### DIFF
--- a/src/js/components/Article.js
+++ b/src/js/components/Article.js
@@ -369,33 +369,39 @@ export default class Article extends Component {
   }
 
   _processTab (event) {
-    const chapter = ReactDOM.findDOMNode(
+    const findNode = node => ReactDOM.findDOMNode(node);
+    const { previous, next } = this.refs;
+
+    const previousBtn = findNode(previous);
+    const nextBtn = findNode(next);
+
+    const chapter = findNode(
       this.refs[`chapter_${this.state.activeIndex}`]
     );
-    var items = chapter.getElementsByTagName('*');
+
+    let items = chapter.getElementsByTagName('*');
     items = DOMUtils.filterByFocusable(items);
 
     if (items && items.length > 0) {
       if (event.shiftKey) {
-        if (document.activeElement === ReactDOM.findDOMNode(this.refs.previous)
-          || (document.activeElement === ReactDOM.findDOMNode(this.refs.next)
-          && this.state.activeIndex === 0)) {
+        if (document.activeElement === previousBtn ||
+          (document.activeElement === nextBtn && this.state.activeIndex === 0)) {
           items[items.length - 1].focus();
           event.preventDefault();
         } else if (document.activeElement === this.refs[`anchor_step_${this.state.activeIndex}`] ||
           event.target === items[0]) {
-          if (this.refs.next) {
-            ReactDOM.findDOMNode(this.refs.next).focus();
-          } else if (this.refs.previous) {
-            ReactDOM.findDOMNode(this.refs.previous).focus();
+          if (next) {
+            nextBtn.focus();
+          } else if (previous) {
+            previousBtn.focus();
           }
           event.preventDefault();
         }
       } else if (event.target === items[items.length - 1]) {
-        if (this.refs.previous) {
-          ReactDOM.findDOMNode(this.refs.previous).focus();
-        } else if (this.refs.next) {
-          ReactDOM.findDOMNode(this.refs.next).focus();
+        if (previous) {
+          items[0].focus()
+        } else if (next) {
+          nextBtn.focus();
         }
         event.preventDefault();
       }
@@ -491,6 +497,7 @@ export default class Article extends Component {
                 <a tabIndex="-1" aria-hidden='true'
                   ref={`anchor_step_${index}`} onFocus={element.props.onFocus} />
                 {elementClone}
+                {controls}
               </div>
             );
           }
@@ -509,7 +516,6 @@ export default class Article extends Component {
         onTouchMove={this._onTouchMove}
         primary={this.props.primary}>
         {children}
-        {controls}
       </Box>
     );
   }

--- a/src/js/components/Chart.js
+++ b/src/js/components/Chart.js
@@ -292,7 +292,7 @@ export default class Chart extends Component {
   // redo the bounds calculations.
   // Called whenever the browser resizes or new properties arrive.
   _layout () {
-    if (this.props.legend && 'below' !== this.props.legend.position) {
+    if (this.props.legend && 'overlay' === this.props.legend.position) {
       this._alignLegend();
     }
     let element = this.refs.chart;
@@ -511,6 +511,7 @@ export default class Chart extends Component {
 
     let values = bounds.xAxis.data.map((obj, xIndex) => {
       let baseY = bounds.minY;
+      let legend = [];
       let stepBars = this.props.series.map((item, seriesIndex) => {
 
         let colorIndex = item.colorIndex || ('graph-' + (seriesIndex + 1));
@@ -520,7 +521,9 @@ export default class Chart extends Component {
         baseY += value[1];
 
         let classes = [CLASS_ROOT + "__values-bar", "color-index-" + colorIndex];
-        if (! this.props.legend || xIndex === this.state.activeXIndex) {
+        if (! this.props.legend ||
+          'inline' === this.props.legend.position ||
+          xIndex === this.state.activeXIndex) {
           classes.push(CLASS_ROOT + "__values-bar--active");
         }
 
@@ -531,7 +534,6 @@ export default class Chart extends Component {
         const width = bounds.xStepWidth - (2 * bounds.barPadding);
         const x = (this._translateX(value[0]) + bounds.barPadding) +
           (width / 2);
-
         if (segmented) {
           stepBarBase =
             Math.floor(stepBarBase / BAR_SEGMENT_HEIGHT) * BAR_SEGMENT_HEIGHT;
@@ -539,6 +541,15 @@ export default class Chart extends Component {
             Math.floor(stepBarHeight / BAR_SEGMENT_HEIGHT) * BAR_SEGMENT_HEIGHT;
         }
         const y = this.state.height - (stepBarHeight + stepBarBase);
+
+        if (this.props.legend && 'inline' === this.props.legend.position) {
+          legend.push(
+            <text key={'bar-value_' + item.label || seriesIndex}
+              x={x} y={y} role="presentation" textAnchor="middle" fontSize={24}>
+              {value[1]}
+            </text>
+          );
+        }
 
         return (
           <line key={'bar_' + item.label || seriesIndex}
@@ -551,6 +562,7 @@ export default class Chart extends Component {
       return (
         <g key={'bar_' + xIndex}>
           {stepBars}
+          {legend}
         </g>
       );
     });
@@ -765,7 +777,7 @@ export default class Chart extends Component {
             x={x} y={0} width={bounds.xStepWidth} height={this.state.height} />
         </g>
       );
-    }, this);
+    });
 
     return (
       <g ref={layer} className={className}>
@@ -898,7 +910,8 @@ export default class Chart extends Component {
 
     let cursor = null;
     let legend = null;
-    if (this.props.legend && this.state.activeXIndex >= 0 &&
+    if (this.props.legend && 'inline' !== this.props.legend.position &&
+      this.state.activeXIndex >= 0 &&
       this.props.series[0].values.length > 0) {
       cursor = this._renderCursor();
       legend = this._renderLegend();
@@ -973,7 +986,7 @@ Chart.propTypes = {
   important: PropTypes.number,
   large: PropTypes.bool,
   legend: PropTypes.shape({
-    position: PropTypes.oneOf(['overlay', 'after']),
+    position: PropTypes.oneOf(['overlay', 'after', 'inline']),
     total: PropTypes.bool
   }),
   max: PropTypes.number,

--- a/src/js/utils/DOM.js
+++ b/src/js/utils/DOM.js
@@ -48,12 +48,12 @@ export default {
   filterByFocusable (elements) {
     return Array.prototype.filter.call(elements || [], function(element) {
       var currentTag = element.tagName.toLowerCase();
-      var validTags = /(svg|a|area|input|select|textarea|button|iframe)$/;
+      var validTags = /(svg|a|area|input|select|textarea|button|iframe|div)$/;
       var isValidTag = currentTag.match(validTags) && element.focus;
 
       if (currentTag === 'a') {
-        return isValidTag && element.childNodes.length > 0;
-      } else if (currentTag === 'svg') {
+        return isValidTag && element.childNodes.length > 0 && element.getAttribute('href');
+      } else if (currentTag === 'svg' || currentTag === 'div') {
         return isValidTag && element.hasAttribute('tabindex');
       }
 

--- a/src/scss/grommet-core/_objects.chart.scss
+++ b/src/scss/grommet-core/_objects.chart.scss
@@ -13,152 +13,154 @@
 .chart {
   position: relative;
   display: block;
+}
 
-  &__grid {
-    stroke: $border-color;
-  }
+.chart__grid {
+  stroke: $border-color;
+}
 
-  &__graphic {
-    width: 100%;
-    height: $graphic-size;
-    max-height: calc(100vh - #{double($header-height)});
-  }
+.chart__graphic {
+  width: 100%;
+  height: $graphic-size;
+  max-height: calc(100vh - #{double($header-height)});
+}
 
-  &__values {
+.chart__values {
 
-    @include media-query(lap-and-up) {
-      g {
-        @include animation('reveal-chart 1.5s');
-      }
-    }
-
-    &-line {
-      stroke-width: 3px;
-      @include graph-stroke-color();
-    }
-
-    &-bar,
-    &-area {
-      @include graph-fill-color-translucent(0.7);
-
-      &--active {
-        @include graph-fill-color;
-      }
-    }
-
-    &-point {
-      stroke-width: 3px;
-      @include graph-stroke-color();
-      fill: $background-color;
-    }
-
-    &--loading {
-      stroke-width: $inuit-base-spacing-unit;
-      @include graph-stroke-color();
+  @include media-query(lap-and-up) {
+    g {
+      @include animation('reveal-chart 1.5s');
     }
   }
+}
 
-  &__threshold {
-    stroke-width: 2px;
-    stroke: $threshold-color;
-    pointer-events: none;
+.chart__values-line {
+  stroke-width: 3px;
+  @include graph-stroke-color();
+}
+
+.chart__values-area {
+  @include graph-fill-color-translucent(0.7);
+}
+
+.chart__values-area--active {
+  @include graph-fill-color;
+}
+
+.chart__values-bar {
+  @include graph-stroke-color-translucent(0.7);
+
+  &--active {
+    @include graph-stroke-color;
+  }
+}
+
+.chart--segmented {
+  .chart__values-bar {
+    stroke-dasharray: 12 6;
+  }
+}
+
+.chart__values-point {
+  stroke-width: 3px;
+  @include graph-stroke-color();
+  fill: $background-color;
+}
+
+.chart__values--loading {
+  stroke-width: $inuit-base-spacing-unit;
+  @include graph-stroke-color();
+}
+
+.chart__threshold {
+  stroke-width: 2px;
+  stroke: $threshold-color;
+  pointer-events: none;
+}
+
+.chart__yaxis .chart__bar {
+  @include graph-fill-color-translucent(0.5);
+}
+
+.chart__xaxis-index {
+  text {
+    fill: $secondary-text-color;
+  }
+}
+
+.chart__xaxis-index--eclipse {
+  text {
+    fill: transparent;
+  }
+}
+
+.chart__xaxis-index--active {
+  text {
+    fill: $text-color;
+  }
+}
+
+.chart__front-xband-background {
+  fill: rgba(0, 0, 0, 0);
+}
+
+.chart__cursor {
+  stroke: $cursor-color;
+  stroke-width: 2;
+  pointer-events: none;
+}
+
+.chart__cursor-point {
+  stroke-width: 2;
+  @include graph-fill-color();
+}
+
+.chart__legend--overlay {
+  padding: halve($inuit-base-spacing-unit);
+  pointer-events: none;
+
+  @include media-query(palm) {
+    margin: 0px auto;
   }
 
-  &__yaxis .chart__bar {
-    @include graph-fill-color-translucent(0.5);
+  @include media-query(lap-and-up) {
+    position: absolute;
+    left: 0px;
+    margin: 0px;
+    background-color: $active-background-color;
+  }
+}
+
+.chart--area,
+.chart--bar {
+  .chart__gradient {
+    @include graph-fill-color-gradient();
+  }
+}
+
+.chart--small {
+  .chart__graphic {
+    height: $graphic-small-size;
+  }
+}
+
+.chart--large {
+  .chart__graphic {
+    height: $graphic-large-size;
+  }
+}
+
+.chart--sparkline {
+  display: inline-block;
+  margin-right: quarter($inuit-base-spacing-unit);
+
+  .chart__graphic {
+    width: auto;
+    height: $sparkline-height;
   }
 
-  &__xaxis {
-    &-index {
-      text {
-        fill: $secondary-text-color;
-      }
-
-      &--eclipse {
-        text {
-          fill: transparent;
-        }
-      }
-
-      &--active {
-        text {
-          fill: $text-color;
-        }
-      }
-    }
-  }
-
-  &__front {
-    &-xband {
-      &-background {
-        fill: rgba(0, 0, 0, 0);
-      }
-    }
-  }
-
-  &__cursor {
-    stroke: $cursor-color;
-    stroke-width: 2;
-    pointer-events: none;
-
-    &-point {
-      stroke-width: 2;
-      @include graph-fill-color();
-    }
-  }
-
-  &__legend {
-
-    &--overlay {
-      padding: halve($inuit-base-spacing-unit);
-      pointer-events: none;
-
-      @include media-query(palm) {
-        margin: 0px auto;
-      }
-
-      @include media-query(lap-and-up) {
-        position: absolute;
-        left: 0px;
-        margin: 0px;
-        background-color: $active-background-color;
-      }
-    }
-  }
-
-  &--area,
-  &--bar {
-    .chart__gradient {
-      @include graph-fill-color-gradient();
-    }
-  }
-
-  &--small {
-    .chart__graphic {
-      height: $graphic-small-size;
-    }
-  }
-
-  &--large {
-    .chart__graphic {
-      height: $graphic-large-size;
-    }
-  }
-
-  &--sparkline {
-    display: inline-block;
-    margin-right: quarter($inuit-base-spacing-unit);
-
-    .chart__graphic {
-      width: auto;
-      height: $sparkline-height;
-    }
-
-    .chart__values {
-      &-bar,
-      &-area {
-        @include graph-fill-color();
-      }
-    }
+  .chart__values-bar,
+  .chart__values-area {
+    @include graph-fill-color();
   }
 }


### PR DESCRIPTION
* When `<tab>` was pressed continuously through the cycle of the view it would jump to the fist child, regardless of index position. Behavior that was unlike `<shift + tab>`.
- Did some reference caching.

tldr; The real fix is on line 402 and 500.

Signed-off-by: Derek Ahn <git.derek@gmail.com>