### PR TITLE
fixes Anchors attachUnlisten react-router-v4 bug

### DIFF
--- a/src/js/components/Anchor.js
+++ b/src/js/components/Anchor.js
@@ -28,16 +28,19 @@ export default class Anchor extends Component {
 
   componentDidMount () {
     const { path } = this.props;
+    const { router } = this.context;
+
     if (path) {
-      this._attachUnlisten(this.context.router.history || this.context.router);
+      this._attachUnlisten(router.history || router);
     }
   }
 
   componentWillReceiveProps(nextProps) {
     const { path } = nextProps;
     const { router } = this.context;
+
     if (path && path !== this.props.path) {
-      this._attachUnlisten(router);
+      this._attachUnlisten(router.history || router);
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
Fixes passing of wrong history object to Anchor

#### What does this PR do?
Uses version agnostic passing of react-router history object to Anchors attachUnlisten method

#### Where should the reviewer start?
Anchor Component

#### What testing has been done on this PR?
Test project

#### How should this be manually tested?
Change an Anchors path

#### What are the relevant issues?
-

#### Do the grommet docs need to be updated?
no

#### Is this change backwards compatible or is it a breaking change?
backwards compatible
