### PR TITLE
Tile hoverBorderSize option (small, medium, large) + padding between Tiles

### DIFF
--- a/src/js/components/Tile.js
+++ b/src/js/components/Tile.js
@@ -10,13 +10,15 @@ const CLASS_ROOT = "tile";
 export default class Tile extends Component {
 
   render () {
-    const { children, className, onClick, wide, status, selected, hoverStyle, hoverColorIndex, hoverBorder } = this.props;
+    const { children, className, onClick, wide, status, selected, hoverStyle, hoverColorIndex, hoverBorder, hoverBorderSize } = this.props;
 
     if (selected) {
       console.log('Selected option has been deprecated, please use selected option at the Tiles level.');
     }
 
     const statusClass = status ? status.toLowerCase() : undefined;
+    // if Tiles flush is true, default borderSize to small (1px)
+    let borderSize = (hoverBorder) ? ((hoverBorderSize) ? hoverBorderSize : 'large') : 'small';
 
     const classes = classnames(
       CLASS_ROOT,
@@ -26,7 +28,8 @@ export default class Tile extends Component {
         [`${CLASS_ROOT}--wide`]: wide,
         [`${CLASS_ROOT}--selectable`]: onClick,
         [`${CLASS_ROOT}--selected`]: selected,
-        [`${hoverStyle}${(hoverStyle == 'border') ? ((hoverBorder) ? '-large' : '-small') : ''}-hover-color-index-${hoverColorIndex}`]: hoverStyle
+        [`${hoverStyle}${(hoverStyle == 'border') ? ((borderSize) ? `-${borderSize}` : '-medium') : ''}-hover-color-index-${hoverColorIndex}`]: hoverStyle,
+        [`${CLASS_ROOT}--hover-border-${borderSize}`]: borderSize
       }
     );
 
@@ -46,6 +49,7 @@ Tile.propTypes = {
   wide: PropTypes.bool,
   hoverStyle: PropTypes.oneOf(['border', 'background', 'none']),
   hoverColorIndex: PropTypes.string,
+  hoverBorderSize: PropTypes.oneOf(['small', 'medium', 'large']),
   ...Box.propTypes
 };
 

--- a/src/scss/grommet-core/_objects.color-index.scss
+++ b/src/scss/grommet-core/_objects.color-index.scss
@@ -62,6 +62,11 @@
     box-shadow: 0 0 0 1px nth($brand-neutral-colors, $i);
   }
 
+  .border-medium-hover-color-index-neutral-#{$i}:hover,
+  .border-medium-hover-color-index-neutral-#{$i + length($brand-neutral-colors)}:hover {
+    box-shadow: 0 0 0 halve($inuit-base-spacing-unit) nth($brand-neutral-colors, $i);
+  }
+
   .border-large-hover-color-index-neutral-#{$i}:hover,
   .border-large-hover-color-index-neutral-#{$i + length($brand-neutral-colors)}:hover {
     box-shadow: 0 0 0 $inuit-base-spacing-unit nth($brand-neutral-colors, $i);
@@ -109,9 +114,14 @@
     background-color: rgba(nth($brand-accent-colors, $i), 0.3);
   }
 
-  .border-smallhover-color-index-accent-#{$i}:hover,
-  .border-smallhover-color-index-accent-#{$i + length($brand-accent-colors)}:hover {
+  .border-small-hover-color-index-accent-#{$i}:hover,
+  .border-small-hover-color-index-accent-#{$i + length($brand-accent-colors)}:hover {
     box-shadow: 0 0 0 1px nth($brand-accent-colors, $i);
+  }
+
+  .border-medium-hover-color-index-accent-#{$i}:hover,
+  .border-medium-hover-color-index-accent-#{$i + length($brand-accent-colors)}:hover {
+    box-shadow: 0 0 0 halve($inuit-base-spacing-unit) nth($brand-accent-colors, $i);
   }
 
   .border-large-hover-color-index-accent-#{$i}:hover,
@@ -144,6 +154,11 @@
   .border-small-hover-color-index-grey-#{$i}:hover,
   .border-small-hover-color-index-grey-#{$i + length($brand-grey-colors)}:hover {
     box-shadow: 0 0 0 1px nth($brand-grey-colors, $i);
+  }
+
+  .border-medium-hover-color-index-grey-#{$i}:hover,
+  .border-medium-hover-color-index-grey-#{$i + length($brand-grey-colors)}:hover {
+    box-shadow: 0 0 0 halve($inuit-base-spacing-unit) nth($brand-grey-colors, $i);
   }
 
   .border-large-hover-color-index-grey-#{$i}:hover,
@@ -185,6 +200,10 @@
     box-shadow: 0 0 0 1px $color;
   }
 
+  .border-medium-hover-color-index-#{$status}:hover {
+    box-shadow: 0 0 0 halve($inuit-base-spacing-unit) $color;
+  }
+
   .border-large-hover-color-index-#{$status}:hover {
     box-shadow: 0 0 0 $inuit-base-spacing-unit $color;
   }
@@ -214,6 +233,11 @@
   .border-small-hover-color-index-light-#{$i}:hover,
   .border-small-hover-color-index-light-#{$i + length($brand-light-colors)}:hover {
     box-shadow: 0 0 0 1px nth($brand-light-colors, $i);
+  }
+
+  .border-medium-hover-color-index-light-#{$i}:hover,
+  .border-medium-hover-color-index-light-#{$i + length($brand-light-colors)}:hover {
+    box-shadow: 0 0 0 halve($inuit-base-spacing-unit) nth($brand-light-colors, $i);
   }
 
   .border-large-hover-color-index-light-#{$i}:hover,

--- a/src/scss/grommet-core/_objects.tile.scss
+++ b/src/scss/grommet-core/_objects.tile.scss
@@ -36,11 +36,21 @@
     }
   }
 
-  &:not(.tiles--flush) > .tile {
-    margin: halve($inuit-base-spacing-unit);
+  &:not(.tiles--flush) {
+    > .tile {
+      margin: halve($inuit-base-spacing-unit);
 
-    &--wide {
-      flex-basis: calc(100% - #{$inuit-base-spacing-unit});
+      &--wide {
+        flex-basis: calc(100% - #{$inuit-base-spacing-unit});
+      }
+
+      &.tile--hover-border-medium {
+        margin: quarter($inuit-base-spacing-unit);
+      }
+
+      &.tile--hover-border-large {
+        margin: halve($inuit-base-spacing-unit);
+      }
     }
   }
 


### PR DESCRIPTION
For Issue: https://github.com/grommet/grommet-estories/issues/264

* setting padding around Tile for border-medium tiles to 6px, so hover borders overlap each other (basically halving hover border thickness for padding around Tile).

* adding hoverBorderSize option (small, medium, or large), and setting the default to large to preserve original behavior.

Signed-off-by: Jackie Wijaya <jackiewijaya@webmocha.com>