### PR TITLE
Transfer App component props

### DIFF
--- a/__tests__/components/App-test.js
+++ b/__tests__/components/App-test.js
@@ -38,4 +38,12 @@ describe('App', () => {
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+  it('has microdata properties rendering', () => {
+    const component = renderer.create(
+      <App itemScope={true} itemType="http://schema.org/Article"
+        itemProp="test"/>
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/__tests__/components/__snapshots__/App-test.js.snap
+++ b/__tests__/components/__snapshots__/App-test.js.snap
@@ -1,6 +1,6 @@
 exports[`App has correct className rendering 1`] = `
 <div
-  className="grommet testing grommetux-app grommetux-app--centered"
+  className="grommet grommetux-app grommetux-app--centered testing"
   lang="en-US">
   <span
     style={
@@ -53,6 +53,25 @@ exports[`App has correct lang="pt=BR" rendering 1`] = `
 <div
   className="grommet grommetux-app grommetux-app--centered"
   lang="pt-BR">
+  <span
+    style={
+      Object {
+        "display": "none"
+      }
+    } />
+  <div
+    aria-live="polite"
+    className="grommetux-app__announcer" />
+</div>
+`;
+
+exports[`App has microdata properties rendering 1`] = `
+<div
+  className="grommet grommetux-app grommetux-app--centered"
+  itemProp="test"
+  itemScope={true}
+  itemType="http://schema.org/Article"
+  lang="en-US">
   <span
     style={
       Object {

--- a/src/js/components/App.js
+++ b/src/js/components/App.js
@@ -45,20 +45,20 @@ export default class App extends Component {
   }
 
   render() {
-    const { centered, children, className, inline } = this.props;
+    const { centered, children, className, inline, ...props } = this.props;
     const { lang } = this.state;
 
     const classes = classnames(
       'grommet',
-      className,
       CLASS_ROOT, {
         [`${CLASS_ROOT}--centered`]: centered,
         [`${CLASS_ROOT}--inline`]: inline
-      }
+      },
+      className
     );
 
     return (
-      <div lang={lang} className={classes}>
+      <div lang={lang} className={classes} {...props}>
         {children}
         <SkipLinks />
         <div className={`${CLASS_ROOT}__announcer`} aria-live='polite' />


### PR DESCRIPTION
This PR references issue #85 regarding microdata properties. 

#### What does this PR do?
This PR adds microdata functionality to the App component. Additionally, I've adjusted the CSS class order to remain consistent with other components.

#### What testing has been done on this PR?
I've added a test specifically for microdata properties. 

#### Any background context you want to provide?
Issue #85.

#### Is this change backwards compatible or is it a breaking change?
This change is backward compatible.