### PR TITLE
Fix Table cell headers in FF<45

### DIFF
--- a/src/js/components/Table.js
+++ b/src/js/components/Table.js
@@ -143,7 +143,8 @@ export default class Table extends Component {
 
         [].forEach.call(rows, (row) => {
           [].forEach.call(row.cells, (cell, index) => {
-            cell.setAttribute('data-th', headerCells[index].innerText);
+            cell.setAttribute('data-th', 
+              headerCells[index].innerText || headerCells[index].textContent);
           });
         });
       }


### PR DESCRIPTION
#### What does this PR do?

Fixes Table cell headers (data-th attribute) in older Firefox versions.

#### What testing has been done on this PR?

Manual testing in Firefox & Chrome.

#### Any background context you want to provide?

Firefox added support for non-standard [innerText property](https://developer.mozilla.org/en-US/docs/Web/API/Node/innerText) only recently (v 45, March 2016). So, if relying on innerText only, cell header text ends up to be "undefined". (I happened to have a bit outdated Firefox install.)

Using textContent by default might [improve performance](http://perfectionkills.com/the-poor-misunderstood-innerText/#note-on-perf) significantly but it's not 100 % equivalent of innerText.

#### Do the grommet docs need to be updated?

No.

#### Is this change backwards compatible or is it a breaking change?

Compatible.