### PR TITLE
Enhance Meter to support float number

### DIFF
--- a/src/js/components/Meter.js
+++ b/src/js/components/Meter.js
@@ -226,11 +226,24 @@ export default class Meter extends Component {
   }
 
   _seriesTotal (series) {
-    let total = 0;
-    series.some(function (item) {
-      total += item.value;
+    let values = [];
+    series.forEach(function(item) {
+      let decimalDigits;
+      try{
+        decimalDigits = item.value.toString().split(".")[1].length;
+      } catch(e) {
+        decimalDigits=0;
+      }
+      values.push(decimalDigits);
     });
-    return total;
+
+    let maxDecimalDigits = Math.pow(10, Math.max.apply(null, values));
+    let total = 0;
+
+    series.forEach(function(item) {
+      total += item.value * maxDecimalDigits;
+    });
+    return total = total / maxDecimalDigits;
   }
 
   _seriesMax (series) {


### PR DESCRIPTION
Hi Grommet Team,

Javascript use IEEE754 to calculate float and int number. Sometimes it’s hard to use binary to express a float number very exactly. 
 
For example, input below expression in browser console:
0.1+(0.2+0.3);  // 0.6
(0.1+0.2)+0.3;  // 0.6000000000000001
 
4.54+5.03;  // 9.57
4.47 + 5.09;  // 9.559999999999999
 
Current Meter only support integer, I enhance it to support float number.
 
Change grommet/src/js/components/Meter.js
From:
value: function _seriesTotal(series) {
  var total = 0;
  series.some(function (item) {
    total += item.value;
  });
  return total;
}
 
To:
value: function _seriesTotal(series) {
    let values = [];
    series.forEach(function(item) {
      let decimalDigits;
      try{
        decimalDigits = item.value.toString().split(".")[1].length;
      } catch(e) {
        decimalDigits=0;
      }
      values.push(decimalDigits);
    });

    let maxDecimalDigits = Math.pow(10, Math.max.apply(null, values));
    let total = 0;

    series.forEach(function(item) {
      total += item.value * maxDecimalDigits;
    });
    return total = total / maxDecimalDigits;
}

Original, not support float number
![original](https://cloud.githubusercontent.com/assets/16797825/18163503/e53d46bc-706d-11e6-8561-676ac674836e.png)

Ehanhce Meter, it supports float number
![now](https://cloud.githubusercontent.com/assets/16797825/18163510/eb4caea8-706d-11e6-96e0-30e9b71890d2.png)

