### PR TITLE
Fix Layer overlay in safari when zooming out

### DIFF
--- a/src/scss/grommet-core/_objects.layer.scss
+++ b/src/scss/grommet-core/_objects.layer.scss
@@ -150,8 +150,8 @@
 
   &.#{$grommet-namespace}layer--hidden {
 
-    left: -100vw;
-    right: 100vw;
+    left: -100%;
+    right: 100%;
     z-index: -1;
 
     &.#{$grommet-namespace}layer--align {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fix Layer overlay in Safari when zooming out.
When you zoom out in safari, `left: -100vw` doesn’t take the whole viewport width so the Layer overlay becomes visible.
Set `left` to use a percentage unit rather than `vw`.
Resolves #692. 

#### What testing has been done on this PR?

Tested in Chrome, Firefox, & Safari. 

#### How should this be manually tested?

Open the grommet docs page in Safari & zoom out (`cmd` + `-`).

#### What are the relevant issues?
#692.

