### PR TITLE
Bind the function to the dom to avoid Illegal invocation

### DIFF
--- a/src/js/utils/Selection.js
+++ b/src/js/utils/Selection.js
@@ -63,7 +63,7 @@ function onClick (event, options) {
   let item = event.target;
   var matchFunction = item.matches || item.matchesElement || item.msMatchesSelector;
   if (matchFunction) {
-    while (item && !matchFunction(options.childSelector)) {
+    while (item && !matchFunction.bind(item, options.childSelector)()) {
       item = item.parentNode;
     }
   }


### PR DESCRIPTION
This matchFunction need the dom element, 
so bind the function to the dom to avoid Illegal invocation