### PR TITLE
Removes hardcoded full prop in Notification

### DIFF
--- a/src/js/components/Notification.js
+++ b/src/js/components/Notification.js
@@ -76,11 +76,12 @@ export default class Notification extends Component {
     }
 
     let boxProps = Props.pick(this.props, Object.keys(Box.propTypes));
+    let fullBox = boxProps.hasOwnProperty('full') ? boxProps.full : 'horizontal';
 
     return (
       <Box {...boxProps} className={classes} direction="row" responsive={false}>
         {status}
-        <Box full="horizontal">
+        <Box full={fullBox}>
           <span className={`${CLASS_ROOT}__message`}>
             {this.props.message}
           </span>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
* Addresses issue when embedding Notification in Layer
* Still defaults to 'horizontal' for IE fix (#675)

#### Where should the reviewer start?
Check out http://codepen.io/michaelgilley/pen/YWZVwP. The Layer component should **not** expand the full width of the viewport.

#### What testing has been done on this PR?
In browser, css testing.

#### How should this be manually tested?
Use codepen above.

#### Any background context you want to provide?
#675 introduced a regression on Layer implementation

#### What are the relevant issues?
#675 #652 

#### Do the grommet docs need to be updated?
Perhaps?

#### Should this PR be mentioned in the release notes?
Probably not.

#### Is this change backwards compatible or is it a breaking change?
Should work as before. 🎸