### PR TITLE
Fixed Hero nested Box bug.

### DIFF
--- a/src/scss/grommet-core/_objects.hero.scss
+++ b/src/scss/grommet-core/_objects.hero.scss
@@ -57,7 +57,7 @@
 .#{$grommet-namespace}hero__overlay.#{$grommet-namespace}box {
   z-index: 1;
 
-  .#{$grommet-namespace}box {
+  & > .#{$grommet-namespace}box {
     width: 50%;
 
     @include media-query(palm) {


### PR DESCRIPTION
This PR fixes a bug in the Hero component which reduced nested overlay Boxes width to 50%.

# Before
![screen shot 2016-10-20 at 3 42 01 pm](https://cloud.githubusercontent.com/assets/5983843/19575301/e206252e-96db-11e6-85b2-0880184ab637.png)

# After
![screen shot 2016-10-20 at 3 41 41 pm](https://cloud.githubusercontent.com/assets/5983843/19575308/e7090802-96db-11e6-9255-bf8857a556c8.png)
