### PR TITLE
fixes Search dropdown not closing after react-router push

### DIFF
--- a/src/js/components/Search.js
+++ b/src/js/components/Search.js
@@ -281,7 +281,6 @@ export default class Search extends Component {
       event.preventDefault(); // prevent submitting forms
     }
 
-    this._onRemoveDrop();
     if (activeSuggestionIndex >= 0) {
       const suggestion = suggestions[activeSuggestionIndex];
       this.setState({ value: suggestion }, () => {
@@ -300,6 +299,8 @@ export default class Search extends Component {
         target: this._inputRef || this._controlRef
       }, false);
     }
+
+    this._onRemoveDrop();
   }
 
   _onClickSuggestion (suggestion) {


### PR DESCRIPTION
Signed-off-by: Raphael Gruber <raphi011@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes bug #1272 


#### Where should the reviewer start?
Search components onEnter method

#### What testing has been done on this PR?
Test project

#### How should this be manually tested?
Using this gist https://gist.github.com/raphi011/31444b68cd7224f63e18306c9d69c11f

#### Any background context you want to provide?
Is an annoying bug in my project. Not entirely sure why this was a problem, my guess is that setState() is called twice in onEnter, but somehow it works if you call onRemoveDrop at the end of the method.

#### What are the relevant issues?
#1272

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no

#### Should this PR be mentioned in the release notes?
If you want

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible