### PR TITLE
Tile: Remove scroll from Tiles

### DIFF
--- a/src/scss/grommet-core/_objects.layer.scss
+++ b/src/scss/grommet-core/_objects.layer.scss
@@ -58,6 +58,10 @@
     }
   }
 
+  .#{$grommet-namespace}tiles {
+    overflow: auto;
+  }
+
   .#{$grommet-namespace}tiles__more {
     position: relative;
   }

--- a/src/scss/grommet-core/_objects.tile.scss
+++ b/src/scss/grommet-core/_objects.tile.scss
@@ -10,7 +10,6 @@
 
 .#{$grommet-namespace}tiles {
   width: 100%;
-  overflow: auto;
 
   @include pad();
 }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Remove scroll from `Tiles`. Fixes https://github.com/grommet/grommet-docs/issues/124

#### Any background context you want to provide?

`overflow: auto` was added to `.grommetux-tiles` to fix infinite scroll in `Layer` component.
https://github.com/grommet/grommet/pull/866#pullrequestreview-861943

#### What are the relevant issues?

https://github.com/grommet/grommet-docs/issues/124

#### Screenshots (if appropriate)

![scroll-animation](https://cloud.githubusercontent.com/assets/3210082/19205571/04faaa9e-8c7f-11e6-9a52-d93b9a916712.gif)

#### Is this change backwards compatible or is it a breaking change?

Yes, backwards compatible.