### PR TITLE
Fix IE11 Notification component not wrapping

### DIFF
--- a/src/js/components/Notification.js
+++ b/src/js/components/Notification.js
@@ -80,7 +80,7 @@ export default class Notification extends Component {
     return (
       <Box {...boxProps} className={classes} direction="row" responsive={false}>
         {status}
-        <Box>
+        <Box full="horizontal">
           <span className={`${CLASS_ROOT}__message`}>
             {this.props.message}
           </span>


### PR DESCRIPTION
Related to #652.

Currently not wrapping: 
![image](https://cloud.githubusercontent.com/assets/3210082/16538019/fc777c78-3fb0-11e6-8073-7c78434c93d8.png)

Fixed screenshot:
![image](https://cloud.githubusercontent.com/assets/3210082/16538020/0143e656-3fb1-11e6-99af-c5215e1628e8.png)
