### PR TITLE
update flex value to avoid horizontal scrollbar at narrow widths

### DIFF
--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -207,6 +207,8 @@ $colored-select-drop-caret: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB
     input[type=number] {
       display: inline-block;
       flex: 1;
+      flex-basis: inherit; // required for firefox to prevent horizontal scrollbar
+      width: 0; // required to keep reset input width and let flex-grow handle it
       border: none;
       padding: 0 $form-horizontal-padding;
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes issue #698.

#### How should this be manually tested?
Put a `NumberInput` inside a `FormField` that has a narrow width (< 300 px). Scrollbar should not be present.
