### PR TITLE
Removes scrollbars for Article Control arrows

### DIFF
--- a/src/scss/grommet-core/_objects.article.scss
+++ b/src/scss/grommet-core/_objects.article.scss
@@ -55,6 +55,10 @@
   }
 }
 
+.button.article__control.button--plain.button--icon {
+  overflow: hidden;
+}
+
 .article__control {
   position: fixed;
   z-index: 10;


### PR DESCRIPTION
### Removing unwarranted scrollbars around Article controls in mobile viewing

For mobile viewing in some browsers there would be a vertical scroll bar appearing around the controls.

Before:

![screen shot 2016-05-04 at 3 57 35 am](https://cloud.githubusercontent.com/assets/5381156/15012315/99c09bdc-11ac-11e6-9054-92bb44b5d692.png)

After:
![screen shot 2016-05-04 at 3 51 28 am](https://cloud.githubusercontent.com/assets/5381156/15012320/a144f722-11ac-11e6-98a1-3f88f658c9a0.png)

Signed-off-by: DerekAhn <git.derek@gmail.com>