### PR TITLE
Menu drop jump bug fix

### DIFF
--- a/__tests__/components/__snapshots__/Menu-test.js.snap
+++ b/__tests__/components/__snapshots__/Menu-test.js.snap
@@ -1,6 +1,7 @@
 exports[`Menu has correct default options 1`] = `
 <nav
   className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-none grommetux-menu grommetux-menu--column grommetux-menu--inline"
+  focusControl={true}
   id={undefined}
   onClick={undefined}
   role={undefined}

--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -308,7 +308,7 @@ export default class Menu extends Component {
             {
               align: this.props.dropAlign,
               colorIndex: this.props.dropColorIndex,
-              focusControl: true
+              focusControl: this.props.focusControl
             });
           break;
       }
@@ -487,6 +487,7 @@ Menu.propTypes = {
   closeOnClick: PropTypes.bool,
   dropAlign: Drop.alignPropType,
   dropColorIndex: PropTypes.string,
+  focusControl: PropTypes.bool,
   icon: PropTypes.node,
   id: PropTypes.string,
   inline: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['expand'])]),
@@ -506,5 +507,6 @@ Menu.defaultProps = {
   closeOnClick: true,
   direction: 'column',
   dropAlign: {top: 'top', left: 'left'},
+  focusControl: true,
   pad: 'none'
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
#### What does this PR do?

Adds focusControl option to Menu. Defaults to true, to preserve existing behavior, but allows focusControl to be set to false (for Drop.js).
#### What testing has been done on this PR?

Tested in Chrome, Safari, and Firefox.
In Firefox, the page jumps to the top on Menu button click during the [`.focus` call in Drop.js](https://github.com/grommet/grommet/blob/master/src/js/utils/Drop.js#L36)
In Chrome and Safari, the page jumps to the top on button click during the [`.scrollIntoView` call in Drop.js](https://github.com/grommet/grommet/blob/master/src/js/utils/Drop.js#L37) (after focusing).
#### Screenshots (if appropriate)

Page jumping to top on menu button click:
![fixed-menu-drop-bug](https://cloud.githubusercontent.com/assets/10161095/19737118/e128d630-9b4d-11e6-904d-3d843f1535b3.gif)

With added focusControl option set to false:
![fixed-menu-drop](https://cloud.githubusercontent.com/assets/10161095/19737124/eaa05e4a-9b4d-11e6-80dd-7674c04929e6.gif)
#### Do the grommet docs need to be updated?

Yes. (With added focusControl option.)
#### Is this change backwards compatible or is it a breaking change?

Backwards-compatible.
