### PR TITLE
Fix occasional floating point errors in Legend component.

### DIFF
--- a/__tests__/components/Legend-test.js
+++ b/__tests__/components/Legend-test.js
@@ -58,4 +58,23 @@ describe('Legend', () => {
     // should properly calculate total
     expect(component.getInstance()._seriesTotal()).toBe(125);
   });
+
+  it('has no floating point errors in the total', () => {
+    const component = renderer.create(
+      <Legend
+        units="apples"
+        total
+        series={[
+          {value: 2.53, Label: "a"},
+          {value: 2.01, Label: "c"}
+        ]}
+        max="10"
+      />);
+
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+
+    // should properly calculate total
+    expect(component.getInstance()._seriesTotal()).toBe(4.54);
+  });
 });

--- a/__tests__/components/__snapshots__/Legend-test.js.snap
+++ b/__tests__/components/__snapshots__/Legend-test.js.snap
@@ -190,3 +190,69 @@ exports[`Legend has correct default options 1`] = `
   </li>
 </ul>
 `;
+
+exports[`Legend has no floating point errors in the total 1`] = `
+<ul
+  className="grommetux-list grommetux-legend"
+  max="10"
+  role="list">
+  <li
+    className="grommetux-box grommetux-box--direction-row grommetux-box--justify-between grommetux-box--align-center grommetux-box--responsive grommetux-box--pad-horizontal-small grommetux-box--separator-none grommetux-list-item grommetux-legend__item"
+    id={undefined}
+    onClick={undefined}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
+    role="listitem"
+    style={Object {}}
+    tabIndex={undefined}>
+    <span
+      className="grommetux-legend__item-value">
+      2.53
+      <span
+        className="grommetux-legend__item-units">
+        apples
+      </span>
+    </span>
+  </li>
+  <li
+    className="grommetux-box grommetux-box--direction-row grommetux-box--justify-between grommetux-box--align-center grommetux-box--responsive grommetux-box--pad-horizontal-small grommetux-box--separator-none grommetux-list-item grommetux-legend__item"
+    id={undefined}
+    onClick={undefined}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
+    role="listitem"
+    style={Object {}}
+    tabIndex={undefined}>
+    <span
+      className="grommetux-legend__item-value">
+      2.01
+      <span
+        className="grommetux-legend__item-units">
+        apples
+      </span>
+    </span>
+  </li>
+  <li
+    className="grommetux-box grommetux-box--direction-row grommetux-box--justify-between grommetux-box--align-center grommetux-box--responsive grommetux-box--pad-horizontal-small grommetux-box--separator-none grommetux-list-item grommetux-legend__total"
+    id={undefined}
+    onClick={undefined}
+    role="listitem"
+    style={Object {}}
+    tabIndex={undefined}>
+    <span
+      className="grommetux-legend__total-label">
+      <span>
+        Total
+      </span>
+    </span>
+    <span
+      className="grommetux-legend__total-value">
+      4.54
+      <span
+        className="grommetux-legend__total-units">
+        apples
+      </span>
+    </span>
+  </li>
+</ul>
+`;

--- a/src/js/components/Legend.js
+++ b/src/js/components/Legend.js
@@ -21,7 +21,7 @@ function getMaxDecimalDigits(series) {
     }
   });
 
-  return Math.pow(10, maxDigits);
+  return maxDigits;
 }
 
 export default class Legend extends Component {
@@ -129,8 +129,8 @@ export default class Legend extends Component {
     let total = 0;
     series.forEach(item =>
       total += (typeof item.value === 'number' ?
-       item.value : 0) * maxDecimalDigits );
-    return total / maxDecimalDigits;
+       item.value : 0));
+    return parseFloat(total.toFixed(maxDecimalDigits));
   }
 
   _renderSeries () {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fix occasional floating point errors in Legend component.

#### Where should the reviewer start?

Look in Legend.js

#### What testing has been done on this PR?

Manual testing and an unit test included.

#### How should this be manually tested?

They can use this codepen as an example of what was broken before: http://codepen.io/coltonw/pen/PWaENd

#### Any background context you want to provide?

Fixes have been attempted on this problem in the past by using arithmetic to work around floating point errors, but it turns out this is extremely hard to actually do.  The "real" solution would probably be to use a real decimal library such as [this one](https://github.com/MikeMcl/bignumber.js/) but doing toFixed (which is what this change uses) will definitely work and requires no extra dependencies.

#### What are the relevant issues?

#1174 

#### Do the grommet docs need to be updated?

Nope.

#### Should this PR be mentioned in the release notes?

Up to you!

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
