### PR TITLE
Removed tabIndex, to prevent jumping to 1st child

### DIFF
--- a/src/js/components/Article.js
+++ b/src/js/components/Article.js
@@ -486,7 +486,7 @@ export default class Article extends Component {
       classes.push(this.props.className);
     }
 
-    let controls;
+   let controls;
     if (this.props.controls) {
       controls = this._renderControls();
     }
@@ -529,7 +529,7 @@ export default class Article extends Component {
         className={classes.join(' ')} onFocus={this._onFocusChange}
         onScroll={this._onScroll} onTouchStart={this._onTouchStart}
         onTouchMove={this._onTouchMove} primary={this.props.primary}>
-        <a tabIndex="-1" aria-hidden='true'
+        <a aria-hidden='true'
           ref='anchorStep' />
         {children}
         {controls}


### PR DESCRIPTION
This prevents the `<Article/>` component jumping back to the first child/view when tabbing. However, in firefox and IE tabbing does allow for tabbing to the next focusable item on the next view. Was not sure if we want to target and trap focusable items like how it was implemented before to prevent tabbing to the next view in FireFox and IE.

@alansouzati please let me know what you think, and or how you would like me to proceed. But this does solve the accessibility issue of it always jumping back to the first child.


Signed-off-by: DerekAhn <git.derek@gmail.com>