### PR TITLE
fixing missing carousel controls for Safari

### DIFF
--- a/src/js/components/Carousel.js
+++ b/src/js/components/Carousel.js
@@ -221,27 +221,6 @@ export default class Carousel extends Component {
     return nextButton;
   }
 
-  _renderSVGDropShadow () {
-    // SVG fallback for missing controls in Safari
-    // floodColor corresponds to drop-shadow filter color in _objects.carousel.scss
-    return (
-      <svg width="0" height="0">
-        <defs>
-          <filter id="drop-shadow">
-            <feGaussianBlur in="SourceAlpha" stdDeviation="0.5"></feGaussianBlur>
-            <feOffset dx="0.25" dy="0.25" result="offsetblur"></feOffset>
-            <feFlood floodColor="rgba(170, 170, 170, 0.5)" floodOpacity="0.5"></feFlood>
-            <feComposite in2="offsetblur" operator="in"></feComposite>
-            <feMerge>
-              <feMergeNode/>
-              <feMergeNode in="SourceGraphic"></feMergeNode>
-            </feMerge>
-          </filter>
-        </defs>
-      </svg>
-    );
-  }
-
   render () {
     var classes = [CLASS_ROOT];
     if (this.state.hideControls) {
@@ -287,7 +266,6 @@ export default class Carousel extends Component {
     return (
       <div ref="carousel" className={classes.join(' ')}
         onMouseEnter={this._onMouseOver} onMouseLeave={this._onMouseOut}>
-        {this._renderSVGDropShadow()}
         <div className={CLASS_ROOT + "__track"}
           style={{ width: trackWidth, marginLeft: trackPosition }}>
           <Tiles fill={true} responsive={false} wrap={false} direction="row">

--- a/src/js/components/Carousel.js
+++ b/src/js/components/Carousel.js
@@ -221,6 +221,27 @@ export default class Carousel extends Component {
     return nextButton;
   }
 
+  _renderSVGDropShadow () {
+    // SVG fallback for missing controls in Safari
+    // floodColor corresponds to drop-shadow filter color in _objects.carousel.scss
+    return (
+      <svg width="0" height="0">
+        <defs>
+          <filter id="drop-shadow">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="0.5"></feGaussianBlur>
+            <feOffset dx="0.25" dy="0.25" result="offsetblur"></feOffset>
+            <feFlood floodColor="rgba(170, 170, 170, 0.5)" floodOpacity="0.5"></feFlood>
+            <feComposite in2="offsetblur" operator="in"></feComposite>
+            <feMerge>
+              <feMergeNode/>
+              <feMergeNode in="SourceGraphic"></feMergeNode>
+            </feMerge>
+          </filter>
+        </defs>
+      </svg>
+    );
+  }
+
   render () {
     var classes = [CLASS_ROOT];
     if (this.state.hideControls) {
@@ -266,6 +287,7 @@ export default class Carousel extends Component {
     return (
       <div ref="carousel" className={classes.join(' ')}
         onMouseEnter={this._onMouseOver} onMouseLeave={this._onMouseOut}>
+        {this._renderSVGDropShadow()}
         <div className={CLASS_ROOT + "__track"}
           style={{ width: trackWidth, marginLeft: trackPosition }}>
           <Tiles fill={true} responsive={false} wrap={false} direction="row">

--- a/src/scss/grommet-core/_objects.carousel.scss
+++ b/src/scss/grommet-core/_objects.carousel.scss
@@ -136,3 +136,10 @@
     user-drag: none;
   }
 }
+
+// workaround for missing controls in Safari
+_::-webkit-:not(:root:root),
+.#{$grommet-namespace}carousel__control,
+.#{$grommet-namespace}carousel__arrow .#{$grommet-namespace}control-icon { 
+  -webkit-filter: url(#drop-shadow);
+}

--- a/src/scss/grommet-core/_objects.carousel.scss
+++ b/src/scss/grommet-core/_objects.carousel.scss
@@ -141,5 +141,6 @@
 _::-webkit-:not(:root:root),
 .#{$grommet-namespace}carousel__control,
 .#{$grommet-namespace}carousel__arrow .#{$grommet-namespace}control-icon { 
-  -webkit-filter: url(#drop-shadow);
+  -webkit-filter: none;
+  -webkit-svg-shadow: 1px 1px 1px $button-drop-shadow-color;
 }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
adds SVG filter fallback for drop-shadow -webkit-filter, and applies it to carousel controls (with drop shadows) within a Safari-only selector.

#### Where should the reviewer start?
Check default appearance of carousel controls in Chrome, and compare it to appearance in Safari.

#### What testing has been done on this PR?
tested Carousel Docs page in webkit browser (Chrome and Safari) to make sure Safari-only selector didn't affect Chrome.

#### How should this be manually tested?
1) With grommet PR branch checked out, run grommet-docs with `useAlias` flag.

2) Open Carousel Docs page in Safari, and check for visible controls (dots) and arrows.
http://localhost:8002/docs/develop/carousel

3) Open Carousel Docs page in Chrome to make sure controls are still visible/unaffected by svg fallback.

#### Any background context you want to provide?
Safari has an issue rendering drop-shadow filters on SVGs, and two potential workarounds are (1) creating and applying an SVG filter fallback and (2) using CSS hack to select Safari-only styles, and modify -webkit-filter style without affecting Chrome.

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/691

#### Screenshots (if appropriate)
Before PR fix, in Safari:
![screen shot 2016-07-14 at 11 21 34 am](https://cloud.githubusercontent.com/assets/10161095/16860285/52994f34-49d2-11e6-9e6d-671d22e9b7f0.png)

After (with visible controls), in Safari:
![screen shot 2016-07-14 at 2 51 26 pm](https://cloud.githubusercontent.com/assets/10161095/16860292/769245bc-49d2-11e6-96ad-86797ce38c1e.png)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.