### PR TITLE
Transfer SocialShare component props

### DIFF
--- a/__tests__/components/SocialShare-test.js
+++ b/__tests__/components/SocialShare-test.js
@@ -57,4 +57,12 @@ describe('SocialShare', () => {
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+  it('has correct className rendering', () => {
+    const component = renderer.create(
+      <SocialShare type="linkedin" link="http://grommet.io"
+         className="testing" />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/__tests__/components/__snapshots__/SocialShare-test.js.snap
+++ b/__tests__/components/__snapshots__/SocialShare-test.js.snap
@@ -1,3 +1,32 @@
+exports[`SocialShare has correct className rendering 1`] = `
+<a
+  aria-label={undefined}
+  className="grommetux-anchor testing grommetux-anchor--animate-icon grommetux-anchor--icon"
+  href="https://www.linkedin.com/shareArticle?mini=true&url=http%3A%2F%2Fgrommet.io&title=&summary="
+  id={undefined}
+  onClick={undefined}
+  target="_blank">
+  <span
+    className="grommetux-anchor__icon">
+    <svg
+      aria-label="Share on Linkedin"
+      className="grommetux-control-icon grommetux-control-icon-social-linkedin grommetux-control-icon--responsive"
+      height="24px"
+      role="img"
+      version="1.1"
+      viewBox="0 0 24 24"
+      width="24px">
+      <g>
+        <path
+          d="M22,23 L18,23 L18,17 C18,15 17.5,13 15,13 C12.5,13 12,15 12,17 L12,23 L8,23 L8,9 L12,9 L12,12 C12,12 13.5,9 17,9 C19.5,9 22,11 22,15.5 L22,23 Z M6,23 L2,23 L2,9 L6,9 L6,23 Z M4,7 C5,7 6.5,6 6.5,4.5 C6.5,3 5,2 4,2 C2.5,2 1.5,3 1.5,4.5 C1.5,6 2.5,7 4,7 Z"
+          fill="#000000"
+          stroke="none" />
+      </g>
+    </svg>
+  </span>
+</a>
+`;
+
 exports[`SocialShare has correct email rendering 1`] = `
 <a
   aria-label={undefined}

--- a/src/js/components/SocialShare.js
+++ b/src/js/components/SocialShare.js
@@ -10,7 +10,9 @@ import SocialEmailIcon from './icons/base/SocialEmail';
 
 export default class SocialShare extends Component {
   render () {
-    const { colorIndex, type, link, text, title, a11yTitle } = this.props;
+    const {
+      colorIndex, type, link, text, title, a11yTitle, ...props
+    } = this.props;
 
     let socialIcon = undefined;
     let href = '';
@@ -49,7 +51,7 @@ export default class SocialShare extends Component {
     }
 
     return (
-      <Anchor href={href} icon={socialIcon} target={target} />
+      <Anchor {...props} href={href} icon={socialIcon} target={target} />
     );
   }
 };
@@ -65,6 +67,6 @@ SocialShare.propTypes = {
 };
 
 SocialShare.defaultProps = {
-  title: '',
-  text: ''
+  text: '',
+  title: ''
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Transfer **`SocialShare`** component props to underlying DOM element & add test.

#### What testing has been done on this PR?

Tested on grommet docs page.

#### What are the relevant issues?

#85 

#### Is this change backwards compatible or is it a breaking change?

Yes, backwards compatible.
