### PR TITLE
Ensure that bad input is parsed correctly

### DIFF
--- a/src/js/components/NumberInput.js
+++ b/src/js/components/NumberInput.js
@@ -41,7 +41,7 @@ export default class NumberInput extends Component {
       input.stepUp();
     } catch (e) {
       // IE11 workaround. See known issue #5 at http://caniuse.com/#search=number
-      let value = parseInt(input.value, 10) + (this.props.step || 1);
+      let value = (parseInt(input.value, 10) || 0) + (this.props.step || 1);
       if (this.props.max !== undefined) {
         value = Math.min(value, this.props.max);
       }
@@ -56,7 +56,7 @@ export default class NumberInput extends Component {
       input.stepDown();
     } catch (e) {
       // IE11 workaround. See known issue #5 at http://caniuse.com/#search=number
-      let value = parseInt(input.value, 10) - (this.props.step || 1);
+      let value = (parseInt(input.value, 10) || 0) - (this.props.step || 1);
       if (this.props.min !== undefined) {
         value = Math.max(value, this.props.min);
       }


### PR DESCRIPTION
We need to coerce `NaN` from bad input to `parseInt` to 0 so we don't break the maths.

Signed-off-by: Michael Gilley <michaelgilley@gmail.com>