### PR TITLE
Add two tests and update Tile test.

### DIFF
--- a/__tests__/components/SkipLinkAnchor-test.js
+++ b/__tests__/components/SkipLinkAnchor-test.js
@@ -1,0 +1,20 @@
+// (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
+
+import React from 'react';
+import renderer from 'react/lib/ReactTestRenderer';
+
+import SkipLinkAnchor from '../../src/js/components/SkipLinkAnchor';
+
+// needed because this:
+// https://github.com/facebook/jest/issues/1353
+jest.mock('react-dom');
+
+describe('SkipLinks', () => {
+  it('has correct default options', () => {
+    const component = renderer.create(
+       <SkipLinkAnchor label="Beer Me" />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/__tests__/components/SkipLinks-test.js
+++ b/__tests__/components/SkipLinks-test.js
@@ -14,7 +14,7 @@ describe('SkipLinks', () => {
     const component = renderer.create(
        <SkipLinks />
     );
-    let tree = component.toJSON();
+    const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/__tests__/components/Tiles-test.js
+++ b/__tests__/components/Tiles-test.js
@@ -5,6 +5,10 @@ import renderer from 'react/lib/ReactTestRenderer';
 
 import Tiles from '../../src/js/components/Tiles';
 import Tile from '../../src/js/components/Tile';
+import Box from '../../src/js/components/Box';
+import Header from '../../src/js/components/Header';
+import Footer from '../../src/js/components/Footer';
+import Menu from '../../src/js/components/Menu';
 
 // needed because this:
 // https://github.com/facebook/jest/issues/1353
@@ -26,6 +30,113 @@ describe('Tiles', () => {
       </Tiles>
     );
     let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with the Not flush, Centered Example', () => {
+    const component = renderer.create(
+      <Tiles flush={false}
+        justify="center" colorIndex="light-2" full="horizontal">
+        <Tile align="start" colorIndex="light-1">
+          <Header tag="h4" size="small" pad={{"horizontal": "small"}}>
+            <strong>
+              Tile 1
+            </strong>
+          </Header>
+          <Box pad="small">
+            <p>
+              Tile summary content.
+            </p>
+          </Box>
+          <Footer justify="between">
+            <span />
+            <Menu inline={false}
+              dropAlign={{"bottom": "bottom", "right": "right"}}>
+              <a>
+                action 1
+              </a>
+              <a>
+                action 2
+              </a>
+              <a>
+                action 3
+              </a>
+            </Menu>
+          </Footer>
+        </Tile>
+        <Tile align="start" colorIndex="light-1">
+          <Header tag="h4" size="small" pad={{"horizontal": "small"}}>
+            <strong>
+              Tile 2
+            </strong>
+          </Header>
+          <Box pad="small">
+            <p>
+              Tile summary content.
+            </p>
+          </Box>
+          <Footer justify="between">
+            <span />
+            <Menu inline={false}
+              dropAlign={{"bottom": "bottom", "right": "right"}}>
+              <a>
+                action 1
+              </a>
+              <a>
+                action 2
+              </a>
+              <a>
+                action 3
+              </a>
+            </Menu>
+          </Footer>
+        </Tile>
+      </Tiles>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with the Fill, Flush Example.', () => {
+    const component = renderer.create(
+      <Tiles fill={true}>
+        <Tile align="start" colorIndex="neutral-1">
+          <Header tag="h4" size="small" pad={{"horizontal": "small"}}>
+            <strong>
+              Tile 1
+            </strong>
+          </Header>
+          <Box pad="small">
+            <p>
+              Tile summary content.
+            </p>
+          </Box>
+        </Tile>
+        <Tile align="start" colorIndex="neutral-2">
+          <Header tag="h4" size="small" pad={{"horizontal": "small"}}>
+            <strong>
+              Tile 2
+            </strong>
+          </Header>
+          <Box pad="small">
+            <p>
+              Tile summary content.
+            </p>
+          </Box>
+        </Tile>
+        <Tile align="start" colorIndex="neutral-3">
+          <Header tag="h4" size="small" pad={{"horizontal": "small"}}>
+            <strong>
+              Tile 3
+            </strong>
+          </Header>
+          <Box pad="small">
+            <p>
+              Tile summary content.
+            </p>
+          </Box>
+        </Tile>
+      </Tiles>
+    );
+    const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/__tests__/components/Tip-test.js
+++ b/__tests__/components/Tip-test.js
@@ -1,0 +1,34 @@
+// (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
+
+import React from 'react';
+import renderer from 'react/lib/ReactTestRenderer';
+
+import Tip from '../../src/js/components/Tip';
+
+// needed because this:
+// https://github.com/facebook/jest/issues/1353
+jest.mock('react-dom');
+
+describe('SkipLinks', () => {
+  it('has correct default options', () => {
+    const component = renderer.create(
+      <div>
+        <div id="test-target"></div>
+        <Tip onClose={(e) => e} target="test-target" />
+      </div>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with a different colorIndex value', () => {
+    const component = renderer.create(
+      <div>
+        <div id="test-target"></div>
+        <Tip colorIndex="brand"
+          onClose={(e) => e} target="test-target" />
+      </div>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/__tests__/components/__snapshots__/Carousel-test.js.snap
+++ b/__tests__/components/__snapshots__/Carousel-test.js.snap
@@ -73,7 +73,7 @@ exports[`Carousel has correct default options 1`] = `
             y="1.2071" />
           <polyline
             fill="none"
-            points="16.1397,0.7071 5.1397,11.7071 16.1397,22.7071 	"
+            points="16.1397,0.7071 5.1397,11.7071  16.1397,22.7071 	"
             stroke="#000000"
             strokeMiterlimit="10"
             strokeWidth="2" />

--- a/__tests__/components/__snapshots__/SkipLinkAnchor-test.js.snap
+++ b/__tests__/components/__snapshots__/SkipLinkAnchor-test.js.snap
@@ -1,0 +1,9 @@
+exports[`SkipLinks has correct default options 1`] = `
+<a
+  aria-hidden="true"
+  className="grommetux-skip-link-anchor"
+  id="skip-link-beer_me"
+  tabIndex="-1">
+  Beer Me
+</a>
+`;

--- a/__tests__/components/__snapshots__/Tiles-test.js.snap
+++ b/__tests__/components/__snapshots__/Tiles-test.js.snap
@@ -35,3 +35,299 @@ exports[`Tiles has correct default options 1`] = `
   </div>
 </div>
 `;
+
+exports[`Tiles renders with the Fill, Flush Example. 1`] = `
+<div
+  className="grommetux-box grommetux-box--direction-row grommetux-box--justify-start grommetux-box--responsive grommetux-box--pad-small grommetux-box--wrap grommetux-tiles grommetux-tiles--fill grommetux-tiles--flush"
+  id={undefined}
+  onClick={undefined}
+  role={undefined}
+  style={Object {}}
+  tabIndex={undefined}>
+  <div
+    className="grommetux-box grommetux-box--direction-column grommetux-box--align-start grommetux-box--responsive grommetux-box--pad-none grommetux-background-color-index-neutral-1 grommetux-tile grommetux-none-hover-color-index-disabled grommetux-tile--hover-border-small"
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}>
+    <h4
+      className="grommetux-box grommetux-box--direction-row grommetux-box--align-center grommetux-box--pad-horizontal-small grommetux-header grommetux-header--small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <strong>
+        Tile 1
+      </strong>
+    </h4>
+    <div
+      className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <p>
+        Tile summary content.
+      </p>
+    </div>
+  </div>
+  <div
+    className="grommetux-box grommetux-box--direction-column grommetux-box--align-start grommetux-box--responsive grommetux-box--pad-none grommetux-background-color-index-neutral-2 grommetux-tile grommetux-none-hover-color-index-disabled grommetux-tile--hover-border-small"
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}>
+    <h4
+      className="grommetux-box grommetux-box--direction-row grommetux-box--align-center grommetux-box--pad-horizontal-small grommetux-header grommetux-header--small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <strong>
+        Tile 2
+      </strong>
+    </h4>
+    <div
+      className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <p>
+        Tile summary content.
+      </p>
+    </div>
+  </div>
+  <div
+    className="grommetux-box grommetux-box--direction-column grommetux-box--align-start grommetux-box--responsive grommetux-box--pad-none grommetux-background-color-index-neutral-3 grommetux-tile grommetux-none-hover-color-index-disabled grommetux-tile--hover-border-small"
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}>
+    <h4
+      className="grommetux-box grommetux-box--direction-row grommetux-box--align-center grommetux-box--pad-horizontal-small grommetux-header grommetux-header--small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <strong>
+        Tile 3
+      </strong>
+    </h4>
+    <div
+      className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <p>
+        Tile summary content.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Tiles renders with the Not flush, Centered Example 1`] = `
+<div
+  className="grommetux-box grommetux-box--full-horizontal grommetux-box--direction-row grommetux-box--justify-center grommetux-box--responsive grommetux-box--pad-small grommetux-box--wrap grommetux-background-color-index-light-2 grommetux-tiles"
+  id={undefined}
+  onClick={undefined}
+  role={undefined}
+  style={Object {}}
+  tabIndex={undefined}>
+  <div
+    className="grommetux-box grommetux-box--direction-column grommetux-box--align-start grommetux-box--responsive grommetux-box--pad-none grommetux-background-color-index-light-1 grommetux-tile grommetux-none-hover-color-index-disabled grommetux-tile--hover-border-large"
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}>
+    <h4
+      className="grommetux-box grommetux-box--direction-row grommetux-box--align-center grommetux-box--pad-horizontal-small grommetux-header grommetux-header--small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <strong>
+        Tile 1
+      </strong>
+    </h4>
+    <div
+      className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <p>
+        Tile summary content.
+      </p>
+    </div>
+    <footer
+      className="grommetux-box grommetux-box--direction-row grommetux-box--justify-between grommetux-box--pad-none grommetux-footer"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <span />
+      <div>
+        <button
+          aria-label="Open  Menu"
+          className="grommetux-button grommetux-menu grommetux-menu--column grommetux-menu--controlled grommetux-menu__control grommetux-button--plain grommetux-button--icon"
+          disabled={false}
+          href={undefined}
+          id={undefined}
+          onClick={[Function bound _onOpen]}
+          type="button">
+          <span
+            className="grommetux-button__icon">
+            <svg
+              aria-labelledby="more-title"
+              className="grommetux-control-icon grommetux-control-icon-more"
+              height="24px"
+              role="img"
+              version="1.1"
+              viewBox="0 0 24 24"
+              width="24px">
+              <title
+                id="more-title">
+                <span
+                  id="more">
+                  more
+                </span>
+              </title>
+              <g>
+                <rect
+                  fill="none"
+                  height="24"
+                  width="24"
+                  x="0"
+                  y="0" />
+                <rect
+                  height="4"
+                  width="4"
+                  x="0"
+                  y="10" />
+                <rect
+                  height="4"
+                  width="4"
+                  x="10"
+                  y="10" />
+                <rect
+                  height="4"
+                  width="4"
+                  x="20"
+                  y="10" />
+              </g>
+            </svg>
+          </span>
+        </button>
+      </div>
+    </footer>
+  </div>
+  <div
+    className="grommetux-box grommetux-box--direction-column grommetux-box--align-start grommetux-box--responsive grommetux-box--pad-none grommetux-background-color-index-light-1 grommetux-tile grommetux-none-hover-color-index-disabled grommetux-tile--hover-border-large"
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}>
+    <h4
+      className="grommetux-box grommetux-box--direction-row grommetux-box--align-center grommetux-box--pad-horizontal-small grommetux-header grommetux-header--small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <strong>
+        Tile 2
+      </strong>
+    </h4>
+    <div
+      className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-small"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <p>
+        Tile summary content.
+      </p>
+    </div>
+    <footer
+      className="grommetux-box grommetux-box--direction-row grommetux-box--justify-between grommetux-box--pad-none grommetux-footer"
+      id={undefined}
+      onClick={undefined}
+      role={undefined}
+      style={Object {}}
+      tabIndex={undefined}>
+      <span />
+      <div>
+        <button
+          aria-label="Open  Menu"
+          className="grommetux-button grommetux-menu grommetux-menu--column grommetux-menu--controlled grommetux-menu__control grommetux-button--plain grommetux-button--icon"
+          disabled={false}
+          href={undefined}
+          id={undefined}
+          onClick={[Function bound _onOpen]}
+          type="button">
+          <span
+            className="grommetux-button__icon">
+            <svg
+              aria-labelledby="more-title"
+              className="grommetux-control-icon grommetux-control-icon-more"
+              height="24px"
+              role="img"
+              version="1.1"
+              viewBox="0 0 24 24"
+              width="24px">
+              <title
+                id="more-title">
+                <span
+                  id="more">
+                  more
+                </span>
+              </title>
+              <g>
+                <rect
+                  fill="none"
+                  height="24"
+                  width="24"
+                  x="0"
+                  y="0" />
+                <rect
+                  height="4"
+                  width="4"
+                  x="0"
+                  y="10" />
+                <rect
+                  height="4"
+                  width="4"
+                  x="10"
+                  y="10" />
+                <rect
+                  height="4"
+                  width="4"
+                  x="20"
+                  y="10" />
+              </g>
+            </svg>
+          </span>
+        </button>
+      </div>
+    </footer>
+  </div>
+</div>
+`;

--- a/__tests__/components/__snapshots__/Tip-test.js.snap
+++ b/__tests__/components/__snapshots__/Tip-test.js.snap
@@ -1,0 +1,15 @@
+exports[`SkipLinks has correct default options 1`] = `
+<div>
+  <div
+    id="test-target" />
+  <span />
+</div>
+`;
+
+exports[`SkipLinks renders with a different colorIndex value 1`] = `
+<div>
+  <div
+    id="test-target" />
+  <span />
+</div>
+`;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds tests for several components, and updates the Tiles test with more examples to snapshot.  I believe that with this PR, we have test coverage for _every_ grommet component, at least with Jest.  I would love to dig into introspection testing with Enzyme, or whatever else, once that is setup.

#### Where should the reviewer start?
New Tests:
- __tests__/components/SkipLinkAnchor-test.js
- __tests__/components/Tip-test.js
Updated test:
- __tests__/components/Tiles-test.js

#### What testing has been done on this PR?
Ran gulp test before and after writing these test.

#### How should this be manually tested?
N/A, but the reviewer should not that one test is still failing, the Carousel-Test.  I do not know enough about the project yet to make an assumption about why it is failing.

#### Any background context you want to provide?
N/A

#### What are the relevant issues?
N/A

#### Screenshots (if appropriate)
N/A

#### Do the grommet docs need to be updated?
N/A

#### Should this PR be mentioned in the release notes?
N/A

#### Is this change backwards compatible or is it a breaking change?
N/A