### PR TITLE
Menu: Remove `dropColorIndex` from spread props

### DIFF
--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -161,9 +161,10 @@ class MenuDrop extends Component {
     const {
       dropAlign, size, children, control, colorIndex, onClick, ...props
     } = this.props;
-    const restProps = Props.omit(props,
-      Object.keys(MenuDrop.childContextTypes));
-    delete restProps.dropColorIndex;
+    const restProps = Props.omit(props, [
+      ...Object.keys(MenuDrop.childContextTypes),
+      ...Object.keys(MenuDrop.propTypes)
+    ]);
 
     // Put nested Menus inline
     const menuDropChildren = React.Children.map(children, child => {
@@ -209,6 +210,7 @@ class MenuDrop extends Component {
 MenuDrop.propTypes = {
   control: PropTypes.node,
   dropAlign: Drop.alignPropType,
+  dropColorIndex: PropTypes.string,
   onClick: PropTypes.func.isRequired,
   router: PropTypes.any,
   size: PropTypes.oneOf(['small', 'medium', 'large']),

--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -163,6 +163,7 @@ class MenuDrop extends Component {
     } = this.props;
     const restProps = Props.omit(props,
       Object.keys(MenuDrop.childContextTypes));
+    delete restProps.dropColorIndex;
 
     // Put nested Menus inline
     const menuDropChildren = React.Children.map(children, child => {
@@ -433,6 +434,7 @@ export default class Menu extends Component {
       pad, ...props
     } = this.props;
     delete props.closeOnClick;
+    delete props.dropColorIndex;
     delete props.dropAlign;
     delete props.icon;
     delete props.inline;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Remove `dropColorIndex` from spread props in Menu component.

#### Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/3210082/19138203/c1644ba6-8b15-11e6-9e73-d564820aaa84.png)

#### Is this change backwards compatible or is it a breaking change?

Yes, backwards compatible.
