### PR TITLE
Adds onChange prop to the LoginForm

### DIFF
--- a/__tests__/components/LoginForm-test.js
+++ b/__tests__/components/LoginForm-test.js
@@ -17,4 +17,21 @@ describe('LoginForm', () => {
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('onChange behaves properly', () => {
+    const onChangeFn = jest.fn();
+    const component = renderer.create(
+      <LoginForm onSubmit={() => {}} onChange={onChangeFn} />
+    );
+
+    component.getInstance()._onUsernameChange(
+      { target: { value: 'will@isthecoolest.com' }});
+    component.getInstance()._onPasswordChange(
+      { target: { value: 'm0desty' }});
+    component.getInstance()._onRememberMeChange(
+      { target: { value: true }});
+
+    expect(onChangeFn.mock.calls.length).toBe(3);
+    expect(onChangeFn.mock.calls[0][0].username).toBe('will@isthecoolest.com');
+  });
 });

--- a/src/js/components/LoginForm.js
+++ b/src/js/components/LoginForm.js
@@ -26,6 +26,7 @@ export default class LoginForm extends Component {
     this._onUsernameChange = this._onUsernameChange.bind(this);
     this._onPasswordChange = this._onPasswordChange.bind(this);
     this._onRememberMeChange = this._onRememberMeChange.bind(this);
+    this._onChange = this._onChange.bind(this);
 
     this.state = {
       password: '',
@@ -40,16 +41,30 @@ export default class LoginForm extends Component {
     }
   }
 
+  _onChange (args) {
+    const { onChange } = this.props;
+
+    if (onChange) {
+      onChange(args);
+    }
+  }
+
   _onUsernameChange (event) {
-    this.setState({ username: event.target.value });
+    const username = event.target.value;
+    this.setState({ username });
+    this._onChange({ event, username });
   }
 
   _onPasswordChange (event) {
-    this.setState({ password: event.target.value });
+    const password = event.target.value;
+    this.setState({ password });
+    this._onChange({ event, password });
   }
 
   _onRememberMeChange (event) {
-    this.setState({ rememberMe: event.target.checked });
+    const rememberMe = event.target.checked;
+    this.setState({ rememberMe });
+    this._onChange({ event, rememberMe });
   }
 
   _onSubmit (event) {
@@ -163,6 +178,7 @@ LoginForm.propTypes = {
   forgotPassword: PropTypes.node,
   logo: PropTypes.node,
   onSubmit: PropTypes.func,
+  onChange: PropTypes.func,
   rememberMe: PropTypes.bool,
   secondaryText: PropTypes.string,
   title: PropTypes.string,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds an optional create account button to the LoginForm. Also adds a small convenience property to LoginForm for onFieldChange events.

#### Where should the reviewer start?

Smallish change, so I would just review the code and make sure existing login pages don't break.

#### What testing has been done on this PR?

Tested manually using our own login page with and without create account buttons and with and without the field change function.

#### How should this be manually tested?

Check that login pages still work as expected and then add an empty create account function and see that it still works.

#### Any background context you want to provide?

We are currently running in production with a modified LoginForm component manually checked into our repo. We would love for this to get in because we need the ability to have our users create an account.

#### What are the relevant issues?

#### Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/169011/18588608/2ae10ba8-7bf5-11e6-8e39-7938ecf5f552.png)

#### Do the grommet docs need to be updated?

Yes.

#### Should this PR be mentioned in the release notes?

Probably?

#### Is this change backwards compatible or is it a breaking change?

Fully backwards compatible.

… LoginForm.