### PR TITLE
Adding precommit hook via guppy

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -31,3 +31,5 @@ gulp.task('dev', () =>
     'Running "gulp dev" at Grommet root folder is not supported. To test Grommet components locally clone the grommet-docs repo into your project.'
   )
 );
+
+gulp.task('pre-commit', ['jslint','scsslint','test']);

--- a/package.json
+++ b/package.json
@@ -77,8 +77,9 @@
     "gulp-prompt": "^0.2.0",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.2.0",
-    "react-test-renderer": "^15.3.0",
+    "guppy-pre-commit": "^0.4.0",
     "mkdirp": "^0.5.1",
+    "react-test-renderer": "^15.3.0",
     "run-sequence": "^1.1.5",
     "webpack": "^1.12.14",
     "webpack-stream": "^3.1.0"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds pre-commit hook which runs `jslint`, `scsslint`, and `test` gulp tasks.

#### What testing has been done on this PR?
Tested by manually invoking pre-commit hook and when submitting this PR, the pre-commit hooks were invoked.

#### How should this be manually tested?

1. `npm install`
2. `.git/hooks/pre-commit`

#### What are the relevant issues?
#816 

#### Do the grommet docs need to be updated?
Yes, the [CONTRIBUTING](https://github.com/grommet/grommet/blob/master/CONTRIBUTING.md) guide should be updated to mention pre-commit hooks.

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible

Signed-off-by: Bryan Jacquot <jacquot@hpe.com>