### PR TITLE
Updated HPE theme's Anchor styling.

### DIFF
--- a/src/scss/hpe/_objects.anchor-hpe.scss
+++ b/src/scss/hpe/_objects.anchor-hpe.scss
@@ -1,0 +1,33 @@
+// (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
+
+// This updates the primary Anchors and Anchors with icons 
+// to $brand-color while maintaining inherit for 
+// non primary Anchors.
+//
+// The non primary links are kept as text color to maintain
+// accessability as the HPE $brand-color is not considered
+// accessible below 19px.
+@mixin link-color-check($link-color, $updated-color) {
+  @if $link-color == 'inherit' {
+    color: $updated-color;
+  }
+}
+
+.#{$grommet-namespace}anchor {
+  &--primary,
+  &--icon-label {
+    @include link-color-check($link-color, $brand-color);
+
+    &:visited {
+      @include link-color-check($link-color, $brand-color);
+    }
+
+    &:hover:not(.#{$grommet-namespace}anchor--disabled) {
+       @include link-color-check($link-color, $control-brand-color);
+    }
+  }
+
+  &--primary {
+    @include link-color-check($link-color, $brand-color);
+  }
+}

--- a/src/scss/hpe/index.scss
+++ b/src/scss/hpe/index.scss
@@ -1,3 +1,4 @@
 @import 'hpe.defaults';
 @import '../grommet-core/index';
 @import 'objects.button-hpe';
+@import 'objects.anchor-hpe';


### PR DESCRIPTION
This PR references issue [#77](https://github.com/grommet/grommet-docs/issues/77) on grommet-docs. 

#### What does this PR do?
This PR brings the HPE themed Anchor inline with other Grommet themes. It specifically target primary Anchors along with Anchors with icons and styles them with the brand color. 

#### What testing has been done on this PR?
This has been tested within the docs.

#### How should this be manually tested?
This PR should be tested in the grommet-docs Anchor examples.

#### Any background context you want to provide?
This PR references issue [#77](https://github.com/grommet/grommet-docs/issues/77) on grommet-docs. The HPE theme's primary Anchors along with Anchors with icons text color did not match the icon color.

#### What are the relevant issues?
The Menu component will still target the primary Anchors/Anchors with icons and add a different color on hover. To fix this we could craft a PR specifically targeting the Menu component. I felt these fixes should be separated via component.

I should also note this fix is conditional in that it will only update the anchor styling as long as the `$link-color` default is set to `inherit`. This is to preserve theming where a user could change HPE's `$link-color` to an actual color value and the theme would update normally.

#### Screenshots (if appropriate)
![screen shot 2016-09-22 at 10 42 18 am](https://cloud.githubusercontent.com/assets/5983843/18752719/44be0e0c-80b1-11e6-8998-22118dbd5aa3.png)

#### Do the grommet docs need to be updated?
Nope.

#### Should this PR be mentioned in the release notes?
This is probably not necessary.

#### Is this change backwards compatible or is it a breaking change?
This is backwards compatible.

