### PR TITLE
Tip's drop isn't removed properly (race condition)

### DIFF
--- a/src/js/components/Tip.js
+++ b/src/js/components/Tip.js
@@ -45,16 +45,12 @@ export default class Tip extends Component {
         }
       );
 
-      // we need a timeout here to avoid wrong bounding rect
-      // for the target element
-      setTimeout(() => {
-        this._drop = Drop.add(target, this._renderDrop(), {
-          align: align,
-          className: classNames,
-          colorIndex: colorIndex,
-          responsive: false
-        });
-      }, 1);
+      this._drop = Drop.add(target, this._renderDrop(), {
+        align: align,
+        className: classNames,
+        colorIndex: colorIndex,
+        responsive: false
+      });
 
       target.addEventListener('click', onClose);
       target.addEventListener('blur', onClose);
@@ -64,7 +60,11 @@ export default class Tip extends Component {
   componentWillUnmount () {
     const { onClose } = this.props;
     const target = this._getTarget();
-    this._drop.remove();
+
+    // if the drop was created successfully, remove it
+    if (this._drop) {
+      this._drop.remove();
+    }
     
     if (target) {
       target.removeEventListener('click', onClose);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
Occasionally, when the "remove" method is called on Tip's drop, there's an error if the drop is null.  The current implementation of Tip uses a 1ms timeout (Tip.js line 50) to set up the drop.  This causes a race condition because it's conceivable that `componentWillUnmount` gets called **before** the timeout fires.  If this permutation of events happens, then the drop never gets initialized and the "remove" method will be called on null thus causing the error.  The possibility of this happening increases because Javascript setTimeout isn't a real-time system i.e. the timeout may not occur precisely after 1ms.

(see discussion about setTimeout's bad accuracy:
http://stackoverflow.com/questions/21097421/what-is-the-reason-javascript-settimeout-is-so-inaccurate)

A suggested fix in Grommet's slack channel was to have `if (this._drop) this._drop.remove()` to ensure the remove error doesn't occur.  That fix does indeed achieve that goal, however, if the timeout fires after `componentWillUnmount`, then the drop is permanently in the DOM.  The drop persists at a fixed position and will not be dismissed upon a click.  We've have several cases of this on a large-scale project.

The reasoning for the setTimeout line is provided as a comment in the code (line 48):

> we need a timeout here to avoid wrong bounding rect for the target element

However, the target's bounding box is calculated at line 23, which is **before** the line is run.  The result of the bounding box (`align`) is then passed to the `Drop.add` method.  So, it appears that in the current version of Grommet, this reasoning for the timeout is no longer meaningful.

I've removed the timeout and added some error checking in componentWillUnmount, then run a series of tests.  See results below.

#### What does this PR do?
Ensures that the drop is created and remove properly.

#### Where should the reviewer start?
Open Tip.js and review the dicussion above.

#### What testing has been done on this PR?
On all the platforms below, the Tip appears to work correctly even while resizing and scrolling.

Win10: Chrome, IE11, Edge, Firefox
Mac Sierra: Safari
iPhone 6S iOS 9: Safari
Galaxy S7 Android 6.

#### How should this be manually tested?
The problem is hard to reproduce because it's a race condition; it happens occasionally.  However, we've noticed some consistency on Chrome:

1. Open the dev console
2. Click "device toolbar" to go into mobile mode (cursor changes to touch symbol)
3. Click on a Tip and notice the error.

![image](https://cloud.githubusercontent.com/assets/14231471/20554618/06572874-b112-11e6-9d77-3a2664908e04.png)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
No

