### PR TITLE
Feat: add form test and snapshots

### DIFF
--- a/__tests__/components/Form-test.js
+++ b/__tests__/components/Form-test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import renderer from 'react/lib/ReactTestRenderer';
+
+import Form from '../../src/js/components/Form';
+import FormFields from '../../src/js/components/FormFields';
+import FormField from '../../src/js/components/FormField';
+
+// needed because this:
+// https://github.com/facebook/jest/issues/1353
+jest.mock('react-dom');
+
+describe('Form', () => {
+  it('has correct default options', () => {
+    const component = renderer.create(
+      <Form
+        onSubmit={(e) => e}>
+        <FormFields>
+          <FormField label="Item 1" htmlFor="item1">
+            <input id="item1" type="text" />
+          </FormField>
+        </FormFields>
+      </Form>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with alternate props', () => {
+    const component = renderer.create(
+      <Form pad={{ horizontal: 'large', vertical: 'large'}}
+        compact fill onSubmit={(e) => e}>
+        <FormFields>
+          <FormField label="Item 1" htmlFor="item1">
+            <input id="item1" type="text" />
+          </FormField>
+        </FormFields>
+      </Form>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/__tests__/components/Notification-test.js
+++ b/__tests__/components/Notification-test.js
@@ -1,0 +1,61 @@
+// (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
+
+import React from 'react';
+import renderer from 'react/lib/ReactTestRenderer';
+
+import Notification from '../../src/js/components/Notification';
+
+// needed because this:
+// https://github.com/facebook/jest/issues/1353
+jest.mock('react-dom');
+
+describe('Notification', () => {
+  it('has correct default options', () => {
+    const component = renderer.create(
+      <Notification message="You will need a tray. The food is hot." />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with status option given', () => {
+    const component = renderer.create(
+      <Notification status="warning"
+        message="You will need a tray. The food is hot." />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with closer set to true', () => {
+    const component = renderer.create(
+      <Notification closer
+        message="You will need a tray. The food is hot." />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with closer set to true', () => {
+    const component = renderer.create(
+      <Notification flush
+        message="You will need a tray. The food is hot." />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with padding set', () => {
+    const component = renderer.create(
+      <Notification padding={{ horizontal: 'large', vertical: 'large' }}
+        message="You will need a tray. The food is hot." />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with a padding', () => {
+    const component = renderer.create(
+      <Notification flush closer status="critical"
+        padding={{ horizontal: 'medium', vertical: 'medium' }}
+        message="You will need a tray. The food is hot." />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/__tests__/components/Notification-test.js
+++ b/__tests__/components/Notification-test.js
@@ -14,7 +14,7 @@ describe('Notification', () => {
     const component = renderer.create(
       <Notification message="You will need a tray. The food is hot." />
     );
-    let tree = component.toJSON();
+    const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
   it('renders with status option given', () => {
@@ -22,7 +22,7 @@ describe('Notification', () => {
       <Notification status="warning"
         message="You will need a tray. The food is hot." />
     );
-    let tree = component.toJSON();
+    const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
   it('renders with closer set to true', () => {
@@ -30,7 +30,7 @@ describe('Notification', () => {
       <Notification closer
         message="You will need a tray. The food is hot." />
     );
-    let tree = component.toJSON();
+    const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
   it('renders with closer set to true', () => {
@@ -38,7 +38,7 @@ describe('Notification', () => {
       <Notification flush
         message="You will need a tray. The food is hot." />
     );
-    let tree = component.toJSON();
+    const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
   it('renders with padding set', () => {
@@ -46,7 +46,7 @@ describe('Notification', () => {
       <Notification padding={{ horizontal: 'large', vertical: 'large' }}
         message="You will need a tray. The food is hot." />
     );
-    let tree = component.toJSON();
+    const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
   it('renders with a padding', () => {
@@ -55,7 +55,7 @@ describe('Notification', () => {
         padding={{ horizontal: 'medium', vertical: 'medium' }}
         message="You will need a tray. The food is hot." />
     );
-    let tree = component.toJSON();
+    const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/__tests__/components/__snapshots__/Form-test.js.snap
+++ b/__tests__/components/__snapshots__/Form-test.js.snap
@@ -1,0 +1,49 @@
+exports[`Form has correct default options 1`] = `
+<form
+  className="grommetux-form grommetux-form--pad-none"
+  onSubmit={[Function onSubmit]}>
+  <div
+    className="grommetux-form-fields">
+    <div
+      className="grommetux-form-field grommetux-form-field--text grommetux-form-field--size-medium"
+      onClick={[Function bound _onClick]}>
+      <label
+        className="grommetux-form-field__label"
+        htmlFor="item1">
+        Item 1
+      </label>
+      <span
+        className="grommetux-form-field__contents">
+        <input
+          id="item1"
+          type="text" />
+      </span>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`Form renders with alternate props 1`] = `
+<form
+  className="grommetux-form grommetux-form--compact grommetux-form--fill grommetux-form--pad-horizontal-large grommetux-form--pad-vertical-large"
+  onSubmit={[Function onSubmit]}>
+  <div
+    className="grommetux-form-fields">
+    <div
+      className="grommetux-form-field grommetux-form-field--text grommetux-form-field--size-medium"
+      onClick={[Function bound _onClick]}>
+      <label
+        className="grommetux-form-field__label"
+        htmlFor="item1">
+        Item 1
+      </label>
+      <span
+        className="grommetux-form-field__contents">
+        <input
+          id="item1"
+          type="text" />
+      </span>
+    </div>
+  </div>
+</form>
+`;

--- a/__tests__/components/__snapshots__/Notification-test.js.snap
+++ b/__tests__/components/__snapshots__/Notification-test.js.snap
@@ -1,0 +1,346 @@
+exports[`Notification has correct default options 1`] = `
+<div
+  className={undefined}
+  style={Object {}}>
+  <div
+    className="grommetux-box grommetux-box--full-horizontal grommetux-box--direction-row grommetux-box--align-start grommetux-box--pad-small grommetux-notification grommetux-notification--status-unknown grommetux-background-color-index-unknown grommetux-notification--disabled"
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}>
+    <div
+      className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <svg
+        aria-labelledby="unknown-title"
+        className="grommetux-status-icon grommetux-status-icon-unknown grommetux-notification__status"
+        role="img"
+        version="1.1"
+        viewBox="0 0 24 24">
+        <title
+          id="unknown-title">
+          <span
+            id="Unknown">
+            Unknown
+          </span>
+        </title>
+        <g
+          className="grommetux-status-icon__base">
+          <path
+            d="M12,2 C17.5,2 22,6.5 22,12 C22,17.5 17.5,22 12,22 C6.5,22 2,17.5 2,12 C2,6.5 6.5,2 12,2 L12,2 Z M12,0 C5.4,0 0,5.4 0,12 C0,18.6 5.4,24 12,24 C18.6,24 24,18.6 24,12 C24,5.4 18.6,0 12,0 L12,0 L12,0 Z"
+            role="presentation"
+            stroke="none" />
+        </g>
+        <g
+          className="grommetux-status-icon__detail">
+          <path
+            d="M9,10.4 C9,8.8 10.4,7.6 12,7.6 C13.6,7.6 14.9,9 15,10.4 C15,11.7 14.1,12.7 12.9,13.1 C12.4,13.2 12,13.7 12,14.2 L12,15.5"
+            fill="none"
+            role="presentation"
+            strokeWidth="2" />
+          <circle
+            cx="12"
+            cy="17.6"
+            r="1"
+            role="presentation"
+            stroke="none" />
+        </g>
+      </svg>
+    </div>
+    <div
+      className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--flex grommetux-box--pad-small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <span
+        className="grommetux-notification__message">
+        You will need a tray. The food is hot.
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Notification renders with a padding 1`] = `
+<div
+  className={undefined}
+  style={Object {}}>
+  <div
+    className="grommetux-box grommetux-box--full-horizontal grommetux-box--direction-row grommetux-box--align-start grommetux-box--pad-small grommetux-notification grommetux-notification--status-critical grommetux-background-color-index-critical grommetux-notification--disabled"
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}>
+    <div
+      className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <svg
+        aria-labelledby="critical-title"
+        className="grommetux-status-icon grommetux-status-icon-critical grommetux-notification__status"
+        role="img"
+        version="1.1"
+        viewBox="0 0 24 24">
+        <title
+          id="critical-title">
+          <span
+            id="Critical">
+            Critical
+          </span>
+        </title>
+        <g
+          className="grommetux-status-icon__base"
+          stroke="none">
+          <path
+            d="M12,0 L24,12 L12,24 L0,12 Z"
+            role="presentation" />
+        </g>
+        <g
+          className="grommetux-status-icon__detail"
+          fill="none">
+          <path
+            d="M8,8 L16,16"
+            role="presentation"
+            strokeWidth="2" />
+          <path
+            d="M8,16 L16,8"
+            role="presentation"
+            strokeWidth="2" />
+        </g>
+      </svg>
+    </div>
+    <div
+      className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--flex grommetux-box--pad-small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <span
+        className="grommetux-notification__message">
+        You will need a tray. The food is hot.
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Notification renders with closer set to true 1`] = `
+<div
+  className={undefined}
+  style={Object {}}>
+  <div
+    className="grommetux-box grommetux-box--full-horizontal grommetux-box--direction-row grommetux-box--align-start grommetux-box--pad-small grommetux-notification grommetux-notification--status-unknown grommetux-background-color-index-unknown grommetux-notification--disabled"
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}>
+    <div
+      className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <svg
+        aria-labelledby="unknown-title"
+        className="grommetux-status-icon grommetux-status-icon-unknown grommetux-notification__status"
+        role="img"
+        version="1.1"
+        viewBox="0 0 24 24">
+        <title
+          id="unknown-title">
+          <span
+            id="Unknown">
+            Unknown
+          </span>
+        </title>
+        <g
+          className="grommetux-status-icon__base">
+          <path
+            d="M12,2 C17.5,2 22,6.5 22,12 C22,17.5 17.5,22 12,22 C6.5,22 2,17.5 2,12 C2,6.5 6.5,2 12,2 L12,2 Z M12,0 C5.4,0 0,5.4 0,12 C0,18.6 5.4,24 12,24 C18.6,24 24,18.6 24,12 C24,5.4 18.6,0 12,0 L12,0 L12,0 Z"
+            role="presentation"
+            stroke="none" />
+        </g>
+        <g
+          className="grommetux-status-icon__detail">
+          <path
+            d="M9,10.4 C9,8.8 10.4,7.6 12,7.6 C13.6,7.6 14.9,9 15,10.4 C15,11.7 14.1,12.7 12.9,13.1 C12.4,13.2 12,13.7 12,14.2 L12,15.5"
+            fill="none"
+            role="presentation"
+            strokeWidth="2" />
+          <circle
+            cx="12"
+            cy="17.6"
+            r="1"
+            role="presentation"
+            stroke="none" />
+        </g>
+      </svg>
+    </div>
+    <div
+      className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--flex grommetux-box--pad-small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <span
+        className="grommetux-notification__message">
+        You will need a tray. The food is hot.
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Notification renders with padding set 1`] = `
+<div
+  className={undefined}
+  style={Object {}}>
+  <div
+    className="grommetux-box grommetux-box--full-horizontal grommetux-box--direction-row grommetux-box--align-start grommetux-box--pad-small grommetux-notification grommetux-notification--status-unknown grommetux-background-color-index-unknown grommetux-notification--disabled"
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}>
+    <div
+      className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <svg
+        aria-labelledby="unknown-title"
+        className="grommetux-status-icon grommetux-status-icon-unknown grommetux-notification__status"
+        role="img"
+        version="1.1"
+        viewBox="0 0 24 24">
+        <title
+          id="unknown-title">
+          <span
+            id="Unknown">
+            Unknown
+          </span>
+        </title>
+        <g
+          className="grommetux-status-icon__base">
+          <path
+            d="M12,2 C17.5,2 22,6.5 22,12 C22,17.5 17.5,22 12,22 C6.5,22 2,17.5 2,12 C2,6.5 6.5,2 12,2 L12,2 Z M12,0 C5.4,0 0,5.4 0,12 C0,18.6 5.4,24 12,24 C18.6,24 24,18.6 24,12 C24,5.4 18.6,0 12,0 L12,0 L12,0 Z"
+            role="presentation"
+            stroke="none" />
+        </g>
+        <g
+          className="grommetux-status-icon__detail">
+          <path
+            d="M9,10.4 C9,8.8 10.4,7.6 12,7.6 C13.6,7.6 14.9,9 15,10.4 C15,11.7 14.1,12.7 12.9,13.1 C12.4,13.2 12,13.7 12,14.2 L12,15.5"
+            fill="none"
+            role="presentation"
+            strokeWidth="2" />
+          <circle
+            cx="12"
+            cy="17.6"
+            r="1"
+            role="presentation"
+            stroke="none" />
+        </g>
+      </svg>
+    </div>
+    <div
+      className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--flex grommetux-box--pad-small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <span
+        className="grommetux-notification__message">
+        You will need a tray. The food is hot.
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Notification renders with status option given 1`] = `
+<div
+  className={undefined}
+  style={Object {}}>
+  <div
+    className="grommetux-box grommetux-box--full-horizontal grommetux-box--direction-row grommetux-box--align-start grommetux-box--pad-small grommetux-notification grommetux-notification--status-warning grommetux-background-color-index-warning grommetux-notification--disabled"
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}>
+    <div
+      className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <svg
+        aria-labelledby="warning-title"
+        className="grommetux-status-icon grommetux-status-icon-warning grommetux-notification__status"
+        role="img"
+        version="1.1"
+        viewBox="0 0 24 24">
+        <title
+          id="warning-title">
+          <span
+            id="Warning">
+            Warning
+          </span>
+        </title>
+        <g
+          className="grommetux-status-icon__base">
+          <path
+            d="M12,0 L0,22 L24,22 L12,0 L12,0 Z"
+            role="presentation"
+            stroke="none" />
+        </g>
+        <g
+          className="grommetux-status-icon__detail"
+          strokeWidth="2"
+          transform="translate(11.000000, 8.000000)">
+          <path
+            d="M1,0 L1,6"
+            fill="none"
+            role="presentation" />
+          <path
+            d="M1,8 L1,10"
+            fill="none"
+            role="presentation" />
+        </g>
+      </svg>
+    </div>
+    <div
+      className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--flex grommetux-box--pad-small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <span
+        className="grommetux-notification__message">
+        You will need a tray. The food is hot.
+      </span>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
It adds a test for the Form and Notification components (More coming!).

#### Where should the reviewer start?
__tests__/components/Form-test.js
__tests__/components/Notification-test.js

#### What testing has been done on this PR?
Ran gulp test before and after snapshot generation

#### How should this be manually tested?
gulp test, also the coveralls should increase

#### Any background context you want to provide?
N/A

#### What are the relevant issues?
N/A

#### Screenshots (if appropriate)
N/A

#### Do the grommet docs need to be updated?
N/A

#### Should this PR be mentioned in the release notes?
N/A

#### Is this change backwards compatible or is it a breaking change?
N/A

