### PR TITLE
feat: allow custom icon with label in <Menu /> component

### DIFF
--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -382,21 +382,17 @@ export default class Menu extends Component {
 
   _renderButtonProps () {
     const { icon, label } = this.props;
-    let buttonIcon, buttonLabel;
+    // Use default icon if no label or icon is provided
+    if (!label && !icon) {
+      return {icon: <MoreIcon />};
+    }
 
-    // If this is a collapsed inline Menu, use any icon and/or label provided,
-    // revert to default icon if neither.
-    if (icon) {
-      buttonIcon = icon;
-    }
-    if (label) {
-      buttonLabel = label;
-      buttonIcon = <DropCaretIcon a11yTitle='menu-down' />;
-    }
-    if (! buttonIcon && ! buttonLabel) {
-      buttonIcon = <MoreIcon />;
-    }
-    return { icon: buttonIcon, label: buttonLabel };
+    // Return provided label(if any) and provided icon, or default
+    // to DropCaretIcon
+    return {
+      label,
+      icon: icon || <DropCaretIcon a11yTitle='menu-down' />
+    };
   }
 
   _renderMenuDrop () {

--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -159,7 +159,7 @@ class MenuDrop extends Component {
       if (child && isFunction(child.type) &&
         child.type.prototype._renderMenuDrop) {
         result = React.cloneElement(child,
-          {inline: 'explode', direction: 'column'});
+          { inline: 'explode', direction: 'column' });
       }
       return result;
     });
@@ -384,7 +384,7 @@ export default class Menu extends Component {
     const { icon, label } = this.props;
     // Use default icon if no label or icon is provided
     if (!label && !icon) {
-      return {icon: <MoreIcon />};
+      return { icon: <MoreIcon /> };
     }
 
     // Return provided label(if any) and provided icon, or default


### PR DESCRIPTION
Use the provided icon even when a label is provided for the `<Menu />` component. This is useful for very specific menues, e.g. a "Settings" menu with a settings cog instead of a dropdown caret.

#### What does this PR do?
- Changes the way a label in combination with an icon behaves in the `<Menu />` component

#### Where should the reviewer start?

- The effects are easily verified in the `<Menu />` examples of grommet-docs. Look there and compare to master and you will see that you're now able to have a custom icon for your labeled `<Menu />`
#### What testing has been done on this PR?

- I wanted to create some unit tests for `_renderButtonProps` but didn't fully understand how the test framework worked so only light manual testing has been done. LGTM :slightly_smiling_face: 

#### How should this be manually tested?
#### What are the relevant issues?
- That we weren't able to have a custom icon when we used it in combination with a label.

#### Do the grommet docs need to be updated?
- No there was nothing in the docs, AFAIK, regarding this.

#### Should this PR be mentioned in the release notes?
- I think so, since it changes old behavior.

#### Is this change backwards compatible or is it a breaking change?
- It's a breaking change, however it's no major change.