### PR TITLE
Adds pagination property to show page number on bottom of page

### DIFF
--- a/src/js/components/Article.js
+++ b/src/js/components/Article.js
@@ -425,16 +425,16 @@ export default class Article extends Component {
   }
 
   _renderPagination () {
-    if (this.state.atBottom) {
-      const childCount = React.Children.count(this.props.children);
-      return (
-        <Box className="article__pagination" align="center">
-          <Box align="center">
-            <Paragraph size="large">{this.state.selectedIndex+1} of {childCount}</Paragraph>
-          </Box>
+    const childCount = React.Children.count(this.props.children);
+    return (
+      <Box className={`${CLASS_ROOT}__pagination`} align="center">
+        <Box align="center">
+          <Paragraph size="large">
+            {this.state.selectedIndex + 1} of {childCount}
+          </Paragraph>
         </Box>
-      );
-    }
+      </Box>
+    );
   }
 
   _renderControls () {
@@ -502,7 +502,9 @@ export default class Article extends Component {
     }
 
     let pagination;
-    if (this.props.pagination) {
+    if (this.props.pagination &&
+      this.state.atBottom  &&
+      'row' === this.props.direction) {
       pagination = this._renderPagination();
     }
 

--- a/src/js/components/Article.js
+++ b/src/js/components/Article.js
@@ -3,6 +3,7 @@
 import React, { Component, PropTypes, Children } from 'react';
 import {findDOMNode} from 'react-dom';
 import Box from './Box';
+import Paragraph from './Paragraph';
 import KeyboardAccelerators from '../utils/KeyboardAccelerators';
 import DOMUtils from '../utils/DOM';
 import Props from '../utils/Props';
@@ -41,7 +42,8 @@ export default class Article extends Component {
     this.state = {
       selectedIndex: props.selected || 0,
       playing: false,
-      showControls: this.props.controls
+      showControls: this.props.controls,
+      pagination: false
     };
   }
 
@@ -422,6 +424,19 @@ export default class Article extends Component {
     }
   }
 
+  _renderPagination () {
+    if (this.state.atBottom) {
+      const childCount = React.Children.count(this.props.children);
+      return (
+        <Box className="article__pagination" align="center">
+          <Box align="center">
+            <Paragraph size="large">{this.state.selectedIndex+1} of {childCount}</Paragraph>
+          </Box>
+        </Box>
+      );
+    }
+  }
+
   _renderControls () {
     const CONTROL_CLASS_PREFIX =
       `${CLASS_ROOT}__control ${CLASS_ROOT}__control`;
@@ -486,6 +501,11 @@ export default class Article extends Component {
       classes.push(this.props.className);
     }
 
+    let pagination;
+    if (this.props.pagination) {
+      pagination = this._renderPagination();
+    }
+
     let controls;
     if (this.props.controls) {
       controls = this._renderControls();
@@ -533,6 +553,7 @@ export default class Article extends Component {
           ref='anchorStep' />
         {children}
         {controls}
+        {pagination}
       </Box>
     );
   }
@@ -542,6 +563,7 @@ Article.propTypes = {
   controls: PropTypes.bool,
   primary: PropTypes.bool,
   scrollStep: PropTypes.bool,
+  pagination: PropTypes.bool,
   ...Box.propTypes,
   a11yTitle: PropTypes.shape({
     next: PropTypes.string,

--- a/src/scss/grommet-core/_objects.article.scss
+++ b/src/scss/grommet-core/_objects.article.scss
@@ -59,6 +59,10 @@
   position: fixed;
   z-index: 10;
 
+  .button__icon {
+    padding: halve($inuit-base-spacing-unit);
+  }
+
   @include media-query(lap-and-up) {
     .button__icon {
       background-color: lighten(rgba(nth($brand-grey-colors, 3), 0.5), 50%);

--- a/src/scss/grommet-core/_objects.article.scss
+++ b/src/scss/grommet-core/_objects.article.scss
@@ -59,8 +59,16 @@
   position: fixed;
   z-index: 10;
 
-  .button__icon {
-    padding: $inuit-base-spacing-unit;
+  @include media-query(lap-and-up) {
+    .button__icon {
+      background-color: lighten(rgba(nth($brand-grey-colors, 3), 0.5), 50%);
+    }
+  }
+
+   @include media-query(palm) {
+    .button__icon {
+      background-color: transparent;
+    }
   }
 }
 
@@ -103,5 +111,12 @@
 }
 
 .grommet article:not(.article) {
+  width: 100%;
+}
+
+.article__pagination {
+  position: fixed;
+  bottom: 0;
+  left: 0;
   width: 100%;
 }


### PR DESCRIPTION
Adds pagination property to show page number on bottom of page

Per the requested changes from the prior PR

- Moves conditional to render pagination to the render function
- uses class_root for className
- adds spacing between operator and number 
- adds a conditional to check for the direction to be row
- adds back padding which is smaller than before because it looked quite large after a background color was added and looked large compared to designs 

signed-off-by: Kent Salcedo <kentsalcedo@webmocha.com>