### PR TITLE
add 'fit' propType to Image component

### DIFF
--- a/src/js/components/Image.js
+++ b/src/js/components/Image.js
@@ -9,11 +9,12 @@ const CLASS_ROOT = CSSClassnames.IMAGE;
 
 export default class Image extends Component {
   render () {
-    const { caption, className, full, mask, size, ...props } = this.props;
+    const { caption, className, full, mask, size, fit, ...props } = this.props;
     const classes = classnames(
       CLASS_ROOT,
       {
         [`${CLASS_ROOT}--${size}`]: size,
+        [`${CLASS_ROOT}--${fit}`]: fit,
         [`${CLASS_ROOT}--full`]: typeof full === 'boolean' && full,
         [`${CLASS_ROOT}--full-${full}`]: typeof full === 'string',
         [`${CLASS_ROOT}--mask`]: mask
@@ -51,6 +52,7 @@ Image.propTypes = {
   caption: PropTypes.oneOfType([
     PropTypes.bool, PropTypes.string
   ]),
+  fit: PropTypes.oneOf(['contain', 'cover']),
   full: PropTypes.oneOf([true, 'horizontal', 'vertical', false]),
   mask: PropTypes.bool,
   size: PropTypes.oneOf(['small', 'medium', 'large', 'thumb']),

--- a/src/scss/grommet-core/_objects.image.scss
+++ b/src/scss/grommet-core/_objects.image.scss
@@ -27,6 +27,14 @@
   }
 }
 
+.#{$grommet-namespace}image--cover {
+  object-fit: cover;
+}
+
+.#{$grommet-namespace}image--contain {
+  object-fit: contain;
+}
+
 .#{$grommet-namespace}image--full {
   width: 100%;
 }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Allows user to specify `object-fit` CSS property on Image components.

#### Any background context you want to provide?
Landscape images are constrained to a 48x48px container when `size="thumb"`. This allows to set both `size="thumb"` and `fit="contain" so that the entire image is scaled to fit within the 48x48px container, instead of the left and right of the image being cut off.

#### Screenshots (if appropriate)
Thumbnail default:
![comparing grommet master nickjvm image-thumb-contain grommet-grommet - google chrome - oct 4 2016 1 45 57 pm](https://cloud.githubusercontent.com/assets/4998403/19089752/e3d9b118-8a38-11e6-8ffd-1ffde9dfc96c.png)
Thumbnail with `fit="contain"`
![screen shot 2016-10-04 at 1 45 50 pm](https://cloud.githubusercontent.com/assets/4998403/19089751/e3d787e4-8a38-11e6-93cf-938045507d56.png)

#### Do the grommet docs need to be updated?
The new prop should be added to documentation.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.
