### PR TITLE
Bug Fixes: ie11 box vertical centering + article control arrows (mobile scrollbars)

### DIFF
--- a/src/scss/grommet-core/_objects.article.scss
+++ b/src/scss/grommet-core/_objects.article.scss
@@ -63,6 +63,11 @@
   // hindering scrollbar usage
   margin: $inuit-base-spacing-unit;
 
+  // removes scrollbars from article control arrows in mobile
+  &.button--plain.button--icon {
+    overflow: hidden;
+  }
+
   .button__icon {
     padding: 0;
   }

--- a/src/scss/grommet-core/_objects.box.scss
+++ b/src/scss/grommet-core/_objects.box.scss
@@ -75,8 +75,13 @@
 }
 
 .box--full-vertical {
-  min-height: 100%;
-  height: 100vh;
+  min-height: 100vh;
+
+  // IE11 specific fix for aligning content vertically centered
+  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    min-height: 100%;
+    height: 100vh;
+  }
 }
 
 .box--direction-row {


### PR DESCRIPTION
* moving box vertical centering styles into ie11-specific media-query so that they do not break other box in browsers
* removing unwanted scrollbars around article controls for mobile (in place of PR: https://github.com/grommet/grommet/pull/562)