### PR TITLE
Override Box's display flex to show ellipsis

### DIFF
--- a/src/scss/grommet-core/_objects.title.scss
+++ b/src/scss/grommet-core/_objects.title.scss
@@ -6,6 +6,7 @@
   text-overflow: ellipsis;
   font-weight: normal;
   white-space: nowrap;
+  display: block;
   @include inuit-font-size(24px, inherit);
 
   @include media-query(lap-and-up) {


### PR DESCRIPTION
In response to issue #613 [Title in IE11 cuts off long text without Ellipsis](https://github.com/grommet/grommet/issues/613). It appeared to be a cross browser issue as well.

![screen shot 2016-06-08 at 9 24 47 pm](https://cloud.githubusercontent.com/assets/5381156/15918820/ea64acfc-2dbf-11e6-872f-a1ea5ccf9f97.png)

![screen shot 2016-06-08 at 9 24 59 pm](https://cloud.githubusercontent.com/assets/5381156/15918822/f0a6efe4-2dbf-11e6-9213-7061c1437827.png)

Signed-off-by: DerekAhn <git.derek@gmail.com>