### PR TITLE
Updated Footer to transfer component props.

### DIFF
--- a/__tests__/components/Footer-test.js
+++ b/__tests__/components/Footer-test.js
@@ -17,4 +17,19 @@ describe('Footer', () => {
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+  it('renders a class name', () => {
+    const component = renderer.create(
+      <Footer className="test">Testing</Footer>
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders microdata properties', () => {
+    const component = renderer.create(
+      <Footer itemScope={true} itemType="http://schema.org/WPFooter"
+        itemProp="test">Testing</Footer>
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/__tests__/components/__snapshots__/Footer-test.js.snap
+++ b/__tests__/components/__snapshots__/Footer-test.js.snap
@@ -9,3 +9,30 @@ exports[`Footer has correct default options 1`] = `
   Testing
 </footer>
 `;
+
+exports[`Footer renders a class name 1`] = `
+<footer
+  className="grommetux-box grommetux-box--direction-row grommetux-box--pad-none grommetux-footer test"
+  id={undefined}
+  onClick={undefined}
+  role={undefined}
+  style={Object {}}
+  tabIndex={undefined}>
+  Testing
+</footer>
+`;
+
+exports[`Footer renders microdata properties 1`] = `
+<footer
+  className="grommetux-box grommetux-box--direction-row grommetux-box--pad-none grommetux-footer"
+  id={undefined}
+  itemProp="test"
+  itemScope={true}
+  itemType="http://schema.org/WPFooter"
+  onClick={undefined}
+  role={undefined}
+  style={Object {}}
+  tabIndex={undefined}>
+  Testing
+</footer>
+`;

--- a/src/js/components/Footer.js
+++ b/src/js/components/Footer.js
@@ -55,48 +55,52 @@ export default class Footer extends Component {
   }
 
   render () {
-    let classes = classnames(
+    const { 
+      children, className, colorIndex, fixed, float, primary, size
+    } = this.props;
+    const restProps = Props.omit(this.props, Object.keys(Footer.propTypes));
+    const classes = classnames(
       CLASS_ROOT,
-      this.props.className,
       {
-        [`${CLASS_ROOT}--${this.props.size}`]: (
-          this.props.size && typeof this.props.size === 'string'),
-        [`${CLASS_ROOT}--float`]: this.props.float
-      }
+        [`${CLASS_ROOT}--${size}`]: (
+          size && typeof size === 'string'),
+        [`${CLASS_ROOT}--float`]: float
+      },
+      className
     );
 
-    let containerClasses = classnames(
+    const containerClasses = classnames(
       `${CLASS_ROOT}__container`,
       {
-        [`${CLASS_ROOT}__container--float`]: this.props.float,
-        [`${CLASS_ROOT}__container--fixed`]: this.props.fixed,
+        [`${CLASS_ROOT}__container--float`]: float,
+        [`${CLASS_ROOT}__container--fixed`]: fixed,
         [`${CLASS_ROOT}__container--fill`]: (
           // add default color index if none is provided
-          this.props.fixed && !this.props.colorIndex
+          fixed && !colorIndex
         )
       }
     );
 
-    let wrapperClasses = classnames(
+    const wrapperClasses = classnames(
       `${CLASS_ROOT}__wrapper`,
       {
-        [`${CLASS_ROOT}__wrapper--${this.props.size}`]: (
-          this.props.size && typeof this.props.size === 'string')
+        [`${CLASS_ROOT}__wrapper--${size}`]: (
+          size && typeof size === 'string')
       }
     );
 
     let footerSkipLink;
-    if (this.props.primary) {
+    if (primary) {
       footerSkipLink = <SkipLinkAnchor label="Footer" />;
     }
 
-    let boxProps = Props.pick(this.props, Object.keys(Box.propTypes));
+    const boxProps = Props.pick(this.props, Object.keys(Box.propTypes));
     // don't transfer size to Box since it means something different
     delete boxProps.size;
 
-    if (this.props.fixed) {
+    if (fixed) {
       return (
-        <div className={containerClasses}>
+        <div className={containerClasses} {...restProps}>
           <div ref={ref => this.mirrorRef = ref}
             className={`${CLASS_ROOT}__mirror`} />
           <div className={wrapperClasses}>
@@ -104,18 +108,18 @@ export default class Footer extends Component {
               {...boxProps} tag="footer" className={classes}
               primary={false}>
               {footerSkipLink}
-              {this.props.children}
+              {children}
             </Box>
           </div>
         </div>
       );
     } else {
       return (
-        <Box {...boxProps} tag="footer" className={classes}
+        <Box {...restProps} {...boxProps} tag="footer" className={classes}
           containerClassName={containerClasses}
           primary={false}>
           {footerSkipLink}
-          {this.props.children}
+          {children}
         </Box>
       );
     }
@@ -125,8 +129,8 @@ export default class Footer extends Component {
 Footer.propTypes = {
   fixed: PropTypes.bool,
   float: PropTypes.bool,
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
   primary: PropTypes.bool,
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
   ...Box.propTypes
 };
 


### PR DESCRIPTION
This PR references issue #85 regarding microdata properties and brings the Footer component in line with Grommet's consistent component structure. This PR also adds tests for microdata properties and custom class names.