### PR TITLE
Card updates - remove summary, rename details to text, backwards compatible

### DIFF
--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -19,25 +19,21 @@ const TEXT_TAGS = {
   xlarge: {
     label: 'large',
     heading: 'h1',
-    summary: 'xlarge',
     details: 'large'
   },
   large: {
     label: 'medium',
     heading: 'h1',
-    summary: 'xlarge',
     details: 'large'
   },
   medium: {
     label: 'medium',
     heading: 'h2',
-    summary: 'large',
     details: 'medium'
   },
   small: {
     label: 'small',
     heading: 'h3',
-    summary: 'medium',
     details: 'small'
   }
 };
@@ -129,7 +125,7 @@ export default class Card extends Component {
 
   render () {
     const { children, className, colorIndex, details, direction, heading,
-      headingStrong, label, onClick, pad, reverse, summary, textSize, thumbnail,
+      headingStrong, label, onClick, pad, reverse, textSize, thumbnail,
       video } = this.props;
     const tileProps = Props.pick(this.props, Object.keys(Tile.propTypes));
     delete tileProps.colorIndex;
@@ -167,7 +163,6 @@ export default class Card extends Component {
             {heading}
           </Heading>
         }
-        {this._renderParagraph(summary, tag.summary, 'summary')}
         {this._renderParagraph(details, tag.details, 'details')}
         {children}
         {this._renderLink()}
@@ -225,7 +220,6 @@ Card.propTypes = {
   link: PropTypes.element,
   onClick: PropTypes.func,
   reverse: PropTypes.bool,
-  summary: PropTypes.node,
   textSize: PropTypes.oneOf(['small', 'medium', 'large', 'xlarge']),
   thumbnail: PropTypes.string,
   video: PropTypes.oneOfType([

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -124,13 +124,18 @@ export default class Card extends Component {
   }
 
   render () {
-    const { children, className, colorIndex, direction, heading, headingStrong,
-      label, onClick, pad, reverse, text, textSize, thumbnail, video
-    } = this.props;
+    const { children, className, colorIndex, description, direction, heading,
+      headingStrong, label, onClick, pad, reverse, text, textSize, thumbnail,
+      video } = this.props;
     const tileProps = Props.pick(this.props, Object.keys(Tile.propTypes));
     delete tileProps.colorIndex;
     delete tileProps.onClick;
     delete tileProps.pad;
+
+    if (description) {
+      console.warn('\'description\' prop has been renamed to \'text\'.' +
+        ' Support for \'description\' will be removed in a future release.');
+    }
 
     const classes = classnames(
       CLASS_ROOT,
@@ -163,7 +168,7 @@ export default class Card extends Component {
             {heading}
           </Heading>
         }
-        {this._renderParagraph(text, tag.text, 'text')}
+        {this._renderParagraph(text || description, tag.text, 'text')}
         {children}
         {this._renderLink()}
       </Box>
@@ -213,6 +218,7 @@ export default class Card extends Component {
 };
 
 Card.propTypes = {
+  description: PropTypes.string,
   heading: PropTypes.string,
   headingStrong: PropTypes.bool,
   label: PropTypes.string,

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -19,22 +19,22 @@ const TEXT_TAGS = {
   xlarge: {
     label: 'large',
     heading: 'h1',
-    details: 'large'
+    text: 'large'
   },
   large: {
     label: 'medium',
     heading: 'h1',
-    details: 'large'
+    text: 'large'
   },
   medium: {
     label: 'medium',
     heading: 'h2',
-    details: 'medium'
+    text: 'medium'
   },
   small: {
     label: 'small',
     heading: 'h3',
-    details: 'small'
+    text: 'small'
   }
 };
 
@@ -124,9 +124,9 @@ export default class Card extends Component {
   }
 
   render () {
-    const { children, className, colorIndex, details, direction, heading,
-      headingStrong, label, onClick, pad, reverse, textSize, thumbnail,
-      video } = this.props;
+    const { children, className, colorIndex, direction, heading, headingStrong,
+      label, onClick, pad, reverse, text, textSize, thumbnail, video
+    } = this.props;
     const tileProps = Props.pick(this.props, Object.keys(Tile.propTypes));
     delete tileProps.colorIndex;
     delete tileProps.onClick;
@@ -163,7 +163,7 @@ export default class Card extends Component {
             {heading}
           </Heading>
         }
-        {this._renderParagraph(details, tag.details, 'details')}
+        {this._renderParagraph(text, tag.text, 'text')}
         {children}
         {this._renderLink()}
       </Box>
@@ -213,13 +213,13 @@ export default class Card extends Component {
 };
 
 Card.propTypes = {
-  details: PropTypes.node,
   heading: PropTypes.string,
   headingStrong: PropTypes.bool,
   label: PropTypes.string,
   link: PropTypes.element,
   onClick: PropTypes.func,
   reverse: PropTypes.bool,
+  text: PropTypes.node,
   textSize: PropTypes.oneOf(['small', 'medium', 'large', 'xlarge']),
   thumbnail: PropTypes.string,
   video: PropTypes.oneOfType([

--- a/src/scss/grommet-core/_objects.card.scss
+++ b/src/scss/grommet-core/_objects.card.scss
@@ -168,15 +168,9 @@ $card-hover-color: #EBEBEB;
     }
   }
 
-  &__summary {
+  &__text {
     &.#{$grommet-namespace}paragraph {
-      margin-top: 0.125em;
-      margin-bottom: 0.5em;
-    }
-  }
-
-  &__details {
-    &.#{$grommet-namespace}paragraph {
+      margin-top: 0.333em;
       margin-bottom: 0.333em;
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Updates to Card component.
Remove summary prop.
Rename `details` -> `text` prop.
Allow `description` to be backwards compatible. 

#### Do the grommet docs need to be updated?

Yes. grommet/grommet-docs#102