### PR TITLE
Transfer RadioButton component props

### DIFF
--- a/__tests__/components/__snapshots__/Markdown-test.js.snap
+++ b/__tests__/components/__snapshots__/Markdown-test.js.snap
@@ -1,5 +1,6 @@
 exports[`Markdown has correct default options 1`] = `
-<p>
+<p
+  className="grommetux-paragraph grommetux-paragraph--large testing">
   test
 </p>
 `;

--- a/__tests__/components/__snapshots__/RadioButton-test.js.snap
+++ b/__tests__/components/__snapshots__/RadioButton-test.js.snap
@@ -4,13 +4,9 @@ exports[`RadioButton has correct default options 1`] = `
   <input
     checked={true}
     className="grommetux-radio-button__input"
-    defaultChecked={undefined}
-    disabled={undefined}
     id="choice"
     name="choice"
-    onChange={undefined}
-    type="radio"
-    value={undefined} />
+    type="radio" />
   <span
     className="grommetux-radio-button__control" />
   <span

--- a/src/js/components/RadioButton.js
+++ b/src/js/components/RadioButton.js
@@ -8,26 +8,22 @@ const CLASS_ROOT = CSSClassnames.RADIO_BUTTON;
 
 export default class RadioButton extends Component {
   render () {
-    let classes = classnames(
+    const { className, label, ...props } = this.props;
+    const classes = classnames(
       CLASS_ROOT,
-      this.props.className,
       {
-        [`${CLASS_ROOT}--disabled`]: this.props.disabled
-      }
+        [`${CLASS_ROOT}--disabled`]: props.disabled
+      },
+      className
     );
 
     return (
       <label className={classes}>
-        <input className={`${CLASS_ROOT}__input`}
-          id={this.props.id} name={this.props.name} type="radio"
-          disabled={this.props.disabled}
-          checked={this.props.checked}
-          defaultChecked={this.props.defaultChecked}
-          value={this.props.value}
-          onChange={this.props.onChange} />
+        <input {...props} className={`${CLASS_ROOT}__input`}
+          type="radio" />
         <span className={`${CLASS_ROOT}__control`} />
           <span className={`${CLASS_ROOT}__label`}>
-            {this.props.label}
+            {label}
           </span>
       </label>
     );


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Transfer RadioButton component props to underlying DOM element.

#### What testing has been done on this PR?

Tested on grommet docs page.

#### What are the relevant issues?

#85

#### Is this change backwards compatible or is it a breaking change?

Yes, backwards compatible.
