### PR TITLE
Fix Issue: Table selection in IE 11 is wrong

### DIFF
--- a/src/js/utils/Selection.js
+++ b/src/js/utils/Selection.js
@@ -69,6 +69,10 @@ function onClick (event, options) {
     while (item && ! item.matchesElement(options.childSelector)) {
       item = item.parentNode;
     }
+  } else if (item.msMatchesSelector) {
+    while (item.msMatchesSelector && !item.msMatchesSelector(options.childSelector)) {
+      item = item.parentNode;
+    }
   }
 
   // determine the index of the clicked element


### PR DESCRIPTION
The function matches and matchesElement is not supported in IE 11, so, just msMatchesSelector instead

Issue details: #246