### PR TITLE
Fixed a failing unit test in Calendar component

### DIFF
--- a/__tests__/components/Calendar-test.js
+++ b/__tests__/components/Calendar-test.js
@@ -12,7 +12,7 @@ jest.mock('react-dom');
 describe('Calendar', () => {
   it('has correct default options', () => {
     const component = renderer.create(
-      <Calendar id="item1" name="item-1" />
+      <Calendar id="item1" name="item-1" value="2015-06-03" />
     );
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();

--- a/__tests__/components/__snapshots__/Calendar-test.js.snap
+++ b/__tests__/components/__snapshots__/Calendar-test.js.snap
@@ -6,7 +6,7 @@ exports[`Calendar has correct default options 1`] = `
     id="item1"
     name="item-1"
     onChange={[Function bound _onInputChange]}
-    value="2016-09-06" />
+    value="2015-06-03" />
   <button
     aria-label={undefined}
     className="grommetux-button grommetux-calendar__control grommetux-button--plain grommetux-button--icon"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes a failing test case in the Calendar component.  If no value is specified, the Calendar uses the current date.  When comparing this date to the corresponding field in the snapshot, the unit test fails.  This PR sets the value for both the Calendar component and the Calendar snapshot.

#### Where should the reviewer start?
Review both of the modified files.  Confirm the dates match.

#### What testing has been done on this PR?
After running gulp dist, all the unit tests pass.  The following message is displayed: `133 tests passed (133 total in 64 test suites, 138 snapshots, run time 42.875s)`

#### How should this be manually tested?
Clone Grommet, run npm install, run gulp dist.  Notice that all test cases pass.

#### Any background context you want to provide?
See discussion is Slack.  Search for "Calendar test fails".

#### What are the relevant issues?
Failing unit tests.

#### Screenshots (if appropriate)
![error](https://cloud.githubusercontent.com/assets/14231471/18331813/97997bbc-7516-11e6-866b-d5455a72013d.png)


#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Unsure