### PR TITLE
Updated Chart Axis styling.

### DIFF
--- a/__tests__/components/Chart-test.js
+++ b/__tests__/components/Chart-test.js
@@ -23,7 +23,7 @@ describe('Calendar', () => {
   it('has correct default options', () => {
     const component = renderer.create(
       <Chart vertical={false}>
-        <Axis vertical={true} ticks={true} count={5}
+        <Axis vertical={true} ticks={true} count={5} tickAlign="end"
           labels={
             [{"index": 2, "label": "50"}, {"index": 4, "label": "100"}]
           } />

--- a/__tests__/components/__snapshots__/Chart-test.js.snap
+++ b/__tests__/components/__snapshots__/Chart-test.js.snap
@@ -5,7 +5,7 @@ exports[`Calendar has correct default options 1`] = `
   role="group">
   <div
     aria-label="AxisLabel"
-    className="grommetux-chart-axis grommetux-chart-axis--vertical grommetux-chart-axis--align-end grommetux-chart-axis--ticks"
+    className="grommetux-chart-axis grommetux-chart-axis--vertical grommetux-chart-axis--align-end grommetux-chart-axis--ticks grommetux-chart-axis--ticks--end"
     id={undefined}
     role="rowgroup"
     style={
@@ -22,9 +22,7 @@ exports[`Calendar has correct default options 1`] = `
         Object {
           "flexBasis": "12.5%"
         }
-      }>
-      <span />
-    </div>
+      } />
     <div
       className="grommetux-chart-axis__slot"
       role={undefined}
@@ -32,9 +30,7 @@ exports[`Calendar has correct default options 1`] = `
         Object {
           "flexBasis": "12.5%"
         }
-      }>
-      <span />
-    </div>
+      } />
     <div
       className="grommetux-chart-axis__slot"
       role="row"
@@ -54,9 +50,7 @@ exports[`Calendar has correct default options 1`] = `
         Object {
           "flexBasis": "25%"
         }
-      }>
-      <span />
-    </div>
+      } />
     <div
       className="grommetux-chart-axis__slot"
       role="row"

--- a/__tests__/components/__snapshots__/Chart-test.js.snap
+++ b/__tests__/components/__snapshots__/Chart-test.js.snap
@@ -16,13 +16,15 @@ exports[`Calendar has correct default options 1`] = `
       }
     }>
     <div
-      className="grommetux-chart-axis__slot grommetux-chart-axis__slot--flip"
+      className="grommetux-chart-axis__slot"
       role={undefined}
       style={
         Object {
           "flexBasis": "12.5%"
         }
-      } />
+      }>
+      <span />
+    </div>
     <div
       className="grommetux-chart-axis__slot"
       role={undefined}
@@ -30,7 +32,9 @@ exports[`Calendar has correct default options 1`] = `
         Object {
           "flexBasis": "12.5%"
         }
-      } />
+      }>
+      <span />
+    </div>
     <div
       className="grommetux-chart-axis__slot"
       role="row"
@@ -39,7 +43,9 @@ exports[`Calendar has correct default options 1`] = `
           "flexBasis": "25%"
         }
       }>
-      50
+      <span>
+        50
+      </span>
     </div>
     <div
       className="grommetux-chart-axis__slot"
@@ -48,7 +54,9 @@ exports[`Calendar has correct default options 1`] = `
         Object {
           "flexBasis": "25%"
         }
-      } />
+      }>
+      <span />
+    </div>
     <div
       className="grommetux-chart-axis__slot"
       role="row"
@@ -57,7 +65,9 @@ exports[`Calendar has correct default options 1`] = `
           "flexBasis": "25%"
         }
       }>
-      100
+      <span>
+        100
+      </span>
     </div>
   </div>
   <div
@@ -385,14 +395,16 @@ exports[`Calendar has correct default options 1`] = `
         }
       }>
       <div
-        className="grommetux-chart-axis__slot grommetux-chart-axis__slot--flip"
+        className="grommetux-chart-axis__slot"
         role="row"
         style={
           Object {
             "flexBasis": "50%"
           }
         }>
-        2014
+        <span>
+          2014
+        </span>
       </div>
       <div
         className="grommetux-chart-axis__slot"
@@ -402,7 +414,9 @@ exports[`Calendar has correct default options 1`] = `
             "flexBasis": "50%"
           }
         }>
-        2015
+        <span>
+          2015
+        </span>
       </div>
     </div>
   </div>

--- a/src/js/components/chart/Axis.js
+++ b/src/js/components/chart/Axis.js
@@ -38,7 +38,6 @@ export default class Axis extends Component {
       }
       if (0 === index) {
         item.basis = basis / 2;
-        item.flip = true;
       } else if (1 === index) {
         item.basis = basis / 2;
       } else {
@@ -50,7 +49,8 @@ export default class Axis extends Component {
   }
 
   render () {
-    const { a11yTitle, align, reverse, ticks, vertical } = this.props;
+    const { a11yTitle, align, reverse, ticks, vertical, 
+      tickAlign } = this.props;
     const { items } = this.state;
     const { intl } = this.context;
 
@@ -67,6 +67,9 @@ export default class Axis extends Component {
     if (ticks) {
       classes.push(`${CLASS_ROOT}--ticks`);
     }
+    if (tickAlign) {
+      classes.push(`${CLASS_ROOT}--ticks--${tickAlign}`);
+    }
     if (this.props.className) {
       classes.push(this.props.className);
     }
@@ -74,9 +77,7 @@ export default class Axis extends Component {
     let elements = items.map(item => {
 
       let classes = [`${CLASS_ROOT}__slot`];
-      if (item.flip) {
-        classes.push(`${CLASS_ROOT}__slot--flip`);
-      }
+
       if (item.placeholder) {
         classes.push(`${CLASS_ROOT}__slot--placeholder`);
       }
@@ -88,7 +89,7 @@ export default class Axis extends Component {
         <div key={item.value || item.index}
           className={classes.join(' ')} role={role}
           style={{ flexBasis: `${item.basis}%` }}>
-          {item.label}
+          <span>{item.label}</span>
         </div>
       );
     });
@@ -122,5 +123,6 @@ Axis.propTypes = {
   })),
   reverse: PropTypes.bool,
   ticks: PropTypes.bool,
+  tickAlign: PropTypes.oneOf(['start', 'end']),
   vertical: PropTypes.bool
 };

--- a/src/js/components/chart/Axis.js
+++ b/src/js/components/chart/Axis.js
@@ -85,11 +85,13 @@ export default class Axis extends Component {
         classes.push(`${COLOR_INDEX}-${item.colorIndex}`);
       }
       const role = item.label && item.label !== '' ? 'row' : undefined;
+      const label = item.label ? <span>{item.label}</span> : null;
+      
       return (
         <div key={item.value || item.index}
           className={classes.join(' ')} role={role}
           style={{ flexBasis: `${item.basis}%` }}>
-          <span>{item.label}</span>
+          {label}
         </div>
       );
     });

--- a/src/scss/grommet-core/_objects.chart.scss
+++ b/src/scss/grommet-core/_objects.chart.scss
@@ -265,19 +265,17 @@
 
 .#{$grommet-namespace}chart-axis--ticks {
   .#{$grommet-namespace}chart-axis__slot {
-    border-color: $border-color;
-    border-width: 1px;
-
     #{$dark-background-context} & {
-      border-color: $colored-border-color;
+      &::before,
+      &::after {
+        background-color: $colored-border-color;
+      }
     }
   }
 }
 
 .#{$grommet-namespace}chart-axis--vertical {
   flex-direction: column-reverse;
-  // padding-top: round($inuit-base-spacing-unit / 3);
-  // padding-bottom: round($inuit-base-spacing-unit / 3);
   margin-left: halve($inuit-base-spacing-unit);
   margin-right: halve($inuit-base-spacing-unit);
 
@@ -285,8 +283,8 @@
     min-width: 1em;
     justify-content: flex-start;
 
-    &.#{$grommet-namespace}chart-axis__slot--flip {
-      justify-content: flex-end;
+    &:first-child {
+      flex-direction: column-reverse;
     }
   }
 
@@ -308,11 +306,24 @@
 
   &.#{$grommet-namespace}chart-axis--ticks {
     .#{$grommet-namespace}chart-axis__slot:not(.#{$grommet-namespace}chart-axis__slot--placeholder) {
-      border-top-style: solid;
+      &::before {
+        display: block;
+        content: "";
+        height: 1px;
+        width: halve(halve($inuit-base-spacing-unit));
+        background-color: $border-color;
+      }
+    }
 
-      &.#{$grommet-namespace}chart-axis__slot--flip {
-        border-top-style: none;
-        border-bottom-style: solid;
+    &.#{$grommet-namespace}chart-axis--ticks--start {
+      .#{$grommet-namespace}chart-axis__slot {
+        align-items: flex-start;
+      }
+    }
+
+    &.#{$grommet-namespace}chart-axis--ticks--end {
+      .#{$grommet-namespace}chart-axis__slot {
+        align-items: flex-end;
       }
     }
   }
@@ -321,22 +332,28 @@
     flex-direction: column;
 
     .#{$grommet-namespace}chart-axis__slot {
-      justify-content: flex-end;
+      justify-content: flex-start;
+      flex-direction: column-reverse;
 
-      &.#{$grommet-namespace}chart-axis__slot--flip {
+      &:first-child {
+        flex-direction: column;
+        justify-content: flex-start;
+      }
+
+      &:last-child {
         justify-content: flex-start;
       }
     }
 
-    &.#{$grommet-namespace}chart-axis--ticks {
+    &.#{$grommet-namespace}chart-axis--ticks--start {
       .#{$grommet-namespace}chart-axis__slot {
-        border-top-style: none;
-        border-bottom-style: solid;
+        align-items: flex-start;
+      }
+    }
 
-        &.#{$grommet-namespace}chart-axis__slot--flip {
-          border-top-style: solid;
-          border-bottom-style: none;
-        }
+    &.#{$grommet-namespace}chart-axis--ticks--end {
+      .#{$grommet-namespace}chart-axis__slot {
+        align-items: flex-end;
       }
     }
   }
@@ -344,26 +361,32 @@
 
 .#{$grommet-namespace}chart-axis:not(.#{$grommet-namespace}chart-axis--vertical) {
   flex-direction: row;
-  // padding-left: round($inuit-base-spacing-unit / 3);
-  // padding-right: round($inuit-base-spacing-unit / 3);
   margin-top: halve($inuit-base-spacing-unit);
   margin-bottom: halve($inuit-base-spacing-unit);
 
   .#{$grommet-namespace}chart-axis__slot {
     min-height: $inuit-base-spacing-unit;
-    align-items: flex-end;
+    align-items: flex-start;
+    justify-content: flex-end;
+    flex-direction: row;
 
-    &.#{$grommet-namespace}chart-axis__slot--flip {
+    &:first-child {
       align-items: flex-start;
+      flex-direction: row-reverse;
+      padding-left: 0;
+    }
+
+    &::after {
+      display: block;
+      content: "";
+      height: halve(halve($inuit-base-spacing-unit));
+      width: 1px;
+      background-color: $border-color;
     }
   }
 
   &.#{$grommet-namespace}chart-axis--align-start {
     align-items: flex-start;
-
-    .#{$grommet-namespace}chart-axis__slot {
-      justify-content: flex-start;
-    }
   }
 
   &.#{$grommet-namespace}chart-axis--align-end {
@@ -375,13 +398,21 @@
   }
 
   &.#{$grommet-namespace}chart-axis--ticks {
-    .#{$grommet-namespace}chart-axis__slot:not(.#{$grommet-namespace}chart-axis__slot--placeholder) {
-      border-right-style: solid;
-      padding: 0 quarter($inuit-base-spacing-unit);
+    &.#{$grommet-namespace}chart-axis--ticks--end {
+      .#{$grommet-namespace}chart-axis__slot:not(.#{$grommet-namespace}chart-axis__slot--placeholder) {
+        align-items: flex-end;
+      }
+    }
 
-      &.#{$grommet-namespace}chart-axis__slot--flip {
-        border-right-style: none;
-        border-left-style: solid;
+    &.#{$grommet-namespace}chart-axis--ticks--start {
+      .#{$grommet-namespace}chart-axis__slot:not(.#{$grommet-namespace}chart-axis__slot--placeholder) {
+        align-items: flex-start;
+      }
+    }
+
+    .#{$grommet-namespace}chart-axis__slot:not(.#{$grommet-namespace}chart-axis__slot--placeholder) {
+      span {
+        padding: 0 quarter($inuit-base-spacing-unit);
       }
     }
   }
@@ -391,20 +422,16 @@
 
     .#{$grommet-namespace}chart-axis__slot {
       align-items: flex-start;
-
-      &.#{$grommet-namespace}chart-axis__slot--flip {
-        align-items: flex-end;
-      }
     }
 
     &.#{$grommet-namespace}chart-axis--ticks {
       .#{$grommet-namespace}chart-axis__slot {
-        border-right-style: none;
-        border-left-style: solid;
+        align-items: flex-start;
+        justify-content: flex-end;
+        flex-direction: row-reverse;
 
-        &.#{$grommet-namespace}chart-axis__slot--flip {
-          border-right-style: solid;
-          border-left-style: none;
+        &:first-child {
+          flex-direction: row;
         }
       }
     }


### PR DESCRIPTION
#### What does this PR do?
This PR updates the Chart Axis component's styling.

#### Where should the reviewer start?
The reviewer can clone the latest changes and review in the grommet-docs application.

#### What testing has been done on this PR?
The Axis has been tested with the chart examples as well as various combinations during development.

#### How should this be manually tested?
grommet-docs would be a great starting point. To control the tick alignment I've added the property `tickAlign` to the Axis component. This prop can be either `start` or `end`, this adjusts the tick mark alignment so the tick marks can remain flush to the chart regardless of their orientation to the chart. An axis which should sit horizontally on a chart would look like the following `<Axis vertical={true} ticks={true} tickAlign="end" count={5} />`

#### Any background context you want to provide?
This is the approved styling which was decided upon during various Grommet based infographic projects.

#### What are the relevant issues?
None.

#### Screenshots (if appropriate)
![screen shot 2016-09-15 at 2 22 31 pm](https://cloud.githubusercontent.com/assets/5983843/18568464/749b180e-7b6b-11e6-9614-60b5bc5c97a6.png)

#### Do the grommet docs need to be updated?
Yes, once this has been approved I will update the chart examples in grommet-docs.

#### Should this PR be mentioned in the release notes?
Sure!

#### Is this change backwards compatible or is it a breaking change?
This change depreciates the `flip` property on the Axis component.  