### PR TITLE
Cleaned up Checkbox for consistent structure.

### DIFF
--- a/__tests__/components/CheckBox-test.js
+++ b/__tests__/components/CheckBox-test.js
@@ -47,4 +47,12 @@ describe('CheckBox', () => {
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+  it('has correct microdata property rendering', () => {
+    const component = renderer.create(
+      <CheckBox id="test" label="Test CheckBox" itemScope={true} 
+        itemType="http://schema.org/Boolean" itemProp="test"/>
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/__tests__/components/__snapshots__/CheckBox-test.js.snap
+++ b/__tests__/components/__snapshots__/CheckBox-test.js.snap
@@ -134,6 +134,43 @@ exports[`CheckBox has correct disabled=true rendering 1`] = `
 </label>
 `;
 
+exports[`CheckBox has correct microdata property rendering 1`] = `
+<label
+  aria-label="Test CheckBox"
+  className="grommetux-check-box"
+  itemProp="test"
+  itemScope={true}
+  itemType="http://schema.org/Boolean">
+  <span>
+    <input
+      checked={undefined}
+      className="grommetux-check-box__input"
+      defaultChecked={undefined}
+      disabled={undefined}
+      id="test"
+      name={undefined}
+      onChange={undefined}
+      tabIndex="0"
+      type="checkbox" />
+    <span
+      className="grommetux-check-box__control">
+      <svg
+        className="grommetux-check-box__control-check"
+        preserveAspectRatio="xMidYMid meet"
+        viewBox="0 0 24 24">
+        <path
+          d="M6,11.3 L10.3,16 L18,6.2"
+          fill="none" />
+      </svg>
+    </span>
+  </span>
+  <span
+    className="grommetux-check-box__label">
+    Test CheckBox
+  </span>
+</label>
+`;
+
 exports[`CheckBox has correct reverse=true rendering 1`] = `
 <label
   aria-label="Test CheckBox"

--- a/src/js/components/CheckBox.js
+++ b/src/js/components/CheckBox.js
@@ -16,11 +16,11 @@ export default class CheckBox extends Component {
     } = this.props;
 
     const classes = classnames(
-      CLASS_ROOT,
-      className, {
+      CLASS_ROOT, {
         [`${CLASS_ROOT}--toggle`]: toggle,
         [`${CLASS_ROOT}--disabled`]: disabled
-      }
+      },
+      className
     );
     const restProps = Props.omit(this.props, Object.keys(CheckBox.propTypes));
 


### PR DESCRIPTION
This PR brings the Checkbox component in line with Grommet's consistent component structure by moving `className` to the bottom of classname's array. This PR also adds additional tests for custom class names and microdata properties. 