### PR TITLE
Disable IE’s clear field `X` button

### DIFF
--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -119,6 +119,11 @@ $colored-select-drop-caret: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB
     padding-right: 0px;
   }
 
+  // Disable IE's clear field 'X' button
+  > input::-ms-clear {
+    display: none;
+  }
+
   > select {
     display: block;
     background-image: $select-drop-caret;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Keep browser input consistent, disable IE’s clear field `X` button.
Resolves #715.

#### What testing has been done on this PR?

Tested on IE11. 

#### What are the relevant issues?

#715
