### PR TITLE
Check that mouseUpIndex is within range boundaries

### DIFF
--- a/src/js/components/chart/Range.js
+++ b/src/js/components/chart/Range.js
@@ -80,9 +80,15 @@ export default class Range extends Component {
 
   _onMouseUp (event) {
     window.removeEventListener('mouseup', this._onMouseUp);
-    const { active, onActive } = this.props;
+    const { active, onActive, count } = this.props;
     const { mouseDown, mouseDownIndex, moved } = this.state;
-    const mouseUpIndex = this._mouseIndex(event);
+    let mouseUpIndex = this._mouseIndex(event);
+
+    if (mouseUpIndex < 0) {
+      mouseUpIndex = 0;
+    } else if (mouseUpIndex > count) {
+      mouseUpIndex = count;
+    }
 
     this.setState({
       mouseDown: false,


### PR DESCRIPTION
This PR addresses an issue with the `_onMouseUp` method in the range component.

#### What does this PR do?
The range component returns extraneous values if the user drags the mouse outside of its boundaries. The PR checks for this and sets the `mouseUpIndex` to either `0` or `count` depending on which side of the component the mouse exits. 

#### Where should the reviewer start?
`./components/chart/Range.js` `_onMouseUp` method

#### How should this be manually tested?
Drag one end of the slider past the range component's boundary and witness the `active` prop's values. With this fix in place, active start/end values should not exceed the count or drop below zero. 

#### What are the relevant issues?
Dragging the range slider off of the chart returns a non-existent value outside of the range of the xAxis. 

#### Do the grommet docs need to be updated?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.
