### PR TITLE
remove height of anchor icons within drop menu

### DIFF
--- a/src/scss/grommet-core/_objects.menu.scss
+++ b/src/scss/grommet-core/_objects.menu.scss
@@ -154,6 +154,7 @@
   .#{$grommet-namespace}anchor__icon {
     padding-left: 0;
     vertical-align: middle;
+    height: inherit;
   }
 
   .#{$grommet-namespace}anchor--reverse .#{$grommet-namespace}anchor__icon {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Removes height of anchor icons within drop menu, thus resolving a display issue with vertical alignment (see screenshot / codepen below)

#### Screenshots (if appropriate)
Here's a codpen to demonstrate the issue: http://codepen.io/nickjvm/pen/gwzjYz?editors=0110
![screen shot 2016-10-11 at 1 36 53 pm](https://cloud.githubusercontent.com/assets/4998403/19285619/e8a57e64-8fb7-11e6-918b-f834c1e7e40f.png)