### PR TITLE
Fix NumberInput component to handle floats in IE

### DIFF
--- a/src/js/components/NumberInput.js
+++ b/src/js/components/NumberInput.js
@@ -43,7 +43,7 @@ export default class NumberInput extends Component {
     } catch (e) {
       // IE11 workaround. See known issue #5 at
       // http://caniuse.com/#search=number
-      let value = (parseInt(input.value, 10) || 0) + (this.props.step || 1);
+      let value = (parseFloat(input.value) || 0) + (this.props.step || 1);
       if (this.props.max !== undefined) {
         value = Math.min(value, this.props.max);
       }
@@ -59,7 +59,7 @@ export default class NumberInput extends Component {
     } catch (e) {
       // IE11 workaround. See known issue #5 at
       // http://caniuse.com/#search=number
-      let value = (parseInt(input.value, 10) || 0) - (this.props.step || 1);
+      let value = (parseFloat(input.value) || 0) - (this.props.step || 1);
       if (this.props.min !== undefined) {
         value = Math.max(value, this.props.min);
       }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fix NumberInput component to handle floats in IE.

#### What testing has been done on this PR?

Tested in IE11.

#### How should this be manually tested?

Set `step={0.1}` to `NumberInput` component.

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/868

#### Screenshots (if appropriate)

**Current issue on IE11:**
![numberinput-ie-bug](https://cloud.githubusercontent.com/assets/3210082/18938063/82ecdd2c-8591-11e6-94b7-c90830b8f56b.gif)

**With fix on IE11:**
![numberinput](https://cloud.githubusercontent.com/assets/3210082/18938079/9ee1aad0-8591-11e6-83ff-9697db3e7a7c.gif)



