### PR TITLE
allowing colorIndex to be set for SocialShare icons

### DIFF
--- a/src/js/components/SocialShare.js
+++ b/src/js/components/SocialShare.js
@@ -10,7 +10,7 @@ import SocialEmailIcon from './icons/base/SocialEmail';
 
 export default class SocialShare extends Component {
   render () {
-    const { type, link, text, title } = this.props;
+    const { colorIndex, type, link, text, title } = this.props;
 
     let socialIcon = undefined;
     let href = '';
@@ -21,21 +21,26 @@ export default class SocialShare extends Component {
     const encodedText = encodeURIComponent(text);
 
     if (type === 'twitter') {
-      socialIcon = <SocialTwitterIcon a11yTitle='Share on Twitter' />;
+      socialIcon = (<SocialTwitterIcon a11yTitle='Share on Twitter'
+        colorIndex={colorIndex} />);
       href = `https://twitter.com/intent/tweet?url=` +
         `${encodedLink}&text=${encodedText}`;
     } else if (type === 'linkedin') {
-      socialIcon = <SocialLinkedinIcon a11yTitle='Share on LinkedIn' />;
+      socialIcon = (<SocialLinkedinIcon a11yTitle='Share on LinkedIn'
+        colorIndex={colorIndex} />);
       href = `https://www.linkedin.com/shareArticle?mini=true&url=` +
         `${encodedLink}&title=${encodedTitle}&summary=${encodedText}`;
     } else if (type === 'google') {
-      socialIcon = <SocialGoogleIcon a11yTitle='Share on Google' />;
+      socialIcon = (<SocialGoogleIcon a11yTitle='Share on Google'
+        colorIndex={colorIndex} />);
       href = `https://plus.google.com/share?url=${encodedLink}`;
     } else if (type === 'facebook') {
-      socialIcon = <SocialFacebookIcon a11yTitle='Share on Facebook' />;
+      socialIcon = (<SocialFacebookIcon a11yTitle='Share on Facebook'
+        colorIndex={colorIndex} />);
       href = `https://www.facebook.com/sharer/sharer.php?u=${encodedLink}`;
     } else if (type === 'email') {
-      socialIcon = <SocialEmailIcon a11yTitle='Share on Email' />;
+      socialIcon = (<SocialEmailIcon a11yTitle='Share on Email'
+        colorIndex={colorIndex} />);
       href = `mailto:?subject=` +
         `${encodedTitle}&body=${encodedText}%0D%0A${encodedLink}`;
       target = '_self';
@@ -48,6 +53,7 @@ export default class SocialShare extends Component {
 };
 
 SocialShare.propTypes = {
+  colorIndex: PropTypes.string,
   type: PropTypes.oneOf(['email', 'facebook', 'twitter', 'linkedin',
     'google']).isRequired,
   link: PropTypes.string.isRequired,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
allows colorIndex to be set for SocialShare icons

#### What testing has been done on this PR?
grommet-docs: tested setting colorIndex attribute on SocialShare component

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/817

#### Screenshots (if appropriate)
Before (colorIndex option not available for SocialShare):
![screen shot 2016-09-02 at 2 36 52 pm](https://cloud.githubusercontent.com/assets/10161095/18221586/7c5b4596-711b-11e6-807b-c338f54730a7.png)

After:
![screen shot 2016-09-02 at 2 40 34 pm](https://cloud.githubusercontent.com/assets/10161095/18221587/7c5e4a2a-711b-11e6-823d-00631fe42d2f.png)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards-compatible.