### PR TITLE
add a size property to Spinning

### DIFF
--- a/__tests__/components/icons/Spinning-test.js
+++ b/__tests__/components/icons/Spinning-test.js
@@ -20,6 +20,41 @@ describe('Spinning', () => {
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+  it('has correct rendering when size=small', () => {
+    const component = renderer.create(
+      <Spinning size="small" />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('has correct rendering when size=medium', () => {
+    const component = renderer.create(
+      <Spinning size="medium" />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('has correct rendering when size=large', () => {
+    const component = renderer.create(
+      <Spinning size="large" />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('has correct rendering when size=xlarge', () => {
+    const component = renderer.create(
+      <Spinning size="xlarge" />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('has correct rendering when size=huge', () => {
+    const component = renderer.create(
+      <Spinning size="huge" />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
   it('has correct className rendering', () => {
     const component = renderer.create(
       <Spinning className='testing' />

--- a/__tests__/components/icons/__snapshots__/Spinning-test.js.snap
+++ b/__tests__/components/icons/__snapshots__/Spinning-test.js.snap
@@ -1,7 +1,7 @@
 exports[`Spinning has correct className rendering 1`] = `
 <svg
   aria-label="Spinning"
-  className="grommetux-icon-spinning testing"
+  className="grommetux-icon-spinning grommetux-icon-spinning--responsive testing"
   role="img"
   version="1.1"
   viewBox="0 0 48 48">
@@ -27,7 +27,137 @@ exports[`Spinning has correct className rendering 1`] = `
 exports[`Spinning has correct default options 1`] = `
 <svg
   aria-label="Spinning"
-  className="grommetux-icon-spinning"
+  className="grommetux-icon-spinning grommetux-icon-spinning--responsive"
+  role="img"
+  version="1.1"
+  viewBox="0 0 48 48">
+  <circle
+    cx="24"
+    cy="24"
+    fill="none"
+    r="20"
+    stroke="#ddd"
+    strokeDasharray="24px 8px"
+    strokeWidth="4" />
+  <circle
+    cx="24"
+    cy="24"
+    fill="none"
+    r="20"
+    stroke="#333"
+    strokeDasharray="24px 104px"
+    strokeWidth="4" />
+</svg>
+`;
+
+exports[`Spinning has correct rendering when size=huge 1`] = `
+<svg
+  aria-label="Spinning"
+  className="grommetux-icon-spinning grommetux-icon-spinning--huge grommetux-icon-spinning--responsive"
+  role="img"
+  version="1.1"
+  viewBox="0 0 48 48">
+  <circle
+    cx="24"
+    cy="24"
+    fill="none"
+    r="20"
+    stroke="#ddd"
+    strokeDasharray="24px 8px"
+    strokeWidth="4" />
+  <circle
+    cx="24"
+    cy="24"
+    fill="none"
+    r="20"
+    stroke="#333"
+    strokeDasharray="24px 104px"
+    strokeWidth="4" />
+</svg>
+`;
+
+exports[`Spinning has correct rendering when size=large 1`] = `
+<svg
+  aria-label="Spinning"
+  className="grommetux-icon-spinning grommetux-icon-spinning--large grommetux-icon-spinning--responsive"
+  role="img"
+  version="1.1"
+  viewBox="0 0 48 48">
+  <circle
+    cx="24"
+    cy="24"
+    fill="none"
+    r="20"
+    stroke="#ddd"
+    strokeDasharray="24px 8px"
+    strokeWidth="4" />
+  <circle
+    cx="24"
+    cy="24"
+    fill="none"
+    r="20"
+    stroke="#333"
+    strokeDasharray="24px 104px"
+    strokeWidth="4" />
+</svg>
+`;
+
+exports[`Spinning has correct rendering when size=medium 1`] = `
+<svg
+  aria-label="Spinning"
+  className="grommetux-icon-spinning grommetux-icon-spinning--medium grommetux-icon-spinning--responsive"
+  role="img"
+  version="1.1"
+  viewBox="0 0 48 48">
+  <circle
+    cx="24"
+    cy="24"
+    fill="none"
+    r="20"
+    stroke="#ddd"
+    strokeDasharray="24px 8px"
+    strokeWidth="4" />
+  <circle
+    cx="24"
+    cy="24"
+    fill="none"
+    r="20"
+    stroke="#333"
+    strokeDasharray="24px 104px"
+    strokeWidth="4" />
+</svg>
+`;
+
+exports[`Spinning has correct rendering when size=small 1`] = `
+<svg
+  aria-label="Spinning"
+  className="grommetux-icon-spinning grommetux-icon-spinning--small grommetux-icon-spinning--responsive"
+  role="img"
+  version="1.1"
+  viewBox="0 0 48 48">
+  <circle
+    cx="24"
+    cy="24"
+    fill="none"
+    r="20"
+    stroke="#ddd"
+    strokeDasharray="24px 8px"
+    strokeWidth="4" />
+  <circle
+    cx="24"
+    cy="24"
+    fill="none"
+    r="20"
+    stroke="#333"
+    strokeDasharray="24px 104px"
+    strokeWidth="4" />
+</svg>
+`;
+
+exports[`Spinning has correct rendering when size=xlarge 1`] = `
+<svg
+  aria-label="Spinning"
+  className="grommetux-icon-spinning grommetux-icon-spinning--xlarge grommetux-icon-spinning--responsive"
   role="img"
   version="1.1"
   viewBox="0 0 48 48">
@@ -53,7 +183,7 @@ exports[`Spinning has correct default options 1`] = `
 exports[`Spinning has correct small=true rendering 1`] = `
 <svg
   aria-label="Spinning"
-  className="grommetux-icon-spinning grommetux-icon-spinning--small"
+  className="grommetux-icon-spinning grommetux-icon-spinning--small grommetux-icon-spinning--responsive"
   role="img"
   version="1.1"
   viewBox="0 0 48 48">
@@ -79,7 +209,7 @@ exports[`Spinning has correct small=true rendering 1`] = `
 exports[`Spinning has microdata properties rendering 1`] = `
 <svg
   aria-label="Spinning"
-  className="grommetux-icon-spinning"
+  className="grommetux-icon-spinning grommetux-icon-spinning--responsive"
   itemProp="test"
   itemScope={true}
   itemType="http://schema.org/Article"

--- a/src/js/components/icons/Spinning.js
+++ b/src/js/components/icons/Spinning.js
@@ -9,12 +9,18 @@ const CLASS_ROOT = CSSClassnames.SPINNING;
 
 export default class Spinning extends Component {
   render () {
-    const { a11yTitle, className, small, ...props } = this.props;
+    const {
+      a11yTitle, className, small, size, responsive, ...props
+    } = this.props;
     const { intl } = this.context;
+
+    let sizeOverride = small ? 'small' : size;
+
     const classes = classnames(
       CLASS_ROOT,
       {
-        [`${CLASS_ROOT}--small`]: small
+        [`${CLASS_ROOT}--${sizeOverride}`]: sizeOverride,
+        [`${CLASS_ROOT}--responsive`]: responsive
       },
       className
     );
@@ -35,8 +41,14 @@ Spinning.contextTypes = {
   intl: PropTypes.object
 };
 
+Spinning.defaultProps = {
+  responsive: true
+};
+
 Spinning.propTypes = {
   a11yTitle: PropTypes.string,
   className: PropTypes.string,
-  small: PropTypes.bool
+  small: PropTypes.bool,
+  size: PropTypes.oneOf(['small', 'medium', 'large', 'xlarge', 'huge']),
+  responsive: PropTypes.bool
 };

--- a/src/scss/grommet-core/_objects.icon.scss
+++ b/src/scss/grommet-core/_objects.icon.scss
@@ -189,6 +189,29 @@ $social-linkedin-color: #0077B5;
   height: halve($inuit-base-spacing-unit);
 }
 
+.#{$grommet-namespace}icon-spinning--large {
+  width: round($inuit-base-spacing-unit * 2);
+  height: round($inuit-base-spacing-unit * 2);
+}
+
+.#{$grommet-namespace}icon-spinning--xlarge {
+  width: round($inuit-base-spacing-unit * 6);
+  height: round($inuit-base-spacing-unit * 6);
+}
+
+.#{$grommet-namespace}icon-spinning--huge {
+  width: round($inuit-base-spacing-unit * 12);
+  height: round($inuit-base-spacing-unit * 12);
+}
+
+.#{$grommet-namespace}icon-spinning--xlarge.#{$grommet-namespace}icon-spinning--responsive,
+.#{$grommet-namespace}icon-spinning--huge.#{$grommet-namespace}icon-spinning--responsive {
+  @include media-query(palm) {
+    width: round($inuit-base-spacing-unit * 2);
+    height: round($inuit-base-spacing-unit * 2);
+  }
+}
+
 $logo-size: double($inuit-base-spacing-unit);
 $logo-dash-size: round($logo-size * 16);
 


### PR DESCRIPTION
Signed-off-by: Cullan Springstead <cullan.springstead@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
It adds a size property to Spinning that works the same as the other icons.
#### Where should the reviewer start?
Classes for the sizes were added to_objects.icon.scss. They were copied from the control-icon classes. The classes are added to the component in Spinning.js.
#### What testing has been done on this PR?
I compared the behavior to the base icons and examined the test snapshots.
#### How should this be manually tested?
Add Spinning icons with various sizes to a page.
#### Do the grommet docs need to be updated?
Yes. The size property information from Icon needs to be copied to the Spinner page.
#### Should this PR be mentioned in the release notes?
Yes.
#### Is this change backwards compatible or is it a breaking change?
It is backwards compatible because it keeps the old small property by setting the size to small when small={true}.