### PR TITLE
Also adding the same tabbing fix for Edge

### DIFF
--- a/src/js/components/Article.js
+++ b/src/js/components/Article.js
@@ -355,7 +355,8 @@ export default class Article extends Component {
             this.props.onSelect(selectedIndex);
           }
           const isFirefox = navigator.userAgent.indexOf("Firefox") >= 0;
-          if (this.props.direction === 'row' && !isFirefox) {
+          const isEdge = navigator.userAgent.indexOf("isEdge") >= 0;
+          if (this.props.direction === 'row' && !isFirefox || !isEdge) {
             this.refs.anchorStep.focus();
             this._updateHiddenElements();
           }
@@ -500,9 +501,10 @@ export default class Article extends Component {
     }
 
     const isFirefox = navigator && navigator.userAgent.indexOf("Firefox") >= 0;
+    const isEdge = navigator && navigator.userAgent.indexOf("Edge") >= 0;
 
     let anchorStepNode;
-    if (!isFirefox) {
+    if (!isFirefox && !isEdge) {
       anchorStepNode = (
         <a tabIndex="-1" aria-hidden='true' ref='anchorStep' />
       );
@@ -519,7 +521,7 @@ export default class Article extends Component {
           let elementNode = elementClone;
 
           let ariaHidden;
-          if (!isFirefox && this.state.selectedIndex !== index) {
+          if (!isFirefox && !isEdge && this.state.selectedIndex !== index) {
             ariaHidden = 'true';
           }
 

--- a/src/js/components/Article.js
+++ b/src/js/components/Article.js
@@ -55,6 +55,7 @@ export default class Article extends Component {
           right: this._onNext
         };
 
+        // Necessary to detect for Firefox or Edge to implement accessibility tabbing
         if (typeof navigator !== 'undefined' && navigator.userAgent.indexOf("Firefox") === -1) {
           this._updateHiddenElements();
         }
@@ -354,6 +355,8 @@ export default class Article extends Component {
           if (this.props.onSelect) {
             this.props.onSelect(selectedIndex);
           }
+
+          // Necessary to detect for Firefox or Edge to implement accessibility tabbing
           const isFirefox = navigator.userAgent.indexOf("Firefox") >= 0;
           const isEdge = navigator.userAgent.indexOf("isEdge") >= 0;
           if (this.props.direction === 'row' && !isFirefox || !isEdge) {
@@ -500,6 +503,7 @@ export default class Article extends Component {
       controls = this._renderControls();
     }
 
+    // Necessary to detect for Firefox or Edge to implement accessibility tabbing
     const isFirefox = navigator && navigator.userAgent.indexOf("Firefox") >= 0;
     const isEdge = navigator && navigator.userAgent.indexOf("Edge") >= 0;
 


### PR DESCRIPTION
Alleviates the flashing of the first slide in the `<Article />` component for the Edge browser. 

Signed-off-by: DerekAhn <git.derek@gmail.com>