### PR TITLE
Refactors and styles timeline chapters to match mockup

### DIFF
--- a/src/js/components/Video.js
+++ b/src/js/components/Video.js
@@ -209,12 +209,13 @@ export default class Video extends Component {
         );
 
         return (
-          <div key={chapter.time} className={timelineClasses}
+          <Box key={chapter.time} className={timelineClasses}
+            pad={{vertical: 'small'}}
             style={{left: percent.toString() + '%'}}
             onClick={this._onClickChapter.bind(this, chapter.time)}>
             <label>{chapter.label}</label>
             <time>{time}</time>
-          </div>
+          </Box>
         );
       }, this);
 

--- a/src/scss/grommet-core/_objects.video.scss
+++ b/src/scss/grommet-core/_objects.video.scss
@@ -113,7 +113,7 @@
       }
 
       label {
-        font-weight: bold;
+        font-weight: 600;
       }
     }
 
@@ -133,7 +133,7 @@
 
   &__progress {
     position: absolute;
-    background-color: rgba(nth($brand-grey-colors, 3), 0.7);
+    background-color: lighten(rgba(nth($brand-grey-colors, 3), 0.7), 20%);
     left: 0px;
     right: 0px;
     height: quarter($inuit-base-spacing-unit);


### PR DESCRIPTION
- Changes progress bar color to lighter shade of brand-grey-color
- Vertical align label and time
- Makes labels less bold

![image](https://cloud.githubusercontent.com/assets/14192753/14973696/cbfb47ae-1086-11e6-9ce3-6472d19fc217.png)

Signed-off-by: Kent Salcedo <kentsalcedo@webmocha.com>