### PR TITLE
Add Watch (video play) icon

### DIFF
--- a/src/img/icons/watch.svg
+++ b/src/img/icons/watch.svg
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
    viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
-<style type="text/css">
-  .st0{fill:#0F1231;}
-</style>
-<g id="XMLID_2_">
-  <path id="XMLID_4_" class="st0" d="M12,0C5.4,0,0,5.4,0,12s5.4,12,12,12s12-5.4,12-12S18.6,0,12,0z M12,22C6.5,22,2,17.5,2,12
+<g>
+  <path d="M12,0C5.4,0,0,5.4,0,12s5.4,12,12,12s12-5.4,12-12S18.6,0,12,0z M12,22C6.5,22,2,17.5,2,12
     S6.5,2,12,2s10,4.5,10,10S17.5,22,12,22z"/>
-  <polygon id="XMLID_3_" class="st0" points="9,16 17,12 9,8   "/>
+  <polygon points="9,16 17,12 9,8"/>
 </g>
 </svg>

--- a/src/img/icons/watch.svg
+++ b/src/img/icons/watch.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+   viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+  .st0{fill:#0F1231;}
+</style>
+<g id="XMLID_2_">
+  <path id="XMLID_4_" class="st0" d="M12,0C5.4,0,0,5.4,0,12s5.4,12,12,12s12-5.4,12-12S18.6,0,12,0z M12,22C6.5,22,2,17.5,2,12
+    S6.5,2,12,2s10,4.5,10,10S17.5,22,12,22z"/>
+  <polygon id="XMLID_3_" class="st0" points="9,16 17,12 9,8   "/>
+</g>
+</svg>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds Watch (video play) icon for grommet based project, and ContentCard component.

Used for anchor icon and thumbnail image overlay:
![screen shot 2016-08-16 at 4 46 35 pm](https://cloud.githubusercontent.com/assets/10161095/17722885/55a80daa-63d1-11e6-8a0c-c7085b30b2c0.png)
![screen shot 2016-08-16 at 4 47 10 pm](https://cloud.githubusercontent.com/assets/10161095/17722911/81cf5758-63d1-11e6-8fd1-263ce378f10d.png)

#### What are the relevant issues?
https://github.com/grommet/hpe-digitaltoolkit/pull/112
https://github.com/grommet/hpe-digitaltoolkit/issues/31

#### Do the grommet docs need to be updated?
No.
