### PR TITLE
Fixed Tiles row endless loop.

### DIFF
--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -271,16 +271,31 @@ export default class Tiles extends Component {
 
   _layout () {
     const { direction } = this.props;
+
     if ('row' === direction) {
       // determine if we have more tiles than room to fit
       const tiles = findDOMNode(this.tilesRef);
+
       // 20 is to allow some fuzziness as scrollbars come and go
-      this.setState({
+      const newState = {
         overflow: (tiles.scrollWidth > (tiles.offsetWidth + 20)),
         overflowStart: (tiles.scrollLeft <= 20),
-        overflowEnd:
-          (tiles.scrollLeft >= (tiles.scrollWidth - tiles.offsetWidth))
-      });
+        overflowEnd: 
+          (tiles.scrollLeft >= (tiles.scrollWidth - tiles.offsetWidth)),
+        scrollWidth: tiles.scrollWidth
+      };
+
+      const state = {
+        overflow: this.state.overflow,
+        overflowStart: this.state.overflowStart,
+        overflowEnd: this.state.overflowEnd,
+        scrollWidth: this.state.scrollWidth
+      };
+
+      // Shallow compare states.
+      if (JSON.stringify(newState) !== JSON.stringify(state)) {
+        this.setState({ ...newState });
+      }
 
       // mark any tiles that might be clipped
       const rect = tiles.getBoundingClientRect();


### PR DESCRIPTION
While working on a site which uses Grommet I noticed when changing routes Tiles.js would throw an error `Uncaught TypeError: Cannot read property 'scrollWidth' of null`. I also noticed quite slow performance on a site using 2 carousels, I believe this to be due to an endless loop which `Tiles.js` was stuck in. 

#### What does this PR do?
This PR introduces a shallow compare in Tiles' `_layout` method which judges whether to set state. The shallow compare will only happen on Tiles set to `direction=row`.

#### What testing has been done on this PR?
Tested in grommet-docs.

#### How should this be manually tested?
Test in grommet-docs - specifically in [Tiles example #4](https://grommet.github.io/docs/tiles/examples#4), navigate to either another route via an anchor or navigate to the next example via the arrow button. Errors will be thrown in the console. The bug is also visible in the Carousel component as this uses Tiles' row feature.

#### Do the grommet docs need to be updated?
Nope.

#### Should this PR be mentioned in the release notes?
No, but I do think developers making heavy use of carousels in their apps could benefit from this fix.

#### Is this change backwards compatible or is it a breaking change?
Compatible.