### PR TITLE
Fix for article flashing arrows/rerendering in Firefox palm media query.

### DIFF
--- a/src/js/components/Article.js
+++ b/src/js/components/Article.js
@@ -219,13 +219,13 @@ export default class Article extends Component {
 
   _onScroll (event) {
     if ('row' === this.props.direction) {
+      const { selectedIndex } = this.state;
+      const childElement = findDOMNode(this.refs[selectedIndex]);
+      let rect = childElement.getBoundingClientRect();
       if (event.target === this._scrollParent) {
         // scrolling Article
         if (this._scrollingVertically) {
           // prevent Article horizontal scrolling while scrolling vertically
-          const { selectedIndex } = this.state;
-          const childElement = findDOMNode(this.refs[selectedIndex]);
-          const rect = childElement.getBoundingClientRect();
           this._scrollParent.scrollLeft += rect.left;
         } else {
           const scrollingRight = this._priorScrollLeft < this._scrollParent.scrollLeft;
@@ -246,9 +246,13 @@ export default class Article extends Component {
       } else if (event.target.parentNode === this._scrollParent) {
         // scrolling child
         // Has it scrolled near the bottom?
-        const grandchildren = event.target.children;
-        const lastGrandChild = grandchildren[grandchildren.length - 1];
-        const rect = lastGrandChild.getBoundingClientRect();
+        if (this.state.accessibilityTabbingCompatible) {
+          // only use lastGrandChild logic if we're not using Firefox or IE.
+          // causes flashing in Firefox, but required for Safari scrolling.
+          const grandchildren = event.target.children;
+          const lastGrandChild = grandchildren[grandchildren.length - 1];
+          rect = lastGrandChild.getBoundingClientRect();
+        }
         if (rect.bottom <= (window.innerHeight + 24)) {
           // at the bottom
           this.setState({ atBottom: true });


### PR DESCRIPTION
_onScroll in Article.js causes multiple rerenderings and flashing of arrows/section content in Firefox palm/mobile screen sizes.

* in Firefox, grandchildren will oscillate between different article chapters, and not necessarily be the selectedIndex/selected chapter, which causes flashing/rerendering of arrows when height of [grandchild](https://github.com/grommet/grommet/blob/master/src/js/components/Article.js#L249) is less than or equal to `window.innerHeight + 24`. Using a check for Firefox/IE, to make sure we measure the currently selected chapter element's dimensions in Firefox.
* using grandchildren dimensions to render arrows is needed for Safari, to prevent horizontal wiggling when scrolling vertically on trackpad.

Signed-off-by: Jackie Wijaya <jackiewijaya@webmocha.com>