### PR TITLE
Allow Menu inline state to be changed via props

### DIFF
--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -292,6 +292,12 @@ export default class Menu extends Component {
     }
   }
 
+  componentWillReceiveProps (nextProps) {
+    if (this.props.inline !== nextProps.inline) {
+      this.setState({ inline: nextProps.inline });
+    }
+  }
+
   componentDidUpdate (prevProps, prevState) {
     if (this.state.state !== prevState.state) {
       let activeKeyboardHandlers = {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Add `componentWillReceiveProps` lifecycle hook to update Menu component `inline` state when `this.props.inline` changes.
Resolves #645.

