### PR TITLE
fixing dropdown component's position in IE11 and Firefox.

### DIFF
--- a/src/js/utils/Drop.js
+++ b/src/js/utils/Drop.js
@@ -350,12 +350,17 @@ export default {
       }
     }
 
+    //for Chrome, Safari, and Opera, use document.body
+    //for Firefox and IE, use document.documentElement
+    let scrollTop = (document.documentElement
+      && document.documentElement.scrollTop) || document.body.scrollTop;
+
     container.style.left = `${left}px`;
     container.style.width = `${width}px`;
     // We use position:absolute and the body element's position
     // to handle mobile browsers better. We used to use position:fixed
     // but that didn't work on mobile browsers as well.
-    container.style.top = `${top + document.body.scrollTop}px`;
+    container.style.top = `${top + scrollTop}px`;
     container.style.maxHeight = `${maxHeight}px`;
 
   }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
In IE11: If there's a Select component that's towards the middle or bottom of the page, then if the user clicks the dropdown, the Drop is not aligned with the Select.

Example, open this in **IE11 or Firefox**: http://codepen.io/mcwagner10/pen/EgdaNg?editors=1010

#### What does this PR do?
Resolving this issue: https://github.com/grommet/grommet/issues/1043

#### Where should the reviewer start?
See Drop.js.

#### What testing has been done on this PR?
Tested on:
Win10: IE11, Edge, Firefox, Chrome
Mac: Safari
Latest iOS
Galaxy S7

#### How should this be manually tested?
Open Firefox or IE, make a dropdown that's lower down on the page.  Open the dropdown, scroll up and down, then notice the dropdown stays in the correct spot.

#### Any background context you want to provide?
Issue was discovered when a Select component is further down on the page.  Bug is only a problem in IE11 and Firefox because both those browsers use document.documentElement.scrollTop and not document.body.scrollTop

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/1043

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
I believe it's backwards compatible.
