### PR TITLE
Updated Form to transfer component props.

### DIFF
--- a/__tests__/components/Form-test.js
+++ b/__tests__/components/Form-test.js
@@ -38,4 +38,32 @@ describe('Form', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+  it('renders a class name', () => {
+    const component = renderer.create(
+      <Form className="test"
+        onSubmit={(e) => e}>
+        <FormFields>
+          <FormField label="Item 1" htmlFor="item1">
+            <input id="item1" type="text" />
+          </FormField>
+        </FormFields>
+      </Form>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders microdata properties', () => {
+    const component = renderer.create(
+      <Form itemScope={true} itemType="http://schema.org/Article"
+        itemProp="test" onSubmit={(e) => e}>
+        <FormFields>
+          <FormField label="Item 1" htmlFor="item1">
+            <input id="item1" type="text" />
+          </FormField>
+        </FormFields>
+      </Form>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/__tests__/components/__snapshots__/Form-test.js.snap
+++ b/__tests__/components/__snapshots__/Form-test.js.snap
@@ -23,6 +23,59 @@ exports[`Form has correct default options 1`] = `
 </form>
 `;
 
+exports[`Form renders a class name 1`] = `
+<form
+  className="grommetux-form grommetux-form--pad-none test"
+  onSubmit={[Function onSubmit]}>
+  <div
+    className="grommetux-form-fields">
+    <div
+      className="grommetux-form-field grommetux-form-field--text grommetux-form-field--size-medium"
+      onClick={[Function bound _onClick]}>
+      <label
+        className="grommetux-form-field__label"
+        htmlFor="item1">
+        Item 1
+      </label>
+      <span
+        className="grommetux-form-field__contents">
+        <input
+          id="item1"
+          type="text" />
+      </span>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`Form renders microdata properties 1`] = `
+<form
+  className="grommetux-form grommetux-form--pad-none"
+  itemProp="test"
+  itemScope={true}
+  itemType="http://schema.org/Article"
+  onSubmit={[Function onSubmit]}>
+  <div
+    className="grommetux-form-fields">
+    <div
+      className="grommetux-form-field grommetux-form-field--text grommetux-form-field--size-medium"
+      onClick={[Function bound _onClick]}>
+      <label
+        className="grommetux-form-field__label"
+        htmlFor="item1">
+        Item 1
+      </label>
+      <span
+        className="grommetux-form-field__contents">
+        <input
+          id="item1"
+          type="text" />
+      </span>
+    </div>
+  </div>
+</form>
+`;
+
 exports[`Form renders with alternate props 1`] = `
 <form
   className="grommetux-form grommetux-form--compact grommetux-form--fill grommetux-form--pad-horizontal-large grommetux-form--pad-vertical-large"

--- a/__tests__/components/__snapshots__/LoginForm-test.js.snap
+++ b/__tests__/components/__snapshots__/LoginForm-test.js.snap
@@ -1,6 +1,6 @@
 exports[`LoginForm has correct default options 1`] = `
 <form
-  className="grommetux-form grommetux-login-form grommetux-form--pad-medium"
+  className="grommetux-form grommetux-form--pad-medium grommetux-login-form"
   onSubmit={[Function bound _onSubmit]}>
   <div
     className="grommetux-box grommetux-box--direction-column grommetux-box--align-center grommetux-box--responsive grommetux-box--pad-none"

--- a/src/js/components/Form.js
+++ b/src/js/components/Form.js
@@ -8,10 +8,9 @@ const CLASS_ROOT = CSSClassnames.FORM;
 
 export default class Form extends Component {
   render () {
-    let { className, compact, fill, pad } = this.props;
-    let classes = classnames(
+    const { className, compact, fill, pad, ...props } = this.props;
+    const classes = classnames(
       CLASS_ROOT,
-      className,
       {
         [`${CLASS_ROOT}--compact`]: compact,
         [`${CLASS_ROOT}--fill`]: fill,
@@ -20,11 +19,12 @@ export default class Form extends Component {
           typeof pad === 'object' && 'horizontal' in pad,
         [`${CLASS_ROOT}--pad-vertical-${pad.vertical}`]:
           typeof pad === 'object' && 'vertical' in pad
-      }
+      },
+      className
     );
 
     return (
-      <form className={classes} onSubmit={this.props.onSubmit}>
+      <form className={classes} {...props} onSubmit={this.props.onSubmit}>
         {this.props.children}
       </form>
     );

--- a/src/js/components/Form.js
+++ b/src/js/components/Form.js
@@ -24,7 +24,7 @@ export default class Form extends Component {
     );
 
     return (
-      <form className={classes} {...props} onSubmit={this.props.onSubmit}>
+      <form {...props} className={classes} onSubmit={this.props.onSubmit}>
         {this.props.children}
       </form>
     );


### PR DESCRIPTION
This PR references issue #85 regarding microdata properties and brings the Form component in line with Grommet's consistent component structure. This PR also adds tests for microdata properties and custom class names.