### PR TITLE
Don't transfer Menu size= to Box

### DIFF
--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -176,6 +176,8 @@ class MenuDrop extends Component {
 
     delete boxProps.onClick;
 
+    delete boxProps.size;
+    
     // Put nested Menus inline
     const children = React.Children.map(this.props.children, child => {
       let result = child;


### PR DESCRIPTION
This fixes #540. Size means something different for menus, so don't pass the prop on to `Box`.

Fixed the same way it was fixed for a similar issue in `Header` and `Footer`, https://github.com/grommet/grommet/commit/249d383446c55d26e0947f1d4672452d39cf2396