### PR TITLE
Added hover support for button

### DIFF
--- a/src/js/components/Button.js
+++ b/src/js/components/Button.js
@@ -8,8 +8,8 @@ const CLASS_ROOT = CSSClassnames.BUTTON;
 
 export default class Button extends Component {
 
-  constructor () {
-    super();
+  constructor (props, context) {
+    super(props, context);
     this._onClick = this._onClick.bind(this);
     this._onMouseDown = this._onMouseDown.bind(this);
     this._onMouseUp = this._onMouseDown.bind(this);
@@ -19,6 +19,12 @@ export default class Button extends Component {
       mouseActive: false,
       focus: false
     };
+
+    if (props.hover && !props.plain) {
+      console.warn(
+        'Button: hover prop only works for plain buttons.'
+      );
+    }
   }
 
   _onClick (event) {
@@ -75,7 +81,7 @@ export default class Button extends Component {
 
   render () {
     const {
-      a11yTitle, accent, align, children, className, fill, href, icon,
+      a11yTitle, accent, align, children, className, fill, hover, href, icon,
       label, onClick, path, plain, primary, reverse, secondary, type, ...props
     } = this.props;
     delete props.method;
@@ -116,7 +122,8 @@ export default class Button extends Component {
         [`${CLASS_ROOT}--fill`]: fill,
         [`${CLASS_ROOT}--plain`]: plain || Children.count(children) > 0 ||
           (icon && ! label),
-        [`${CLASS_ROOT}--align-${align}`]: align
+        [`${CLASS_ROOT}--align-${align}`]: align,
+        [`${CLASS_ROOT}--hover`]: plain && hover
       },
       className
     );
@@ -156,6 +163,7 @@ Button.propTypes = {
   accent: PropTypes.bool,
   align: PropTypes.oneOf(['start', 'center', 'end']),
   fill: PropTypes.bool,
+  hover: PropTypes.bool,
   href: PropTypes.string,
   icon: PropTypes.element,
   label: PropTypes.node,

--- a/src/js/components/Button.js
+++ b/src/js/components/Button.js
@@ -2,9 +2,22 @@
 
 import React, { Children, Component, PropTypes } from 'react';
 import classnames from 'classnames';
-import CSSClassnames from '../utils/CSSClassnames';
+import CSSClassnames, { namespace } from '../utils/CSSClassnames';
 
 const CLASS_ROOT = CSSClassnames.BUTTON;
+
+function getHoverModifier(hoverIndicator) {
+  if (hoverIndicator) {
+    if (hoverIndicator.background) {
+      if (typeof hoverIndicator.background === 'string') {
+        const prefix = `${namespace}background-hover-color-index-`;
+        return `${prefix}${hoverIndicator.background}`;
+      }
+      return `${CLASS_ROOT}--hover-background`;
+    }
+    return (`${CLASS_ROOT}--hover-${hoverIndicator}`); 
+  }
+}
 
 export default class Button extends Component {
 
@@ -19,12 +32,6 @@ export default class Button extends Component {
       mouseActive: false,
       focus: false
     };
-
-    if (props.hover && !props.plain) {
-      console.warn(
-        'Button: hover prop only works for plain buttons.'
-      );
-    }
   }
 
   _onClick (event) {
@@ -81,8 +88,9 @@ export default class Button extends Component {
 
   render () {
     const {
-      a11yTitle, accent, align, children, className, fill, hover, href, icon,
-      label, onClick, path, plain, primary, reverse, secondary, type, ...props
+      a11yTitle, accent, align, children, className, fill, hoverIndicator,
+      href, icon, label, onClick, path, plain, primary, reverse, secondary,
+      type, ...props
     } = this.props;
     delete props.method;
     const { router } = this.context;
@@ -123,7 +131,7 @@ export default class Button extends Component {
         [`${CLASS_ROOT}--plain`]: plain || Children.count(children) > 0 ||
           (icon && ! label),
         [`${CLASS_ROOT}--align-${align}`]: align,
-        [`${CLASS_ROOT}--hover`]: plain && hover
+        [getHoverModifier(hoverIndicator)]: hoverIndicator
       },
       className
     );
@@ -163,7 +171,15 @@ Button.propTypes = {
   accent: PropTypes.bool,
   align: PropTypes.oneOf(['start', 'center', 'end']),
   fill: PropTypes.bool,
-  hover: PropTypes.bool,
+  hoverIndicator: PropTypes.oneOfType([
+    PropTypes.oneOf(['background']),
+    PropTypes.shape({
+      background: PropTypes.oneOfType([
+        PropTypes.bool,
+        PropTypes.string
+      ])
+    })
+  ]),
   href: PropTypes.string,
   icon: PropTypes.element,
   label: PropTypes.node,

--- a/src/js/components/Button.js
+++ b/src/js/components/Button.js
@@ -8,21 +8,24 @@ const CLASS_ROOT = CSSClassnames.BUTTON;
 
 function getHoverModifier(hoverIndicator) {
   if (hoverIndicator) {
-    if (hoverIndicator.background) {
-      if (typeof hoverIndicator.background === 'string') {
-        const prefix = `${namespace}background-hover-color-index-`;
-        return `${prefix}${hoverIndicator.background}`;
+    if (typeof hoverIndicator === 'object') {
+      if (hoverIndicator.background) {
+        if (typeof hoverIndicator.background === 'string') {
+          const prefix = `${namespace}background-hover-color-index-`;
+          return `${prefix}${hoverIndicator.background}`;
+        }
+        return `${CLASS_ROOT}--hover-background`;
       }
-      return `${CLASS_ROOT}--hover-background`;
+    } else if (typeof hoverIndicator === 'string') {
+      return (`${CLASS_ROOT}--hover-${hoverIndicator}`); 
     }
-    return (`${CLASS_ROOT}--hover-${hoverIndicator}`); 
   }
 }
 
 export default class Button extends Component {
 
-  constructor (props, context) {
-    super(props, context);
+  constructor () {
+    super();
     this._onClick = this._onClick.bind(this);
     this._onMouseDown = this._onMouseDown.bind(this);
     this._onMouseUp = this._onMouseDown.bind(this);

--- a/src/scss/grommet-core/_objects.button.scss
+++ b/src/scss/grommet-core/_objects.button.scss
@@ -64,7 +64,7 @@ $button-horizontal-padding:
   @include background-context-color($button-text-color, $button-text-color);
 }
 
-.#{$grommet-namespace}button--hover-background:hover:not([class*="background-hover-color-index-"]) {
+.#{$grommet-namespace}button--hover-background:hover {
   background-color: $hover-background-color;
   color: $hover-text-color;
 

--- a/src/scss/grommet-core/_objects.button.scss
+++ b/src/scss/grommet-core/_objects.button.scss
@@ -57,11 +57,26 @@ $button-horizontal-padding:
   @include basic-button();
 
   &--focus {
-    border-color: $focus-border-color;
+    border: 1px solid $focus-border-color;
     box-shadow: 0 0 1px 1px $focus-border-color;
   }
 
   @include background-context-color($button-text-color, $button-text-color);
+}
+
+.#{$grommet-namespace}button--hover:hover:not([class*="background-hover-color-index-"]) {
+  background-color: $hover-background-color;
+  color: $hover-text-color;
+
+  #{$dark-background-context} {
+    background-color: $colored-hover-background-color;
+    color: $active-colored-text-color;
+  }
+
+  #{$light-background-context} {
+    background-color: $hover-background-color;
+    color: $hover-text-color;
+  }
 }
 
 .#{$grommet-namespace}button:hover {
@@ -108,7 +123,6 @@ $button-horizontal-padding:
 }
 
 .#{$grommet-namespace}button--plain {
-  border: none;
   padding: 0;
   width: auto;
   height: auto;
@@ -128,6 +142,10 @@ $button-horizontal-padding:
       margin-left: 0;
     }
   }
+}
+
+.#{$grommet-namespace}button--plain:not(.#{$grommet-namespace}button--focus) {
+  border: 1px solid transparent;
 }
 
 .#{$grommet-namespace}button:not(.#{$grommet-namespace}button--plain) {

--- a/src/scss/grommet-core/_objects.button.scss
+++ b/src/scss/grommet-core/_objects.button.scss
@@ -64,7 +64,7 @@ $button-horizontal-padding:
   @include background-context-color($button-text-color, $button-text-color);
 }
 
-.#{$grommet-namespace}button--hover:hover:not([class*="background-hover-color-index-"]) {
+.#{$grommet-namespace}button--hover-background:hover:not([class*="background-hover-color-index-"]) {
   background-color: $hover-background-color;
   color: $hover-text-color;
 

--- a/src/scss/grommet-core/_objects.button.scss
+++ b/src/scss/grommet-core/_objects.button.scss
@@ -57,7 +57,7 @@ $button-horizontal-padding:
   @include basic-button();
 
   &--focus {
-    border: 1px solid $focus-border-color;
+    border: $button-border-width solid $focus-border-color;
     box-shadow: 0 0 1px 1px $focus-border-color;
   }
 
@@ -145,7 +145,7 @@ $button-horizontal-padding:
 }
 
 .#{$grommet-namespace}button--plain:not(.#{$grommet-namespace}button--focus) {
-  border: 1px solid transparent;
+  border: $button-border-width solid transparent;
 }
 
 .#{$grommet-namespace}button:not(.#{$grommet-namespace}button--plain) {


### PR DESCRIPTION
Sometimes we need some hover capabilities when using plain Buttons

#### What does this PR do?
Adds hover support to `plain` Button

#### Where should the reviewer start?

Button.js

#### What testing has been done on this PR?

Manual testing

#### How should this be manually tested?

Reading the changed files

#### Do the grommet docs need to be updated?

Yes

#### Should this PR be mentioned in the release notes?

Yes

#### Is this change backwards compatible or is it a breaking change?

Backwars compatible