### PR TITLE
Replace deprecated "customEslintPath" with "eslintOverride".

### DIFF
--- a/templates/init/grommet-toolbox.config.js
+++ b/templates/init/grommet-toolbox.config.js
@@ -12,6 +12,6 @@ export default {
   mainJs: 'src/js/index.js',
   mainScss: 'src/scss/index.scss',
   devServerPort: 9000,
-  customEslintPath: path.resolve(__dirname, 'customEslintrc'),
+  eslintOverride: path.resolve(__dirname, 'customEslintrc'),
   scsslint: true
 };


### PR DESCRIPTION
Fixes warning during "gulp dist":

`customEslintPath has been deprecated. You should use eslintOverride instead`

When building an app that has been initialized using:

`grommet init <appname>`

Signed-off-by: Steve Mays <steve@accuzonix.com>