### PR TITLE
oneOf expected instance of array

### DIFF
--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -519,7 +519,7 @@ Menu.propTypes = {
   dropColorIndex: PropTypes.string,
   icon: PropTypes.node,
   id: PropTypes.string,
-  inline: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf('expand')]),
+  inline: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['expand'])]),
   label: PropTypes.string,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   ...Box.propTypes


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

change PropTypes.oneOf('expand'); to PropTypes.oneOf(['expand']) 
in latest React passing string to oneOf throw an error