### PR TITLE
Fix Anchor icon accessibility

### DIFF
--- a/__tests__/components/__snapshots__/Anchor-test.js.snap
+++ b/__tests__/components/__snapshots__/Anchor-test.js.snap
@@ -105,7 +105,7 @@ exports[`Anchor has correct primary=true rendering 1`] = `
   onClick={undefined}
   target={undefined}>
   <svg
-    aria-labelledby="undefined-icon"
+    aria-labelledby="anchor-next-title-id"
     className="grommetux-control-icon grommetux-control-icon-link-next grommetux-control-icon--responsive"
     height="24px"
     role="img"
@@ -113,8 +113,8 @@ exports[`Anchor has correct primary=true rendering 1`] = `
     viewBox="0 0 24 24"
     width="24px">
     <title
-      id="undefined-icon">
-      undefined-icon
+      id="anchor-next-title-id">
+      link next
     </title>
     <g>
       <rect

--- a/src/js/components/Anchor.js
+++ b/src/js/components/Anchor.js
@@ -16,8 +16,13 @@ export default class Anchor extends Component {
       icon = this.props.icon;
     } else if (this.props.primary) {
       icon = (
-        <LinkNextIcon a11yTitle={`${this.props.id}-icon` || 'primary icon'}
-          a11yTitleId={`${this.props.id}-icon` || 'anchor-next-title-id'} />
+        <LinkNextIcon
+          a11yTitle={this.props.id ? `${this.props.id}-icon` : 'primary icon'}
+          a11yTitleId={this.props.id ?
+            `${this.props.id}-icon` :
+            'anchor-next-title-id'
+          }
+        />
       );
     }
 

--- a/src/js/components/Anchor.js
+++ b/src/js/components/Anchor.js
@@ -17,7 +17,7 @@ export default class Anchor extends Component {
     } else if (this.props.primary) {
       icon = (
         <LinkNextIcon
-          a11yTitle={this.props.id ? `${this.props.id}-icon` : 'primary icon'}
+          a11yTitle={this.props.id ? `${this.props.id}-icon` : 'link next'}
           a11yTitleId={this.props.id ?
             `${this.props.id}-icon` :
             'anchor-next-title-id'


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes `undefined-icon` on Anchor component & set title to be more meaningful.

#### How should this be manually tested?

With a screen reader focus on the arrow icon.

#### What are the relevant issues?

grommet/hpe-digitaltoolkit#127

#### Screenshots (if appropriate)

Current issue:
![image](https://cloud.githubusercontent.com/assets/3210082/18911402/917ba0ae-8518-11e6-9fc3-3da788f46976.png)

#### Is this change backwards compatible or is it a breaking change?

Yes, backwards compatible.
