### PR TITLE
Disabling accessibility tabbing for FireFox

### DIFF
--- a/src/js/components/Article.js
+++ b/src/js/components/Article.js
@@ -555,7 +555,8 @@ export default class Article extends Component {
         onFocus={this._onFocusChange}
         onScroll={this._onScroll}
         onTouchStart={this._onTouchStart}
-        onTouchMove={this._onTouchMove} primary={this.props.primary}>
+        onTouchMove={this._onTouchMove}
+        primary={this.props.primary}>
         {addScrollStep}
         {children}
         {controls}

--- a/src/js/components/Article.js
+++ b/src/js/components/Article.js
@@ -534,13 +534,29 @@ export default class Article extends Component {
 
     delete other.a11yTitle;
 
+    // Workaround firefox's accessibility tabbing
+    let notFirefox;
+    try {
+      const hasUserAgent = str => navigator.userAgent.indexOf(str) === -1;
+      notFirefox = hasUserAgent('Firefox');
+    } catch (e) {}
+
+    let addScrollStep;
+    if (notFirefox) {
+      addScrollStep = <a tabIndex="-1" aria-hidden='true' ref='anchorStep' />;
+    }
+
     return (
-      <Box ref="component" tag="article" {...other}
-        className={classes.join(' ')} onFocus={this._onFocusChange}
-        onScroll={this._onScroll} onTouchStart={this._onTouchStart}
+      <Box
+        ref="component"
+        tag="article"
+        {...other}
+        className={classes.join(' ')}
+        onFocus={this._onFocusChange}
+        onScroll={this._onScroll}
+        onTouchStart={this._onTouchStart}
         onTouchMove={this._onTouchMove} primary={this.props.primary}>
-        <a tabIndex="-1" aria-hidden='true'
-          ref='anchorStep' />
+        {addScrollStep}
         {children}
         {controls}
       </Box>


### PR DESCRIPTION
Due to firefox's lack of accessibility coverage for tabbing, disabling the `<a>`'s anchorStep.

Signed-off-by: DerekAhn <git.derek@gmail.com>