### PR TITLE
Cleaning intl warning

### DIFF
--- a/src/js/messages/icons/en-US.js
+++ b/src/js/messages/icons/en-US.js
@@ -284,6 +284,7 @@ export default {
   tree: 'tree',
   trigger: 'trigger',
   trophy: 'trophy',
+  troubleshoot: 'troubleshoot',
   troubleshooting: 'troubleshooting',
   unlock: 'unlock',
   up: 'up',


### PR DESCRIPTION
Adding missing reference to troubleshoot icon

#### What does this PR do?
Adding troubleshoot string to icons en-US file to eliminate warning on console:
![image](https://cloud.githubusercontent.com/assets/6320236/19700341/22174978-9ab4-11e6-8821-f1c608e2bd86.png)

#### Where should the reviewer start?
the committed file
#### What testing has been done on this PR?
Using the troubleshoot icon and seeing the warning isn't there

#### How should this be manually tested?
use the icon and see the warning disappear
#### Any background context you want to provide?
We don't want console warning :)
#### What are the relevant issues?

#### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/6320236/19700381/5d4d97ae-9ab4-11e6-9528-9146dee5d5ca.png)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Yes (backwards compatible)
