### PR TITLE
Make sure that IE11 doesn't squash paragraphs inside Box

### DIFF
--- a/src/scss/grommet-core/_objects.box.scss
+++ b/src/scss/grommet-core/_objects.box.scss
@@ -356,6 +356,7 @@
   .paragraph {
     width: 100%;
     max-width: 100%;
+    flex: 0 0 auto;
   }
 
   &-xsmall {


### PR DESCRIPTION
Signed-off-by: Michael Gilley <michaelgilley@gmail.com>

Fixes an issue with flex-shrink in IE11:

<img width="704" alt="screen shot 2016-06-01 at 3 01 08 pm" src="https://cloud.githubusercontent.com/assets/473729/15725571/c86e3c14-2809-11e6-93a2-9c9cf0d4ca3d.png">
