### PR TITLE
Card Style Fixes

### DIFF
--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -2,6 +2,7 @@
 
 import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
+import CSSClassnames from '../utils/CSSClassnames';
 import Props from '../utils/Props';
 import Box from './Box';
 import Tile from './Tile';
@@ -12,7 +13,7 @@ import Layer from './Layer';
 import Video from './Video';
 import WatchIcon from './icons/base/Watch';
 
-const CLASS_ROOT = 'card';
+const CLASS_ROOT = CSSClassnames.CARD;
 
 export default class Card extends Component {
   constructor (props) {
@@ -110,7 +111,7 @@ export default class Card extends Component {
         <Box className={`${CLASS_ROOT}__thumbnail`}
           backgroundImage={`url(${thumbnail})`}
           justify="center" align="center">
-          {(video) ? <Anchor icon={<WatchIcon size="xlarge" />} /> : null}}
+          {(video) ? <Anchor icon={<WatchIcon size="xlarge" />} /> : null}
         </Box>
       );
     }

--- a/src/js/utils/CSSClassnames.js
+++ b/src/js/utils/CSSClassnames.js
@@ -15,6 +15,7 @@ export default {
   BRICK: `${namespace}brick`,
   BUTTON: `${namespace}button`,
   CALENDAR: `${namespace}calendar`,
+  CARD: `${namespace}card`,
   CAROUSEL: `${namespace}carousel`,
   CAROUSEL_CONTROLS: `${namespace}carousel-controls`,
   CHART: `${namespace}chart`,

--- a/src/scss/grommet-core/_objects.card.scss
+++ b/src/scss/grommet-core/_objects.card.scss
@@ -137,7 +137,7 @@ $card-hover-color: #EBEBEB;
   }
 
   &--selectable {
-    &:hover:not(.#{$grommet-namespace}tile--selected) {
+    &.#{$grommet-namespace}tile--selectable:hover:not(.#{$grommet-namespace}tile--selected) {
       // hide Tile hover border style (gets set by onClick prop)
       background-color: transparent;
     }

--- a/src/scss/grommet-core/_objects.card.scss
+++ b/src/scss/grommet-core/_objects.card.scss
@@ -19,7 +19,7 @@ $card-hover-color: #EBEBEB;
   }
 }
 
-.card {
+.#{$grommet-namespace}card {
   @include media-query(palm) {
     padding: 0;
 
@@ -104,7 +104,7 @@ $card-hover-color: #EBEBEB;
   &--direction-row {
     max-width: $size-large;
 
-    .card__thumbnail {
+    .#{$grommet-namespace}card__thumbnail {
       height: auto;
       width: $inuit-base-spacing-unit * 13; // 312px
 
@@ -114,7 +114,7 @@ $card-hover-color: #EBEBEB;
       }
     }
 
-    .card__content {
+    .#{$grommet-namespace}card__content {
       min-width: $inuit-base-spacing-unit * 11;
 
       @include media-query(palm) {
@@ -147,7 +147,7 @@ $card-hover-color: #EBEBEB;
       color: $hover-text-color;
       cursor: pointer;
 
-      .card__content {
+      .#{$grommet-namespace}card__content {
         .#{$grommet-namespace}paragraph::after {
           background: linear-gradient(to right, transparent, $card-hover-color 50%);
         }

--- a/src/scss/grommet-core/_objects.scss
+++ b/src/scss/grommet-core/_objects.scss
@@ -11,6 +11,7 @@
 @import "objects.brick";
 @import "objects.button";
 @import "objects.calendar";
+@import "objects.card";
 @import "objects.carousel";
 @import "objects.chart";
 @import "objects.check-box";


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Applies Card styles to Card components. Previously CSSClassnames, _objects.scss wasn't updated to include new Card component. Also prefixing styles with grommet namespace.

#### Do the grommet docs need to be updated?
Yes. PR Pending: https://github.com/grommet/grommet-docs/pull/86

