### PR TITLE
Transfer Spinning component props

### DIFF
--- a/__tests__/components/icons/Spinning-test.js
+++ b/__tests__/components/icons/Spinning-test.js
@@ -27,4 +27,12 @@ describe('Spinning', () => {
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+  it('has microdata properties rendering', () => {
+    const component = renderer.create(
+      <Spinning itemScope={true} itemType="http://schema.org/Article"
+        itemProp="test"/>
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/__tests__/components/icons/__snapshots__/Spinning-test.js.snap
+++ b/__tests__/components/icons/__snapshots__/Spinning-test.js.snap
@@ -81,3 +81,34 @@ exports[`Spinning has correct small=true rendering 1`] = `
     strokeWidth="4" />
 </svg>
 `;
+
+exports[`Spinning has microdata properties rendering 1`] = `
+<svg
+  className="grommetux-icon-spinning"
+  itemProp="test"
+  itemScope={true}
+  itemType="http://schema.org/Article"
+  role="img"
+  version="1.1"
+  viewBox="0 0 48 48">
+  <title>
+    Spinning
+  </title>
+  <circle
+    cx="24"
+    cy="24"
+    fill="none"
+    r="20"
+    stroke="#ddd"
+    strokeDasharray="24px 8px"
+    strokeWidth="4" />
+  <circle
+    cx="24"
+    cy="24"
+    fill="none"
+    r="20"
+    stroke="#333"
+    strokeDasharray="24px 104px"
+    strokeWidth="4" />
+</svg>
+`;

--- a/src/js/components/icons/Spinning.js
+++ b/src/js/components/icons/Spinning.js
@@ -1,22 +1,25 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
+import classnames from 'classnames';
 import CSSClassnames from '../../utils/CSSClassnames';
 
 const CLASS_ROOT = CSSClassnames.SPINNING;
 
 export default class Spinning extends Component {
   render () {
-    var classes = [CLASS_ROOT];
-    if (this.props.small) {
-      classes.push(CLASS_ROOT + "--small");
-    }
-    if (this.props.className) {
-      classes.push(this.props.className);
-    }
+    const { className, small, ...props } = this.props;
+    const classes = classnames(
+      CLASS_ROOT,
+      {
+        [`${CLASS_ROOT}--small`]: small
+      },
+      className
+    );
+
     return (
-      <svg className={classes.join(' ')} viewBox="0 0 48 48" version="1.1"
-        role='img'>
+      <svg {...props} className={classes} viewBox="0 0 48 48" version="1.1"
+        role="img">
         <title>Spinning</title>
         <circle stroke="#ddd" strokeWidth="4" strokeDasharray="24px 8px"
           fill="none" cx="24" cy="24" r="20" />
@@ -26,3 +29,7 @@ export default class Spinning extends Component {
     );
   }
 }
+
+Spinning.propTypes = {
+  small: PropTypes.bool
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Transfer **`Spinning`** component props to underlying DOM element, use classnames, add test, & propType validation.

#### What testing has been done on this PR?

Tested on grommet docs page.

#### What are the relevant issues?

#85 

#### Is this change backwards compatible or is it a breaking change?

Yes, backwards compatible.
