### PR TITLE
Fixed issue where Carousel component does not get rendered properly when it's being rendered on the server side first.

### DIFF
--- a/src/js/components/Carousel.js
+++ b/src/js/components/Carousel.js
@@ -270,7 +270,10 @@ export default class Carousel extends Component {
       <div ref={ref => this.carouselRef = ref} className={classes.join(' ')}
         onMouseEnter={this._onMouseOver} onMouseLeave={this._onMouseOut}>
         <div className={CLASS_ROOT + "__track"}
-          style={{ width: trackWidth, marginLeft: trackPosition }}>
+          style={{
+            width: (trackWidth && trackWidth !== 0) ? trackWidth : '',
+            marginLeft: trackPosition
+          }}>
           <Tiles fill={true} responsive={false} wrap={false} direction="row">
             {tiles}
           </Tiles>

--- a/src/js/components/Carousel.js
+++ b/src/js/components/Carousel.js
@@ -271,7 +271,7 @@ export default class Carousel extends Component {
         onMouseEnter={this._onMouseOver} onMouseLeave={this._onMouseOut}>
         <div className={CLASS_ROOT + "__track"}
           style={{
-            width: (trackWidth && trackWidth !== 0) ? trackWidth : '',
+            width: (trackWidth && trackWidth > 0) ? trackWidth : '',
             marginLeft: trackPosition
           }}>
           <Tiles fill={true} responsive={false} wrap={false} direction="row">


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixed issue where Carousel component does not get rendered properly when it's being rendered on the server side first.

#### Where should the reviewer start?
Server side Carousel component rendering.

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No


