### PR TITLE
merge of #1262 TextInput null handling

### DIFF
--- a/src/js/components/TextInput.js
+++ b/src/js/components/TextInput.js
@@ -252,7 +252,7 @@ export default class TextInput extends Component {
   }
 
   _renderLabel (suggestion) {
-    if (typeof suggestion === 'object' && suggestion !== null) {
+    if (suggestion && typeof suggestion === 'object') {
       return suggestion.label || suggestion.value;
     } else {
       return suggestion;

--- a/src/js/components/TextInput.js
+++ b/src/js/components/TextInput.js
@@ -252,7 +252,7 @@ export default class TextInput extends Component {
   }
 
   _renderLabel (suggestion) {
-    if (typeof suggestion === 'object') {
+    if (typeof suggestion === 'object' && suggestion !== null) {
       return suggestion.label || suggestion.value;
     } else {
       return suggestion;


### PR DESCRIPTION
[Note: the other approach would be to alter the function _typeof to handle nulls]

null type is object, so need to check for it

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
handles possibility of null property for value or suggestion

#### Where should the reviewer start?
at reviewer's discretion

#### What testing has been done on this PR?
repro steps in case #1262 and codepen

#### How should this be manually tested?
repro steps in case #1262 and codepen

#### Any background context you want to provide?
a dynamic prop can sometimes have an unexpected value such as null

#### What are the relevant issues?
the unexpected unmount caused by this error can cause other issues. See commentary in https://github.com/grommet/grommet/pull/1230

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no

#### Should this PR be mentioned in the release notes?
as you wish

#### Is this change backwards compatible or is it a breaking change?
backward compatible