### PR TITLE
Makes Button compatible with react router 4; closes #1274

### DIFF
--- a/src/js/components/Button.js
+++ b/src/js/components/Button.js
@@ -28,9 +28,9 @@ export default class Button extends Component {
     event.preventDefault();
 
     if ('push' === method) {
-      router.push(path);
+      (router.history || router).push(path.path || path);
     } else if ('replace' === method) {
-      router.replace(path);
+      (router.history || router).replace(path.path || path);
     }
 
     if (onClick) {
@@ -91,7 +91,17 @@ export default class Button extends Component {
       buttonLabel = <span className={`${CLASS_ROOT}__label`}>{label}</span>;
     }
 
-    let adjustedHref = (path && router) ? router.createPath(path) : href;
+    const target = path ? path.path || path : undefined;
+    let adjustedHref;
+    if (router && router.createPath) {
+      adjustedHref = (path && router) ?
+        router.createPath(target) : href;
+    } else {
+      adjustedHref = (path && router && router.history) ?
+        router.history.createHref(
+          typeof target === 'string' ? { pathname: target } : target
+        ) : href;
+    }
 
     const classes = classnames(
       CLASS_ROOT,

--- a/src/js/components/Button.js
+++ b/src/js/components/Button.js
@@ -28,9 +28,9 @@ export default class Button extends Component {
     event.preventDefault();
 
     if ('push' === method) {
-      (router.history || router).push(path.path || path);
+      (router.history || router).push(path);
     } else if ('replace' === method) {
-      (router.history || router).replace(path.path || path);
+      (router.history || router).replace(path);
     }
 
     if (onClick) {
@@ -91,15 +91,14 @@ export default class Button extends Component {
       buttonLabel = <span className={`${CLASS_ROOT}__label`}>{label}</span>;
     }
 
-    const target = path ? path.path || path : undefined;
     let adjustedHref;
     if (router && router.createPath) {
       adjustedHref = (path && router) ?
-        router.createPath(target) : href;
+        router.createPath(path) : href;
     } else {
       adjustedHref = (path && router && router.history) ?
         router.history.createHref(
-          typeof target === 'string' ? { pathname: target } : target
+          { pathname: path }
         ) : href;
     }
 


### PR DESCRIPTION
Signed-off-by: Zack Sinclair <zacksinclair@gmail.com>

#### What does this PR do?
Makes Button compatible with React Router 4 w/ the same implementation as Anchor. 

#### What testing has been done on this PR?
All tests pass. Locally tested that this works for both RR3 and RR4.

#### How should this be manually tested?
Use Button with a path defined. Test that react router 3 / 4 both transition to the path

#### Any background context you want to provide?
@alansouzati made this nice and easy via his Anchor RR4 commit:
https://github.com/grommet/grommet/commit/74ee5fe625e7777d30d6c49098b72863a4dfd1a6

You'll notice this was mostly a cut and paste job.

#### What are the relevant issues?
#1274 

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes, in combination with 74ee5fe625e7777d30d6c49098b72863a4dfd1a6, release notes should state that grommet now supports react router 4 in both Anchor and Button components.

#### Is this change backwards compatible or is it a breaking change?
Yes backwards compatible
