### PR TITLE
Updated FormField to transfer component props.

### DIFF
--- a/__tests__/components/FormField-test.js
+++ b/__tests__/components/FormField-test.js
@@ -19,4 +19,23 @@ describe('FormField', () => {
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+  it('renders a class name', () => {
+    const component = renderer.create(
+      <FormField label="Item 1" htmlFor="item1" className="test">
+        <input id="item1" type="text" />
+      </FormField>
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders microdata properties', () => {
+    const component = renderer.create(
+      <FormField label="Item 1" htmlFor="item1" itemScope={true} 
+        itemType="http://schema.org/Article" itemProp="test">
+        <input id="item1" type="text" />
+      </FormField>
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/__tests__/components/__snapshots__/FormField-test.js.snap
+++ b/__tests__/components/__snapshots__/FormField-test.js.snap
@@ -15,3 +15,42 @@ exports[`FormField has correct default options 1`] = `
   </span>
 </div>
 `;
+
+exports[`FormField renders a class name 1`] = `
+<div
+  className="grommetux-form-field grommetux-form-field--text grommetux-form-field--size-medium test"
+  onClick={[Function bound _onClick]}>
+  <label
+    className="grommetux-form-field__label"
+    htmlFor="item1">
+    Item 1
+  </label>
+  <span
+    className="grommetux-form-field__contents">
+    <input
+      id="item1"
+      type="text" />
+  </span>
+</div>
+`;
+
+exports[`FormField renders microdata properties 1`] = `
+<div
+  className="grommetux-form-field grommetux-form-field--text grommetux-form-field--size-medium"
+  itemProp="test"
+  itemScope={true}
+  itemType="http://schema.org/Article"
+  onClick={[Function bound _onClick]}>
+  <label
+    className="grommetux-form-field__label"
+    htmlFor="item1">
+    Item 1
+  </label>
+  <span
+    className="grommetux-form-field__contents">
+    <input
+      id="item1"
+      type="text" />
+  </span>
+</div>
+`;

--- a/src/js/components/FormField.js
+++ b/src/js/components/FormField.js
@@ -75,17 +75,17 @@ export default class FormField extends Component {
 
     const fieldError = (error)
       ? <span className={CLASS_ROOT + "__error"}>{error}</span>
-      : null;
+      : undefined;
 
     const fieldHelp = (help !== null && help !== undefined)
       ? <span className={CLASS_ROOT + "__help"}>{this.props.help}</span>
-      : null;
+      : undefined;
 
     const labelNode = (label)
       ? <label className={CLASS_ROOT + "__label"} htmlFor={htmlFor}>
           {label}
         </label>
-      : null;
+      : undefined;
 
     return (
       <div className={classes} {...props} onClick={this._onClick}>

--- a/src/js/components/FormField.js
+++ b/src/js/components/FormField.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
 import React, { Component, PropTypes } from 'react';
+import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 
 const CLASS_ROOT = CSSClassnames.FORM_FIELD;
@@ -54,55 +55,46 @@ export default class FormField extends Component {
   }
 
   render () {
-    let classes = [CLASS_ROOT];
-    if (this.state.focus) {
-      classes.push(CLASS_ROOT + "--focus");
-    }
-    if (this.props.hidden) {
-      classes.push(CLASS_ROOT + "--hidden");
-    }
-    if (this.props.htmlFor) {
-      classes.push(CLASS_ROOT + "--text");
-    }
-    if (this.props.size) {
-      classes.push(CLASS_ROOT + "--size-" + this.props.size);
-    }
-    if (this.props.strong) {
-      classes.push(`${CLASS_ROOT}--strong`);
-    }
-    if (this.props.className) {
-      classes.push(this.props.className);
-    }
+    const { 
+      children, className, help, hidden, htmlFor, label, size, strong, error, 
+      ...props
+    } = this.props;
 
-    let error;
-    if (this.props.error) {
-      classes.push(CLASS_ROOT + "--error");
-      error = (
-        <span className={CLASS_ROOT + "__error"}>{this.props.error}</span>
-      );
-    }
-    let help;
-    if (this.props.help !== null && this.props.help !== undefined) {
-      help = <span className={CLASS_ROOT + "__help"}>{this.props.help}</span>;
-    }
+    const classes = classnames(
+      CLASS_ROOT,
+      {
+        [`${CLASS_ROOT}--focus`]: this.state.focus,
+        [`${CLASS_ROOT}--hidden`]: hidden,
+        [`${CLASS_ROOT}--text`]: htmlFor,
+        [`${CLASS_ROOT}--size-${size}`]: size,
+        [`${CLASS_ROOT}--strong`]: strong,
+        [`${CLASS_ROOT}--error`]: error
+      },
+      className
+    );
 
-    let labelNode;
-    if (this.props.label) {
-      labelNode = (
-        <label className={CLASS_ROOT + "__label"} htmlFor={this.props.htmlFor}>
-          {this.props.label}
+    const fieldError = (error)
+      ? <span className={CLASS_ROOT + "__error"}>{error}</span>
+      : null;
+
+    const fieldHelp = (help !== null && help !== undefined)
+      ? <span className={CLASS_ROOT + "__help"}>{this.props.help}</span>
+      : null;
+
+    const labelNode = (label)
+      ? <label className={CLASS_ROOT + "__label"} htmlFor={htmlFor}>
+          {label}
         </label>
-      );
-    }
+      : null;
 
     return (
-      <div className={classes.join(' ')} onClick={this._onClick}>
-        {error}
+      <div className={classes} {...props} onClick={this._onClick}>
+        {fieldError}
         {labelNode}
-        {help}
+        {fieldHelp}
         <span ref={ref => this.contentsRef = ref}
           className={CLASS_ROOT + "__contents"}>
-          {this.props.children}
+          {children}
         </span>
       </div>
     );


### PR DESCRIPTION
This PR references issue #85 regarding microdata properties and brings the FormField component in line with Grommet's consistent component structure. This PR also adds tests for microdata properties and custom class names.