### PR TITLE
Add a responsive property to Legend, passed down to its ListItems

### DIFF
--- a/src/js/components/Legend.js
+++ b/src/js/components/Legend.js
@@ -127,14 +127,14 @@ export default class Legend extends Component {
     const { series } = this.props;
     const maxDecimalDigits = getMaxDecimalDigits(series);
     let total = 0;
-    series.forEach(item => 
+    series.forEach(item =>
       total += (typeof item.value === 'number' ?
        item.value : 0) * maxDecimalDigits );
     return total / maxDecimalDigits;
   }
 
   _renderSeries () {
-    const { series } = this.props;
+    const { series, responsive } = this.props;
     const { activeIndex } = this.state;
 
     return series.map((item, index) => {
@@ -165,7 +165,8 @@ export default class Legend extends Component {
           separator='none' pad={{ horizontal: 'small' }}
           key={item.label || index} className={legendClasses}
           onMouseOver={this._onActive.bind(this, index)}
-          onMouseOut={this._onActive.bind(this, undefined)} >
+          onMouseOut={this._onActive.bind(this, undefined)}
+          responsive={responsive} >
           {label}
           {value}
         </ListItem>
@@ -174,7 +175,7 @@ export default class Legend extends Component {
   }
 
   _renderTotal () {
-    const { total, units } = this.props;
+    const { total, units, responsive } = this.props;
     let totalValue;
     if (total !== true) {
       totalValue = total;
@@ -203,7 +204,8 @@ export default class Legend extends Component {
 
     return (
       <ListItem className={`${CLASS_ROOT}__total`}
-        justify='between' separator='none' pad={{ horizontal: 'small' }}>
+        justify='between' separator='none' pad={{ horizontal: 'small' }}
+        responsive={responsive} >
         <span className={`${CLASS_ROOT}__total-label`}>
           <FormattedMessage id="Total" defaultMessage="Total" />
         </span>
@@ -222,6 +224,7 @@ export default class Legend extends Component {
     delete props.announce;
     delete props.onActive;
     delete props.units;
+    delete props.responsive;
 
     const classes = classnames(
       CLASS_ROOT,
@@ -285,5 +288,6 @@ Legend.propTypes = {
       prefix: PropTypes.string,
       suffix: PropTypes.string
     })
-  ])
+  ]),
+  responsive: PropTypes.bool
 };


### PR DESCRIPTION
Signed-off-by: Mike Turley <mturley@hpe.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

It adds a `responsive` property to the Legend component, which is passed down to its ListItem children.  This allows an instance of Legend to be created with responsive={false}, in which the values will remain to the right of the series names rather than wrapping to the next line on mobile views.  This is useful if a Legend is placed somewhere where it will always have plenty of horizontal space, such as full-width below some visualization.

#### Where should the reviewer start?

Look at changes to the Legend component, they are fairly straightforward.  The `delete props.responsive` in the render method is to prevent the property from being placed on the List itself, which makes React complain about an unknown property.

#### What testing has been done on this PR?

Pre-commit tests were run, and I verified that leaving the responsive property out of the existing Legend test does not affect the snapshot.  I also manually tested this by using a Legend with responsive={false} in my own project and verifying that its layout does not change when switching to a mobile viewport size.

#### How should this be manually tested?

Simply try using a Legend with responsive={false} and observe how its layout does not change when entering a mobile viewport size.

#### Any background context you want to provide?

We are using Legends below Meters in full-width, and with the existing behavior of the Legend ListItems being responsive Boxes, they wrap in an ugly way on mobile.  See screenshots below.

#### Screenshots (if appropriate)

Before (Legend with default properties):
<img width="396" alt="screen shot 2017-02-06 at 6 15 10 pm" src="https://cloud.githubusercontent.com/assets/811963/22670765/b1117d5c-ec98-11e6-8bb5-db6265c97059.png">


After (Legend with `responsive={false}`):
<img width="381" alt="screen shot 2017-02-06 at 6 14 26 pm" src="https://cloud.githubusercontent.com/assets/811963/22670781/d173479c-ec98-11e6-9d06-0f40deb7106e.png">



#### Do the grommet docs need to be updated?

Yes, the `responsive` property should be added to the docs for Legend, describing that it is used for the ListItems and referring to the `responsive` property of Box.

#### Should this PR be mentioned in the release notes?

Sure?

#### Is this change backwards compatible or is it a breaking change?

Backwards-compatible.  When the responsive property is left out, nothing different is passed down to the ListItem children.