### PR TITLE
Transfer Button component props.

### DIFF
--- a/__tests__/components/Button-test.js
+++ b/__tests__/components/Button-test.js
@@ -50,4 +50,19 @@ describe('Button', () => {
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+  it('has className property rendering', () => {
+    const component = renderer.create(
+      <Button className="test">test</Button>
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('has microdata properties rendering', () => {
+    const component = renderer.create(
+      <Button itemScope={true} itemType="http://schema.org/Article"
+        itemProp="test">test</Button>
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/__tests__/components/__snapshots__/Button-test.js.snap
+++ b/__tests__/components/__snapshots__/Button-test.js.snap
@@ -1,7 +1,7 @@
 exports[`Button has className property rendering 1`] = `
 <button
   aria-label={undefined}
-  className="grommetux-button test grommetux-button--disabled"
+  className="grommetux-button grommetux-button--disabled test"
   disabled={true}
   href={undefined}
   id={undefined}

--- a/__tests__/components/__snapshots__/Button-test.js.snap
+++ b/__tests__/components/__snapshots__/Button-test.js.snap
@@ -1,3 +1,20 @@
+exports[`Button has className property rendering 1`] = `
+<button
+  aria-label={undefined}
+  className="grommetux-button test grommetux-button--disabled"
+  disabled={true}
+  href={undefined}
+  id={undefined}
+  onBlur={[Function onBlur]}
+  onClick={undefined}
+  onFocus={[Function onFocus]}
+  onMouseDown={[Function onMouseDown]}
+  onMouseUp={[Function onMouseUp]}
+  type="button">
+  test
+</button>
+`;
+
 exports[`Button has correct default options 1`] = `
 <button
   aria-label={undefined}
@@ -96,6 +113,26 @@ exports[`Button has correct primary={true} rendering 1`] = `
   onMouseUp={[Function onMouseUp]}
   type="button">
   Test me
+</button>
+`;
+
+exports[`Button has microdata properties rendering 1`] = `
+<button
+  aria-label={undefined}
+  className="grommetux-button grommetux-button--disabled"
+  disabled={true}
+  href={undefined}
+  id={undefined}
+  itemProp="test"
+  itemScope={true}
+  itemType="http://schema.org/Article"
+  onBlur={[Function onBlur]}
+  onClick={undefined}
+  onFocus={[Function onFocus]}
+  onMouseDown={[Function onMouseDown]}
+  onMouseUp={[Function onMouseUp]}
+  type="button">
+  test
 </button>
 `;
 

--- a/__tests__/components/__snapshots__/Carousel-test.js.snap
+++ b/__tests__/components/__snapshots__/Carousel-test.js.snap
@@ -48,7 +48,7 @@ exports[`Carousel has correct default options 1`] = `
   </div>
   <button
     aria-label="Previous Slide"
-    className="grommetux-button grommetux-carousel__arrow grommetux-carousel__arrow--prev grommetux-button--plain grommetux-button--icon"
+    className="grommetux-button grommetux-button--plain grommetux-button--icon grommetux-carousel__arrow grommetux-carousel__arrow--prev"
     disabled={false}
     href={undefined}
     id={undefined}
@@ -93,7 +93,7 @@ exports[`Carousel has correct default options 1`] = `
   </button>
   <button
     aria-label="Next Slide"
-    className="grommetux-button grommetux-carousel__arrow grommetux-carousel__arrow--next grommetux-button--plain grommetux-button--icon"
+    className="grommetux-button grommetux-button--plain grommetux-button--icon grommetux-carousel__arrow grommetux-carousel__arrow--next"
     disabled={false}
     href={undefined}
     id={undefined}

--- a/__tests__/components/__snapshots__/DateTime-test.js.snap
+++ b/__tests__/components/__snapshots__/DateTime-test.js.snap
@@ -10,7 +10,7 @@ exports[`DateTime has correct default options 1`] = `
     value="4/7/2015 10:00 am" />
   <button
     aria-label={undefined}
-    className="grommetux-button grommetux-date-time__control grommetux-button--plain grommetux-button--icon"
+    className="grommetux-button grommetux-button--plain grommetux-button--icon grommetux-date-time__control"
     disabled={false}
     href={undefined}
     id={undefined}

--- a/__tests__/components/__snapshots__/NumberInput-test.js.snap
+++ b/__tests__/components/__snapshots__/NumberInput-test.js.snap
@@ -18,7 +18,7 @@ exports[`NumberInput has correct default options 1`] = `
     value={10} />
   <button
     aria-label={undefined}
-    className="grommetux-button grommetux-number-input__subtract grommetux-button--plain grommetux-button--icon"
+    className="grommetux-button grommetux-button--plain grommetux-button--icon grommetux-number-input__subtract"
     disabled={false}
     href={undefined}
     id={undefined}
@@ -67,7 +67,7 @@ exports[`NumberInput has correct default options 1`] = `
   </button>
   <button
     aria-label={undefined}
-    className="grommetux-button grommetux-number-input__add grommetux-button--plain grommetux-button--icon"
+    className="grommetux-button grommetux-button--plain grommetux-button--icon grommetux-number-input__add"
     disabled={false}
     href={undefined}
     id={undefined}

--- a/__tests__/components/__snapshots__/Search-test.js.snap
+++ b/__tests__/components/__snapshots__/Search-test.js.snap
@@ -2,7 +2,7 @@ exports[`Search has correct default options 1`] = `
 <div>
   <button
     aria-label={undefined}
-    className="grommetux-button grommetux-search grommetux-search--controlled grommetux-search--icon-align-end grommetux-button--plain grommetux-button--icon"
+    className="grommetux-button grommetux-button--plain grommetux-button--icon grommetux-search grommetux-search--controlled grommetux-search--icon-align-end"
     disabled={false}
     href={undefined}
     id={undefined}

--- a/__tests__/components/__snapshots__/Search-test.js.snap
+++ b/__tests__/components/__snapshots__/Search-test.js.snap
@@ -6,11 +6,12 @@ exports[`Search has correct default options 1`] = `
     disabled={false}
     href={undefined}
     id={undefined}
-    onBlur={[Function onBlur]}
+    onBlur={[Function bound _onBlurControl]}
     onClick={[Function bound _onAddDrop]}
-    onFocus={[Function onFocus]}
+    onFocus={[Function bound _onFocusControl]}
     onMouseDown={[Function onMouseDown]}
     onMouseUp={[Function onMouseUp]}
+    tabIndex="0"
     type="button">
     <span
       className="grommetux-button__icon">

--- a/__tests__/components/__snapshots__/SearchInput-test.js.snap
+++ b/__tests__/components/__snapshots__/SearchInput-test.js.snap
@@ -13,7 +13,7 @@ exports[`SearchInput has correct default options 1`] = `
     value="one" />
   <button
     aria-label={undefined}
-    className="grommetux-button grommetux-search-input__control grommetux-button--plain grommetux-button--icon"
+    className="grommetux-button grommetux-button--plain grommetux-button--icon grommetux-search-input__control"
     disabled={false}
     href={undefined}
     id={undefined}

--- a/__tests__/components/__snapshots__/Select-test.js.snap
+++ b/__tests__/components/__snapshots__/Select-test.js.snap
@@ -9,7 +9,7 @@ exports[`Select has correct default options 1`] = `
     value="one" />
   <button
     aria-label={undefined}
-    className="grommetux-button grommetux-select__control grommetux-button--plain grommetux-button--icon"
+    className="grommetux-button grommetux-button--plain grommetux-button--icon grommetux-select__control"
     disabled={false}
     href={undefined}
     id={undefined}

--- a/__tests__/components/__snapshots__/Tabs-test.js.snap
+++ b/__tests__/components/__snapshots__/Tabs-test.js.snap
@@ -7,7 +7,9 @@ exports[`Tabs has correct default options 1`] = `
       className="grommetux-tab grommetux-tab--active"
       id="tab-0">
       <button
+        aria-expanded={true}
         aria-label={undefined}
+        aria-selected={true}
         className="grommetux-button grommetux-button--plain"
         disabled={false}
         href={undefined}
@@ -17,6 +19,7 @@ exports[`Tabs has correct default options 1`] = `
         onFocus={[Function onFocus]}
         onMouseDown={[Function onMouseDown]}
         onMouseUp={[Function onMouseUp]}
+        role="tab"
         type="button">
         <label
           className="grommetux-tab__label"
@@ -29,7 +32,9 @@ exports[`Tabs has correct default options 1`] = `
       className="grommetux-tab"
       id="tab-1">
       <button
+        aria-expanded={false}
         aria-label={undefined}
+        aria-selected={false}
         className="grommetux-button grommetux-button--plain"
         disabled={false}
         href={undefined}
@@ -39,6 +44,7 @@ exports[`Tabs has correct default options 1`] = `
         onFocus={[Function onFocus]}
         onMouseDown={[Function onMouseDown]}
         onMouseUp={[Function onMouseUp]}
+        role="tab"
         type="button">
         <label
           className="grommetux-tab__label"
@@ -67,7 +73,9 @@ exports[`Tabs has correct initialIndex=0 rendering 1`] = `
       className="grommetux-tab grommetux-tab--active"
       id="tab-0">
       <button
+        aria-expanded={true}
         aria-label={undefined}
+        aria-selected={true}
         className="grommetux-button grommetux-button--plain"
         disabled={false}
         href={undefined}
@@ -77,6 +85,7 @@ exports[`Tabs has correct initialIndex=0 rendering 1`] = `
         onFocus={[Function onFocus]}
         onMouseDown={[Function onMouseDown]}
         onMouseUp={[Function onMouseUp]}
+        role="tab"
         type="button">
         <label
           className="grommetux-tab__label"
@@ -89,7 +98,9 @@ exports[`Tabs has correct initialIndex=0 rendering 1`] = `
       className="grommetux-tab"
       id="tab-1">
       <button
+        aria-expanded={false}
         aria-label={undefined}
+        aria-selected={false}
         className="grommetux-button grommetux-button--plain"
         disabled={false}
         href={undefined}
@@ -99,6 +110,7 @@ exports[`Tabs has correct initialIndex=0 rendering 1`] = `
         onFocus={[Function onFocus]}
         onMouseDown={[Function onMouseDown]}
         onMouseUp={[Function onMouseUp]}
+        role="tab"
         type="button">
         <label
           className="grommetux-tab__label"
@@ -127,7 +139,9 @@ exports[`Tabs has correct initialIndex=0 rendering 2`] = `
       className="grommetux-tab"
       id="tab-0">
       <button
+        aria-expanded={false}
         aria-label={undefined}
+        aria-selected={false}
         className="grommetux-button grommetux-button--plain"
         disabled={false}
         href={undefined}
@@ -137,6 +151,7 @@ exports[`Tabs has correct initialIndex=0 rendering 2`] = `
         onFocus={[Function onFocus]}
         onMouseDown={[Function onMouseDown]}
         onMouseUp={[Function onMouseUp]}
+        role="tab"
         type="button">
         <label
           className="grommetux-tab__label"
@@ -149,7 +164,9 @@ exports[`Tabs has correct initialIndex=0 rendering 2`] = `
       className="grommetux-tab grommetux-tab--active"
       id="tab-1">
       <button
+        aria-expanded={true}
         aria-label={undefined}
+        aria-selected={true}
         className="grommetux-button grommetux-button--plain"
         disabled={false}
         href={undefined}
@@ -159,6 +176,7 @@ exports[`Tabs has correct initialIndex=0 rendering 2`] = `
         onFocus={[Function onFocus]}
         onMouseDown={[Function onMouseDown]}
         onMouseUp={[Function onMouseUp]}
+        role="tab"
         type="button">
         <label
           className="grommetux-tab__label"

--- a/__tests__/components/__snapshots__/Video-test.js.snap
+++ b/__tests__/components/__snapshots__/Video-test.js.snap
@@ -51,7 +51,7 @@ exports[`Video has correct default options 1`] = `
         tabIndex={undefined}>
         <button
           aria-label="Play Video"
-          className="grommetux-button grommetux-video__play grommetux-button--primary grommetux-button--plain grommetux-button--icon"
+          className="grommetux-button grommetux-button--primary grommetux-button--plain grommetux-button--icon grommetux-video__play"
           disabled={false}
           href={undefined}
           id={undefined}

--- a/src/js/components/Button.js
+++ b/src/js/components/Button.js
@@ -17,18 +17,16 @@ export default class Button extends Component {
   }
 
   render () {
-    const {a11yTitle, accent, align, children, className, fill, href, icon, id, 
-      label, onClick, plain, primary, secondary, type, ...props} = this.props;
+    const {
+      a11yTitle, accent, align, children, className, fill, href, icon, id, 
+      label, onClick, plain, primary, secondary, type, ...props
+    } = this.props;
 
-    const buttonPlain = (plain !== undefined ? plain :
-      (icon && ! label));
+    const buttonPlain = (plain !== undefined ? plain : (icon && ! label));
 
     let buttonIcon;
-    if (icon) {
-      buttonIcon = (<span className={`${CLASS_ROOT}__icon`}>
-        {icon}
-      </span>);
-    }
+    if (icon) buttonIcon =
+      <span className={`${CLASS_ROOT}__icon`}>{icon}</span>;
 
     let hasIcon = buttonIcon !== undefined;
     let buttonChildren = React.Children.map(children, child => {
@@ -39,9 +37,8 @@ export default class Button extends Component {
       return child;
     });
 
-    let classes = classnames(
+    const classes = classnames(
       CLASS_ROOT,
-      className,
       {
         [`${CLASS_ROOT}--focus`]: this.state.focus,
         [`${CLASS_ROOT}--primary`]: primary,
@@ -52,14 +49,15 @@ export default class Button extends Component {
         [`${CLASS_ROOT}--plain`]: buttonPlain,
         [`${CLASS_ROOT}--icon`]: icon || hasIcon,
         [`${CLASS_ROOT}--align-${align}`]: align
-      }
+      },
+      className
     );
 
     if (!buttonChildren) {
       buttonChildren = label;
     }
 
-    let Tag = href ? 'a' : 'button';
+    const Tag = href ? 'a' : 'button';
     let buttonType;
     if (!href) {
       buttonType = type;

--- a/src/js/components/Button.js
+++ b/src/js/components/Button.js
@@ -15,17 +15,23 @@ export default class Button extends Component {
       focus: false
     };
   }
-  render () {
-    const plain = (this.props.plain !== undefined ? this.props.plain :
-      (this.props.icon && ! this.props.label));
 
-    let icon;
-    if (this.props.icon) {
-      icon = <span className={`${CLASS_ROOT}__icon`}>{this.props.icon}</span>;
+  render () {
+    const {a11yTitle, accent, align, children, className, fill, href, icon, id, 
+      label, onClick, plain, primary, secondary, type, ...props} = this.props;
+
+    const buttonPlain = (plain !== undefined ? plain :
+      (icon && ! label));
+
+    let buttonIcon;
+    if (icon) {
+      buttonIcon = (<span className={`${CLASS_ROOT}__icon`}>
+        {icon}
+      </span>);
     }
 
-    let hasIcon = icon !== undefined;
-    let children = React.Children.map(this.props.children, child => {
+    let hasIcon = buttonIcon !== undefined;
+    let buttonChildren = React.Children.map(children, child => {
       if (child && child.type && child.type.icon) {
         hasIcon = true;
         child = <span className={`${CLASS_ROOT}__icon`}>{child}</span>;
@@ -35,34 +41,35 @@ export default class Button extends Component {
 
     let classes = classnames(
       CLASS_ROOT,
-      this.props.className,
+      className,
       {
         [`${CLASS_ROOT}--focus`]: this.state.focus,
-        [`${CLASS_ROOT}--primary`]: this.props.primary,
-        [`${CLASS_ROOT}--secondary`]: this.props.secondary,
-        [`${CLASS_ROOT}--accent`]: this.props.accent,
-        [`${CLASS_ROOT}--disabled`]: !this.props.onClick && !this.props.href,
-        [`${CLASS_ROOT}--fill`]: this.props.fill,
-        [`${CLASS_ROOT}--plain`]: plain,
-        [`${CLASS_ROOT}--icon`]: this.props.icon || hasIcon,
-        [`${CLASS_ROOT}--align-${this.props.align}`]: this.props.align
+        [`${CLASS_ROOT}--primary`]: primary,
+        [`${CLASS_ROOT}--secondary`]: secondary,
+        [`${CLASS_ROOT}--accent`]: accent,
+        [`${CLASS_ROOT}--disabled`]: !onClick && !href,
+        [`${CLASS_ROOT}--fill`]: fill,
+        [`${CLASS_ROOT}--plain`]: buttonPlain,
+        [`${CLASS_ROOT}--icon`]: icon || hasIcon,
+        [`${CLASS_ROOT}--align-${align}`]: align
       }
     );
 
-    if (!children) {
-      children = this.props.label;
+    if (!buttonChildren) {
+      buttonChildren = label;
     }
 
-    let Tag = this.props.href ? 'a' : 'button';
-    let type;
-    if (!this.props.href) {
-      type = this.props.type;
+    let Tag = href ? 'a' : 'button';
+    let buttonType;
+    if (!href) {
+      buttonType = type;
     }
+
     return (
-      <Tag href={this.props.href} id={this.props.id} type={type}
-        className={classes} aria-label={this.props.a11yTitle}
-        onClick={this.props.onClick}
-        disabled={!this.props.onClick && !this.props.href}
+      <Tag href={href} id={id} type={buttonType}
+        className={classes} aria-label={a11yTitle}
+        onClick={onClick}
+        disabled={!onClick && !href}
         onMouseDown={() => this.setState({ mouseActive: true })}
         onMouseUp={() => this.setState({ mouseActive: false })}
         onFocus={() => {
@@ -70,9 +77,10 @@ export default class Button extends Component {
             this.setState({ focus: true });
           }
         }}
-        onBlur={() => this.setState({ focus: false })}>
-        {icon}
-        {children}
+        onBlur={() => this.setState({ focus: false })}
+        {...props}>
+        {buttonIcon}
+        {buttonChildren}
       </Tag>
     );
   }

--- a/src/js/components/LoginForm.js
+++ b/src/js/components/LoginForm.js
@@ -142,7 +142,7 @@ export default class LoginForm extends Component {
           align={center ? 'stretch' : 'start'}
           pad={{vertical: 'none', between: 'medium'}}>
           {rememberMeNode}
-          <Button primary={true} strong={true} fill={center}
+          <Button primary={true} fill={center}
             type="submit" label={login}
             onClick={onSubmit ? this._onSubmit : undefined} />
           {forgotPassword}


### PR DESCRIPTION
This PR references issue #85 regarding transferring microdata properties to components. 

#### What does this PR do?
Destructures `this.props` on the button component to allow for additional properties to be rendered. Additionally, I've removed the `strong` property on the login form button as this is not a valid Prop type. 

#### What testing has been done on this PR?
I've written additional tests to support this functionality and tested within grommet-docs.

#### What are the relevant issues?
Updating other components snapshots was necessary to pass tests - specifically aria properties. 

#### Is this change backwards compatible or is it a breaking change?
This is backward compatible. 
