### PR TITLE
Allow overriding TextInput's autoComplete property

### DIFF
--- a/__tests__/components/TextInput-test.js
+++ b/__tests__/components/TextInput-test.js
@@ -17,4 +17,9 @@ describe('TextInput', () => {
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+  it('can set autocomplete', () => {
+    expect(
+      renderer.create(<TextInput autoComplete="on" />).toJSON()
+    ).toMatchSnapshot();
+  });
 });

--- a/__tests__/components/__snapshots__/TextInput-test.js.snap
+++ b/__tests__/components/__snapshots__/TextInput-test.js.snap
@@ -1,3 +1,15 @@
+exports[`TextInput can set autocomplete 1`] = `
+<input
+  autoComplete="on"
+  className="grommetux-text-input grommetux-input"
+  defaultValue={undefined}
+  onChange={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  placeholder={undefined}
+  value={undefined} />
+`;
+
 exports[`TextInput has correct default options 1`] = `
 <input
   autoComplete="off"

--- a/src/js/components/TextInput.js
+++ b/src/js/components/TextInput.js
@@ -305,8 +305,11 @@ export default class TextInput extends Component {
     );
 
     return (
-      <input ref={ref => this.componentRef = ref} {...props}
-        className={classes} autoComplete="off"
+      <input
+        ref={ref => this.componentRef = ref}
+        autoComplete="off"
+        {...props}
+        className={classes}
         defaultValue={this._renderLabel(defaultValue)}
         value={this._renderLabel(value)}
         placeholder={placeHolder}


### PR DESCRIPTION

#### What does this PR do?

Moves the `autoComplete` property on `input` to before passed in props are set.

This way parent components can set `autoComplete="on"` and override the default of `off`.  

Sometimes when users are setting an address or other personal information it's a good idea to allow the browser auto-complete to function.

#### Should this PR be mentioned in the release notes?

I wouldn't think so

#### Is this change backwards compatible or is it a breaking change?

Is backwards compatible
