### PR TITLE
fixing DOM util function for IE11 error: Unable to get property 'innerHTML' of undefined or null reference DOM.js (91,3)

### DIFF
--- a/src/js/utils/DOM.js
+++ b/src/js/utils/DOM.js
@@ -99,8 +99,12 @@ export default {
     let id;
     const elementId = element.getAttribute('id');
     if (!elementId) {
-      id = hash(element.parentElement.innerHTML);
-      element.setAttribute('id', id);
+      // IE11 fix: check for parentNode instead of parentElement
+      const parentElement = element.parentElement || element.parentNode;
+      if (parentElement) {
+        id = hash(parentElement.innerHTML);
+        element.setAttribute('id', id);
+      }
     } else {
       id = elementId;
     }


### PR DESCRIPTION
fixing DOM util function so IE11 doesn't get error (stops rest of grommet app from loading in IE):
Unable to get property 'innerHTML' of undefined or null reference DOM.js (91,3)

Signed-off-by: Jackie Wijaya <jackiewijaya@webmocha.com>