### PR TITLE
Menu: Fix caret icon wrapping

### DIFF
--- a/src/scss/grommet-core/_objects.menu.scss
+++ b/src/scss/grommet-core/_objects.menu.scss
@@ -2,6 +2,7 @@
 
 .#{$grommet-namespace}menu {
   position: relative;
+  white-space: nowrap;
   @include inuit-font-size($menu-font-size);
 
   > * {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes #975 - Caret positioning in menu.
Don’t wrap caret icon in Menu component.

#### What testing has been done on this PR?

Tested on CodePen below & grommet docs.

#### Any background context you want to provide?

http://codepen.io/mcwagner10/pen/vXmAEE?editors=1010

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/975

#### Screenshots (if appropriate)

Issue:
![image](https://cloud.githubusercontent.com/assets/3210082/19430152/0997c9ca-9408-11e6-98f6-e2238c0a9b8a.png)

Fixed:
![image](https://cloud.githubusercontent.com/assets/3210082/19430161/118a8eb0-9408-11e6-9ad2-bb97d8ba9eed.png)

#### Do the grommet docs need to be updated?

Nope.

#### Is this change backwards compatible or is it a breaking change?

Yes, backwards compatible.
