### PR TITLE
Article.js: allow updates to selected props to trigger new chapter select + Article Control/Scrollbar Overlap Fix

### DIFF
--- a/src/js/components/Article.js
+++ b/src/js/components/Article.js
@@ -77,6 +77,13 @@ export default class Article extends Component {
     this._onSelect(this.state.selectedIndex);
   }
 
+  componentWillReceiveProps (nextProps) {
+    // allow updates to selected props to trigger new chapter select
+    if ((typeof nextProps.selected !== 'undefined') && (nextProps.selected !== this.state.selectedIndex)) {
+      this._onSelect(nextProps.selected);
+    }
+  }
+
   componentWillUnmount () {
     if (this.props.scrollStep) {
       KeyboardAccelerators.stopListeningToKeyboard(this, this._keys);

--- a/src/js/components/Article.js
+++ b/src/js/components/Article.js
@@ -79,7 +79,7 @@ export default class Article extends Component {
 
   componentWillReceiveProps (nextProps) {
     // allow updates to selected props to trigger new chapter select
-    if ((typeof nextProps.selected !== 'undefined') && (nextProps.selected !== this.state.selectedIndex)) {
+    if ((typeof nextProps.selected !== 'undefined') && (nextProps.selected !== null) && (nextProps.selected !== this.state.selectedIndex)) {
       this._onSelect(nextProps.selected);
     }
   }

--- a/src/scss/grommet-core/_objects.article.scss
+++ b/src/scss/grommet-core/_objects.article.scss
@@ -58,9 +58,13 @@
 .article__control {
   position: fixed;
   z-index: 10;
+  // using margin instead of padding for article control
+  // to prevent arrow from overlapping scrollbar and
+  // hindering scrollbar usage
+  margin: $inuit-base-spacing-unit;
 
   .button__icon {
-    padding: $inuit-base-spacing-unit;
+    padding: 0;
   }
 }
 


### PR DESCRIPTION
* Article.js: allow updates to selected props to trigger new chapter select
* using margin instead of padding for article control to prevent arrow from overlapping scrollbar and hindering scrollbar usage
