### PR TITLE
ie11 fixes for Box's vertical alignment

### DIFF
--- a/src/scss/grommet-core/_objects.box.scss
+++ b/src/scss/grommet-core/_objects.box.scss
@@ -64,9 +64,13 @@
   max-width: 100%;
   width: 100vw;
   min-height: 100vh;
-  // min-height doesn't work for IE and vertical centering
-  // https://connect.microsoft.com/IE/feedback/details/816293/ie11-flexbox-with-min-height-not-vertically-aligning-with-align-items-center
   height: 100%;
+  // IE11 specific fix for aligning content vertically centered
+  // height gets over written by the > min-height
+  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    min-height: 100vh;
+    height: 50vh;
+  }
 }
 
 .box--full-horizontal {
@@ -78,9 +82,10 @@
   min-height: 100vh;
 
   // IE11 specific fix for aligning content vertically centered
+  // height gets over written by the > min-height
   @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-    min-height: 100%;
-    height: 100vh;
+    min-height: 100vh;
+    height: 50vh;
   }
 }
 


### PR DESCRIPTION
This is in regards to issue #613.

> The fix that was in place earlier wasn't working in ie11.

 By setting a height less than the min-height the min-height will override the height. Works in ie11 and edge.

<img width="1440" alt="screen shot 2016-06-09 at 3 19 44 pm" src="https://cloud.githubusercontent.com/assets/5381156/15948672/ea85d7e6-2e56-11e6-94c2-1af671093a23.png">


Signed-off-by: DerekAhn <git.derek@gmail.com>