### PR TITLE
Fixes Search input select bug in Safari.

### DIFF
--- a/src/js/components/Search.js
+++ b/src/js/components/Search.js
@@ -239,6 +239,12 @@ export default class Search extends Component {
     }
   }
 
+  _onMouseUp(event) {
+    // This fixes a Safari bug which prevents the input
+    // text from being selected on focus.
+    event.preventDefault();
+  }
+
   _onSink (event) {
     event.stopPropagation();
     event.nativeEvent.stopImmediatePropagation();
@@ -369,7 +375,8 @@ export default class Search extends Component {
             className={`${CLASS_ROOT}__input`}
             onFocus={this._onFocusInput}
             onBlur={this._onBlurInput}
-            onChange={this._onChangeInput} />
+            onChange={this._onChangeInput}
+            onMouseUp={this._onMouseUp} />
           <SearchIcon />
         </div>
       );


### PR DESCRIPTION
This PR fixes a bug mentioned in issue #623. The intended functionality is that the value of the search input is highlighted when the input receives focus, this functionality was not working properly in Safari. Safari was preventing the highlight capability by listening to the mouse up events. This PR removes the mouse up events from the Search input.