### PR TITLE
Fix DateTime component usability issue (#786)

### DIFF
--- a/src/js/components/DateTimeDrop.js
+++ b/src/js/components/DateTimeDrop.js
@@ -80,6 +80,8 @@ export default class DateTimeDrop extends Component {
   _buildDateRows (state) {
     const { timeOfDay, value } = state;
     const start = moment(value).startOf('month').startOf('week').add(timeOfDay);
+    // Always display 6 weeks in the calendar, to keep the date/time
+    // change controls from jumping around.
     const end = moment(start).add(41, 'days').add(timeOfDay);
     let date = moment(start);
     const dateRows = [];

--- a/src/js/components/DateTimeDrop.js
+++ b/src/js/components/DateTimeDrop.js
@@ -80,7 +80,7 @@ export default class DateTimeDrop extends Component {
   _buildDateRows (state) {
     const { timeOfDay, value } = state;
     const start = moment(value).startOf('month').startOf('week').add(timeOfDay);
-    const end = moment(start).add(41, 'days');
+    const end = moment(start).add(41, 'days').add(timeOfDay);
     let date = moment(start);
     const dateRows = [];
     let activeCell;

--- a/src/js/components/DateTimeDrop.js
+++ b/src/js/components/DateTimeDrop.js
@@ -80,7 +80,7 @@ export default class DateTimeDrop extends Component {
   _buildDateRows (state) {
     const { timeOfDay, value } = state;
     const start = moment(value).startOf('month').startOf('week').add(timeOfDay);
-    const end = moment(value).endOf('month').endOf('week').add(timeOfDay);
+    const end = moment(start).add(41, 'days');
     let date = moment(start);
     const dateRows = [];
     let activeCell;


### PR DESCRIPTION
#### What does this PR do?
Always show 6 weeks of days in the calendar dropdown to keep date change controls from jumping around (Issue #786).

#### Where should the reviewer start?
DateTimeDrop.js

#### What testing has been done on this PR?
Created a test page in my sample app and wired in the DateTime component to verify that it is working correctly.

#### How should this be manually tested?
- Browse to a test page with the DateTime component wired into it. 
- Click on the icon to cause the calendar dropdown to  be displayed. 
- Use the change controls at the top of the page to change the months. Notice that there are always 6 weeks shown, and these controls no longer jump around.
- Use the odometer controls at the bottom of the calendar to change months and years. They no longer jump around either.

#### Any background context you want to provide?
None

#### What are the relevant issues?
1. It's hard to tell the difference between days in the selected month and those that aren't in the month. The styling for the other-month is being applied correctly, but the contrast between the secondary text color and the primary text color is not great enough for me to readily see. Can we change the stylings to increase the contrast between the text colors?

2. For some months, there are a lot of extra days shown at the end that aren't in the selected month. Is this OK, or should we create a new styling to hide these extra days?

#### Screenshots (if appropriate)
![datetimedrop-screenshot](https://cloud.githubusercontent.com/assets/25066338/23566286/79fc552e-000e-11e7-8348-8c48ee4c0888.PNG)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Probably not. Once other DateTime issues are fixed, then maybe announce that DateTime usability has been enhanced.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
