### PR TITLE
Playhead and progress bar styling enhancement

### DIFF
--- a/src/js/components/Video.js
+++ b/src/js/components/Video.js
@@ -225,20 +225,59 @@ export default class Video extends Component {
       );
     }
 
+    let progressTicks;
+    if (this.props.timeline && this.props.duration) {
+
+      let chapters = this.props.timeline.map(function (chapter, index, chapters) {
+        let percent = Math.round((chapter.time / this.props.duration) * 100);
+        let currentProgress = this.state.progress;
+        let nextChapter = chapters[Math.min(chapters.length - 1, index + 1)];
+
+        let progressTicksClasses = classnames(
+          `${CLASS_ROOT}__progress-ticks-chapter`,
+          {
+            [`${CLASS_ROOT}__progress-ticks-active`]: (currentProgress !== 0 && currentProgress >= chapter.time && currentProgress < nextChapter.time)
+          }
+        );
+
+        return (
+          <div key={chapter.time} className={progressTicksClasses}
+            style={{left: percent.toString() + '%'}}
+            onClick={this._onClickChapter.bind(this, chapter.time)}>
+          </div>
+        );
+      }, this);
+ 
+      progressTicks = (
+        <div className={`${CLASS_ROOT}__progress-ticks`}>
+          {chapters}
+        </div>
+      );
+    }
+
     let progress;
     if (this.props.duration) {
-      // making sure percent is <= 100,
-      // so that progress bar does not extend beyond container width
+      const progressClass = classnames(
+        `${CLASS_ROOT}__progress`,
+        {
+          [`${CLASS_ROOT}--has-timeline`]: this.props.timeline
+        }
+      );
+
       let percent = Math.min((Math.round((this.state.progress / this.props.duration) * 100)), 100);
       progress = (
-        <div className={`${CLASS_ROOT}__progress`}>
+        <div className={progressClass}>
           <div className={`${CLASS_ROOT}__progress-meter`}
             style={{width: percent.toString() + '%'}}></div>
+          {progressTicks}
         </div>
       );
     }
 
     let onClickControl = this.props.onClick || this._onClickControl;
+    // when iconSize is small (mobile screen sizes), remove the extra padding
+    // so that the play control is centered
+    let emptyBox = this.state.iconSize === 'small' ? null : <Box />;
 
     return (
       <div className={classes.join(' ')} onMouseMove={this._onMouseMove}>
@@ -247,13 +286,13 @@ export default class Video extends Component {
         </video>
         <Box pad="none" align="center" justify={videoSummaryJustify} className={`${CLASS_ROOT}__summary`}>
           {videoHeader}
-          <Box pad="none" align="center" justify="center">
+          <Box pad="medium" align="center" justify="center">
             <Button className={`${CLASS_ROOT}__control`} plain={true}
               primary={true} onClick={onClickControl}
               icon={controlIcon} a11yTitle={a11yControlButtonTitle} />
             {title}
           </Box>
-          <Box />
+          {emptyBox}
         </Box>
         {timeline}
         {progress}

--- a/src/scss/grommet-core/_objects.video.scss
+++ b/src/scss/grommet-core/_objects.video.scss
@@ -15,6 +15,11 @@
     &__timeline {
       visibility: hidden;
     }
+
+    &__progress,
+    &--has-timeline {
+      bottom: 0px;
+    }
   }
 
   @include media-query(lap-and-up) {
@@ -33,6 +38,10 @@
     &--large {
       width: $video-large-width;
     }
+
+    &--has-timeline {
+      bottom: round($inuit-base-spacing-unit * 3);
+    }
   }
 
   &--full {
@@ -41,6 +50,7 @@
 
   video {
     width: 100%;
+    display: block;
   }
 
   &__summary {
@@ -89,8 +99,6 @@
     &-active {
       position: absolute;
       height: 100%;
-      padding-left: quarter($inuit-base-spacing-unit);
-      border-left: 2px solid $colored-icon-color;
       text-align: left;
       cursor: pointer;
 
@@ -102,6 +110,10 @@
       time {
         display: block;
         @include inuit-font-size($label-font-size, $inuit-base-spacing-unit);
+      }
+
+      label {
+        font-weight: bold;
       }
     }
 
@@ -121,15 +133,52 @@
 
   &__progress {
     position: absolute;
+    background-color: rgba(nth($brand-grey-colors, 3), 0.7);
     left: 0px;
     right: 0px;
-    bottom: 0px;
     height: quarter($inuit-base-spacing-unit);
     text-align: left;
 
     &-meter {
       height: 100%;
       background-color: $brand-color;
+    }
+
+    &:not(.video--has-timeline) {
+      bottom: 0px;
+    }
+  }
+
+&__progress-ticks {
+    position: absolute;
+    left: 0px;
+    right: 0px;
+    bottom: quarter($inuit-base-spacing-unit);
+    color: $colored-text-color;
+    background-color: rgba(nth($brand-grey-colors, 1), 0.7);
+
+    &-chapter,
+    &-active {
+      position: absolute;
+      height: quarter($inuit-base-spacing-unit);
+      border-left: 2px solid $colored-icon-color;
+      text-align: left;
+      cursor: pointer;
+
+      &:hover {
+        color: $active-colored-text-color;
+        border-color: $active-colored-icon-color;
+      }
+    }
+
+    &-active {
+      $brand-accent-color-index: 3;
+      @if ($brand-accent-color-index <= length($brand-accent-colors)) {
+        $chapter-current-color: nth($brand-accent-colors, $brand-accent-color-index);
+      } @else {
+        $chapter-current-color: $brand-color;
+      }
+      border-color: $chapter-current-color;
     }
   }
 
@@ -145,15 +194,30 @@
   &--playing {
     &:not(.video--interacting) {
       .video__control,
-      .video__timeline,
-      .video__progress {
+      .video__timeline {
         opacity: 0;
         transition: opacity 1s;
+      }
+
+      .video__progress {
+        bottom: 0px;
+        transition: ease 1s;
+      }
+
+      .video__progress-ticks {
+        bottom: quarter($inuit-base-spacing-unit);
+        transition: ease 1s;
       }
     }
 
     .video__title {
       visibility: hidden;
+    }
+
+    &--interacting {
+      .video--has-timeline {
+        bottom: round($inuit-base-spacing-unit * 3);
+      }
     }
   }
 }


### PR DESCRIPTION
Adds styling enhancements to progress bar. On mobile view, collapses the timeline and only shows progress bar. If there is a timeline, the progress bar will be above the timeline. If the user hovers and interacts with the video, the timeline will expand and the progress bar will move to the top signed-off-by: Kent Salcedo <kentsalcedo@webmocha.com>

https://github.com/grommet/grommet-estories/issues/219