### PR TITLE
Bar Chart Bug Fix - Cutoff Legend Label

### DIFF
--- a/src/js/components/Chart.js
+++ b/src/js/components/Chart.js
@@ -217,6 +217,11 @@ export default class Chart extends Component {
 
     let graphWidth = width;
     let graphHeight = height;
+    if (this.props.legend && 'inline' === this.props.legend.position) {
+      // provides a buffer at the top of the graph to ensure
+      // none of the labels are cutoff by the bounds
+      graphHeight -= XAXIS_HEIGHT;
+    }
     if (this.props.thresholds) {
       graphWidth -= YAXIS_WIDTH;
     }


### PR DESCRIPTION
Fixes bug if bar chart has legend inline, the top value would be partially cutoff by the bounds of the chart signed-off-by: Kent Salcedo <kentsalcedo@webmocha.com>

See screenshots below, top screenshot is current bar chart with inline legend (notice the label of the first bar has been cutoff), second screenshot is fixed chart
![screen shot 2016-05-19 at 10 25 21 am](https://cloud.githubusercontent.com/assets/14192753/15408653/fbdc72bc-1dac-11e6-979f-2b42840e7f87.png)
![screen shot 2016-05-19 at 10 27 46 am](https://cloud.githubusercontent.com/assets/14192753/15408652/fbdae5fa-1dac-11e6-9163-d19efd6f9848.png)

