### PR TITLE
Fixing ESLint errors for gulp dist

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,12 +1,14 @@
 ---
 parser: babel-eslint
 
+parserOptions:
+  ecmaFeatures:
+    experimentalObjectRestSpread: true
+    jsx: true
+  sourceType: "module"
+
 plugins:
   - react
-
-ecmaFeatures:
-  jsx: true
-  modules: true
 
 env:
   browser: true


### PR DESCRIPTION
updating eslintrc to include parserOptions to fix the following errors (object rest spread, jsx, and source type module) for ESLint v2.0.0:

* `Parsing error: 'import' and 'export' may appear only with 'sourceType: module'`
* `Parsing error: Unexpected token <`
* `Parsing error: Unexpected token ..`

Signed-off-by: Jackie Wijaya <jackiewijaya@webmocha.com>