### PR TITLE
changing anchor icon hover to scale instead of increase stroke width

### DIFF
--- a/src/img/icons/overlay.svg
+++ b/src/img/icons/overlay.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="24px" height="24px" viewBox="-1 -1 26 26" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 3.6.1 (26313) - http://www.bohemiancoding.com/sketch -->
     <title>new-window-24</title>
     <desc>Created with Sketch.</desc>

--- a/src/img/icons/overlay.svg
+++ b/src/img/icons/overlay.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="24px" height="24px" viewBox="-1 -1 26 26" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 3.6.1 (26313) - http://www.bohemiancoding.com/sketch -->
     <title>new-window-24</title>
     <desc>Created with Sketch.</desc>

--- a/src/scss/grommet-core/_objects.anchor.scss
+++ b/src/scss/grommet-core/_objects.anchor.scss
@@ -67,7 +67,7 @@
 
   &:hover:not(.anchor--disabled) {
     .control-icon {
-      @include icon-hover-bold($control-brand-color);
+      @include icon-hover-grow($control-brand-color);
     }
   }
 }

--- a/src/scss/grommet-core/_tools.icon.scss
+++ b/src/scss/grommet-core/_tools.icon.scss
@@ -5,14 +5,10 @@
   stroke: $icon-color;
 }
 
-@mixin icon-hover-bold($icon-hover-color) {
+@mixin icon-hover-grow($icon-hover-color) {
   fill: $icon-hover-color;
   stroke: $icon-hover-color;
-
-  path,
-  polyline {
-    stroke-width: 3px;
-  }
+  transform: scale(1.1);
 }
 
 @mixin dark-background-context-icon {


### PR DESCRIPTION
updating viewBox of Overlay icon so that hover will have even lineweights
https://github.com/grommet/grommet-estories/issues/128

Signed-off-by: Jackie Wijaya <jackiewijaya@webmocha.com>

(Screenshot shows left: before and right: after.)
<img width="693" alt="screen shot 2016-04-25 at 9 27 34 pm" src="https://cloud.githubusercontent.com/assets/10161095/14810283/ce657f4a-0b2d-11e6-8044-d2c149bc5e43.png">
