### PR TITLE
Fix Accordion active state

### DIFF
--- a/src/js/components/Accordion.js
+++ b/src/js/components/Accordion.js
@@ -42,13 +42,13 @@ export default class Accordion extends Component {
   }
 
   componentWillReceiveProps (newProps) {
-    if (newProps.active !== this.state.active) {
+    if (newProps.active !== this.props.active) {
       this.setState({active: newProps.active || []});
     }
   }
 
   _onPanelChange (index) {
-    let { active } = this.state;
+    let active = [...this.state.active];
     const { onActive, openMulti } = this.props;
 
     const activeIndex = active.indexOf(index);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fix Accordion active state.

In `componentWillRecieveProps` we should be checking `props` rather than `state`, then we update `state` with the `newProps`.

Also clone `this.state.active` since `.splice` & `.push` mutates the original array.

#### Any background context you want to provide?

CodePen with **issue**: http://codepen.io/mcwagner10/pen/gwLGXj
CodePen with **fix**: http://codepen.io/epilande/pen/zKNZxV

