### PR TITLE
Fix InfiniteScroll onEnd() not being called

### DIFF
--- a/src/js/utils/InfiniteScroll.js
+++ b/src/js/utils/InfiniteScroll.js
@@ -16,7 +16,8 @@ function _evaluate(scrollState) {
     }
     var indicatorRect = scrollState.indicatorElement.getBoundingClientRect();
     // Only if bottom isn't zero. This can happen when content hasn't arrived yet.
-    if (bottom && indicatorRect.bottom <= bottom) {
+    // 10px offset is to ensure onEnd() gets called
+    if (bottom && indicatorRect.bottom <= (bottom + 10)) {
       scrollState.onEnd();
     }
   }


### PR DESCRIPTION
Resolves #620.

Depending on screen size, if user is zoomed in, & amount of Tiles, the `scrollState.onEnd()` function may not get called.

**Problem:** `scrollState.onEnd()` not getting called
![infinitescroll-broken](https://cloud.githubusercontent.com/assets/3210082/16766843/16d9aea4-47d8-11e6-9f18-dfdaf5be60e3.gif)


**Fixed:**
![infinitescroll-fixed](https://cloud.githubusercontent.com/assets/3210082/16766898/62ee3634-47d8-11e6-92c5-d4fc74886107.gif)


