### PR TITLE
Fix Animate component children appearing immediately

### DIFF
--- a/src/js/components/Animate.js
+++ b/src/js/components/Animate.js
@@ -57,7 +57,7 @@ class AnimateChild extends Component {
       node.style.transitionDuration = '';
       node.classList.remove('animate', `${leaveClass}--leave`);
       node.classList.add(`${enterClass}--enter`);
-      setTimeout(callback, delay);
+      setTimeout(callback, delay || 50);
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fix Animate component children appearing immediately when added too quickly. 
If delay is undefined, default to 50ms. 

#### What testing has been done on this PR?

Tested in grommet-docs page on Chrome, Firefox, & Safari

#### What are the relevant issues?

grommet/hpe-digitaltoolkit#119

#### Screenshots (if appropriate)

### Without fix
![animate-bug](https://cloud.githubusercontent.com/assets/3210082/18408116/021c2a92-76c1-11e6-9e85-8fda18a62067.gif)

### With fix
![animate-fixed](https://cloud.githubusercontent.com/assets/3210082/18408117/0858caa0-76c1-11e6-89aa-10ef55f04fe4.gif)
