### PR TITLE
Collapse timeline and only show progress bar in mobile view

### DIFF
--- a/src/scss/grommet-core/_objects.video.scss
+++ b/src/scss/grommet-core/_objects.video.scss
@@ -11,6 +11,10 @@
     &__title {
       visibility: hidden;
     }
+
+    &__timeline {
+      visibility: hidden;
+    }
   }
 
   @include media-query(lap-and-up) {


### PR DESCRIPTION
Fix for Issue #154 - collapses video timeline chapter bar when in mobile view signed-off-by: Kent Salcedo kentsalcedo@webmocha.com

Replaces closed PR https://github.com/grommet/grommet-estories/pull/192