### PR TITLE
Menu: Fix menu inline state in componentWillReceiveProps

### DIFF
--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -254,7 +254,9 @@ export default class Menu extends Component {
   componentWillReceiveProps (nextProps) {
     if (this.props.inline !== nextProps.inline ||
       this.props.icon !== nextProps.icon) {
-      this.setState({ inline: nextProps.inline || !nextProps.icon });
+      this.setState({
+        inline: nextProps.inline || (!nextProps.label && !nextProps.icon)
+      });
     }
   }
 

--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -255,7 +255,8 @@ export default class Menu extends Component {
     if (this.props.inline !== nextProps.inline ||
       this.props.icon !== nextProps.icon) {
       this.setState({
-        inline: nextProps.inline || (!nextProps.label && !nextProps.icon)
+        inline: nextProps.hasOwnProperty('inline') ? nextProps.inline
+          : (!nextProps.label && !nextProps.icon)
       });
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fix menu inline state in componentWillReceiveProps.
`nextProps.inline` can be falsey, making the `||` operator go to the next expression.
Also fix labelled menu.

#### What testing has been done on this PR?

Tested on Header & Menu docs page.
https://grommet.github.io/docs/header/examples#3 https://grommet.github.io/docs/menu/examples/#4

#### What are the relevant issues?

Fixes https://github.com/grommet/grommet-docs/issues/130

#### Screenshots (if appropriate)

Should be collapsed as `Label`.
![image](https://cloud.githubusercontent.com/assets/3210082/19329393/2a61df5c-9074-11e6-8d8f-0d0bff348714.png)

Should have default icon (`...`)
![image](https://cloud.githubusercontent.com/assets/3210082/19329396/2dd56532-9074-11e6-9f15-05efc10ff08c.png)

#### Is this change backwards compatible or is it a breaking change?

Yes, backwards compatible.
