### PR TITLE
Word-wrapping long names/email-address without space for checkbox and radio buttons #1205

### DIFF
--- a/src/scss/grommet-core/_objects.check-box.scss
+++ b/src/scss/grommet-core/_objects.check-box.scss
@@ -152,6 +152,7 @@
   color: $secondary-text-color;
   white-space: normal;
   margin-right: $inuit-base-spacing-unit;
+  word-break: break-word;
 
   #{$dark-background-context} {
     color: $colored-text-color;

--- a/src/scss/grommet-core/_objects.radio-button.scss
+++ b/src/scss/grommet-core/_objects.radio-button.scss
@@ -135,6 +135,7 @@
   color: $secondary-text-color;
   white-space: normal;
   margin-right: $inuit-base-spacing-unit;
+  word-break: break-word;
 
   #{$dark-background-context} {
     color: $colored-text-color;


### PR DESCRIPTION
Labels with long names/ email address/ layout which has checkbox/ radio buttons get cut off on smaller screen.  

For issue : https://github.com/grommet/grommet/issues/1205

What does this PR do?
This would create a word wrap of long labels/ email addresses so that the text does not get out of the screen.

Where should the reviewer start?
2 simple changes on the scss file. 

What testing has been done on this PR?
A manual testing on long text without spaces and layout (a checkbox and a small icon next to it) which was getting cut before change, now wraps and shows correctly.

How should this be manually tested?
Having  a long text or layout which is "responsive: false" lay side by side for all checkboxes and radio buttons

Code pen url : http://codepen.io/kanhajeevan/pen/vgwzzz

Do the grommet docs need to be updated?
No.

