### PR TITLE
Filled versions of the Play and Pause icons.

### DIFF
--- a/src/img/icons/pause.svg
+++ b/src/img/icons/pause.svg
@@ -5,6 +5,6 @@
 	 viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
 <g >
 	<rect  y="0" fill="none" width="24" height="24"/>
-	<path fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" d="M15,22V2h5v20H15z M9,22V2H4v20H9z"/>
+	<path fill="#000000" stroke="#000000" stroke-width="2" stroke-miterlimit="10" d="M15,22V2h5v20H15z M9,22V2H4v20H9z"/>
 </g>
 </svg>

--- a/src/img/icons/play.svg
+++ b/src/img/icons/play.svg
@@ -5,6 +5,6 @@
 	 viewBox="0 0 24 24.3317" enable-background="new 0 0 24 24.3317" xml:space="preserve">
 <g >
 	<rect  y="0.1658" fill="none" width="24" height="24"/>
-	<polygon fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" points="6,1.9658 6,22.3658 20,12.1658 	"/>
+	<polygon fill="#000000" stroke="#000000" stroke-width="2" stroke-miterlimit="10" points="6,1.9658 6,22.3658 20,12.1658 	"/>
 </g>
 </svg>


### PR DESCRIPTION
Replaces Play and Pause icons with filled versions instead of the current outlined versions. This is for the new design for the Video Component which goes into the Toolkit Video Marquee (https://github.com/grommet/hpe-digitaltoolkit/issues/103#issuecomment-233465877).

CC: @L0ZZI @kyle-locke @prewalia
