### PR TITLE
Fix JS exception with TextInput that has `autoFocus` property set

### DIFF
--- a/src/js/components/TextInput.js
+++ b/src/js/components/TextInput.js
@@ -215,7 +215,10 @@ export default class TextInput extends Component {
       focused: true,
       activeSuggestionIndex: -1
     });
-    this.componentRef.select();
+    // elements with autoFocus=true will be focused before the ref is available
+    if (this.componentRef) {
+      this.componentRef.select();
+    }
 
     if (onFocus) {
       onFocus(event);


### PR DESCRIPTION
#### What does this PR do?

Fixes a bug when `autoFocus` is set on `TextInput`.  In that case, the onFocus event hander immediatly, before the componentRef is set, causing a failure when `_onFocus` calls `this.componentRef.select();`

#### Where should the reviewer start?

Eh, pretty simple - look at the diff I guess.

#### What testing has been done on this PR?

I've tested it on my application and confirmed it works.  I attempted to write a spec, but `react-test-renderer` doesn't seem to actually focus elements, probably because it's not using a real DOM.

FYI this was the spec:

```javascript
  it('can be rendered with autoFocus=true', () => {
    const onFocusSpy = jest.fn();
    const component = renderer.create(
      <TextInput id="item1" name="item-1" autoFocus value="one" onFocus={onFocusSpy} />
    );
    expect(onFocusSpy).toHaveBeenCalled();
  });
```

#### How should this be manually tested?

Set `autoFocus` on a `TextInput` and render it

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

Here's a stack trace of the bug 😁 
<img width="684" alt="screen shot 2017-02-09 at 9 47 05 pm" src="https://cloud.githubusercontent.com/assets/79566/22813461/5d56022a-ef11-11e6-9efb-293be76e45fd.png">

#### Do the grommet docs need to be updated?
I don't think so, autoFocus isn't really mentioned as a supported prop, but it's the "correct" way to focus input elements IMO.

#### Should this PR be mentioned in the release notes?
Probably not, up to you guys though.

#### Is this change backwards compatible or is it a breaking change?
backwards compatible.