### PR TITLE
fix 'focus jump between components when switch between multiple textinput

### DIFF
--- a/src/js/components/TextInput.js
+++ b/src/js/components/TextInput.js
@@ -215,10 +215,7 @@ export default class TextInput extends Component {
       focused: true,
       activeSuggestionIndex: -1
     });
-    // delay to wait out subsequent render after state change
-    setTimeout(() => {
-      this.componentRef.select();
-    }, 10);
+    this.componentRef.select();
 
     if (onFocus) {
       onFocus(event);


### PR DESCRIPTION
fix 'focus jump between components when switch between multiple textinput component, and focus outside of browser and then back focus on textinput' issue

Previous version works incorrectly in below code:
`class TestComponent extends Component {
  
  constructor(props) {
    super(props);
    this.state = {
      ldap_root_group_filter: '',
      ldap_group_base_filter: '',
      ldap_default_group: '',

    }
  }

  handleRootGroupFilterChange = (event) => {
    this.setState({
      ldap_root_group_filter: event.target.value
    })
  }

  handleGroupBaseFilterChange = (event) => {
    this.setState({
      ldap_group_base_filter: event.target.value
    })
  }

  handleDefaultGroupChange = (event) => {
    this.setState({
      ldap_default_group: event.target.value
    })
  }

  render() {

    return (
      <div>

        <TextInput key={1} id="ldap_root_group_filter" name="ldap_root_group_filter"
                   placeHolder="(&(objectclass=groupOfUniqueNames)(cn=Group*))"
                   value={this.state.ldap_root_group_filter}
                   onDOMChange={this.handleRootGroupFilterChange}
        />
        <TextInput key={2} id="ldap_group_base_filter" name="ldap_group_base_filter"
                   placeHolder="(objectclass=groupOfUniqueNames)"
                   value={this.state.ldap_group_base_filter}
                   onDOMChange={this.handleGroupBaseFilterChange}
        />

        <TextInput key={3} id="ldap_default_group" name="ldap_default_group"
                   placeHolder="itpeople"
                   value={this.state.ldap_default_group}
                   onDOMChange={this.handleDefaultGroupChange}
        />

      </div>
    );

  }
}`

if render above component and do below steps, will see focus jump between different components issue.
1. Focus on the first TextInput.
2. Move focus on second TextInput.
3. Move focus out of current browser and focus on other text editor like Code IDE.
4. Focus back on the first TextInput in the browser 

It is cause by below code:
` setTimeout(() => {
     this.componentRef.select();
    }, 10);`
 


