### PR TITLE
rule wrap-multilines renamed to jsx-wrap-multilines in v6.0.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -85,4 +85,4 @@ rules:
   react/react-in-jsx-scope: 1
   react/self-closing-comp: 1
   react/sort-comp: 1
-  react/wrap-multilines: 1
+  react/jsx-wrap-multilines: 1


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
updates .eslintrc to use `react/jsx-wrap-multilines` instead of `react/wrap-multilines` which was depricated in `eslint-plugin-react` v6.0.0. Currently there's a console warning when running `gulp jslint`.

![grommet -bash 108x55 - terminal - oct 4 2016 3 05 38 pm](https://cloud.githubusercontent.com/assets/4998403/19092717/29fea836-8a45-11e6-8bb0-3d31a7967816.png)

https://github.com/yannickcr/eslint-plugin-react/releases/tag/v6.0.0

