### PR TITLE
Add indexLink property to Anchor

### DIFF
--- a/src/js/components/Anchor.js
+++ b/src/js/components/Anchor.js
@@ -38,7 +38,7 @@ export default class Anchor extends Component {
   render () {
     const {
       a11yTitle, align, animateIcon, children, className, disabled, href, icon,
-      label, onClick, path, primary, reverse, tag, ...props
+      label, onClick, path, primary, reverse, tag, indexLink, ...props
     } = this.props;
     delete props.method;
     const { router } = this.context;
@@ -77,7 +77,7 @@ export default class Anchor extends Component {
         [`${CLASS_ROOT}--align-${align}`]: align,
         [`${CLASS_ROOT}--primary`]: primary,
         [`${CLASS_ROOT}--reverse`]: reverse,
-        [`${CLASS_ROOT}--active`]: (router && path && router.isActive(path))
+        [`${CLASS_ROOT}--active`]: (router && path && router.isActive(path, indexLink))
       },
       className
     );
@@ -139,7 +139,8 @@ schema(Anchor, {
         defaultProp: 'a'
       }
     ],
-    target: [PropTypes.string, 'Target of the link.']
+    target: [PropTypes.string, 'Target of the link.'],
+    indexLink: [PropTypes.bool, 'If true, the link will not be set as active unless the path matches exactly.'],
   }
 });
 

--- a/src/js/components/Anchor.js
+++ b/src/js/components/Anchor.js
@@ -77,7 +77,8 @@ export default class Anchor extends Component {
         [`${CLASS_ROOT}--align-${align}`]: align,
         [`${CLASS_ROOT}--primary`]: primary,
         [`${CLASS_ROOT}--reverse`]: reverse,
-        [`${CLASS_ROOT}--active`]: (router && path && router.isActive(path, indexLink))
+        [`${CLASS_ROOT}--active`]: (router && path &&
+                                    router.isActive(path, indexLink))
       },
       className
     );
@@ -140,7 +141,9 @@ schema(Anchor, {
       }
     ],
     target: [PropTypes.string, 'Target of the link.'],
-    indexLink: [PropTypes.bool, 'If true, the link will not be set as active unless the path matches exactly.'],
+    indexLink: [PropTypes.bool, 'If true, the link will not be set' +
+      'as active unless the path matches exactly.'
+    ]
   }
 });
 


### PR DESCRIPTION
#### What does this PR do?
This change adds the indexLink property to Anchor. This allows control of whether a link should be active if it is an index route or not.

#### What are the relevant issues?
As it stands, there is no control over whether links to index routes should be active when their child links are navigated to. This change allows users to specify whether they wish for the links to be active when a child route is active.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.