### PR TITLE
Fix to Estories Issue 99 - Full box background not working leaving white gap

### DIFF
--- a/src/scss/grommet-core/_objects.box.scss
+++ b/src/scss/grommet-core/_objects.box.scss
@@ -66,7 +66,6 @@
   min-height: 100vh;
   // min-height doesn't work for IE and vertical centering
   // https://connect.microsoft.com/IE/feedback/details/816293/ie11-flexbox-with-min-height-not-vertically-aligning-with-align-items-center
-  height: 100%;
 }
 
 .box--full-horizontal {


### PR DESCRIPTION
Adds fix to get rid of white gap on bottom of hooks page on estories. Also fixes a gap that is on IE11. signed-off-by: Kent Salcedo <kentsalcedo@webmocha.com>