### PR TITLE
Box: fix animation when within Accordion

### DIFF
--- a/src/scss/grommet-core/_objects.box.scss
+++ b/src/scss/grommet-core/_objects.box.scss
@@ -471,6 +471,7 @@
 
 .#{$grommet-namespace}box--size {
   max-width: 100%;
+  max-height: 100%;
 
   // deprecate? remove?
   .#{grommet-namespace}paragraph {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes an animation issue when `Box` (or related components such as `Card`) appears within an `Accordion`.  If the `Card` contains a video, the video placeholder image only animates in Chrome (see gifs below).

Issue was seen on Firefox and Edge.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested on the following:
* Firefox 49 on OSX
* Edge on Windows 10
* Chrome 54 on OSX

#### How should this be manually tested?

#### Any background context you want to provide?
Codepen: http://codepen.io/franksvalli/pen/kkqkOm?editors=0010

You can manually add `max-height: 100%` to `.grommetux-box--size` to test it out.

#### What are the relevant issues?
grommet/hpe-digitaltoolkit#158

Also related to grommet/hpe-digitaltoolkit#161

#### Screenshots (if appropriate)
Before:
![before](https://cloud.githubusercontent.com/assets/120596/19673971/7964274e-9a39-11e6-93a1-4bd5bc94a238.gif)

After:
![after](https://cloud.githubusercontent.com/assets/120596/19673973/7d09068a-9a39-11e6-8a0b-eb68c82b36bd.gif)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible