### PR TITLE
Fix for double enter issue in search input

### DIFF
--- a/src/js/components/SearchInput.js
+++ b/src/js/components/SearchInput.js
@@ -155,6 +155,12 @@ export default class SearchInput extends Component {
       if (this.props.onSelect) {
         this.props.onSelect({target: this.refs.input, suggestion: suggestion});
       }
+    } else if (this.props.onSubmit) {
+    /*
+	 * if user click enter after typing key word for search, then onSubmit call
+	 * back function will executed which will act like form submit
+	 */
+      this.props.onSubmit();
     }
   }
 
@@ -266,5 +272,6 @@ SearchInput.propTypes = {
       value: PropTypes.string
     }),
     PropTypes.string
-  ])
+  ]),
+  onSubmit: PropTypes.func
 };


### PR DESCRIPTION
Hi Grommet Team,

I have created onSubmit props which will act like a call back function & If user clicks enter after typing keyword in search input, then at this point call back function will be executed as this.state.activeSuggestionIndex value is -1 . I used this.state.activeSuggestionIndex to differentiate suggestion enter and key word enter. The call back function onSubmit will act like form submit , for which there is no need to include search input inside the Form tag, but while using search input tag we have to use like below ,
<SearchInput placeHolder={placeHolder} id="searchInputBoxResult" onSubmit={this.submitHandler} ref="search" onDOMChange={this.changeHandler} suggestions={valueArray} />