### PR TITLE
Adds missing style property for header--large Header from PR #617

### DIFF
--- a/src/scss/grommet-core/_objects.header.scss
+++ b/src/scss/grommet-core/_objects.header.scss
@@ -28,6 +28,7 @@
 
 .header--large {
   min-height: $large-header-height;
+  height: $large-header-height - 1;
 
   .header__content {
     line-height: $large-header-height;


### PR DESCRIPTION
Adds missing style property for `header--large` from https://github.com/grommet/grommet/pull/617

This is affecting `header--large` Header in Safari both on desktop and iOS.

https://github.com/grommet/hpe-digitaltoolkit/issues/86