### PR TITLE
Remove Article's window scroll listener on componentWillUnmount.

### DIFF
--- a/src/js/components/Article.js
+++ b/src/js/components/Article.js
@@ -87,9 +87,7 @@ export default class Article extends Component {
     }
 
     if (this.props.onProgress) {
-      window.addEventListener('scroll', (event) => {
-        this._updateProgress(event);
-      });
+      window.addEventListener('scroll', this._updateProgress);
 
       if (this.props.direction === 'row') 
         this._responsive = Responsive.start(this._onResponsive);
@@ -115,6 +113,9 @@ export default class Article extends Component {
     }
     if (this._responsive) {
       this._responsive.stop();
+    }
+    if (this.props.onProgress) {
+      window.removeEventListener('scroll', this._updateProgress);
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
I noticed a bug in the Article's onProgress functionality which would throw an error after changing routes.

#### What does this PR do?
This fixes a bug which did not remove the scroll listener when the Article component unmounts.

#### How should this be manually tested?
Create a basic React Router app which features an Article component with and without progress update. When the user switches routes using React Router's Link from an Article with progress monitoring to one without an error will be logged. This error is now fixed.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.

