### PR TITLE
Selection: Multi-select shift click to deselect

### DIFF
--- a/src/js/utils/Selection.js
+++ b/src/js/utils/Selection.js
@@ -127,6 +127,10 @@ function onClick (event, options) {
           }
         }
 
+        if (indexInPrior > -1) {
+          selectedIndexes.splice(indexInPrior, 1);
+        }
+
         // Remove text selection. This often happens when shift multi-selecting
         window.getSelection().removeAllRanges();
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Allow user to deselect selected Tile, Table, List items. 
Shift-click on a selected item, will deselect the item.

#### What are the relevant issues?

https://github.com/grommet/grommet-docs/issues/134
https://github.com/grommet/grommet-docs/issues/150
https://github.com/grommet/grommet-docs/issues/156

#### Screenshots (if appropriate)

![selection-deselect](https://cloud.githubusercontent.com/assets/3210082/19180237/b9b70642-8bff-11e6-8986-0c01bfd95b99.gif)

#### Is this change backwards compatible or is it a breaking change?

Yes, backwards compatible.