### PR TITLE
Card: make copy truncation optional

### DIFF
--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -170,7 +170,7 @@ export default class Card extends Component {
 
   render () {
     const { children, className, contentPad,
-      onClick, reverse, video } = this.props;
+      onClick, reverse, truncateCopy, video } = this.props;
     const boxProps = Props.pick(this.props, Object.keys(Box.propTypes));
 
     const classes = classnames(
@@ -193,8 +193,15 @@ export default class Card extends Component {
     let link = this._renderLink();
     let videoLayer = this._renderVideoLayer();
 
+    const contentClasses = classnames(
+      {
+        [`${CLASS_ROOT}__content`]: true,
+        [`${CLASS_ROOT}__content--truncated`]: truncateCopy
+      }
+    );
+
     const text = (
-      <Box className={`${CLASS_ROOT}__content`} flex={true} pad={contentPad}>
+      <Box className={contentClasses} flex={true} pad={contentPad}>
         {label}
         {heading}
         {description}
@@ -249,6 +256,7 @@ Card.propTypes = {
     PropTypes.string,
     PropTypes.element
   ]),
+  truncateCopy: PropTypes.bool,
   video: PropTypes.oneOfType([
     PropTypes.shape({
       source: PropTypes.string.isRequired,

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -170,7 +170,7 @@ export default class Card extends Component {
 
   render () {
     const { children, className, contentPad,
-      onClick, reverse, truncateCopy, video } = this.props;
+      onClick, reverse, truncate, video } = this.props;
     const boxProps = Props.pick(this.props, Object.keys(Box.propTypes));
 
     const classes = classnames(
@@ -196,7 +196,7 @@ export default class Card extends Component {
     const contentClasses = classnames(
       {
         [`${CLASS_ROOT}__content`]: true,
-        [`${CLASS_ROOT}__content--truncated`]: truncateCopy
+        [`${CLASS_ROOT}__content--truncated`]: truncate
       }
     );
 
@@ -256,7 +256,7 @@ Card.propTypes = {
     PropTypes.string,
     PropTypes.element
   ]),
-  truncateCopy: PropTypes.bool,
+  truncate: PropTypes.bool,
   video: PropTypes.oneOfType([
     PropTypes.shape({
       source: PropTypes.string.isRequired,

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -196,7 +196,7 @@ export default class Card extends Component {
     const contentClasses = classnames(
       {
         [`${CLASS_ROOT}__content`]: true,
-        [`${CLASS_ROOT}__content--truncated`]: truncate
+        [`${CLASS_ROOT}__content--truncate`]: truncate
       }
     );
 

--- a/src/scss/grommet-core/_objects.accordion-panel.scss
+++ b/src/scss/grommet-core/_objects.accordion-panel.scss
@@ -4,10 +4,6 @@
   header:focus {  // too generic, change
     outline: none;
   }
-
-  &.#{$grommet-namespace}list-item {
-    max-width: none;  // allow panel li to expand width fully
-  }
 }
 
 .#{$grommet-namespace}accordion-panel--active {

--- a/src/scss/grommet-core/_objects.accordion-panel.scss
+++ b/src/scss/grommet-core/_objects.accordion-panel.scss
@@ -4,6 +4,10 @@
   header:focus {  // too generic, change
     outline: none;
   }
+
+  &.#{$grommet-namespace}list-item {
+    max-width: none;  // allow panel li to expand width fully
+  }
 }
 
 .#{$grommet-namespace}accordion-panel--active {

--- a/src/scss/grommet-core/_objects.card.scss
+++ b/src/scss/grommet-core/_objects.card.scss
@@ -52,7 +52,7 @@ $card-hover-color: #EBEBEB;
   }
 }
 
-.#{$grommet-namespace}card__content--truncated {
+.#{$grommet-namespace}card__content--truncate {
   // truncate text paragraphs after 8 lines
   .#{$grommet-namespace}paragraph {
     max-width: none;

--- a/src/scss/grommet-core/_objects.card.scss
+++ b/src/scss/grommet-core/_objects.card.scss
@@ -52,7 +52,7 @@ $card-hover-color: #EBEBEB;
   }
 }
 
-.#{$grommet-namespace}card__content {
+.#{$grommet-namespace}card__content--truncated {
   // truncate text paragraphs after 8 lines
   .#{$grommet-namespace}paragraph {
     max-width: none;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
* makes copy truncation for Card optional (`truncateCopy` option, defaults to `false`).
* allow Accordion Panel to expand full container width (currently `.grommet li` max-width gets applied).

#### What testing has been done on this PR?
Tested against hpe-digitaltoolkit repo in Chrome, Firefox, and Safari.

#### Any background context you want to provide?
Copy truncation was previously desired for Card, but after Stack (which was used by Marquee/Section (toolkit components) was merged with Card, the copy truncation behavior was still applied.

#### What are the relevant issues?
https://github.com/grommet/hpe-digitaltoolkit/issues/137

#### Do the grommet docs need to be updated?
Yes, update Card examples with truncateCopy option.

#### Is this change backwards compatible or is it a breaking change?
Breaking change for previously truncated `<p>` copy in Cards.