### PR TITLE
prevent sending size to Notification's Box

### DIFF
--- a/src/js/components/Notification.js
+++ b/src/js/components/Notification.js
@@ -148,6 +148,10 @@ export default class Notification extends Component {
     const fullBox =
       boxProps.hasOwnProperty('full') ? boxProps.full : 'horizontal';
 
+    if (size && typeof size === 'string') {
+      // don't transfer size to Box since it means something different
+      delete boxProps.size;
+    }
     return (
       <Animate enter={{ animation: 'fade', duration: 1000 }}
         leave={{ animation: 'fade', duration: 1000 }}>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Deletes `size` prop before passing props to Box child of Notification.

#### Where should the reviewer start?
src/components/Notification.js

#### What testing has been done on this PR?
Manual UI testing

#### How should this be manually tested?
```
<Notification size="small" message="a notification" status="ok" />
```
And see that the width of the notification is not effected, but the size of the text and icon are still influenced by the `size` prop.

#### Any background context you want to provide?
Discussed with @alansouzati that this prop shouldn't be passed to `Box` since `size` means something different to Box. 

#### What are the relevant issues?
N/A

#### Screenshots (if appropriate)
Codepen of issue: http://codepen.io/nickjvm/pen/zKyGrP

#### Do the grommet docs need to be updated?
No
