### PR TITLE
Improve optstrings handling on grommet tool

### DIFF
--- a/bin/grommet.js
+++ b/bin/grommet.js
@@ -17,67 +17,72 @@ String.prototype.capitalize = function() {
   return words.join(' ');
 };
 
-var task = process.argv[2] || 'init';
-var app = process.argv[3] || 'app-name';
-var title = app.replace(/-|_/g, ' ').capitalize();
-var grommetPath = path.join(__dirname, '..');
-
 function nodeVersionSupported() {
   return Number(process.version.match(/^v(\d+\.\d+)/)[1]) >= 0.10;
 }
 
-var npmVersion;
-function npmVersionSupported() {
-  npmVersion = Number(shelljs.exec('npm --version').stdout.toString().match(/^(\d+\.\d+)/)[1]);
-  return npmVersion  >= 1.4;
+function npmVersionSupported(npmVersion) {
+  return npmVersion >= 1.4;
 }
 
-gulp.task('init', function(done) {
-
-  if (!nodeVersionSupported() || !npmVersionSupported()) {
-    console.error('[grommet] Grommet requires Node v0.10+ and NPM 1.4.x+.');
-    console.error('[grommet] Currently you have Node ' + process.version + ' and NPM ' + npmVersion);
-    process.exit(1);
-  }
-
-  mkdirp('./' + app, function(err) {
-    if (err) {
-      console.log('Error trying to create project: ' + err);
-    } else {
-      process.chdir('./' + app);
-
-      var templateFolder = path.join(grommetPath, 'templates/init/**');
-      var mobileIcon = path.join(grommetPath, 'mobile-app-icon.png');
-      var shortcutIcon = path.join(grommetPath, 'shortcut-icon.png');
-
-      var packageJSON = require(path.join(grommetPath, 'package.json'));
-
-      gulp.src(mobileIcon).pipe(gulp.dest('./src/img'));
-      gulp.src(shortcutIcon).pipe(gulp.dest('./src/img'));
-      gulp.src(templateFolder, { dot: true })
-      .pipe(template({
-        appName: app,
-        appTitle: title,
-        grommetVersion: packageJSON.version
-      }))
-      .pipe(gulp.dest('./'))
-      .pipe(install()).on('finish', function() {
-        done();
-      });
+var tasks = {
+  'version': function() {
+      console.log(packageJSON.version);
+  },
+  'init': function(done) {
+    if (!nodeVersionSupported() || !npmVersionSupported(npmVersion)) {
+      console.error('[grommet] Grommet requires Node v0.10+ and NPM 1.4.x+.');
+      console.error('[grommet] Currently you have Node ' + process.version + ' and NPM ' + npmVersion);
+      process.exit(1);
     }
-  });
 
-});
+    mkdirp('./' + app, function(err) {
+      if (err) {
+      console.log('Error trying to create project: ' + err);
+      } else {
+        process.chdir('./' + app);
 
-gulp.task('export', function() {
-  console.log('[REMOVED] All the example apps now live outside Grommet. Checkout Grommet organization in Github to learn more (https://github.com/grommet).');
-});
+        var templateFolder = path.join(grommetPath, 'templates/init/**');
+        var mobileIcon = path.join(grommetPath, 'mobile-app-icon.png');
+        var shortcutIcon = path.join(grommetPath, 'shortcut-icon.png');
 
-var argv = require('yargs').argv;
+        gulp.src(mobileIcon).pipe(gulp.dest('./src/img'));
+        gulp.src(shortcutIcon).pipe(gulp.dest('./src/img'));
+        gulp.src(templateFolder, { dot: true })
+          .pipe(template({
+            appName: app,
+            appTitle: title,
+            grommetVersion: packageJSON.version
+        }))
+        .pipe(gulp.dest('./'))
+        .pipe(install()).on('finish', function() {
+          done();
+        });
+      }
+    })
+  },
+  'export': function() {
+    console.log('[REMOVED] All the example apps now live outside Grommet. Checkout Grommet organization in Github to learn more (https://github.com/grommet).');
+  }
+}
 
-if (argv.version) {
-  console.log(require(path.join(grommetPath, 'package.json')).version);
-  process.exit(0);
+var grommetPath = path.join(__dirname, '..');
+var packageJSON = require(path.join(grommetPath, 'package.json'));
+var npmVersion = Number(shelljs.exec('npm --version', {silent:true}).stdout.toString().match(/^(\d+\.\d+)/)[1]);
+var argv = require('yargs').boolean('version').argv;
+var options = argv._;
+var command = options[0] || 'init';
+if (command == 'init') {
+  var app = options[1] || 'app-name';
+  var title = app.replace(/-|_/g, ' ').capitalize();
+}
+
+if (command in tasks) {
+  gulp.task(command, tasks[command]);
+  gulp.start(command);
 } else {
-  gulp.start(task);
+  var allTaskNames = Object.keys(tasks).join('|');
+  console.log('[grommet] Command "'+command+'" not supported.');
+  console.log('[grommet] Usage: grommet <'+allTaskNames+'>');
+  process.exit(1);
 }


### PR DESCRIPTION
This change improves the way the grommet command line tool handles the
options from the command line (optstrings) by parsing the initial values
using a single library, yargs.
Also, this change adds an extra validation to the task name given by the
user before trying to executing it.

Other minor changes:
  * Remove print of NPM version every time the grommet tool is executed
  * Remove multiple access to grommet package.json file
  * Add clear error message if task is not supported.