### PR TITLE
Fix Anchor unmount listen bug.

### DIFF
--- a/src/js/components/Anchor.js
+++ b/src/js/components/Anchor.js
@@ -15,7 +15,7 @@ export default class Anchor extends Component {
     super(props, context);
     this._onClick = this._onClick.bind(this);
     this._onLocationChange = this._onLocationChange.bind(this);
-
+    this._attachUnlisten = this._attachUnlisten.bind(this);
     const { path } = props;
     const { router } = context;
 
@@ -29,8 +29,13 @@ export default class Anchor extends Component {
   componentDidMount () {
     const { path } = this.props;
     if (path) {
-      const { router } = this.context;
-      this._unlisten = router.listen(this._onLocationChange);
+      this._attachUnlisten(this.context.router);
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.path && nextProps.path !== this.props.path) {
+      this._attachUnlisten(this.context.router);
     }
   }
 
@@ -40,6 +45,10 @@ export default class Anchor extends Component {
       this._unlisten();
     }
     this._unmounted = true;
+  }
+
+  _attachUnlisten(router) {
+    this._unlisten = router.listen(this._onLocationChange);
   }
 
   _onLocationChange (location) {


### PR DESCRIPTION
#### What does this PR do?
This PR fixes an Anchor bug. In our app we have a few Anchors which have dynamic paths, these Anchors render and then pass in a path after the async request has been completed. The initial render of the Anchor component is the only spot which checks for a `path` being passed in via props. I've extended the Anchor component to support checking for a `path` in `componentWillReceiveProps`.

#### Where should the reviewer start?
Cloning branch and testing in docs.

#### What testing has been done on this PR?
Docs and our upcoming app.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.