### PR TITLE
Added tablerow disable property

### DIFF
--- a/__tests__/components/TableRow-test.js
+++ b/__tests__/components/TableRow-test.js
@@ -1,0 +1,20 @@
+// (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import TableRow from '../../src/js/components/TableRow';
+
+// needed because this:
+// https://github.com/facebook/jest/issues/1353
+jest.mock('react-dom');
+
+describe('TableRow', () => {
+  it('has correct default options', () => {
+    const component = renderer.create(
+      <TableRow custom={true} disabled={true} />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/__tests__/components/__snapshots__/TableRow-test.js.snap
+++ b/__tests__/components/__snapshots__/TableRow-test.js.snap
@@ -1,0 +1,8 @@
+exports[`TableRow has correct default options 1`] = `
+<tr
+  className="grommetux-table-row grommetux-table-row--disabled"
+  disabled={true}
+  onClick={null}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]} />
+`;

--- a/src/js/components/TableRow.js
+++ b/src/js/components/TableRow.js
@@ -5,21 +5,98 @@ import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 
 const CLASS_ROOT = CSSClassnames.TABLE_ROW;
+const SELECTED_CLASS = CLASS_ROOT + '--selected';
+const ACTIVE_CLASS = CLASS_ROOT + '--active';
+const DISABLED_CLASS = CLASS_ROOT + '--disabled';
 
 export default class TableRow extends Component {
-  render () {
-    const { children, className, onClick, ...props } = this.props;
+  constructor () {
+    super();
+    this._onSelect = this._onSelect.bind(this);
+    this.state = {
+      hover: false,
+      selected: {},
+      rowIndex: null
+    };
+  }
 
-    const classes = classnames(
+  // added this function explicitly as not passing selectable attribute in table
+  // component which applies hover class to all rows (we want to remove it for 
+  // disabled rows).
+  _onHover (hovered, e) {
+    if (hovered) {
+      const rows = e.target.parentNode.parentElement.rows;
+      var selected = this.state.selected;
+      for (var i = 0; i < rows.length; i++) {
+        var rowId='row'+i;
+        if (rows[i].classList.contains(SELECTED_CLASS)) {
+          selected[rowId] = true;
+        } else {
+          selected[rowId] = false;
+        }
+      }
+      const rowIndex = 'row' + e.currentTarget.sectionRowIndex;
+      this.setState({ selected, rowIndex, hover: true });
+    } else {
+      this.setState({ hover: false });
+    }
+  }
+
+  // added this function explicitly as not passing selectable attribute in table
+  // component which applies selectable class to all rows (we want to remove it
+  // for disabled rows).
+  _onSelect (e) {
+    var rows = e.target.parentNode.parentElement.rows;
+    var selected = this.state.selected;
+    const rowIndex = 'row' + e.currentTarget.sectionRowIndex;
+    for (var i = 0; i < rows.length; i++) {
+      var rowId='row'+i;
+      selected[rowId] = false;
+      if (rows[i].classList.contains(SELECTED_CLASS)) {
+        rows[i].classList.remove(SELECTED_CLASS);
+      }
+    }
+    selected[rowIndex]= true;
+    this.setState({ selected, rowIndex });
+    this.props.onClick(e.currentTarget.sectionRowIndex);
+  }
+
+  render () {
+    var { children, className, onClick, custom, ...props } = this.props;
+
+    var classes = classnames(
       CLASS_ROOT,
       {
         [`${CLASS_ROOT}--selectable`]: onClick
       },
       className
     );
+    var mouseEnter, mouseLeave;
 
+    //attribute custom(type boolean) should be sent 'true' if row is to be
+    // disabled
+    if (custom) {
+      // apply disabled css and remove onClick if row is to be disabled
+      if (this.props.disabled) {
+        onClick = null;
+        classes = classes.concat(' ' + DISABLED_CLASS);
+      } else {
+        onClick = this._onSelect;
+      }
+      // if hover and if row item is not disabled, apply hover css
+      if (this.state.hover && !this.props.disabled) {
+        classes = classes.concat(' ' + ACTIVE_CLASS);
+      }
+      // if row selected, apply row selected css
+      if (this.state.selected[this.state.rowIndex]) {
+        classes = classes.concat(' ' + SELECTED_CLASS);
+      }
+      mouseEnter = this._onHover.bind(this, true);
+      mouseLeave = this._onHover.bind(this, false);
+    }
     return (
-      <tr {...props} className={classes} onClick={onClick}>
+      <tr {...props} className={classes} onClick={onClick}
+      onMouseEnter={mouseEnter} onMouseLeave={mouseLeave}>
         {children}
       </tr>
     );
@@ -27,5 +104,6 @@ export default class TableRow extends Component {
 };
 
 TableRow.propTypes = {
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  custom: PropTypes.bool
 };

--- a/src/scss/grommet-core/_objects.table.scss
+++ b/src/scss/grommet-core/_objects.table.scss
@@ -161,3 +161,17 @@
 .#{$grommet-namespace}table--small {
   @include small-table();
 }
+
+.#{$grommet-namespace}table-row--selected {
+  background-color: $selected-background-color;
+}
+
+.#{$grommet-namespace}table-row--active {
+  background-color: $hover-background-color;
+  color: $hover-text-color;
+  cursor: pointer;
+}
+
+.#{$grommet-namespace}table-row--disabled {
+  background-color: $disabled-background-color;
+}

--- a/src/scss/grommet-core/_settings.color.scss
+++ b/src/scss/grommet-core/_settings.color.scss
@@ -38,6 +38,7 @@ $colored-text-color-lightness-threshold: 63 !default;
 $background-color: #fff !default;
 $secondary-background-color: #f5f5f5 !default;
 $hover-background-color: rgba(#ddd, 0.5) !default;
+$disabled-background-color: #CCCCCC;
 $colored-active-background-color: rgba(0, 0, 0, 0.15) !default;
 $colored-hover-background-color: rgba(0, 0, 0, 0.1) !default;
 $selected-background-color: $brand-color-lighter !default;


### PR DESCRIPTION
Signed-off-by: Jagruti Vichare jagruti.vichare@hpe.com

#### What does this PR do?
It adds disable row property in TableRow.js component

#### Where should the reviewer start? 
Reviewer should start from file TableRow.js(from line #79). ClassNames are included in file '_objects.table.scss' and '_settings.color.scss'

#### What testing has been done on this PR?
It has been confirmed locally
Note : Code pen is available at **https://codepen.io/jagrutivichare/pen/XMdqOg?editors=0010** 
'TableRow.js' file is renamed to 'CustomTableRow.js'

#### How should this be manually tested?
It can be tested at the codepen link mentioned above by changing 'disabled' property of 'CustomTableRow' component

#### Any background context you want to provide?
There was a requirement to have a property to enable/disable table row. Hence adding this functionality so it can be used in other products as well

#### Screen
![screenshot](https://cloud.githubusercontent.com/assets/26401853/24855110/28b678e4-1dfe-11e7-8f12-bfa64c1be9e2.png)

#### Do the grommet docs need to be updated? 
Yes

#### Should this PR be mentioned in the release notes? 
Yes

#### Is this change backwards compatible or is it a breaking change? 
Yes, it is backward compatible