### PR TITLE
Fix arguments being passed to markdown-to-jsx

### DIFF
--- a/src/js/components/Markdown.js
+++ b/src/js/components/Markdown.js
@@ -43,11 +43,7 @@ let Markdown = (props) => {
     }
   }, heading, components);
 
-  return (
-    markdownToJSX(content, {
-      gfm: true
-    }, options)
-  );
+  return markdownToJSX(content, {overrides: options});
 };
 
 Markdown.propTypes = {


### PR DESCRIPTION
The argument syntax changed a bit in 4.x. GFM is always enabled, so no need to pass that explicitly.