### PR TITLE
Anchor and Button components should pass arguments to onClick when using path.

### DIFF
--- a/src/js/components/Anchor.js
+++ b/src/js/components/Anchor.js
@@ -30,7 +30,7 @@ export default class Anchor extends Component {
       }
 
       if (onClick) {
-        onClick();
+        onClick(...arguments);
       }
     }
   }

--- a/src/js/components/Button.js
+++ b/src/js/components/Button.js
@@ -34,7 +34,7 @@ export default class Button extends Component {
     }
 
     if (onClick) {
-      onClick();
+      onClick(...arguments);
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Currently, `Anchor` and `Button` components that use both `path` and `onClick` are provided no arguments to the `onClick` handler. This affects some use cases, such as calling `stopPropagation()` on the click event to stop it bubbling to parent elements.

#### What testing has been done on this PR?

I looked for an existing test for the `path` attribute functionality of `Anchor` to copy or modify, but I couldn't find one.

I have tried this patch in a real use-case where this is happening, and it works for me.

#### How should this be manually tested?

Create a Grommet project with `react-router`, and try something like this:

```js
export default function ExampleAnchorBox () {
  function clickBox () {
    console.log('Box clicked.')
  }

  function stopPropagation (event) {
    event.stopPropagation()
  }

  return <Box onClick={clickBox}>
    <Anchor path='/path/to/somewhere' onClick={stopPropagation}>Click me</Anchor>
  </Box>
}
```

Upon clicking the anchor, you should see an error similar to this:

```
Uncaught TypeError: Cannot read property 'stopPropagation' of undefined
    at stopPropagation...
```

And this message:

    Box clicked.

As a contrast, if you use `href` instead of `path`, there will be no error, and `clickBox()` will not fire.

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

Yes.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.