### PR TITLE
Fix range input getting squished on focus

### DIFF
--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -96,7 +96,6 @@ $colored-select-drop-caret: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB
   }
 
   > input[type=text],
-  > input[type=range],
   > input[type=email],
   > input[type=password],
   > input[type=number],


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
removing horizontal padding from range input in default and focus states so that slider does not shrink (and maintains correct width) on focus.

#### What testing has been done on this PR?
Tested by clicking/dragging range input slider in Chrome, Firefox, Safari, and IE11. Also tested by using keyboard to increase/decrease range value when form field in focus.

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/241 (fixing style in addition to non-updating range input in IE11)

#### Screenshots (if appropriate)
Chrome, before fix:
![chrome-slider-bug](https://cloud.githubusercontent.com/assets/10161095/17537576/7976257a-5e39-11e6-963e-b88b107f3645.gif)

Chrome, after fix:
![chrome-slider-fix](https://cloud.githubusercontent.com/assets/10161095/17537581/7e07b374-5e39-11e6-81d9-d3a2f1fd4e95.gif)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible (unless project depended on input range having `$form-horizontal-padding`.