### PR TITLE
NaN Chart Issue

### DIFF
--- a/src/js/components/chart/Graph.js
+++ b/src/js/components/chart/Graph.js
@@ -125,12 +125,19 @@ export default class Graph extends Component {
     classes.push(`${COLOR_INDEX}-${colorIndex || 'graph-1'}`);
 
     let scale, step;
+    if (max - min === 0) {
+      min = 0;
+    }
     if (vertical) {
       if (values.length <= 1) {
         scale = 1;
         step = height - (2 * pad);
       } else {
-        scale = (width - (2 * pad)) / (max - min);
+        if (max - min === 0) {
+          scale = 1;
+        } else {
+          scale = (width - (2 * pad)) / (max - min);
+        }
         step = (height - (2 * pad)) / (values.length - 1);
       }
     } else {
@@ -138,7 +145,11 @@ export default class Graph extends Component {
         scale = 1;
         step = width - (2 * pad);
       } else {
-        scale = (height - (2 * pad)) / (max - min);
+        if (max - min === 0) {
+          scale = 1;
+        } else {
+          scale = (height - (2 * pad)) / (max - min);
+        }
         step = (width - (2 * pad)) / (values.length - 1);
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Resolves issue where graph components break if the array passed to the `values` prop contains values that are all the same. This is due to the scale calculation returning `Infinity`.

#### Where should the reviewer start?
To see what this fixes, make a `<Bar />` graph and pass it an array with multiple values that are all the same. Example: `[0, 0, 0, 0]` or  `[5, 5, 5, 5]`. Be sure that the max and min props are set as well. 

#### Screenshots (if appropriate)
When the chart receives `values={[0, 0, 0, 0]}` 

![screen shot 2016-10-03 at 12 44 56 pm](https://cloud.githubusercontent.com/assets/11274285/19056819/30512ba2-8967-11e6-9f0a-56fcf94b6e25.png)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.
