### PR TITLE
Pulse: smooth out scale animation

### DIFF
--- a/src/scss/grommet-core/_objects.pulse.scss
+++ b/src/scss/grommet-core/_objects.pulse.scss
@@ -41,7 +41,8 @@ $base-size: double($inuit-base-spacing-unit);
 }
 
 .#{$grommet-namespace}pulse:hover {
-  transform: scale(1.2);
+  // `rotate` is used to trick the browser into rendering the image better
+  transform: scale(1.2) rotate(0.0001deg);
   cursor: pointer;
 
   .#{$grommet-namespace}pulse__icon-anim {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Resolves https://github.com/grommet/grommet-docs/issues/145. 
Smooth out scale animation on hover.

#### Any background context you want to provide?

We're using `rotate` to trick the browser into rendering the image better.

#### What are the relevant issues?

https://github.com/grommet/grommet-docs/issues/145

#### Is this change backwards compatible or is it a breaking change?

Yes, backwards compatible.
