### PR TITLE
Fix row Tile eclipsed on initial load

### DIFF
--- a/src/js/components/Tile.js
+++ b/src/js/components/Tile.js
@@ -12,8 +12,9 @@ const NAMESPACE = CSSClassnames.NAMESPACE;
 export default class Tile extends Component {
 
   render () {
-    const { children, className, onClick, wide, status,
-      hoverStyle, hoverColorIndex, hoverBorder, hoverBorderSize
+    const {
+      children, className, eclipsed, hoverBorder, hoverBorderSize,
+      hoverColorIndex, hoverStyle, onClick, status, wide
     } = this.props;
     const restProps = Props.omit(this.props, Object.keys(Tile.propTypes));
 
@@ -32,7 +33,8 @@ export default class Tile extends Component {
         [`${NAMESPACE}${hoverStyle}${(hoverStyle == 'border') ?
           ((borderSize) ? `-${borderSize}` : '-medium') : ''
         }-hover-color-index-${hoverColorIndex}`]: hoverStyle,
-        [`${CLASS_ROOT}--hover-border-${borderSize}`]: borderSize
+        [`${CLASS_ROOT}--hover-border-${borderSize}`]: borderSize,
+        [`${CLASS_ROOT}--eclipsed`]: eclipsed
       }
     );
 
@@ -48,6 +50,7 @@ export default class Tile extends Component {
 }
 
 Tile.propTypes = {
+  eclipsed: PropTypes.bool,
   hoverStyle: PropTypes.oneOf(['border', 'background', 'none']),
   hoverColorIndex: PropTypes.string,
   hoverBorder: PropTypes.bool,

--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -269,23 +269,24 @@ export default class Tiles extends Component {
   }
 
   _layout () {
-    const { direction } = this.props;
+    const { children, direction } = this.props;
     if ('row' === direction) {
       // determine if we have more tiles than room to fit
       const tiles = findDOMNode(this.tilesRef);
       // mark any tiles that might be clipped
       const rect = tiles.getBoundingClientRect();
-      const children = tiles.querySelectorAll(`.${TILE}`);
 
-      const eclipsed = [];
-
-      Array.from(children).map((child, index) => {
-        const childRect = child.getBoundingClientRect();
-        // 12 accounts for padding
-        if ((childRect.left + 12) < rect.left ||
-          (childRect.right - 12) > rect.right) {
-          eclipsed.push(index);
+      const eclipsed = children.map((child, index) => {
+        if (this[`tileRef${index}`]) {
+          const tile = findDOMNode(this[`tileRef${index}`]);
+          const tileRect = tile.getBoundingClientRect();
+          // 12 accounts for padding
+          if ((tileRect.left + 12) < rect.left ||
+            (tileRect.right - 12) > rect.right) {
+            return index;
+          }
         }
+        return undefined;
       });
 
       this.setState({
@@ -307,7 +308,8 @@ export default class Tiles extends Component {
       if (element.type && element.type.displayName === 'Tile') {
         const elementClone = React.cloneElement(element, {
           eclipsed: this.state.eclipsed.indexOf(index) > -1,
-          hoverBorder: !flush
+          hoverBorder: !flush,
+          ref: ref => this[`tileRef${index}`] = ref
         });
 
         return elementClone;

--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -42,6 +42,7 @@ export default class Tiles extends Component {
 
     this.state = {
       activeTile: undefined,
+      eclipsed: [],
       mouseActive: false,
       overflow: false,
       selected: Selection.normalizeIndexes(props.selected)
@@ -272,38 +273,40 @@ export default class Tiles extends Component {
     if ('row' === direction) {
       // determine if we have more tiles than room to fit
       const tiles = findDOMNode(this.tilesRef);
-      // 20 is to allow some fuzziness as scrollbars come and go
-      this.setState({
-        overflow: (tiles.scrollWidth > (tiles.offsetWidth + 20)),
-        overflowStart: (tiles.scrollLeft <= 20),
-        overflowEnd:
-          (tiles.scrollLeft >= (tiles.scrollWidth - tiles.offsetWidth))
-      });
-
       // mark any tiles that might be clipped
       const rect = tiles.getBoundingClientRect();
       const children = tiles.querySelectorAll(`.${TILE}`);
+
+      const eclipsed = [];
 
       Array.from(children).map((child, index) => {
         const childRect = child.getBoundingClientRect();
         // 12 accounts for padding
         if ((childRect.left + 12) < rect.left ||
           (childRect.right - 12) > rect.right) {
-          child.classList.add(`${TILE}--eclipsed`);
-        } else {
-          child.classList.remove(`${TILE}--eclipsed`);
+          eclipsed.push(index);
         }
+      });
+
+      this.setState({
+        eclipsed,
+        // 20 is to allow some fuzziness as scrollbars come and go
+        overflow: (tiles.scrollWidth > (tiles.offsetWidth + 20)),
+        overflowStart: (tiles.scrollLeft <= 20),
+        overflowEnd:
+          (tiles.scrollLeft >= (tiles.scrollWidth - tiles.offsetWidth))
       });
     }
   }
 
-  _renderChild (element) {
+  _renderChild (element, index) {
     const { flush } = this.props;
 
     if (element) {
       // only clone tile children
       if (element.type && element.type.displayName === 'Tile') {
         const elementClone = React.cloneElement(element, {
+          eclipsed: this.state.eclipsed.indexOf(index) > -1,
           hoverBorder: !flush
         });
 
@@ -393,8 +396,8 @@ export default class Tiles extends Component {
       );
     }
 
-    const tileContents = Children.map(children, (element) => {
-      return this._renderChild(element);
+    const tileContents = Children.map(children, (element, index) => {
+      return this._renderChild(element, index);
     });
 
     let selectableProps;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Pass `eclipsed` prop & handle adding eclipsed class within `Tile` component.
Fix [Tile example#4](https://grommet.github.io/hpe/docs/tiles/examples/#4) on load, far right tile should be faded.

Fixes https://github.com/grommet/grommet-docs/issues/155.

#### What testing has been done on this PR?

Tested on grommet-docs.

#### Any background context you want to provide?

The problem was we're using `element.classList.add('.grommetux-tile--eclipsed')` to add the `eclipsed` class, this just changes the DOM element,  so when `Tile` gets re-rendered the class `.grommetux-tile--eclipsed` gets removed.

#### What are the relevant issues?

https://github.com/grommet/grommet-docs/issues/155

#### Screenshots (if appropriate)

![row-tile](https://cloud.githubusercontent.com/assets/3210082/19225303/874af230-8e35-11e6-9ece-fe91f9bcd44f.gif)

#### Is this change backwards compatible or is it a breaking change?

Yes, backwards compatible.