### PR TITLE
Menu: add touchstart support for mobile (fixes #994)

### DIFF
--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -302,6 +302,7 @@ export default class Menu extends Component {
             this, activeKeyboardHandlers
           );
           document.addEventListener('click', this._onClose);
+          document.addEventListener('touchstart', this._onClose);
           this._drop = Drop.add(this.controlRef,
             this._renderMenuDrop(),
             {
@@ -318,6 +319,7 @@ export default class Menu extends Component {
 
   componentWillUnmount () {
     document.removeEventListener('click', this._onClose);
+    document.removeEventListener('touchstart', this._onClose);
     KeyboardAccelerators.stopListeningToKeyboard(this);
     if (this._drop) {
       this._drop.remove();


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes an issue with dismissing the `Menu` with mobile devices, which handle click events differently.

One way the `Menu` component expects to be dismissed is through a `click` event on the `document` element.  This fix adds an event listener for `touchstart` to document.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested on iPhone 6 Plus on Apple Simulator.

#### How should this be manually tested?
This can be tested by opening up the `Menu` demo in `grommet-docs`: [http://localhost:8002/docs/menu](http://localhost:8002/docs/menu)

#### Any background context you want to provide?

#### What are the relevant issues?
#994

#### Screenshots (if appropriate)
Before:
![before](https://cloud.githubusercontent.com/assets/120596/19582995/e7d7ba82-96ed-11e6-84f1-d02b0a98b7f1.gif)

After:
![after](https://cloud.githubusercontent.com/assets/120596/19582983/d066c3ca-96ed-11e6-91aa-20d422e32389.gif)


#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
