### PR TITLE
DOM: Check if `match` exists before slicing

### DIFF
--- a/src/js/utils/DOM.js
+++ b/src/js/utils/DOM.js
@@ -136,11 +136,15 @@ export default {
     if (element && window.getComputedStyle) {
       const color = window.getComputedStyle(element).backgroundColor;
       const match = color.match(COLOR_REGEXP);
-      const [red, green, blue] = match.slice(1).map(n => parseInt(n, 10));
-      // http://www.had2know.com/technology/
-      //  color-contrast-calculator-web-design.html
-      const brightness = ( (299 * red) + (587 * green) + (114 * blue) ) / 1000;
-      result = brightness < 125;
+      if (match) {
+        const [red, green, blue] = match.slice(1).map(n => parseInt(n, 10));
+        // http://www.had2know.com/technology/
+        //  color-contrast-calculator-web-design.html
+        const brightness = (
+          (299 * red) + (587 * green) + (114 * blue)
+        ) / 1000;
+        result = brightness < 125;
+      }
     }
     return result;
   }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

`match` can be null, causing an error “Cannot read property 'slice' of null”

#### Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/3210082/19138351/0bf2d8f8-8b17-11e6-83f2-42ffc09d4ee3.png)

#### Is this change backwards compatible or is it a breaking change?
 
Yes, backwards compatible.

