### PR TITLE
Fixed horizontal Axis tick display.

### DIFF
--- a/__tests__/components/__snapshots__/Chart-test.js.snap
+++ b/__tests__/components/__snapshots__/Chart-test.js.snap
@@ -5,7 +5,7 @@ exports[`normalization has correct default options 1`] = `
   role="group">
   <div
     aria-label="AxisLabel"
-    className="grommetux-chart-axis grommetux-chart-axis--vertical grommetux-chart-axis--align-end grommetux-chart-axis--ticks grommetux-chart-axis--ticks-end"
+    className="grommetux-chart-axis grommetux-chart-axis--vertical grommetux-chart-axis--align-end grommetux-chart-axis--ticks grommetux-chart-axis--ticks--end"
     role="rowgroup"
     style={
       Object {

--- a/src/js/components/chart/Axis.js
+++ b/src/js/components/chart/Axis.js
@@ -64,7 +64,7 @@ export default class Axis extends Component {
         [`${CLASS_ROOT}--vertical`]: vertical,
         [`${CLASS_ROOT}--align-${align}`]: align,
         [`${CLASS_ROOT}--ticks`]: ticks,
-        [`${CLASS_ROOT}--ticks-${tickAlign}`]: tickAlign
+        [`${CLASS_ROOT}--ticks--${tickAlign}`]: tickAlign
       },
       className
     );

--- a/src/scss/grommet-core/_objects.chart.scss
+++ b/src/scss/grommet-core/_objects.chart.scss
@@ -215,14 +215,6 @@
       flex-direction: row-reverse;
       padding-left: 0;
     }
-
-    &::after {
-      display: block;
-      content: "";
-      height: halve(halve($inuit-base-spacing-unit));
-      width: 1px;
-      background-color: $border-color;
-    }
   }
 
   &.#{$grommet-namespace}chart-axis--align-start {
@@ -238,6 +230,14 @@
   }
 
   &.#{$grommet-namespace}chart-axis--ticks {
+    .#{$grommet-namespace}chart-axis__slot::after {
+      display: block;
+      content: "";
+      height: halve(halve($inuit-base-spacing-unit));
+      width: 1px;
+      background-color: $border-color;
+    }
+
     &.#{$grommet-namespace}chart-axis--ticks--end {
       .#{$grommet-namespace}chart-axis__slot:not(.#{$grommet-namespace}chart-axis__slot--placeholder) {
         align-items: flex-end;


### PR DESCRIPTION
This PR fixes a bug in the chart Axis component which prevented it from hiding the tick marks in a horizontal layout. The issue can be viewed in this [codepen](http://codepen.io/karatechops/pen/vXEPRA?editors=0010).