### PR TITLE
add shape as possible proptype for TextInput suggestion array

### DIFF
--- a/src/js/components/TextInput.js
+++ b/src/js/components/TextInput.js
@@ -340,6 +340,14 @@ TextInput.propTypes = {
   onDOMChange: PropTypes.func,
   onSelect: PropTypes.func,
   placeHolder: PropTypes.string,
-  suggestions: PropTypes.arrayOf(PropTypes.string),
+  suggestions: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.shape({
+        label: PropTypes.node,
+        value: PropTypes.any
+      }),
+      PropTypes.string
+    ])
+  ),
   value: PropTypes.string
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changes `suggestions` prop validation on `TextInput` component to accept array of objects (`value` and `label` are required) as well as array of strings. This mirrors deprecated `SearchInput` props.
