### PR TITLE
Allow 0 to be passed as activeIndex prop in Tabs component

### DIFF
--- a/src/js/components/Tabs.js
+++ b/src/js/components/Tabs.js
@@ -22,7 +22,7 @@ export default class Tabs extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if(typeof nextProps.activeIndex !== 'undefined' &&
+    if ((nextProps.activeIndex || 0 === nextProps.activeIndex) &&
       this.state.activeIndex !== nextProps.activeIndex) {
       this.setState({activeIndex: nextProps.activeIndex});
     }

--- a/src/js/components/Tabs.js
+++ b/src/js/components/Tabs.js
@@ -22,7 +22,7 @@ export default class Tabs extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if(nextProps.activeIndex &&
+    if(typeof nextProps.activeIndex !== 'undefined' &&
       this.state.activeIndex !== nextProps.activeIndex) {
       this.setState({activeIndex: nextProps.activeIndex});
     }

--- a/test/components/Tabs-test.js
+++ b/test/components/Tabs-test.js
@@ -27,3 +27,20 @@ test('loads a basic Tabs', (t) => {
     t.fail('Tabs does not have class');
   }
 });
+
+test('updates activeIndex state when activeIndex prop changes', (t) => {
+  t.plan(4);
+  const component = TestUtils.renderIntoDocument(<Tabs />);
+
+  // test defaultProps state.
+  t.equal(component.state.activeIndex, 0);
+  // test state updating when activeIndex is truthy.
+  component.componentWillReceiveProps({activeIndex: 1});
+  t.equal(component.state.activeIndex, 1);
+  // test state updating when activeIndex is non-integer.
+  component.componentWillReceiveProps({activeIndex: null});
+  t.equal(component.state.activeIndex, 1);
+  // test state updating when activeIndex is falsey.
+  component.componentWillReceiveProps({activeIndex: 0});
+  t.equal(component.state.activeIndex, 0);
+});


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
allows passing of `activeIndex === 0` to `Tabs` component.

#### What testing has been done on this PR?
Updated unit tests to test `componentWillRecieveProps` with truthy and falsey values passed to activeIndex

#### How should this be manually tested?
1. Mount Tabs component with multiple tabs
1. Programatically change `activeIndex` to 1.
1. Programatically change `activeindex` back to 0.
1. Tabs component should re-render with first tab being active

#### Do the grommet docs need to be updated?
`activeIndex` prop is not currently documented.
