### PR TITLE
Fix Split's priority when precisely on breakpoint

### DIFF
--- a/src/js/components/Split.js
+++ b/src/js/components/Split.js
@@ -80,7 +80,7 @@ export default class Split extends Component {
   _layout () {
     const splitElement = this.splitRef;
     if (splitElement) {
-      if (splitElement.offsetWidth < smallSize() &&
+      if (splitElement.offsetWidth <= smallSize() &&
         this.props.showOnResponsive === 'priority') {
         this._setResponsive('single');
       } else {


### PR DESCRIPTION
Signed-off-by: Zack Sinclair <zacksinclair@gmail.com>

When on the exact small breakpoint (719px width for me), split prioritizes incorrectly because it compares smallSize with < instead of <=

#### What does this PR do?
< -> <=

#### What testing has been done on this PR?
Locally confirmed

#### How should this be manually tested?
Before:  have a split component that toggles priority between left and right based on smallSize. Go to 719px width, see that it is prioritized incorrectly
After: 719px correctly prioritizes

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible