### PR TITLE
resolving unknown props React warning

### DIFF
--- a/src/js/components/Tile.js
+++ b/src/js/components/Tile.js
@@ -15,6 +15,10 @@ export default class Tile extends Component {
     const { children, className, onClick, wide, status, selected,
       hoverStyle, hoverColorIndex, hoverBorder, hoverBorderSize } = this.props;
     const restProps = Props.omit(this.props, Object.keys(Box.propTypes));
+    delete restProps.hoverStyle;
+    delete restProps.hoverColorIndex;
+    delete restProps.hoverBorder;
+    delete restProps.hoverBorderSize;
 
     if (selected) {
       console.warn('Selected option has been deprecated, please use ' +


### PR DESCRIPTION
https://github.com/grommet/grommet/issues/679

* stops passing unknown props from Tile to Box component, which was causing console warnings in grommet-core and other grommet projects.

<img width="533" alt="screen shot 2016-07-08 at 7 01 00 am" src="https://cloud.githubusercontent.com/assets/10161095/16695499/f4d49138-44db-11e6-9eb7-f95a5040f4a5.png">
