### PR TITLE
Accordion enhancements

### DIFF
--- a/src/js/components/Accordion.js
+++ b/src/js/components/Accordion.js
@@ -27,6 +27,7 @@ export default class Accordion extends Component {
       animate,
       className,
       children,
+      icon,
       openMulti,
       ...props
     } = this.props;
@@ -45,7 +46,8 @@ export default class Accordion extends Component {
           onActive: () => {
             this._activatePanel(index);
           },
-          animate
+          animate,
+          icon
         });
       });
 
@@ -64,6 +66,10 @@ export default class Accordion extends Component {
 Accordion.propTypes = {
   animate: PropTypes.bool,
   openMulti: PropTypes.bool,
+  icon: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.bool
+  ]),
   initialIndex: PropTypes.number
 };
 

--- a/src/js/components/Accordion.js
+++ b/src/js/components/Accordion.js
@@ -27,6 +27,7 @@ export default class Accordion extends Component {
       animate,
       className,
       children,
+      disabled,
       icon,
       openMulti,
       ...props
@@ -34,7 +35,10 @@ export default class Accordion extends Component {
 
     const classes = classnames(
       CLASS_ROOT,
-      className
+      className,
+      {
+        [`${CLASS_ROOT}--disabled`]: disabled
+      }
     );
 
     const accordionChildren = React.Children
@@ -47,6 +51,7 @@ export default class Accordion extends Component {
             this._activatePanel(index);
           },
           animate,
+          disabled,
           icon
         });
       });
@@ -65,6 +70,7 @@ export default class Accordion extends Component {
 
 Accordion.propTypes = {
   animate: PropTypes.bool,
+  disabled: PropTypes.bool,
   openMulti: PropTypes.bool,
   icon: PropTypes.oneOfType([
     PropTypes.element,

--- a/src/js/components/AccordionPanel.js
+++ b/src/js/components/AccordionPanel.js
@@ -32,7 +32,13 @@ export default class AccordionPanel extends Component {
   }
 
   render () {
-    const { animate, className, children, heading } = this.props;
+    const {
+      animate,
+      className,
+      children,
+      heading,
+      icon,
+    } = this.props;
 
     const classes = classnames(
       CLASS_ROOT,
@@ -41,6 +47,13 @@ export default class AccordionPanel extends Component {
         [`${CLASS_ROOT}--active`]: this.state.active
       }
     );
+
+    let controlIcon;
+    if (icon) {
+      controlIcon = icon;
+    } else if (icon === undefined) {
+      controlIcon = <TabNextIcon className={`${CLASS_ROOT}__control`} />;
+    }
 
     return (
       <ListItem className={classes} direction="column" pad="none">
@@ -56,7 +69,7 @@ export default class AccordionPanel extends Component {
           responsive={false}
         >
           {heading}
-          <TabNextIcon className={`${CLASS_ROOT}__control`} />
+          {controlIcon}
         </Header>
         <Collapsible
           role="tabpanel"
@@ -74,5 +87,9 @@ AccordionPanel.propTypes = {
   active: PropTypes.bool,
   animate: PropTypes.bool,
   heading: PropTypes.node.isRequired,
+  icon: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.bool
+  ]),
   onActive: PropTypes.func
 };

--- a/src/js/components/AccordionPanel.js
+++ b/src/js/components/AccordionPanel.js
@@ -38,6 +38,7 @@ export default class AccordionPanel extends Component {
       children,
       heading,
       icon,
+      ...props
     } = this.props;
 
     const classes = classnames(
@@ -56,7 +57,7 @@ export default class AccordionPanel extends Component {
     }
 
     return (
-      <ListItem className={classes} direction="column" pad="none">
+      <ListItem className={classes} direction="column" pad="none" {...props}>
         <Header
           role="tab"
           className={`${CLASS_ROOT}__header`}

--- a/src/js/components/AccordionPanel.js
+++ b/src/js/components/AccordionPanel.js
@@ -27,8 +27,10 @@ export default class AccordionPanel extends Component {
   }
 
   _onClickPanel () {
-    this.setState({ active : !this.state.active });
-    this.props.onActive();
+    if (!this.props.disabled) {
+      this.setState({ active : !this.state.active });
+      this.props.onActive();
+    }
   }
 
   render () {
@@ -87,6 +89,7 @@ export default class AccordionPanel extends Component {
 AccordionPanel.propTypes = {
   active: PropTypes.bool,
   animate: PropTypes.bool,
+  disabled: PropTypes.bool,
   heading: PropTypes.node.isRequired,
   icon: PropTypes.oneOfType([
     PropTypes.element,

--- a/src/scss/grommet-core/_objects.accordion-panel.scss
+++ b/src/scss/grommet-core/_objects.accordion-panel.scss
@@ -1,5 +1,14 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
+.#{$grommet-namespace}accordion {
+
+  &--disabled {
+    .#{$grommet-namespace}accordion-panel__header {
+      cursor: auto;
+    }
+  }
+}
+
 .#{$grommet-namespace}accordion-panel {
 
   &--active {
@@ -17,3 +26,4 @@
     outline: none;
   }
 }
+


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Allow prop to disable Accordion & also use custom icons. 

#### Any background context you want to provide?

On desktop, I want to disable the Accordion & have all the panels expanded.
On mobile, I want the Accordion enabled & all the panels collapsed. 
See gif below

#### Screenshots (if appropriate)

![accordion-mobile](https://cloud.githubusercontent.com/assets/3210082/17773541/b7054f1c-64ea-11e6-8755-f3917152c034.gif)

#### Do the grommet docs need to be updated?

Yes.


#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
