### PR TITLE
Fix full horizontal boxes overflowing centered layers

### DIFF
--- a/src/scss/grommet-core/_objects.layer.scss
+++ b/src/scss/grommet-core/_objects.layer.scss
@@ -56,19 +56,6 @@
         }
       }
     }
-
-    .#{$grommet-namespace}box--full {
-      min-width: calc(100vw - #{double(double($inuit-base-spacing-unit))});
-      min-height: calc(100vh - #{double(double($inuit-base-spacing-unit))});
-    }
-
-    .#{$grommet-namespace}box--full-horizontal {
-      min-width: calc(100vw - #{double(double($inuit-base-spacing-unit))});
-    }
-
-    .#{$grommet-namespace}box--full-vertical {
-      min-height: calc(100vh - #{double(double($inuit-base-spacing-unit))});
-    }
   }
 
   .#{$grommet-namespace}layer__closer {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes an issue where a `<Box>` that has `full` set to `true` or `horizontal` will overflow a `<Layer align="center">`. [Example CodePen](http://codepen.io/jonathonwalz/pen/BporVd), should have a padded red box on both sides, not just the left.

#### What testing has been done on this PR?
Manually tested on the project where the issue was noticed. Tested with various different browser widths from 320px to 2048px.

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Maybe? Not sure what the conventions are

#### Is this change backwards compatible or is it a breaking change?
Yes, just a minor css change