### PR TITLE
IE11 select options: dark background context fix

### DIFF
--- a/__tests__/components/__snapshots__/Accordion-test.js.snap
+++ b/__tests__/components/__snapshots__/Accordion-test.js.snap
@@ -21,7 +21,7 @@ exports[`Accordion has correct default options 1`] = `
       First Title
       <svg
         aria-labelledby="tab-next-title"
-        className="grommetux-control-icon grommetux-control-icon-tab-next grommetux-accordion-panel__control"
+        className="grommetux-control-icon grommetux-control-icon-tab-next grommetux-accordion-panel__control grommetux-control-icon--responsive"
         height="24px"
         role="img"
         version="1.1"
@@ -79,7 +79,7 @@ exports[`Accordion has correct initialIndex=0 rendering 1`] = `
       First Title
       <svg
         aria-labelledby="tab-next-title"
-        className="grommetux-control-icon grommetux-control-icon-tab-next grommetux-accordion-panel__control"
+        className="grommetux-control-icon grommetux-control-icon-tab-next grommetux-accordion-panel__control grommetux-control-icon--responsive"
         height="24px"
         role="img"
         version="1.1"
@@ -141,7 +141,7 @@ exports[`Accordion has correct initialIndex=0 rendering 1`] = `
       Second Title
       <svg
         aria-labelledby="tab-next-title"
-        className="grommetux-control-icon grommetux-control-icon-tab-next grommetux-accordion-panel__control"
+        className="grommetux-control-icon grommetux-control-icon-tab-next grommetux-accordion-panel__control grommetux-control-icon--responsive"
         height="24px"
         role="img"
         version="1.1"
@@ -199,7 +199,7 @@ exports[`Accordion has correct initialIndex=0 rendering 2`] = `
       First Title
       <svg
         aria-labelledby="tab-next-title"
-        className="grommetux-control-icon grommetux-control-icon-tab-next grommetux-accordion-panel__control"
+        className="grommetux-control-icon grommetux-control-icon-tab-next grommetux-accordion-panel__control grommetux-control-icon--responsive"
         height="24px"
         role="img"
         version="1.1"
@@ -261,7 +261,7 @@ exports[`Accordion has correct initialIndex=0 rendering 2`] = `
       Second Title
       <svg
         aria-labelledby="tab-next-title"
-        className="grommetux-control-icon grommetux-control-icon-tab-next grommetux-accordion-panel__control"
+        className="grommetux-control-icon grommetux-control-icon-tab-next grommetux-accordion-panel__control grommetux-control-icon--responsive"
         height="24px"
         role="img"
         version="1.1"
@@ -331,7 +331,7 @@ exports[`Accordion has correct openMulti=true rendering 1`] = `
       First Title
       <svg
         aria-labelledby="tab-next-title"
-        className="grommetux-control-icon grommetux-control-icon-tab-next grommetux-accordion-panel__control"
+        className="grommetux-control-icon grommetux-control-icon-tab-next grommetux-accordion-panel__control grommetux-control-icon--responsive"
         height="24px"
         role="img"
         version="1.1"
@@ -393,7 +393,7 @@ exports[`Accordion has correct openMulti=true rendering 1`] = `
       Second Title
       <svg
         aria-labelledby="tab-next-title"
-        className="grommetux-control-icon grommetux-control-icon-tab-next grommetux-accordion-panel__control"
+        className="grommetux-control-icon grommetux-control-icon-tab-next grommetux-accordion-panel__control grommetux-control-icon--responsive"
         height="24px"
         role="img"
         version="1.1"

--- a/__tests__/components/__snapshots__/Anchor-test.js.snap
+++ b/__tests__/components/__snapshots__/Anchor-test.js.snap
@@ -106,7 +106,7 @@ exports[`Anchor has correct primary=true rendering 1`] = `
   target={undefined}>
   <svg
     aria-labelledby="undefined-icon"
-    className="grommetux-control-icon grommetux-control-icon-link-next"
+    className="grommetux-control-icon grommetux-control-icon-link-next grommetux-control-icon--responsive"
     height="24px"
     role="img"
     version="1.1"

--- a/__tests__/components/__snapshots__/Calendar-test.js.snap
+++ b/__tests__/components/__snapshots__/Calendar-test.js.snap
@@ -19,7 +19,7 @@ exports[`Calendar has correct default options 1`] = `
       className="grommetux-button__icon">
       <svg
         aria-labelledby="calendar-icon-title-id"
-        className="grommetux-control-icon grommetux-control-icon-calendar"
+        className="grommetux-control-icon grommetux-control-icon-calendar grommetux-control-icon--responsive"
         height="24px"
         role="img"
         version="1.1"

--- a/__tests__/components/__snapshots__/Carousel-test.js.snap
+++ b/__tests__/components/__snapshots__/Carousel-test.js.snap
@@ -52,7 +52,7 @@ exports[`Carousel has correct default options 1`] = `
       className="grommetux-button__icon">
       <svg
         aria-labelledby="previous-title"
-        className="grommetux-control-icon grommetux-control-icon-previous grommetux-control-icon--large"
+        className="grommetux-control-icon grommetux-control-icon-previous grommetux-control-icon--large grommetux-control-icon--responsive"
         height="24px"
         role="img"
         version="1.1"
@@ -93,7 +93,7 @@ exports[`Carousel has correct default options 1`] = `
       className="grommetux-button__icon">
       <svg
         aria-labelledby="next-title"
-        className="grommetux-control-icon grommetux-control-icon-next grommetux-control-icon--large"
+        className="grommetux-control-icon grommetux-control-icon-next grommetux-control-icon--large grommetux-control-icon--responsive"
         height="24px"
         role="img"
         version="1.1"

--- a/__tests__/components/__snapshots__/DateTime-test.js.snap
+++ b/__tests__/components/__snapshots__/DateTime-test.js.snap
@@ -20,7 +20,7 @@ exports[`DateTime has correct default options 1`] = `
       className="grommetux-button__icon">
       <svg
         aria-labelledby="clock-title"
-        className="grommetux-control-icon grommetux-control-icon-clock"
+        className="grommetux-control-icon grommetux-control-icon-clock grommetux-control-icon--responsive"
         height="24px"
         role="img"
         version="1.1"

--- a/__tests__/components/__snapshots__/NumberInput-test.js.snap
+++ b/__tests__/components/__snapshots__/NumberInput-test.js.snap
@@ -28,7 +28,7 @@ exports[`NumberInput has correct default options 1`] = `
       className="grommetux-button__icon">
       <svg
         aria-labelledby="subtract-title"
-        className="grommetux-control-icon grommetux-control-icon-subtract"
+        className="grommetux-control-icon grommetux-control-icon-subtract grommetux-control-icon--responsive"
         height="24px"
         role="img"
         version="1.1"
@@ -73,7 +73,7 @@ exports[`NumberInput has correct default options 1`] = `
       className="grommetux-button__icon">
       <svg
         aria-labelledby="add-title"
-        className="grommetux-control-icon grommetux-control-icon-add"
+        className="grommetux-control-icon grommetux-control-icon-add grommetux-control-icon--responsive"
         height="24px"
         role="img"
         version="1.1"

--- a/__tests__/components/__snapshots__/Search-test.js.snap
+++ b/__tests__/components/__snapshots__/Search-test.js.snap
@@ -12,7 +12,7 @@ exports[`Search has correct default options 1`] = `
       className="grommetux-button__icon">
       <svg
         aria-labelledby="search-title"
-        className="grommetux-control-icon grommetux-control-icon-search"
+        className="grommetux-control-icon grommetux-control-icon-search grommetux-control-icon--responsive"
         height="24px"
         role="img"
         version="1.1"

--- a/__tests__/components/__snapshots__/SearchInput-test.js.snap
+++ b/__tests__/components/__snapshots__/SearchInput-test.js.snap
@@ -23,7 +23,7 @@ exports[`SearchInput has correct default options 1`] = `
       className="grommetux-button__icon">
       <svg
         aria-labelledby="search-title"
-        className="grommetux-control-icon grommetux-control-icon-search"
+        className="grommetux-control-icon grommetux-control-icon-search grommetux-control-icon--responsive"
         height="24px"
         role="img"
         version="1.1"

--- a/__tests__/components/__snapshots__/SocialShare-test.js.snap
+++ b/__tests__/components/__snapshots__/SocialShare-test.js.snap
@@ -10,7 +10,7 @@ exports[`SocialShare has correct email rendering 1`] = `
     className="grommetux-anchor__icon">
     <svg
       aria-labelledby="social-email-title"
-      className="grommetux-control-icon grommetux-control-icon-social-email"
+      className="grommetux-control-icon grommetux-control-icon-social-email grommetux-control-icon--responsive"
       height="24px"
       role="img"
       version="1.1"
@@ -43,7 +43,7 @@ exports[`SocialShare has correct facebook rendering 1`] = `
     className="grommetux-anchor__icon">
     <svg
       aria-labelledby="social-facebook-title"
-      className="grommetux-control-icon grommetux-control-icon-social-facebook"
+      className="grommetux-control-icon grommetux-control-icon-social-facebook grommetux-control-icon--responsive"
       height="24px"
       role="img"
       version="1.1"
@@ -76,7 +76,7 @@ exports[`SocialShare has correct google rendering 1`] = `
     className="grommetux-anchor__icon">
     <svg
       aria-labelledby="social-linkedin-title"
-      className="grommetux-control-icon grommetux-control-icon-social-linkedin"
+      className="grommetux-control-icon grommetux-control-icon-social-linkedin grommetux-control-icon--responsive"
       height="24px"
       role="img"
       version="1.1"
@@ -109,7 +109,7 @@ exports[`SocialShare has correct linkedin rendering 1`] = `
     className="grommetux-anchor__icon">
     <svg
       aria-labelledby="social-linkedin-title"
-      className="grommetux-control-icon grommetux-control-icon-social-linkedin"
+      className="grommetux-control-icon grommetux-control-icon-social-linkedin grommetux-control-icon--responsive"
       height="24px"
       role="img"
       version="1.1"
@@ -142,7 +142,7 @@ exports[`SocialShare has correct text rendering 1`] = `
     className="grommetux-anchor__icon">
     <svg
       aria-labelledby="social-linkedin-title"
-      className="grommetux-control-icon grommetux-control-icon-social-linkedin"
+      className="grommetux-control-icon grommetux-control-icon-social-linkedin grommetux-control-icon--responsive"
       height="24px"
       role="img"
       version="1.1"
@@ -175,7 +175,7 @@ exports[`SocialShare has correct title rendering 1`] = `
     className="grommetux-anchor__icon">
     <svg
       aria-labelledby="social-linkedin-title"
-      className="grommetux-control-icon grommetux-control-icon-social-linkedin"
+      className="grommetux-control-icon grommetux-control-icon-social-linkedin grommetux-control-icon--responsive"
       height="24px"
       role="img"
       version="1.1"
@@ -208,7 +208,7 @@ exports[`SocialShare has correct twitter rendering 1`] = `
     className="grommetux-anchor__icon">
     <svg
       aria-labelledby="social-twitter-title"
-      className="grommetux-control-icon grommetux-control-icon-social-twitter"
+      className="grommetux-control-icon grommetux-control-icon-social-twitter grommetux-control-icon--responsive"
       height="24px"
       role="img"
       version="1.1"

--- a/__tests__/components/__snapshots__/Video-test.js.snap
+++ b/__tests__/components/__snapshots__/Video-test.js.snap
@@ -61,7 +61,7 @@ exports[`Video has correct default options 1`] = `
             className="grommetux-button__icon">
             <svg
               aria-labelledby="play-title"
-              className="grommetux-control-icon grommetux-control-icon-play grommetux-control-icon--large"
+              className="grommetux-control-icon grommetux-control-icon-play grommetux-control-icon--large grommetux-control-icon--responsive"
               height="24px"
               role="img"
               version="1.1"

--- a/__tests__/components/icons/__snapshots__/Pulse-test.js.snap
+++ b/__tests__/components/icons/__snapshots__/Pulse-test.js.snap
@@ -5,7 +5,7 @@ exports[`Pulse has correct className rendering 1`] = `
     className="grommetux-pulse__icon">
     <svg
       aria-labelledby="add-title"
-      className="grommetux-control-icon grommetux-control-icon-add"
+      className="grommetux-control-icon grommetux-control-icon-add grommetux-control-icon--responsive"
       height="24px"
       role="img"
       version="1.1"
@@ -45,7 +45,7 @@ exports[`Pulse has correct default options 1`] = `
     className="grommetux-pulse__icon">
     <svg
       aria-labelledby="add-title"
-      className="grommetux-control-icon grommetux-control-icon-add"
+      className="grommetux-control-icon grommetux-control-icon-add grommetux-control-icon--responsive"
       height="24px"
       role="img"
       version="1.1"

--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -169,7 +169,7 @@ $colored-select-drop-caret: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB
       &:focus {
         padding-left: ($inuit-base-spacing-unit - ($input-border-width + 1));
 
-        #{$dark-background-context} & {
+        #{$dark-background-context} & option {
           // fix white dropdown text in IE11
           color: $text-color;
         }

--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -168,6 +168,11 @@ $colored-select-drop-caret: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB
 
       &:focus {
         padding-left: ($inuit-base-spacing-unit - ($input-border-width + 1));
+
+        #{$dark-background-context} & {
+          // fix white dropdown text in IE11
+          color: $text-color;
+        }
       }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixing IE11 dark-background-context issue with select drop down items (text is white on white bg).

Also updating tests.

#### What testing has been done on this PR?
Tested in IE11.

#### How should this be manually tested?
Open grommet-docs in IE11, and check "All field types" Form docs page.
http://localhost:8002/docs/form/examples#2

Toggle dark background, and trigger select drop-down options. Options should be black (default) text on white bg.

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/442

#### Screenshots (if appropriate)
Before PR: 
![screen shot 2016-09-19 at 11 45 36 am](https://cloud.githubusercontent.com/assets/10161095/18650065/ade71da6-7e5e-11e6-912d-776029837d0c.png)

After PR:
![screen shot 2016-09-19 at 11 54 07 am](https://cloud.githubusercontent.com/assets/10161095/18650263/d19d111e-7e5f-11e6-8d17-2e637c1ce12a.png)

#### Do the grommet docs need to be updated?
No.

#### Is this change backwards compatible or is it a breaking change?
Non-breaking change.