### PR TITLE
override inherited styles on select:focus padding-right

### DIFF
--- a/src/scss/grommet-core/_base.input.scss
+++ b/src/scss/grommet-core/_base.input.scss
@@ -44,6 +44,10 @@
     &.plain {
       border: none;
     }
+
+    &:focus {
+      padding-right: double($inuit-base-spacing-unit);
+    }
   }
 
   input[type=range] {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Prevents `select` input from resizing on focus do to inherited `input` padding styles.

#### What testing has been done on this PR?
Manual UI review

#### How should this be manually tested?
Create a `select` and see that the width remains the same when the element is focused

#### Any background context you want to provide?
Grommet-index `Sort` component uses a  `select` input, which is how this issue was discovered. This issue is not present when the `select` is wrapped in a `FormField` container.

#### Screenshots (if appropriate)
codepen of the issue: https://codepen.io/nickjvm/pen/JbYMwj?&editors=0010