### PR TITLE
Remove doubled margin on top/bottom of checkbox/radio inside of form-field

### DIFF
--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -254,8 +254,8 @@ $colored-select-drop-caret: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB
   > .#{$grommet-namespace}radio-button {
     display: block;
     @include inuit-font-size($content-font-size);
-    margin-top: double($form-vertical-padding);
-    margin-bottom: double($form-vertical-padding);
+    margin-top: $form-vertical-padding;
+    margin-bottom: $form-vertical-padding;
     margin-left: $form-horizontal-padding;
     margin-right: $form-horizontal-padding;
   }


### PR DESCRIPTION
This way they'll have the same height as other form elements.  

I'm hoping this is a simple change, but there may be more involved than I'm aware of.   Git blame says the `double` was introduced by commit https://github.com/grommet/grommet/commit/c1b7afd01e5405496c86a4da41102f9e4ecf510c to fix https://github.com/grommet/grommet/issues/143 

I'm working to fix a layout bug where a form looked like so:

![screen shot 2017-04-12 at 4 33 45 pm](https://cloud.githubusercontent.com/assets/79566/24980437/d5ec0b32-1f9d-11e7-98a0-4b38b2273804.png)



After setting the margin top/bottom to 6px instead of 12, the elements have the same height:

![screen shot 2017-04-12 at 4 33 23 pm](https://cloud.githubusercontent.com/assets/79566/24980454/eb49dd42-1f9d-11e7-9823-9edb7dcc9e0f.png)


