### PR TITLE
Updated HPI theme's icon stroke width.

### DIFF
--- a/src/scss/hpinc/_hpinc.defaults.scss
+++ b/src/scss/hpinc/_hpinc.defaults.scss
@@ -34,7 +34,7 @@ $hpinc-fonts-path: "https://hpincfonts.s3.amazonaws.com";
   circle,
   rect,
   polygon {
-    stroke-width: 4px;
+    stroke-width: 2.1px;
     stroke-linecap: round;
     stroke-linejoin: round;
   }


### PR DESCRIPTION
This PR removes the HPI theme stroke width styling to allow Grommet icons to display properly.