### PR TITLE
Clear timeout if Toast was umounted from outside

### DIFF
--- a/src/js/components/Toast.js
+++ b/src/js/components/Toast.js
@@ -30,6 +30,11 @@ class ToastContents extends Component {
       store: this.props.store
     };
   }
+  
+  componentWillUnmount () {
+    clearTimeout(this._timer);
+    this._timer = undefined;
+  }
 
   componentDidMount () {
     this._timer = setTimeout(this._onClose, DURATION);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Enable removing of a toast from outside to display a different toast without waiting 9 seconds

#### Where should the reviewer start?

#### What testing has been done on this PR?
Manual

#### How should this be manually tested?

#### Any background context you want to provide?
Neither can the timeouts for display and animation be controlled nor is there any queue-mechanism if there are 2 toasts to be shown within 10 seconds (display + animation)

#### What are the relevant issues?
setState is called on an unmounted element if the toast was unmounted from outside

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible

