### PR TITLE
Transfer Section component props

### DIFF
--- a/src/js/components/Section.js
+++ b/src/js/components/Section.js
@@ -9,13 +9,14 @@ const CLASS_ROOT = CSSClassnames.SECTION;
 
 export default class Section extends Component {
   render () {
-    var classes = classnames(CLASS_ROOT, this.props.className);
-
-    let boxProps = { ...this.props };
-    delete boxProps.className;
+    const { className, ...props } = this.props;
+    const classes = classnames(
+      CLASS_ROOT,
+      className
+    );
 
     return (
-      <Box {...boxProps} tag="section" className={classes} />
+      <Box {...props} tag="section" className={classes} />
     );
   }
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Transfer Section component props to underlying DOM element.

#### What testing has been done on this PR?

Tested on grommet docs page.

#### What are the relevant issues?

#85 

#### Is this change backwards compatible or is it a breaking change?

Yes, backwards compatible.
