### PR TITLE
Search: Fix onMouseUp `props` undefined

### DIFF
--- a/src/js/components/Search.js
+++ b/src/js/components/Search.js
@@ -31,6 +31,7 @@ export default class Search extends Component {
     this._announceSuggestion = this._announceSuggestion.bind(this);
     this._onEnter = this._onEnter.bind(this);
     this._onClickSuggestion = this._onClickSuggestion.bind(this);
+    this._onMouseUp = this._onMouseUp.bind(this);
     this._onInputKeyDown = this._onInputKeyDown.bind(this);
     this._onSink = this._onSink.bind(this);
     this._onResponsive = this._onResponsive.bind(this);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

`_onMouseUp` is accessing `this.props` without binding in the constructor, causing `this.props` to be null.

#### Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/3210082/19176219/5f372088-8bd9-11e6-977f-a7d15b95e621.png)

#### Is this change backwards compatible or is it a breaking change?

Yes, backwards compatible.
