### PR TITLE
Add default en-US message for "Close  Layer" 

### DIFF
--- a/src/js/messages/en-US.js
+++ b/src/js/messages/en-US.js
@@ -20,6 +20,7 @@ export default {
   Clear: 'Clear',
   Cleared: 'Cleared',
   Close: 'Close',
+  'Close  Layer': 'Close Layer',
   'Close Menu': 'Close Menu',
   Completed: 'Completed',
   created: 'Created',


### PR DESCRIPTION
Resolving react-intl warning:
```
[React Intl] Missing message: "Close  Layer" for locale: "en-US", using default message as fallback.
```