### PR TITLE
move _drop.remove() outside of target check

### DIFF
--- a/src/js/components/Tip.js
+++ b/src/js/components/Tip.js
@@ -64,8 +64,9 @@ export default class Tip extends Component {
   componentWillUnmount () {
     const { onClose } = this.props;
     const target = this._getTarget();
+    this._drop.remove();
+    
     if (target) {
-      this._drop.remove();
       target.removeEventListener('click', onClose);
       target.removeEventListener('blur', onClose);
     }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Removes `this._drop.remove()` call outside of the check for `target` element. This way, even if the target doesn't exist, the tip can still be removed.

#### What testing has been done on this PR?
Manual UI testing

#### How should this be manually tested?
Test against a component similar to https://codepen.io/nickjvm/pen/KgYXkb?&editors=0010

#### What are the relevant issues?
Issue #1012