### PR TITLE
fix/cleaning warnings from Notification component

### DIFF
--- a/src/js/components/Notification.js
+++ b/src/js/components/Notification.js
@@ -49,15 +49,14 @@ export default class Notification extends Component {
     let progress;
     if (this.props.percentComplete || 0 === this.props.percentComplete) {
       progress = (
-        <span>
+        <Box direction="row" align="center">
           <Meter
             series={[{
               value: this.props.percentComplete,
               colorIndex: 'light-1'
-            }]}
-          />
+            }]}/>
           <Value value={this.props.percentComplete} units="%" size="small"/>
-        </span>
+        </Box>
       );
     }
 

--- a/src/js/components/Notification.js
+++ b/src/js/components/Notification.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import { FormattedDate } from 'react-intl';
 import Intl from '../utils/Intl';
 import Box from './Box';
+import Value from './Value';
 import Animate from './Animate';
 import Meter from './Meter';
 import Button from './Button';
@@ -48,12 +49,15 @@ export default class Notification extends Component {
     let progress;
     if (this.props.percentComplete || 0 === this.props.percentComplete) {
       progress = (
-        <Meter units="%"
-          series={[{
-            value: this.props.percentComplete,
-            label: '',
-            colorIndex: 'light-1'
-          }]} />
+        <span>
+          <Meter
+            series={[{
+              value: this.props.percentComplete,
+              colorIndex: 'light-1'
+            }]}
+          />
+          <Value value={this.props.percentComplete} units="%" size="small"/>
+        </span>
       );
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
cleaning warnings from the Notification component.

In grommet 0.6.12; warning messages for meter was added in case of using deprecated meter props.
Grommet is internally using meter within the Notification banner, so it threw warnings. In this PR the warning were fixed

#### Where should the reviewer start?
Removing deprecated props from the Notification meter in order to remove the warning from console log 

#### What testing has been done on this PR?
Integrating with our Hellfire application and making sure the warnings are gone.

#### How should this be manually tested?
run the notification component to see the progress bar running, and make sure the console logs doesn't show warnings.

#### Any background context you want to provide?
In grommet 0.6.12; warning messages for meter was added, in case of using deprecated props.
Grommet is internally using meter within the Notification banner
The Notification component throws warnings
   
#### What are the relevant issues?

#### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/6320236/19006029/e5637a62-871a-11e6-8f78-142a14894526.png)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No 

#### Is this change backwards compatible or is it a breaking change?
Yes
