### PR TITLE
Added guppy pre-comit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "gulp-prompt": "^0.2.0",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.2.0",
+    "guppy-pre-commit": "^0.4.0",
     "react-test-renderer": "^15.3.0",
     "mkdirp": "^0.5.1",
     "run-sequence": "^1.1.5",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

# ATTENTION 
**This PR should not be merged until the https://github.com/grommet/grommet-toolbox/pull/34 is merged and updated in Grommet.  The grommet-toolbox PR contains the gulp tasks which are executed during pre-commit.**

#### What does this PR do?
Adds pre-commit hook

#### What testing has been done on this PR?
Tested by manually updating grommet-toolbox and invoking `gulp pre-commit` hook

#### How should this be manually tested?

1. npm install
2. `gulp pre-commit`

#### What are the relevant issues?
#816 

#### Do the grommet docs need to be updated?
Yes, the [CONTRIBUTING](https://github.com/grommet/grommet/blob/master/CONTRIBUTING.md) guide should be updated to mention pre-commit hooks.

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible

Signed-off-by: Bryan Jacquot <jacquot@hpe.com>