### PR TITLE
Style Tweaks: Paragraph Width, Card (in Tiles & Default BG Color, Box (Max-Width & Separators)

### DIFF
--- a/__tests__/components/__snapshots__/Card-test.js.snap
+++ b/__tests__/components/__snapshots__/Card-test.js.snap
@@ -1,6 +1,6 @@
 exports[`Card has correct default options 1`] = `
 <div
-  className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-none grommetux-box--width-medium grommetux-box--size grommetux-background-color-index-light-1 grommetux-card"
+  className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-none grommetux-box--width-medium grommetux-box--size grommetux-card"
   id={undefined}
   onClick={undefined}
   role={undefined}
@@ -42,7 +42,7 @@ exports[`Card has correct default options 1`] = `
 
 exports[`Card renders a header with the set size 1`] = `
 <div
-  className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-none grommetux-box--width-medium grommetux-box--size grommetux-background-color-index-light-1 grommetux-card"
+  className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-none grommetux-box--width-medium grommetux-box--size grommetux-card"
   id={undefined}
   onClick={undefined}
   role={undefined}
@@ -66,7 +66,7 @@ exports[`Card renders a header with the set size 1`] = `
 
 exports[`Card renders correctly when reverse 1`] = `
 <div
-  className="grommetux-box grommetux-box--direction-column grommetux-box--justify-between grommetux-box--reverse grommetux-box--responsive grommetux-box--pad-none grommetux-box--width-medium grommetux-box--size grommetux-background-color-index-light-1 grommetux-card"
+  className="grommetux-box grommetux-box--direction-column grommetux-box--justify-between grommetux-box--reverse grommetux-box--responsive grommetux-box--pad-none grommetux-box--width-medium grommetux-box--size grommetux-card"
   id={undefined}
   onClick={undefined}
   role={undefined}
@@ -90,7 +90,7 @@ exports[`Card renders correctly when reverse 1`] = `
 
 exports[`Card renders correctly when the direction is set to row 1`] = `
 <div
-  className="grommetux-box grommetux-box--direction-row grommetux-box--responsive grommetux-box--pad-none grommetux-box--width-xlarge grommetux-box--size grommetux-background-color-index-light-1 grommetux-card"
+  className="grommetux-box grommetux-box--direction-row grommetux-box--responsive grommetux-box--pad-none grommetux-box--width-xlarge grommetux-box--size grommetux-card"
   id={undefined}
   onClick={undefined}
   role={undefined}
@@ -114,7 +114,7 @@ exports[`Card renders correctly when the direction is set to row 1`] = `
 
 exports[`Card renders correctly when the headingStrong is false 1`] = `
 <div
-  className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-none grommetux-box--width-medium grommetux-box--size grommetux-background-color-index-light-1 grommetux-card"
+  className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-none grommetux-box--width-medium grommetux-box--size grommetux-card"
   id={undefined}
   onClick={undefined}
   role={undefined}

--- a/__tests__/components/__snapshots__/Card-test.js.snap
+++ b/__tests__/components/__snapshots__/Card-test.js.snap
@@ -19,7 +19,7 @@ exports[`Card has correct default options 1`] = `
     }
     tabIndex={undefined} />
   <div
-    className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-medium grommetux-card__content"
+    className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--flex grommetux-box--pad-medium grommetux-card__content"
     id={undefined}
     onClick={undefined}
     role={undefined}
@@ -49,7 +49,7 @@ exports[`Card renders a header with the set size 1`] = `
   style={Object {}}
   tabIndex={undefined}>
   <div
-    className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-medium grommetux-card__content"
+    className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--flex grommetux-box--pad-medium grommetux-card__content"
     id={undefined}
     onClick={undefined}
     role={undefined}
@@ -73,7 +73,7 @@ exports[`Card renders correctly when reverse 1`] = `
   style={Object {}}
   tabIndex={undefined}>
   <div
-    className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-medium grommetux-card__content"
+    className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--flex grommetux-box--pad-medium grommetux-card__content"
     id={undefined}
     onClick={undefined}
     role={undefined}
@@ -97,7 +97,7 @@ exports[`Card renders correctly when the direction is set to row 1`] = `
   style={Object {}}
   tabIndex={undefined}>
   <div
-    className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-medium grommetux-card__content"
+    className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--flex grommetux-box--pad-medium grommetux-card__content"
     id={undefined}
     onClick={undefined}
     role={undefined}
@@ -121,7 +121,7 @@ exports[`Card renders correctly when the headingStrong is false 1`] = `
   style={Object {}}
   tabIndex={undefined}>
   <div
-    className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-medium grommetux-card__content"
+    className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--flex grommetux-box--pad-medium grommetux-card__content"
     id={undefined}
     onClick={undefined}
     role={undefined}
@@ -145,7 +145,7 @@ exports[`Card renders correctly with a non-default colorIndex 1`] = `
   style={Object {}}
   tabIndex={undefined}>
   <div
-    className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-medium grommetux-card__content"
+    className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--flex grommetux-box--pad-medium grommetux-card__content"
     id={undefined}
     onClick={undefined}
     role={undefined}

--- a/src/js/components/Box.js
+++ b/src/js/components/Box.js
@@ -106,6 +106,10 @@ export default class Box extends Component {
           // don't apply 100% max-width when size using size.width.max option
           classes.push(`${CLASS_ROOT}--size`);
         }
+        if (size.width && size.width.max) {
+          // allow widths to shrink, apply 100% width
+          classes.push(`${CLASS_ROOT}--width-max`);
+        }
       }
     }
 

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -194,7 +194,7 @@ export default class Card extends Component {
     let videoLayer = this._renderVideoLayer();
 
     const text = (
-      <Box className={`${CLASS_ROOT}__content`} pad={contentPad}>
+      <Box className={`${CLASS_ROOT}__content`} flex={true} pad={contentPad}>
         {label}
         {heading}
         {description}

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -260,7 +260,6 @@ Card.propTypes = {
 };
 
 Card.defaultProps = {
-  colorIndex: 'light-1',
   contentPad: 'medium',
   headingStrong: true,
   textSize: 'small'

--- a/src/scss/grommet-core/_objects.box.scss
+++ b/src/scss/grommet-core/_objects.box.scss
@@ -109,12 +109,26 @@
 .#{$grommet-namespace}box--separator-vertical,
 .#{$grommet-namespace}box--separator-all {
   border-left: 1px solid $border-color;
+
+  @include media-query (palm) {
+    .#{$grommet-namespace}box--responsive.#{$grommet-namespace}box--direction-row & {
+      border-left: none;
+      border-top: 1px solid $border-color;
+    }
+  }
 }
 
 .#{$grommet-namespace}box--separator-right,
 .#{$grommet-namespace}box--separator-vertical,
 .#{$grommet-namespace}box--separator-all {
   border-right: 1px solid $border-color;
+
+  @include media-query (palm) {
+    .#{$grommet-namespace}box--responsive.#{$grommet-namespace}box--direction-row & {
+      border-right: none;
+      border-bottom: 1px solid $border-color;
+    }
+  }
 }
 
 #{$dark-background-context}
@@ -317,6 +331,9 @@
 }
 
 // max-width
+.#{$grommet-namespace}box--width-max {
+  width: 100%;
+}
 
 .#{$grommet-namespace}box--width-max-xsmall {
   max-width: $size-xsmall;

--- a/src/scss/grommet-core/_objects.card.scss
+++ b/src/scss/grommet-core/_objects.card.scss
@@ -53,6 +53,10 @@ $card-hover-color: #EBEBEB;
 }
 
 .#{$grommet-namespace}card__content {
+  .#{$grommet-namespace}tiles & {
+    flex-grow: 1;
+  }
+
   // truncate text paragraphs after 8 lines
   .#{$grommet-namespace}paragraph {
     max-width: none;

--- a/src/scss/grommet-core/_objects.card.scss
+++ b/src/scss/grommet-core/_objects.card.scss
@@ -53,10 +53,6 @@ $card-hover-color: #EBEBEB;
 }
 
 .#{$grommet-namespace}card__content {
-  .#{$grommet-namespace}tiles & {
-    flex-grow: 1;
-  }
-
   // truncate text paragraphs after 8 lines
   .#{$grommet-namespace}paragraph {
     max-width: none;

--- a/src/scss/grommet-core/_objects.paragraph.scss
+++ b/src/scss/grommet-core/_objects.paragraph.scss
@@ -32,6 +32,9 @@
 }
 
 .#{$grommet-namespace}paragraph--width-large {
-  width: $inuit-base-spacing-unit * 30;
   max-width: 100%;
+
+  @include media-query(lap-and-up) {
+    width: $inuit-base-spacing-unit * 30;
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
* Only apply paragraph large-width (720px) for desktop sizes so that width doesn't remain large/overflow in mobile.
* Allow Card content in Tiles to expand full height of row.
* Allow Box with max-width size option to shrink in width instead of being stuck at max-width size.
* Also allow horizontal separators in responsive row Boxes to switch to vertical separators when switching to column direction
* Removing default white bg in Card component so that Cards are transparent instead of white when no colorIndex is passed.

#### What testing has been done on this PR?
Tested in Chrome, Firefox, and Safari in grommet-docs and hpe-digitaltoolkit.

#### Screenshots (if appropriate)
**separator="right" option in desktop:**
![screen shot 2016-09-26 at 4 22 49 pm](https://cloud.githubusercontent.com/assets/10161095/18859289/7a6e9854-840e-11e6-9017-c610a53fb5fe.png)

**separator="right" option in mobile (before PR):**
![screen shot 2016-09-26 at 3 59 26 pm](https://cloud.githubusercontent.com/assets/10161095/18859288/7a6514f0-840e-11e6-9427-5f6b59385090.png)

**separator="right" option in mobile (after PR):**
![screen shot 2016-09-26 at 4 22 41 pm](https://cloud.githubusercontent.com/assets/10161095/18859290/7a6e9c3c-840e-11e6-903a-6368b5fd46e0.png)

#### Is this change backwards compatible or is it a breaking change?
Breaks Card bg default (changes default white bg to transparent).