### PR TITLE
Fixing selectable tile hover color index

### DIFF
--- a/src/js/components/Tile.js
+++ b/src/js/components/Tile.js
@@ -7,6 +7,7 @@ import Box from './Box';
 import CSSClassnames from '../utils/CSSClassnames';
 
 const CLASS_ROOT = CSSClassnames.TILE;
+const NAMESPACE = CSSClassnames.NAMESPACE;
 
 export default class Tile extends Component {
 
@@ -33,7 +34,7 @@ export default class Tile extends Component {
         [`${CLASS_ROOT}--wide`]: wide,
         [`${CLASS_ROOT}--selectable`]: onClick,
         [`${CLASS_ROOT}--selected`]: selected,
-        [`${CSSClassnames.namespace}${hoverStyle}${(hoverStyle == 'border') ?
+        [`${NAMESPACE}${hoverStyle}${(hoverStyle == 'border') ?
           ((borderSize) ? `-${borderSize}` : '-medium') : ''
         }-hover-color-index-${hoverColorIndex}`]: hoverStyle,
         [`${CLASS_ROOT}--hover-border-${borderSize}`]: borderSize

--- a/src/js/utils/CSSClassnames.js
+++ b/src/js/utils/CSSClassnames.js
@@ -42,6 +42,7 @@ export default {
   MAP: `${namespace}map`,
   MENU: `${namespace}menu`,
   METER: `${namespace}meter`,
+  NAMESPACE: `${namespace}`,
   NOTIFICATION: `${namespace}notification`,
   NUMBER_INPUT: `${namespace}number-input`,
   OBJECT: `${namespace}object`,


### PR DESCRIPTION
adding NAMESPACE property to CSSClassnames (used by Tile.js to prefix hover color index with grommetux-, since it currently results in undefined).

Previously was adding the CSS class: `undefinedborder-medium-hover-color-index-unknown` instead of `grommetux-border-medium-hover-color-index-unknown`, so hover border wasn't showing up. Prefixes css class so hover border will show, as in screenshot.

![screen shot 2016-06-30 at 4 36 12 pm](https://cloud.githubusercontent.com/assets/10161095/16510468/0c51dd3e-3ee2-11e6-8e88-5555c192f3a8.png)

