### PR TITLE
adds Search onSelect callback when dropdown is not active

### DIFF
--- a/src/js/components/Search.js
+++ b/src/js/components/Search.js
@@ -163,7 +163,10 @@ export default class Search extends Component {
   }
 
   _onInputKeyDown (event) {
-    const { inline, suggestions, onKeyDown } = this.props;
+    const {
+      inline, onSelect, suggestions, activeSuggestionIndex, onKeyDown
+    } = this.props;
+    const enter = 13;
     const { dropActive } = this.state;
     if (suggestions) {
       const up = 38;
@@ -176,6 +179,14 @@ export default class Search extends Component {
           this._onAddDrop();
         }
       }
+    }
+    if (!dropActive && onSelect && event.keyCode === enter) {
+      const suggestion = suggestions[activeSuggestionIndex];
+
+      onSelect({
+        target: this._inputRef || this._controlRef,
+        suggestion: suggestion
+      }, false);
     }
     if (onKeyDown) {
       onKeyDown(event);
@@ -482,6 +493,7 @@ Search.propTypes = {
   inline: PropTypes.bool,
   onDOMChange: PropTypes.func,
   onSelect: PropTypes.func,
+  onKeyDown: PropTypes.func,
   pad: PropTypes.oneOf(['small', 'medium']),
   placeHolder: PropTypes.string,
   responsive: PropTypes.bool,

--- a/src/js/components/Search.js
+++ b/src/js/components/Search.js
@@ -295,6 +295,10 @@ export default class Search extends Component {
           suggestion: suggestion
         }, true);
       }
+    } else {
+      onSelect({
+        target: this._inputRef || this._controlRef
+      }, false);
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Raphael Gruber <raphi011@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Search's onSelect callback gets called when dropdown is not active and enter is pressed.

#### Where should the reviewer start?
Search Component `_onInputKeyDown` method.

#### What testing has been done on this PR?
Tried it out in a test project.

#### How should this be manually tested?
Create a Search component and press enter when dropdown is not active

#### Any background context you want to provide?
I need this feature :)

#### What are the relevant issues?
#1259 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Well it's in the docs but is hasn't worked until now so it MAY be a breaking change for some people who implemented this outside of grommet.