### PR TITLE
Added precision to Legend so that we have control on the number of de…

### DIFF
--- a/src/js/components/Legend.js
+++ b/src/js/components/Legend.js
@@ -111,11 +111,11 @@ export default class Legend extends Component {
   }
 
   _seriesTotal () {
-    const { series } = this.props;
+    const { series, precision } = this.props;
     let total = 0;
     series.forEach(item =>
       total += typeof item.value === 'number' ? item.value  : 0 );
-    return total;
+    return Number(total.toFixed(precision));
   }
 
   _renderSeries () {
@@ -207,6 +207,7 @@ export default class Legend extends Component {
     delete props.announce;
     delete props.onActive;
     delete props.units;
+    delete props.precision;
 
     const classes = classnames(
       CLASS_ROOT,
@@ -270,5 +271,6 @@ Legend.propTypes = {
       prefix: PropTypes.string,
       suffix: PropTypes.string
     })
-  ])
+  ]),
+  precision: PropTypes.number
 };

--- a/src/js/components/Legend.js
+++ b/src/js/components/Legend.js
@@ -11,6 +11,19 @@ import Announcer from '../utils/Announcer';
 const CLASS_ROOT = CSSClassnames.LEGEND;
 const COLOR_INDEX = CSSClassnames.COLOR_INDEX;
 
+function getMaxDecimalDigits(series) {
+  let maxDigits = 0;
+  series.forEach((item) => {
+    const currentDigitsGroup = /\.(\d*)$/.exec(item.value.toString());
+    if (currentDigitsGroup) {
+      const currentDigits = currentDigitsGroup[1].length;
+      maxDigits = Math.max(maxDigits, currentDigits);
+    }
+  });
+
+  return Math.pow(10, maxDigits);
+}
+
 export default class Legend extends Component {
 
   constructor(props, context) {
@@ -111,11 +124,12 @@ export default class Legend extends Component {
   }
 
   _seriesTotal () {
-    const { series, precision } = this.props;
+    const { series } = this.props;
+    const maxDecimalDigits = getMaxDecimalDigits(series);
     let total = 0;
-    series.forEach(item =>
-      total += typeof item.value === 'number' ? item.value  : 0 );
-    return Number(total.toFixed(precision));
+    series.forEach(item => (
+      total += (typeof item.value === 'number' ? item.value : 0) * maxDecimalDigits );
+    return total / maxDecimalDigits;
   }
 
   _renderSeries () {
@@ -207,7 +221,6 @@ export default class Legend extends Component {
     delete props.announce;
     delete props.onActive;
     delete props.units;
-    delete props.precision;
 
     const classes = classnames(
       CLASS_ROOT,
@@ -271,6 +284,5 @@ Legend.propTypes = {
       prefix: PropTypes.string,
       suffix: PropTypes.string
     })
-  ]),
-  precision: PropTypes.number
+  ])
 };

--- a/src/js/components/Legend.js
+++ b/src/js/components/Legend.js
@@ -127,8 +127,9 @@ export default class Legend extends Component {
     const { series } = this.props;
     const maxDecimalDigits = getMaxDecimalDigits(series);
     let total = 0;
-    series.forEach(item => (
-      total += (typeof item.value === 'number' ? item.value : 0) * maxDecimalDigits );
+    series.forEach(item => 
+      total += (typeof item.value === 'number' ?
+       item.value : 0) * maxDecimalDigits );
     return total / maxDecimalDigits;
   }
 


### PR DESCRIPTION
…cimal places to be displayed when displaying a series which has decimal values

Hi Grommet Team,

I have added a new prop 'Precision' for legend component.
If the Legend Series has a total with decimal values, then using my changes, User can specify to what precision we display the decimal values.

example, We have a series total as 6.12457841 and we say we need it upto 2 decimal places (precision as 2 ). then 6.12 would be displayed.

Can someone please review?
