### PR TITLE
Video Timeline + Icons

### DIFF
--- a/src/js/components/Video.js
+++ b/src/js/components/Video.js
@@ -129,6 +129,10 @@ export default class Video extends Component {
   }
 
   _seek(time) {
+    if (time === 0) {
+      return this._video.currentTime = time;
+    }
+
     this._video.currentTime = time || this._video.currentTime;
   }
 
@@ -180,6 +184,7 @@ export default class Video extends Component {
       mute: this._mute,
       unmute: this._unmute,
       seek: this._seek,
+      timeline: this.props.timeline,
       fullscreen: this._fullscreen,
       shareLink: this.props.shareLink,
       shareHeadline: this.props.shareHeadline,
@@ -223,8 +228,7 @@ export default class Video extends Component {
           {...this._mediaEventProps}>
           {this.props.children}
         </video>
-
-        {showControls ? this._renderControls() : undefined}
+        {showControls ? this._renderControls() : null}
       </div>
     );
   }

--- a/src/js/components/video/ProgressBar.js
+++ b/src/js/components/video/ProgressBar.js
@@ -1,6 +1,8 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
 import React, { Component, PropTypes } from 'react';
+import classnames from 'classnames';
+
 import Box from '../Box';
 import CSSClassnames from '../../utils/CSSClassnames';
 
@@ -23,14 +25,56 @@ export default class ProgressBar extends Component {
     this.props.onChange(e.target.value * this.props.duration / 100);
   }
 
+  _onChapterClick (time) {
+    this.props.onChange(time);
+  }
+
+  _onMouseOver (index) {
+    this.props.onChapterHover(index);
+  }
+
+  _renderChapterMarkers () {
+    const { timeline } = this.props;
+
+    if (timeline) {
+      let chapters = timeline.map((chapter, index, chapters) => {
+        let percent = (chapter.time / this.props.duration) * 100;
+        let tickClasses = classnames(
+          `${CLASS_ROOT}__chapter-marker-tick`,
+          {
+            [`${CLASS_ROOT}__chapter-marker-tick-start`]: percent === 0
+          }
+        );
+
+        return (
+          <div className={`${CLASS_ROOT}__chapter-marker`} key={chapter.time}
+            style={{width: percent + '%'}}>
+            <div className={tickClasses}
+              onMouseOver={this._onMouseOver.bind(this, index)}
+              onMouseOut={this.props.onChapterHover}
+              onClick={this._onChapterClick.bind(this, chapter.time)} />
+            <div className={`${CLASS_ROOT}__chapter-marker-track`} />
+          </div>
+        );
+      });
+
+      return (
+        <div className={`${CLASS_ROOT}__chapter-markers`}>
+          {chapters}
+        </div>
+      );
+    }
+  }
+
   render () {
-    const { progress } = this.props;
+    const { progress, timeline } = this.props;
 
     return (
       <Box pad="none" className={`${CLASS_ROOT}__progress`} direction="row">
         <div className={`${CLASS_ROOT}__progress-bar-fill`} style={{
           width: progress + '%'
         }} />
+        {timeline ? this._renderChapterMarkers() : undefined}
         <input className={`${CLASS_ROOT}__progress-bar-input`}
           onChange={this._onProgressBarChange}
           type="range"
@@ -46,7 +90,8 @@ export default class ProgressBar extends Component {
 ProgressBar.propTypes = {
   onClick: PropTypes.func,
   duration: PropTypes.number,
-  progress: PropTypes.number
+  progress: PropTypes.number,
+  onChapterHover: PropTypes.func
 };
 
 ProgressBar.defaultProps = {

--- a/src/js/components/video/Time.js
+++ b/src/js/components/video/Time.js
@@ -5,24 +5,11 @@ import React, { Component, PropTypes } from 'react';
 import Box from '../Box';
 import Heading from '../Heading';
 import CSSClassnames from '../../utils/CSSClassnames';
+import FormatTime from '../../utils/FormatTime';
 
 const CLASS_ROOT = CSSClassnames.VIDEO;
 
 export default class Time extends Component {
-
-  _formatTime (seconds) {
-    const date = new Date(null);
-    seconds = isNaN(seconds) ? 0 : Math.floor(seconds);
-    date.setSeconds(seconds);
-
-    const dateISOString = date.toISOString();
-    let time = dateISOString.substr(11, 8);
-    if (seconds < 3600) {
-      time = dateISOString.substr(14, 5);
-    }
-
-    return time;
-  }
 
   render () {
     const { currentTime, duration } = this.props;
@@ -30,7 +17,7 @@ export default class Time extends Component {
     return (
       <Box pad={{ horizontal: 'small', vertical: 'none' }}>
         <Heading tag="h3" margin="none" className={`${CLASS_ROOT}__time`}>
-          {this._formatTime(currentTime)} / {this._formatTime(duration)}
+          {FormatTime(currentTime)} / {FormatTime(duration)}
         </Heading>
       </Box>
     );

--- a/src/js/utils/FormatTime.js
+++ b/src/js/utils/FormatTime.js
@@ -1,0 +1,13 @@
+export default function (seconds) {
+  const date = new Date(null);
+  seconds = isNaN(seconds) ? 0 : Math.floor(seconds);
+  date.setSeconds(seconds);
+
+  const dateISOString = date.toISOString();
+  let time = dateISOString.substr(11, 8);
+  if (seconds < 3600) {
+    time = dateISOString.substr(14, 5);
+  }
+
+  return time;
+}

--- a/src/scss/grommet-core/_objects.button.scss
+++ b/src/scss/grommet-core/_objects.button.scss
@@ -89,6 +89,19 @@ $button-horizontal-padding: round($inuit-base-spacing-unit) - $button-border-wid
       @include icon-color($colored-icon-color);
     }
 
+    .#{$grommet-namespace}video__controls-primary &,
+    &.#{$grommet-namespace}video__play {
+      .#{$grommet-namespace}control-icon {
+        @include icon-color($inverse-color);
+        opacity: 0.7;
+      }
+
+      .#{$grommet-namespace}control-icon:hover,
+      &:hover .#{$grommet-namespace}control-icon {
+        opacity: 1;
+      }
+    }
+
     &:hover:not(.#{$grommet-namespace}button--disabled) {
       color: $active-colored-text-color;
 

--- a/src/scss/grommet-core/_objects.video.scss
+++ b/src/scss/grommet-core/_objects.video.scss
@@ -77,6 +77,7 @@
     height: round($inuit-base-spacing-unit * 3);
     background-color: rgba(nth($brand-grey-colors, 1), 0.9);
     color: $inverse-color;
+    // transition: 0.4s ease-in-out;
 
     .#{$grommet-namespace}button--primary {
       background-color: transparent;
@@ -117,11 +118,25 @@
     background-color: lighten(rgba(nth($brand-grey-colors, 3), 0.7), 20%);
     transition: height 0.3s;
 
+    & + .#{$grommet-namespace}video__chapter-labels,
+    & ~ .#{$grommet-namespace}video__controls-primary {
+      transition: ease-in-out 0.3s;
+    }  
+
     &:hover {
       height: halve($inuit-base-spacing-unit);
 
       .#{$grommet-namespace}video__progress-bar-fill:after {
         opacity: 1;
+      }
+
+      & + .#{$grommet-namespace}video__chapter-labels {
+        visibility: visible;
+      }
+
+      & ~ .#{$grommet-namespace}video__controls-primary {
+        visibility: hidden;
+        opacity: 0;
       }
     }
 
@@ -139,6 +154,7 @@
       border: none;
       cursor: pointer;
       outline: none;
+      z-index: 30;
     }
   }
 
@@ -150,6 +166,7 @@
     bottom: 0;
     left: 0;
     transition: width 0.3s;
+    z-index: 10;
 
     &:after {
       content: '';
@@ -163,12 +180,100 @@
       border-radius: double($inuit-base-spacing-unit);
       opacity: 0;
       transition: opacity 0.4s ease-in-out;
+      z-index: 20;
+    }
+  }
+
+  &__chapter-labels {
+    position: absolute;
+    bottom: 0px;
+    width: 100%;
+    height: round($inuit-base-spacing-unit * 3);
+    visibility: hidden;
+    background-color: rgba(nth($brand-grey-colors, 1), 0.9);
+    transition: 0.4s ease-in-out;
+
+    span {
+      display: block;
+      color: $colored-text-color;
+    }
+  }
+
+  &__chapter-label {
+    position: absolute;
+    top: halve($inuit-base-spacing-unit);
+
+    &-start {
+      span {
+        margin-left: halve($inuit-base-spacing-unit);
+      }
+    }
+
+    &-active {
+      span {
+        $brand-accent-color-index: 3;
+        @if ($brand-accent-color-index <= length($brand-accent-colors)) {
+          $chapter-current-color: nth($brand-accent-colors, $brand-accent-color-index);
+          color: $chapter-current-color;
+        } @else {
+          $chapter-current-color: $brand-color;
+          color: $chapter-current-color;
+        }
+
+        transition: ease-in-out 0.3s;
+      }
+    }
+  }
+
+  &__chapter-marker {
+    position: absolute;
+    height: 100%;
+    left: 0px;
+
+    &-track {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      transition: ease-in-out 0.3s;
+    }
+
+    &-tick:hover + &-track {
+      background-color: lighten(rgba(nth($brand-grey-colors, 3), 0.7), 40%);
+    }
+
+    &-tick {
+      position: absolute;
+      right: -3px;
+      width: 3px;
+      height: 100%;
+      z-index: 40;
+      transition: ease-in-out 0.3s;
+
+      $brand-accent-color-index: 3;
+      @if ($brand-accent-color-index <= length($brand-accent-colors)) {
+        $chapter-current-color: nth($brand-accent-colors, $brand-accent-color-index);
+        background-color: $chapter-current-color;
+      } @else {
+        $chapter-current-color: $brand-color;
+        background-color: $chapter-current-color;
+      }
+
+      &-start {
+        right: auto;
+        left: 0px;
+      }
+
+      &:hover {
+        width: 8px;
+        right: -8px;
+      }
     }
   }
 
   &--playing {
     &:not(.#{$grommet-namespace}video--interacting) {
       .#{$grommet-namespace}video__controls-primary,
+      .#{$grommet-namespace}video__chapter-labels,
       .#{$grommet-namespace}video__overlay {
         opacity: 0;
         transition: opacity 1s ease-in-out;

--- a/src/scss/grommet-core/_objects.video.scss
+++ b/src/scss/grommet-core/_objects.video.scss
@@ -77,7 +77,6 @@
     height: round($inuit-base-spacing-unit * 3);
     background-color: rgba(nth($brand-grey-colors, 1), 0.9);
     color: $inverse-color;
-    // transition: 0.4s ease-in-out;
 
     .#{$grommet-namespace}button--primary {
       background-color: transparent;
@@ -107,6 +106,7 @@
     border-width: 2px;
     border-style: solid;
     background-color: transparent;
+    color: $colored-icon-color;
   }
 
   &__progress {
@@ -121,7 +121,7 @@
     & + .#{$grommet-namespace}video__chapter-labels,
     & ~ .#{$grommet-namespace}video__controls-primary {
       transition: ease-in-out 0.3s;
-    }  
+    }
 
     &:hover {
       height: halve($inuit-base-spacing-unit);
@@ -216,8 +216,7 @@
           $chapter-current-color: nth($brand-accent-colors, $brand-accent-color-index);
           color: $chapter-current-color;
         } @else {
-          $chapter-current-color: $brand-color;
-          color: $chapter-current-color;
+          color: $inverse-color;
         }
 
         transition: ease-in-out 0.3s;
@@ -248,14 +247,14 @@
       height: 100%;
       z-index: 40;
       transition: ease-in-out 0.3s;
+      cursor: pointer;
 
       $brand-accent-color-index: 3;
       @if ($brand-accent-color-index <= length($brand-accent-colors)) {
         $chapter-current-color: nth($brand-accent-colors, $brand-accent-color-index);
         background-color: $chapter-current-color;
       } @else {
-        $chapter-current-color: $brand-color;
-        background-color: $chapter-current-color;
+        background-color: $inverse-color;
       }
 
       &-start {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds video timeline based on designs:
* https://hp.invisionapp.com/d/main#/projects/8585265
* https://hp.invisionapp.com/share/PR8KJIGA8

**_Video Component Updates_**:
* when timeline ticks are clicked, set video to selected time
* when timeline ticks are hovered, set labels to active color, and highlight progress bar track until tick mark
* transition between primary controls (bottom bar) and timeline labels when progress bar hovered
* adding separate styles (extra left padding for labels, positioning for ticks) for chapter times set at 0:00.
* changing colors from accent to inverse (white) for progress bar ticks in grommet theme (but keeping accent colors for hpe theme).
* fixing video icon colors:
  * using opacity to set colors for play/pause/refresh icons in Video component (otherwise rgba creates strokes on overlapping paths)
  * aligning hovers on play button circle outline with play icon
* moving _formatTime to separate util function (FormatTime.js)

#### What testing has been done on this PR?
Tested PR against grommet-docs video examples in Chrome, Firefox, and Safari.

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/809

#### Screenshots (if appropriate)
**_grommet-theme video timeline:_**
![screen shot 2016-09-15 at 4 10 57 pm](https://cloud.githubusercontent.com/assets/10161095/18573470/8270ed8e-7b5f-11e6-952f-e9e21b11b594.png)

**_hpe-theme video timeline:_**
![screen shot 2016-09-15 at 4 13 16 pm](https://cloud.githubusercontent.com/assets/10161095/18573471/8272a23c-7b5f-11e6-9746-fa2f38035d80.png)

#### Do the grommet docs need to be updated?
No.

#### Is this change backwards compatible or is it a breaking change?
May break custom styles for video player/player icon.