### PR TITLE
Fix Quote borderColorIndex (.grommetux-border-color-index-brand class was missing from SCSS)

### DIFF
--- a/src/scss/grommet-core/_objects.color-index.scss
+++ b/src/scss/grommet-core/_objects.color-index.scss
@@ -24,6 +24,14 @@
   }
 }
 
+.#{$grommet-namespace}border-color-index-brand {
+  border-color: $brand-color;
+
+  &-a {
+    border-color: rgba($brand-color, 0.94);
+  }
+}
+
 @for $i from 1 through length($brand-neutral-colors) {
   .#{$grommet-namespace}background-color-index-neutral-#{$i},
   .#{$grommet-namespace}background-color-index-neutral-#{$i + length($brand-neutral-colors)} {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

(cc @codeswan)

#### What does this PR do?
Add support for `borderColorIndex` on `Quote`.  It looks like the logic was initially added to the JS, but the corresponding SCSS was missing (`.grommetux-border-color-index-brand`).

#### Where should the reviewer start?

#### What testing has been done on this PR?
Chrome only

#### How should this be manually tested?
This can be tested with `grommet-docs`, by adding this example to `QuoteExamplesDoc.js`:

```js
    { label: 'Default', component: QuoteExample,
      props: { children: SINGLE, credit: 'Ricky Baker',
        borderColorIndex: 'brand' }},
```

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
Before:
<img width="819" alt="screen shot 2016-10-20 at 2 55 53 pm" src="https://cloud.githubusercontent.com/assets/120596/19579582/5190ebc8-96d6-11e6-9179-d47ac84b4b10.png">

After:
<img width="822" alt="screen shot 2016-10-20 at 2 55 07 pm" src="https://cloud.githubusercontent.com/assets/120596/19579586/56531780-96d6-11e6-83b5-5750781f7051.png">


#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
