### PR TITLE
Fix Menu onClick scrolls to top on mobile

### DIFF
--- a/src/js/utils/Drop.js
+++ b/src/js/utils/Drop.js
@@ -104,8 +104,6 @@ export default {
       drop.container.className +=
         ` ${BACKGROUND_COLOR_INDEX}-${drop.options.colorIndex}`;
     }
-    // prepend in body to avoid browser scroll issues
-    document.body.insertBefore(drop.container, document.body.firstChild);
     render(content, drop.container);
 
     drop.scrollParents = DOM.findScrollParents(drop.control);
@@ -120,6 +118,9 @@ export default {
 
     // position content
     this._place(drop);
+
+    // prepend in body to avoid browser scroll issues
+    document.body.insertBefore(drop.container, document.body.firstChild);
 
     return drop;
   },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Currently when you click on the Menu on mobile view, the window will scroll to the top (see gif below).
This PR should fix that by positioning the content first, then prepending `drop.container`.
Fixes #690.

#### What testing has been done on this PR?
Tested on mobile view.

#### How should this be manually tested?
Go to the Menu component docs page, resize the browser to mobile view & open a menu example.

#### What are the relevant issues?
#690.

#### Screenshots (if appropriate)
This is the current issue, drop down gets rendered at the top of the page, causing the page to scroll to the top.

![menu-mobile-bug](https://cloud.githubusercontent.com/assets/3210082/17461825/cad1a02c-5c34-11e6-84ad-1f3f35c33c2a.gif)
