### PR TITLE
Fix Issue: Table selection in IE 11 is wrong

### DIFF
--- a/src/js/utils/Selection.js
+++ b/src/js/utils/Selection.js
@@ -61,12 +61,9 @@ function onClick (event, options) {
 
   // Go up the DOM tree until we match the childSelector
   let item = event.target;
-  if (item.matches) {
-    while (item && ! item.matches(options.childSelector)) {
-      item = item.parentNode;
-    }
-  } else if (item.matchesElement) {
-    while (item && ! item.matchesElement(options.childSelector)) {
+  var matchFunction = item.matches || item.matchesElement || item.msMatchesSelector;
+  if (matchFunction) {
+    while (item && !matchFunction(options.childSelector)) {
       item = item.parentNode;
     }
   }


### PR DESCRIPTION
The function matches and matchesElement is not supported in IE 11, so, use msMatchesSelector instead

Issue details: #246