### PR TITLE
Allow accordion content to take full width & fix icons being rotated

### DIFF
--- a/src/js/components/AccordionPanel.js
+++ b/src/js/components/AccordionPanel.js
@@ -46,7 +46,7 @@ export default class AccordionPanel extends Component {
       <ListItem className={classes} direction="column" pad="none">
         <Header
           role="tab"
-          className={`${CLASS_ROOT}-header`}
+          className={`${CLASS_ROOT}__header`}
           pad={{horizontal: 'medium', vertical: 'small'}}
           full="horizontal"
           direction="row"
@@ -56,7 +56,7 @@ export default class AccordionPanel extends Component {
           responsive={false}
         >
           {heading}
-          <TabNextIcon />
+          <TabNextIcon className={`${CLASS_ROOT}__control`} />
         </Header>
         <Collapsible
           role="tabpanel"

--- a/src/js/components/Collapsible.js
+++ b/src/js/components/Collapsible.js
@@ -54,7 +54,7 @@ class Collapsible extends Component {
     const Component = this.props.animate ? TransitionGroup : Box;
 
     return (
-      <Component>
+      <Component className={`${CLASS_ROOT}__wrapper`}>
         {this.props.active &&
           <Collapse {...this.props} />
         }

--- a/src/js/components/Collapsible.js
+++ b/src/js/components/Collapsible.js
@@ -25,6 +25,7 @@ class Collapse extends Component {
 
   componentDidEnter () {
     const node = ReactDOM.findDOMNode(this);
+    node.classList.remove('animate');
     node.style.height = '';
   }
 

--- a/src/scss/grommet-core/_objects.accordion-panel.scss
+++ b/src/scss/grommet-core/_objects.accordion-panel.scss
@@ -3,12 +3,12 @@
 .#{$grommet-namespace}accordion-panel {
 
   &--active {
-    .#{$grommet-namespace}control-icon {
+    .#{$grommet-namespace}accordion-panel__control {
       transform: rotate(90deg);
     }
   }
 
-  &-header {
+  &__header {
     user-select: none;
     -webkit-user-select: none;
   }

--- a/src/scss/grommet-core/_objects.collapsible.scss
+++ b/src/scss/grommet-core/_objects.collapsible.scss
@@ -3,6 +3,10 @@
 .#{$grommet-namespace}collapsible {
   overflow: hidden;
 
+  &__wrapper {
+    width: 100%;
+  }
+
   &.animate {
     transition: height 0.5s ease-out;
   }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

- Allow accordion panel content to take full width.
- Fix icons being rotated in accordion panel when active, only rotate control icon in header. 
- Fix accordion content flashing in Safari. 

#### What testing has been done on this PR?

Chrome, FireFox, Safari, & IE11.