### PR TITLE
Tiles masonry and numColumns options

### DIFF
--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -18,7 +18,9 @@ import CSSClassnames from '../utils/CSSClassnames';
 const CLASS_ROOT = CSSClassnames.TILES;
 const TILE = CSSClassnames.TILE;
 const SELECTED_CLASS = `${TILE}--selected`;
-const MIN_COLUMN_SIZE = 384;  // $tile-large-size = 384px
+const MIN_COLUMN_SIZE_LARGE = 384;  // $tile-large-size = 384px
+const MIN_COLUMN_SIZE = 192;  // $tile-size = 192px
+const MIN_COLUMN_SIZE_SMALL = 92; // $tile-small-size = 92px
 
 export default class Tiles extends Component {
 
@@ -31,8 +33,12 @@ export default class Tiles extends Component {
     this._onResize = this._onResize.bind(this);
     this._layout = this._layout.bind(this);
     this._onClick = this._onClick.bind(this);
+
+    const tileSize = this.props.size;
+    const minColumnWidth = (tileSize === 'small') ? MIN_COLUMN_SIZE_SMALL :
+      ((tileSize === 'large') ? MIN_COLUMN_SIZE_LARGE : MIN_COLUMN_SIZE);
     this._minColumnWidths = Array.apply(null, Array(this.props.numColumns))
-      .map((currentNumColumns, index) => (index + 1) * MIN_COLUMN_SIZE);
+      .map((currentNumColumns, index) => (index + 1) * minColumnWidth);
 
     this.state = {
       overflow: false,

--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -141,7 +141,7 @@ export default class Tiles extends Component {
           return (currentMin > columnWidths[maxIndex]) ? index : maxIndex;
         }, 0);
 
-      maxColumnWidthIndex += 1; // return appropriate number of columns
+      return maxColumnWidthIndex + 1; // return appropriate number of columns
     }
 
     return maxColumnWidthIndex;
@@ -163,7 +163,7 @@ export default class Tiles extends Component {
       const rect = tiles.getBoundingClientRect();
       const children = tiles.querySelectorAll(`.${TILE}`);
 
-      children.map((child, index) => {
+      Array.from(children).map((child, index) => {
         const childRect = child.getBoundingClientRect();
         // 12 accounts for padding
         if ((childRect.left + 12) < rect.left ||

--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -2,6 +2,7 @@
 
 import React, { Component, PropTypes, Children } from 'react';
 import { findDOMNode } from 'react-dom';
+import classnames from 'classnames';
 import Props from '../utils/Props';
 import Box from './Box';
 import Button from './Button';
@@ -17,6 +18,7 @@ import CSSClassnames from '../utils/CSSClassnames';
 const CLASS_ROOT = CSSClassnames.TILES;
 const TILE = CSSClassnames.TILE;
 const SELECTED_CLASS = `${TILE}--selected`;
+const MIN_COLUMN_SIZE = 384;  // $tile-large-size = 384px
 
 export default class Tiles extends Component {
 
@@ -29,10 +31,13 @@ export default class Tiles extends Component {
     this._onResize = this._onResize.bind(this);
     this._layout = this._layout.bind(this);
     this._onClick = this._onClick.bind(this);
+    this._minColumnWidths = Array.apply(null, Array(this.props.numColumns))
+      .map((currentNumColumns, index) => (index + 1) * MIN_COLUMN_SIZE);
 
     this.state = {
       overflow: false,
-      selected: Selection.normalizeIndexes(props.selected)
+      selected: Selection.normalizeIndexes(props.selected),
+      numColumns: this.props.numColumns
     };
   }
 
@@ -46,6 +51,9 @@ export default class Tiles extends Component {
       document.addEventListener('wheel', this._onWheel);
       this._trackHorizontalScroll();
       // give browser a chance to stabilize
+      setTimeout(this._layout, 10);
+    } else if (this.props.masonry) {
+      window.addEventListener('resize', this._onResize);
       setTimeout(this._layout, 10);
     }
   }
@@ -80,19 +88,21 @@ export default class Tiles extends Component {
       window.removeEventListener('resize', this._onResize);
       document.removeEventListener('wheel', this._onWheel);
       if (this._tracking) {
-        var tiles = findDOMNode(this.refs.tiles);
+        const tiles = findDOMNode(this.refs.tiles);
         tiles.removeEventListener('scroll', this._onScrollHorizontal);
       }
+    } else if (this.props.masonry) {
+      window.removeEventListener('resize', this._onResize);
     }
   }
 
   _onLeft () {
-    var tiles = findDOMNode(this.refs.tiles);
+    const tiles = findDOMNode(this.refs.tiles);
     Scroll.scrollBy(tiles, 'scrollLeft', - tiles.offsetWidth);
   }
 
   _onRight () {
-    var tiles = findDOMNode(this.refs.tiles);
+    const tiles = findDOMNode(this.refs.tiles);
     Scroll.scrollBy(tiles, 'scrollLeft', tiles.offsetWidth);
   }
 
@@ -112,10 +122,25 @@ export default class Tiles extends Component {
     }
   }
 
+  _getNumberColumns () {
+    const tiles = findDOMNode(this.refs.tiles);
+
+    const maxColumnWidthIndex = this._minColumnWidths
+      .filter((currentMin) => {
+        return currentMin <= tiles.offsetWidth;
+      })
+      .reduce((maxIndex, currentMin, index, columnWidths) => {
+        return (currentMin > columnWidths[maxIndex]) ? index : maxIndex;
+      }, 0);
+
+    return maxColumnWidthIndex + 1; // return appropriate number of columns
+  }
+
   _layout () {
-    if ('row' === this.props.direction) {
+    const { direction, masonry } = this.props;
+    if ('row' === direction) {
       // determine if we have more tiles than room to fit
-      var tiles = findDOMNode(this.refs.tiles);
+      const tiles = findDOMNode(this.refs.tiles);
       // 20 is to allow some fuzziness as scrollbars come and go
       this.setState({
         overflow: (tiles.scrollWidth > (tiles.offsetWidth + 20)),
@@ -124,11 +149,11 @@ export default class Tiles extends Component {
       });
 
       // mark any tiles that might be clipped
-      var rect = tiles.getBoundingClientRect();
-      var children = tiles.querySelectorAll(`.${TILE}`);
-      for (var i = 0; i < children.length; i += 1) {
-        var child = children[i];
-        var childRect = child.getBoundingClientRect();
+      const rect = tiles.getBoundingClientRect();
+      const children = tiles.querySelectorAll(`.${TILE}`);
+
+      children.map((child, index) => {
+        const childRect = child.getBoundingClientRect();
         // 12 accounts for padding
         if ((childRect.left + 12) < rect.left ||
           (childRect.right - 12) > rect.right) {
@@ -136,8 +161,60 @@ export default class Tiles extends Component {
         } else {
           child.classList.remove(`${TILE}--eclipsed`);
         }
+      });
+    } else if (masonry) {
+      // check for appropriate number of columns, if using masonry option
+      const { numColumns } = this.state;
+      const newNumColumns = this._getNumberColumns();
+      if (numColumns !== newNumColumns) {
+        this.setState({ numColumns: newNumColumns });
       }
     }
+  }
+
+  _renderChild (element) {
+    const { flush } = this.props;
+
+    if (element) {
+      const elementClone = React.cloneElement(element, {
+        hoverBorder: !flush
+      });
+
+      return elementClone;
+    }
+
+    return undefined;
+  }
+
+  _renderMasonryColumns () {
+    const { children } = this.props;
+    const { numColumns } = this.state;
+    let columnContents = {};
+
+    Children.map(children, (element, index) => {
+      let currentColumn = index % numColumns;
+
+      if (!columnContents[`column-${currentColumn}`]) {
+        columnContents[`column-${currentColumn}`] = [];
+      }
+
+      // place children into appropriate column
+      let child = this._renderChild(element);
+      if (child) {
+        columnContents[`column-${currentColumn}`].push(child);
+      }
+    }, this);
+
+    const columnsArray = Array.apply(null, Array(numColumns));
+    let columns = columnsArray.map((current, i) => {
+      return (
+        <Box className={`${CLASS_ROOT}__masonry-column`} key={`column-${numColumns}-${i}`}>
+          {columnContents[`column-${i}`]}
+        </Box>
+      );
+    });
+
+    return columns;
   }
 
   _onResize () {
@@ -148,7 +225,7 @@ export default class Tiles extends Component {
 
   _trackHorizontalScroll () {
     if (this.state.overflow && ! this._tracking) {
-      var tiles = findDOMNode(this.refs.tiles);
+      const tiles = findDOMNode(this.refs.tiles);
       tiles.addEventListener('scroll', this._onScrollHorizontal);
       this._tracking = true;
     }
@@ -187,58 +264,53 @@ export default class Tiles extends Component {
 
   // children should be an array of Tile
   render () {
-    var classes = [CLASS_ROOT];
-    if (this.props.fill) {
-      classes.push(CLASS_ROOT + "--fill");
-    }
-    if (this.props.flush) {
-      classes.push(CLASS_ROOT + "--flush");
-    }
-    if (this.props.size) {
-      classes.push(CLASS_ROOT + "--" + this.props.size);
-    }
-    if (this.props.selectable) {
-      classes.push(CLASS_ROOT + "--selectable");
-    }
-    if (this.props.className) {
-      classes.push(this.props.className);
-    }
+    const { onMore, selectable, masonry, direction } = this.props;
+    const { overflow } = this.state;
 
-    var other = Props.pick(this.props, Object.keys(Box.propTypes));
+    const classes = classnames(
+      CLASS_ROOT,
+      this.props.className,
+      {
+        [`${CLASS_ROOT}--fill`]: this.props.fill,
+        [`${CLASS_ROOT}--flush`]: this.props.flush,
+        [`${CLASS_ROOT}--${this.props.size}`]: this.props.size,
+        [`${CLASS_ROOT}--selectable`]: this.props.selectable,
+        [`${CLASS_ROOT}--moreable`]: this.props.onMore,
+        [`${CLASS_ROOT}--overflowed`]: this.state.overflow,
+        [`${CLASS_ROOT}--masonry`]: this.props.masonry
+      }
+    );
 
-    var more = null;
-    if (this.props.onMore) {
-      classes.push(CLASS_ROOT + "--moreable");
+    const other = Props.pick(this.props, Object.keys(Box.propTypes));
+
+    let more = null;
+    if (onMore) {
       more = (
-        <div ref="more" className={CLASS_ROOT + "__more"}>
+        <div ref="more" className={`${CLASS_ROOT}__more`}>
           <SpinningIcon />
         </div>
       );
     }
 
     let onClickHandler;
-    if (this.props.selectable) {
+    if (selectable) {
       onClickHandler = this._onClick;
     }
 
     let children = this.props.children;
-    children = Children.map(this.props.children, (element, index) => {
-      if (element) {
-        const elementClone = React.cloneElement(element, {
-          hoverBorder: !this.props.flush
-        });
+    if (masonry) {
+      children = this._renderMasonryColumns();
+    } else {
+      children = Children.map(this.props.children, (element) => {
+        return this._renderChild(element);
+      }, this);
+    }
 
-        return elementClone;
-      }
-
-      return undefined;
-    }, this);
-
-    var contents = (
+    let contents = (
       <Box ref="tiles" {...other}
-        wrap={this.props.direction ? false : true}
-        direction={this.props.direction ? this.props.direction : 'row'}
-        className={classes.join(' ')}
+        wrap={direction ? false : true}
+        direction={direction ? direction : 'row'}
+        className={classes}
         onClick={onClickHandler}
         focusable={false}>
         {children}
@@ -246,23 +318,25 @@ export default class Tiles extends Component {
       </Box>
     );
 
-    if (this.state.overflow) {
-      classes.push(CLASS_ROOT + "--overflowed");
+    if (overflow) {
+      let left;
+      let right;
+
       if (! this.state.overflowStart) {
-        var left = (
-          <Button className={CLASS_ROOT + "__left"} icon={<LinkPreviousIcon />}
+        left = (
+          <Button className={`${CLASS_ROOT}__left`} icon={<LinkPreviousIcon />}
             onClick={this._onLeft} />
         );
       }
       if (! this.state.overflowEnd) {
-        var right = (
-          <Button className={CLASS_ROOT + "__right"} icon={<LinkNextIcon />}
+        right = (
+          <Button className={`${CLASS_ROOT}__right`} icon={<LinkNextIcon />}
             onClick={this._onRight} />
         );
       }
 
       contents = (
-        <div className={CLASS_ROOT + "__container"}>
+        <div className={`${CLASS_ROOT}__container`}>
           {left}
           {contents}
           {right}
@@ -289,11 +363,14 @@ Tiles.propTypes = {
     PropTypes.arrayOf(PropTypes.number)
   ]),
   size: PropTypes.oneOf(['small', 'medium', 'large']),
+  numColumns: PropTypes.number,
+  masonry: PropTypes.bool,
   ...Box.propTypes
 };
 
 Tiles.defaultProps = {
   flush: true,
   justify: 'start',
-  pad: 'small'
+  pad: 'small',
+  numColumns: 1
 };

--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -130,16 +130,21 @@ export default class Tiles extends Component {
 
   _getNumberColumns () {
     const tiles = findDOMNode(this.refs.tiles);
+    let maxColumnWidthIndex;
 
-    const maxColumnWidthIndex = this._minColumnWidths
-      .filter((currentMin) => {
-        return currentMin <= tiles.offsetWidth;
-      })
-      .reduce((maxIndex, currentMin, index, columnWidths) => {
-        return (currentMin > columnWidths[maxIndex]) ? index : maxIndex;
-      }, 0);
+    if (tiles) {
+      maxColumnWidthIndex = this._minColumnWidths
+        .filter((currentMin) => {
+          return currentMin <= tiles.offsetWidth;
+        })
+        .reduce((maxIndex, currentMin, index, columnWidths) => {
+          return (currentMin > columnWidths[maxIndex]) ? index : maxIndex;
+        }, 0);
 
-    return maxColumnWidthIndex + 1; // return appropriate number of columns
+      maxColumnWidthIndex += 1; // return appropriate number of columns
+    }
+
+    return maxColumnWidthIndex;
   }
 
   _layout () {
@@ -172,7 +177,7 @@ export default class Tiles extends Component {
       // check for appropriate number of columns, if using masonry option
       const { numColumns } = this.state;
       const newNumColumns = this._getNumberColumns();
-      if (numColumns !== newNumColumns) {
+      if (newNumColumns && (numColumns !== newNumColumns)) {
         this.setState({ numColumns: newNumColumns });
       }
     }

--- a/src/scss/grommet-core/_objects.tile.scss
+++ b/src/scss/grommet-core/_objects.tile.scss
@@ -47,6 +47,7 @@
   .#{$grommet-namespace}tiles__masonry-column {
     > .#{$grommet-namespace}tile {
       @include media-query(lap-and-up) {
+        min-width: $tile-size;
         max-width: $tile-size;
         flex-basis: auto;
       }
@@ -144,6 +145,7 @@
     .#{$grommet-namespace}tiles__masonry-column {
       > .#{$grommet-namespace}tile {
         @include media-query(lap-and-up) {
+          min-width: $tile-small-size;
           max-width: $tile-small-size;
           flex-basis: auto;
         }
@@ -161,6 +163,7 @@
     .#{$grommet-namespace}tiles__masonry-column {
       > .#{$grommet-namespace}tile {
         @include media-query(lap-and-up) {
+          min-width: $tile-large-size;
           max-width: $tile-large-size;
           flex-basis: auto;
         }

--- a/src/scss/grommet-core/_objects.tile.scss
+++ b/src/scss/grommet-core/_objects.tile.scss
@@ -44,7 +44,17 @@
     }
   }
 
+  .#{$grommet-namespace}tiles__masonry-column {
+    > .#{$grommet-namespace}tile {
+      @include media-query(lap-and-up) {
+        max-width: $tile-size;
+        flex-basis: auto;
+      }
+    }
+  }
+
   &:not(.#{$grommet-namespace}tiles--flush) {
+    .#{$grommet-namespace}tiles__masonry-column > .#{$grommet-namespace}tile,
     > .#{$grommet-namespace}tile {
       margin: halve($inuit-base-spacing-unit);
       @include ie-tile-margin($inuit-base-spacing-unit);
@@ -74,6 +84,7 @@
     &.#{$grommet-namespace}box--wrap {
       justify-content: space-around;
 
+      .#{$grommet-namespace}tiles__masonry-column > .#{$grommet-namespace}tile,
       > .#{$grommet-namespace}tile {
         flex-grow: 1;
       }
@@ -83,6 +94,7 @@
   &--flush {
     padding: 0px;
 
+    .#{$grommet-namespace}tiles__masonry-column > .#{$grommet-namespace}tile,
     > .#{$grommet-namespace}tile {
       margin: 0px;
 
@@ -128,12 +140,30 @@
         flex-basis: $tile-small-size;
       }
     }
+
+    .#{$grommet-namespace}tiles__masonry-column {
+      > .#{$grommet-namespace}tile {
+        @include media-query(lap-and-up) {
+          max-width: $tile-small-size;
+          flex-basis: auto;
+        }
+      }
+    }
   }
 
   &--large {
     > .#{$grommet-namespace}tile {
       @include media-query(lap-and-up) {
         flex-basis: $tile-large-size;
+      }
+    }
+
+    .#{$grommet-namespace}tiles__masonry-column {
+      > .#{$grommet-namespace}tile {
+        @include media-query(lap-and-up) {
+          max-width: $tile-large-size;
+          flex-basis: auto;
+        }
       }
     }
   }
@@ -156,6 +186,7 @@
     }
   }
 
+  .#{$grommet-namespace}tiles__masonry-column > .#{$grommet-namespace}chart,
   > .#{$grommet-namespace}chart {
     width: 100%;
   }

--- a/src/scss/grommet-core/_objects.tile.scss
+++ b/src/scss/grommet-core/_objects.tile.scss
@@ -47,8 +47,7 @@
   .#{$grommet-namespace}tiles__masonry-column {
     > .#{$grommet-namespace}tile {
       @include media-query(lap-and-up) {
-        min-width: $tile-size;
-        max-width: $tile-size;
+        width: $tile-size;
         flex-basis: auto;
       }
     }
@@ -145,8 +144,7 @@
     .#{$grommet-namespace}tiles__masonry-column {
       > .#{$grommet-namespace}tile {
         @include media-query(lap-and-up) {
-          min-width: $tile-small-size;
-          max-width: $tile-small-size;
+          width: $tile-small-size;
           flex-basis: auto;
         }
       }
@@ -163,8 +161,7 @@
     .#{$grommet-namespace}tiles__masonry-column {
       > .#{$grommet-namespace}tile {
         @include media-query(lap-and-up) {
-          min-width: $tile-large-size;
-          max-width: $tile-large-size;
+          width: $tile-large-size;
           flex-basis: auto;
         }
       }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- adds masonry and numColumns options to Tiles (fills masonry-style layout with cards/Tiles of varying height in order from left-to-right)


#### Where should the reviewer start?
- pull down related grommet-docs PR (https://github.com/grommet/grommet-docs/pull/65) and check against grommet PR branch using `gulp dev --useAlias`

#### What testing has been done on this PR?
- tested against toolkit contentcard modules/Tile component in Chrome, Safari, and Firefox on desktop and mobile screen widths.

#### How should this be manually tested?
- test applying masonry and numColumns options to Tiles component (use Tile with varying-height content):
```
<Tiles size="large" masonry={true} numColumns={7}>
  ...
</Tiles>
```

#### Any background context you want to provide?
- masonry-style news feed was desired in another project, and some investigation was done to implement a css-only option, but using `column-count` and `column-gap` options lays out Tiles from top-to-bottom instead of left-to-right (which would be desired behavior for dated content).
- JS + CSS implementation allows content to be filled in order from left-to-right.

#### What are the relevant issues?

#### Screenshots (if appropriate)
<img width="639" alt="screen shot 2016-07-26 at 9 18 07 pm" src="https://cloud.githubusercontent.com/assets/10161095/17167282/ff278a28-5377-11e6-8cc6-0ea59dfb143a.png">

#### Do the grommet docs need to be updated?
Yes. See related PR: https://github.com/grommet/grommet-docs/pull/65

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.
