### PR TITLE
Add neutral color to Vanilla theme.

### DIFF
--- a/src/scss/vanilla/_vanilla.defaults.scss
+++ b/src/scss/vanilla/_vanilla.defaults.scss
@@ -1,7 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
 $brand-color: #865CD6;
-$brand-neutral-colors: (#0A64A0, #DC2878, #501EB4);
+$brand-neutral-colors: (#0A64A0, #DC2878, #501EB4, #49516F);
 $brand-accent-colors: (#00CCEB, #FF7D28);
 $brand-link-color: #865CD6;
 $brand-status-colors: (


### PR DESCRIPTION
This PR adds an additional color to Grommet's neutral color set. This additional color supports the latest designs for the upcoming docs templates.
![Grommet neutral color 4](https://cloud.githubusercontent.com/assets/5983843/20848036/656797ac-b89e-11e6-9435-2ccef41320ab.png)
