### PR TITLE
add List default message to en-US

### DIFF
--- a/src/js/messages/en-US.js
+++ b/src/js/messages/en-US.js
@@ -54,6 +54,7 @@ export default {
   hour: 'hour',
   'Grommet Logo': 'Grommet Logo',
   'Layer': 'Layer',
+  List: 'List',
   line: 'line',
   'Loading': 'Loading',
   loginInvalidPassword: 'Please provide Username and Password.',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes react-intl warning for missing "List" message in Grommet 1.0.0.

#### Screenshots (if appropriate)
![screen shot 2016-10-11 at 10 21 02 am](https://cloud.githubusercontent.com/assets/4998403/19278942/890ca934-8f9c-11e6-82b7-4fdb16597dd0.png)
![screen shot 2016-10-11 at 10 20 46 am](https://cloud.githubusercontent.com/assets/4998403/19278943/890e26ce-8f9c-11e6-8d85-6e6378bf285c.png)
