### PR TITLE
Update Chart units options to allow suffix and prefix properties + show units on inline legends

### DIFF
--- a/src/js/components/Legend.js
+++ b/src/js/components/Legend.js
@@ -88,18 +88,30 @@ export default class Legend extends Component {
 
       var value;
       if (item.hasOwnProperty('value')) {
-        var units;
-        if (item.units || this.props.units) {
-          units = (
-            <span className={CLASS_ROOT + "__item-units"}>
-              {item.units || this.props.units}
-            </span>
-          );
+        var unitsValue = item.units || this.props.units;
+        var unitsPrefix;
+        var unitsSuffix;
+        if (unitsValue) {
+          if (unitsValue.prefix) {
+            unitsPrefix = (
+              <span className={CLASS_ROOT + "__item-units"}>
+                {unitsValue.prefix}
+              </span>
+            );
+          }
+          if (unitsValue.suffix || (typeof unitsValue === 'string' || unitsValue instanceof String)) {
+            unitsSuffix = (
+              <span className={CLASS_ROOT + "__item-units"}>
+                {unitsValue.suffix || unitsValue}
+              </span>
+            );
+          }
         }
         value = (
           <span className={valueClasses.join(' ')}>
+            {unitsPrefix}
             {item.value}
-            {units}
+            {unitsSuffix}
           </span>
         );
       }
@@ -123,14 +135,31 @@ export default class Legend extends Component {
       if (true !== this.props.total) {
         totalValue = this.props.total;
       }
+      var unitsPrefix;
+      var unitsSuffix;
+
+      if (this.props.units.prefix) {
+        unitsPrefix = (
+          <span className={CLASS_ROOT + "__total-units"}>{this.props.units.prefix}</span>
+        );
+      }
+      if (this.props.units.suffix || (typeof this.props.units === 'string' || this.props.units instanceof String)) {
+        unitsSuffix = (
+          <span className={CLASS_ROOT + "__total-units"}>
+            {this.props.units.suffix || this.props.units}
+          </span>
+        );
+      }
+
       total = (
         <li className={CLASS_ROOT + "__total"}>
           <span className={CLASS_ROOT + "__total-label"}>
             <FormattedMessage id="Total" defaultMessage="Total" />
           </span>
           <span className={CLASS_ROOT + "__total-value"}>
+            {unitsPrefix}
             {totalValue}
-            <span className={CLASS_ROOT + "__total-units"}>{this.props.units}</span>
+            {unitsSuffix}
           </span>
         </li>
       );
@@ -155,7 +184,13 @@ Legend.propTypes = {
       PropTypes.number,
       PropTypes.node
     ]),
-    units: PropTypes.string,
+    units: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        prefix: PropTypes.string,
+        suffix: PropTypes.string
+      })
+    ]),
     colorIndex: PropTypes.oneOfType([
       PropTypes.number, // 1-6
       PropTypes.string // status
@@ -166,6 +201,12 @@ Legend.propTypes = {
     PropTypes.bool,
     PropTypes.node
   ]),
-  units: PropTypes.string,
+  units: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      prefix: PropTypes.string,
+      suffix: PropTypes.string
+    })
+  ]),
   value: PropTypes.number
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- Updating Chart.js and Legend.js to allow units options to be an object with "prefix" and "suffix" properties (strings) instead of just a string which gets appended to end of chart value.
- Shows units on inline legends.

#### Where should the reviewer start?
- Check ChartsDoc in grommet-docs, and see if configuring `units` option as object (e.g. `{prefix: '$', suffix: 'MN'}` or `{prefix: '$'})` displays correctly on charts with inline legends.

#### What testing has been done on this PR?
Tested changing all the ChartsDoc examples with units to use:
- `{prefix: '$', suffix: 'MN'}`
- `{prefix: '$'}`
- `{suffix: 'MN'}`
- `"MN"` (previous units type, string-only)

Chart units are prefixed/suffixed appropriately, and show up in Chrome, Firefox, and Safari.

#### Any background context you want to provide?
For a grommet-based project, needed a (bar) Chart with inline legend to show units on values (see screenshots), and allow units to be prefixed (e.g. '$'), suffixed (previous behavior), or both.

#### What are the relevant issues?
https://github.com/grommet/grommet-estories/issues/416

#### Screenshots (if appropriate)
Original behavior (units option does not show up on charts with inline legends):
![screen shot 2016-07-28 at 12 24 04 pm](https://cloud.githubusercontent.com/assets/10161095/17236467/de7a8474-54e4-11e6-93b4-26f462270891.png)

Updated behavior (units option shows up on inline legends, and can be prefixed/suffixed on values):
![screen shot 2016-07-28 at 4 58 12 pm](https://cloud.githubusercontent.com/assets/10161095/17236470/e17ed896-54e4-11e6-8452-283cb9b0d8ac.png)

#### Do the grommet docs need to be updated?
Yes.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards-compatible. String values for units option still get suffixed appropriately.