### PR TITLE
left-aligning calendar + drop-down inputs across browsers

### DIFF
--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -95,7 +95,10 @@ $colored-select-drop-caret: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB
     @include form-field-content();
   }
 
-  > .#{$grommet-namespace}calendar input {
+
+  > .#{$grommet-namespace}search-input input,
+  > .#{$grommet-namespace}calendar input,
+  > .#{$grommet-namespace}date-time input {
     // align left padding with other form inputs
     padding-left: $inuit-base-spacing-unit;
   }

--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -95,6 +95,11 @@ $colored-select-drop-caret: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB
     @include form-field-content();
   }
 
+  > .#{$grommet-namespace}calendar input {
+    // align left padding with other form inputs
+    padding-left: $inuit-base-spacing-unit;
+  }
+
   > input[type=text],
   > input[type=range],
   > input[type=email],
@@ -147,6 +152,22 @@ $colored-select-drop-caret: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB
     // Extra padding is added by Firefox (more) and IE (less).
     // Leave it alone as Safari, Chrome, and Opera don't want this.
     // padding-left: #{$form-horizontal-padding - 2};
+
+    // Firefox hack for left-aligning select with other inputs.
+    _:-moz-tree-row(hover),
+    &,
+    &:focus {
+      padding-left: ($inuit-base-spacing-unit - ($input-border-width + 2));
+    }
+
+    // IE11 hack for left-aligning select with other inputs
+    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+      padding-left: ($inuit-base-spacing-unit - ($input-border-width + 1));
+
+      &:focus {
+        padding-left: ($inuit-base-spacing-unit - ($input-border-width + 1));
+      }
+    }
 
     html.rtl & {
       background-position: center left #{$form-horizontal-padding - quarter($inuit-base-spacing-unit)};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- left-aligns calendar, searchinput, and datetime inputs across browsers
- left-aligns select inputs for Firefox and IE11

#### What testing has been done on this PR?
Tested calendar and drop-down (select) inputs on grommet-docs in Chrome, Safari, Firefox, IE, and Android.

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/142

#### Screenshots (if appropriate)
_**IE11 drop-down before (not left-aligned):**_
![ie11dropdownbug](https://cloud.githubusercontent.com/assets/10161095/17503542/5d654f1c-5d8c-11e6-9b39-fe5a616b9ffd.PNG)

_**IE11 drop-down after:**_
![ie11dropdownfix](https://cloud.githubusercontent.com/assets/10161095/17503551/71a66ea2-5d8c-11e6-9ef9-141064d68a40.PNG)

_**Firefox drop-down before:**_
![firefoxform-bug](https://cloud.githubusercontent.com/assets/10161095/17503554/7b690940-5d8c-11e6-8dcd-de63bc0116e7.gif)

_**Firefox drop-down after:**_
![firefoxform](https://cloud.githubusercontent.com/assets/10161095/17503558/8337a0c8-5d8c-11e6-8c2c-08a8a819e323.gif)

_**Calendar input before (Chrome):**_
![screen shot 2016-08-08 at 3 55 05 pm](https://cloud.githubusercontent.com/assets/10161095/17503573/a2f6d65e-5d8c-11e6-88ff-60f15291a71e.png)

_**Calendar input after (Chrome):**_
![screen shot 2016-08-08 at 4 03 15 pm](https://cloud.githubusercontent.com/assets/10161095/17503583/b542e9d8-5d8c-11e6-8af6-c4e5bda8ea0a.png)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Non-breaking change (unless other projects have included css style tweaks to form fields previously).