### PR TITLE
Tags take full width of container in responsive mode.

### DIFF
--- a/src/scss/grommet-core/_objects.tag.scss
+++ b/src/scss/grommet-core/_objects.tag.scss
@@ -5,6 +5,10 @@
   position: relative;
   opacity: 0.7;
 
+  @include media-query(palm) {
+    max-width: inherit;
+  }
+
   a,
   a:hover,
   .anchor:hover:not(.anchor--disabled) {


### PR DESCRIPTION
Fix for https://github.com/grommet/grommet-estories/issues/121