### PR TITLE
Fix TextInput placeHolder (fixes #987)

### DIFF
--- a/__tests__/components/__snapshots__/TextInput-test.js.snap
+++ b/__tests__/components/__snapshots__/TextInput-test.js.snap
@@ -8,5 +8,6 @@ exports[`TextInput has correct default options 1`] = `
   onChange={[Function bound _onInputChange]}
   onFocus={[Function bound _onFocus]}
   onKeyDown={[Function bound _onInputKeyDown]}
+  placeholder={undefined}
   value="one" />
 `;

--- a/src/js/components/TextInput.js
+++ b/src/js/components/TextInput.js
@@ -308,7 +308,6 @@ export default class TextInput extends Component {
     delete props.suggestions;
     delete props.onDOMChange;
     delete props.onSelect;
-    delete props.placeHolder;
     let classes = classnames(
       CLASS_ROOT,
       INPUT,

--- a/src/js/components/TextInput.js
+++ b/src/js/components/TextInput.js
@@ -303,11 +303,12 @@ export default class TextInput extends Component {
 
   render () {
     const {
-      className, defaultValue, value, ...props
+      className, defaultValue, value, placeHolder, ...props
     } = this.props;
     delete props.suggestions;
     delete props.onDOMChange;
     delete props.onSelect;
+    delete props.placeHolder;
     let classes = classnames(
       CLASS_ROOT,
       INPUT,
@@ -322,6 +323,7 @@ export default class TextInput extends Component {
         className={classes} autoComplete="off"
         defaultValue={this._renderLabel(defaultValue)}
         value={this._renderLabel(value)}
+        placeholder={placeHolder}
         onChange={this._onInputChange} onFocus={this._onFocus}
         onKeyDown={this._onInputKeyDown} />
     );


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes the `placeHolder` prop functionality on the `<TextInput>` component.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested in Chrome OSX only (since this isn't a browser bug).

#### How should this be manually tested?
Can be tested by opening `TextInputDoc.js` in `grommet-docs` and adding this to the `TextInput` in the `Examples` section:

```html
<TextInput
...
placeHolder="Some placeholder text!"
...
/>
```

#### Any background context you want to provide?
http://codepen.io/franksvalli/pen/bwOzqJ?editors=0010

#### What are the relevant issues?
#987 

#### Screenshots (if appropriate)
Before:
![before](https://cloud.githubusercontent.com/assets/120596/19616849/908a24f4-97d3-11e6-8516-406b7e1c213f.gif)

After:
![after](https://cloud.githubusercontent.com/assets/120596/19616851/935511bc-97d3-11e6-945c-e1bf80725f6e.gif)


#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
