### PR TITLE
Fix Select scrollbar in Edge & IE

### DIFF
--- a/src/scss/grommet-core/_objects.select.scss
+++ b/src/scss/grommet-core/_objects.select.scss
@@ -3,6 +3,7 @@
 .#{$grommet-namespace}select {
   position: relative;
   cursor: pointer;
+  overflow: hidden;
 }
 
 .#{$grommet-namespace}select__drop {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Resolves #903. Remove tiny scrollbar within Select component in IE. 

#### What testing has been done on this PR?

Tested on Chrome, Firefox, Safari, & IE. 

#### What are the relevant issues?

#903 

#### Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/3210082/19098657/d3089446-8a4a-11e6-87ec-d4970a07bd1e.png)

#### Is this change backwards compatible or is it a breaking change?

Yes, backwards compatible.
