### PR TITLE
Close icon inside layer

### DIFF
--- a/src/scss/grommet-core/_objects.layer.scss
+++ b/src/scss/grommet-core/_objects.layer.scss
@@ -58,6 +58,10 @@
       right: auto;
       left: 0px;
     }
+
+    .button__icon {
+      padding: $inuit-base-spacing-unit;
+    }
   }
 
   &.layer--flush {


### PR DESCRIPTION
Adds styling to close icon to ensure the close icon is `inside` the bounds of the layer instead of original placement being in the absolute upper right corner. Change made per designer request. signed-off-by: Kent Salcedo <kentsalcedo@webmocha.com>