### PR TITLE
Accordion padding

### DIFF
--- a/src/js/components/AccordionPanel.js
+++ b/src/js/components/AccordionPanel.js
@@ -32,7 +32,7 @@ export default class AccordionPanel extends Component {
   }
 
   render () {
-    const { animate, className, children, heading } = this.props;
+    const { animate, className, children, heading, pad } = this.props;
 
     const classes = classnames(
       CLASS_ROOT,
@@ -47,6 +47,7 @@ export default class AccordionPanel extends Component {
         <Header
           role="tab"
           className={`${CLASS_ROOT}__header`}
+          pad={pad}
           full="horizontal"
           direction="row"
           justify="between"
@@ -61,6 +62,7 @@ export default class AccordionPanel extends Component {
           role="tabpanel"
           active={this.state.active}
           animate={animate}
+          pad={pad}
         >
           {children}
         </Collapsible>

--- a/src/js/components/AccordionPanel.js
+++ b/src/js/components/AccordionPanel.js
@@ -47,7 +47,6 @@ export default class AccordionPanel extends Component {
         <Header
           role="tab"
           className={`${CLASS_ROOT}__header`}
-          pad={{horizontal: 'medium', vertical: 'small'}}
           full="horizontal"
           direction="row"
           justify="between"

--- a/src/js/components/Collapsible.js
+++ b/src/js/components/Collapsible.js
@@ -52,7 +52,7 @@ class Collapse extends Component {
       CLASS_ROOT,
       this.props.className
     );
-    return <div {...this.props} className={classes} />;
+    return <Box {...this.props} className={classes} />;
   }
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Remove default padding on Accordion panel headings. 
This will allow callers to pass `pad` prop to AccordionPanel.
Resolves grommet/hpe-digitaltoolkit#118.

#### Screenshots (if appropriate)

### No pad

![image](https://cloud.githubusercontent.com/assets/3210082/18336456/0cd69868-7523-11e6-8ed6-04b57fcba774.png)

### Padded

![image](https://cloud.githubusercontent.com/assets/3210082/18336454/07529ff4-7523-11e6-95ec-73fe451d4e94.png)

#### Do the grommet docs need to be updated?

Yes. grommet/grommet-docs#101