### PR TITLE
Adding attr `width` to help customize <Box/>

### DIFF
--- a/src/js/components/Box.js
+++ b/src/js/components/Box.js
@@ -62,6 +62,7 @@ export default class Box extends Component {
     this._addPropertyClass(classes, CLASS_ROOT, 'separator');
     this._addPropertyClass(classes, CLASS_ROOT, 'size');
     this._addPropertyClass(classes, CLASS_ROOT, 'textAlign', 'text-align');
+    this._addPropertyClass(classes, CLASS_ROOT, 'width');
     this._addPropertyClass(classes, CLASS_ROOT, 'wrap');
     if (this.props.hasOwnProperty('flex')) {
       if (this.props.flex) {
@@ -200,6 +201,7 @@ Box.propTypes = {
     PropTypes.node,
     PropTypes.string
   ]),
+  width: PropTypes.oneOf(['inherit', 'initial', 'auto', 'max']),
   wrap: PropTypes.bool
 };
 

--- a/src/scss/grommet-core/_objects.box.scss
+++ b/src/scss/grommet-core/_objects.box.scss
@@ -55,6 +55,22 @@
   width: 100vw;
 }
 
+.box--width-auto {
+  width: auto;
+}
+
+.box--width-inherit {
+  width: inherit;
+}
+
+.box--width-initial {
+  width: initial;
+}
+
+.box--width-max {
+  width: 100%;
+}
+
 .box--wrap {
   flex-wrap: wrap;
 }


### PR DESCRIPTION
### Width attribute on the <Box /> component

- By adding the attr `width` with one of 4 properties: `max` (100%), `initial`, `inherit`, `auto` it will allow users to control spacing and nexted <Box/>'s with more ease.

Signed-off-by: DerekAhn <git.derek@gmail.com>