### PR TITLE
Fix for browser consistency with Video poster

### DIFF
--- a/src/js/components/Video.js
+++ b/src/js/components/Video.js
@@ -129,9 +129,9 @@ export default class Video extends Component {
       <PauseIcon size={controlIconSize} /> : (this.state.ended ?
         <RefreshIcon size={controlIconSize} /> :
           <PlayIcon size={controlIconSize} />));
-    let a11yControlButtonMessage = (this.state.playing ? 
-      'Pause Video' : (this.state.ended ? 
-        'Restart Video' : 
+    let a11yControlButtonMessage = (this.state.playing ?
+      'Pause Video' : (this.state.ended ?
+        'Restart Video' :
           'Play Video'));
     let a11yControlButtonTitle = Intl.getMessage(this.context.intl, a11yControlButtonMessage);
 
@@ -143,7 +143,7 @@ export default class Video extends Component {
       let a11yExpandButtonTitle = Intl.getMessage(this.context.intl, 'Toggle Fullscreen');
       // fallback to only displaying full screen icon in header
       // if allowing fullscreen
-      
+
       videoHeader = (
         <Box align="end" full="horizontal">
           <Button plain={true} onClick={this._onFullScreen}
@@ -217,14 +217,14 @@ export default class Video extends Component {
 
     return (
       <div className={classes.join(' ')} onMouseMove={this._onMouseMove}>
-        <video ref="video" poster={this.props.poster}>
+        <video className="video--poster" ref="video" poster={this.props.poster}>
           {this.props.children}
         </video>
         <Box pad="none" align="center" justify={videoSummaryJustify} className={`${CLASS_ROOT}__summary`}>
           {videoHeader}
           <Box pad="none" align="center" justify="center">
             <Button className={`${CLASS_ROOT}__control`} plain={true}
-              primary={true} onClick={onClickControl} 
+              primary={true} onClick={onClickControl}
               icon={controlIcon} a11yTitle={a11yControlButtonTitle} />
             {title}
           </Box>

--- a/src/scss/grommet-core/_objects.video.scss
+++ b/src/scss/grommet-core/_objects.video.scss
@@ -37,6 +37,10 @@
 
   video {
     width: 100%;
+
+    .video--poster {
+      width: 100vw;
+    }
   }
 
   &__summary {


### PR DESCRIPTION
- This allows for the width to be responsive and consistent across browsers.

Addresses this [issue 177 from eStories](https://github.com/grommet/grommet-estories/issues/117)

Signed-off-by: DerekAhn <git.derek@gmail.com>