### PR TITLE
Fix for #1285 DateTimeDrop format issue

### DIFF
--- a/src/js/components/DateTimeDrop.js
+++ b/src/js/components/DateTimeDrop.js
@@ -30,7 +30,8 @@ const UNITS = {
   H: 'hour',
   m: 'minute',
   s: 'second',
-  a: 'ampm'
+  a: 'ampm',
+  A: 'ampm'
 };
 
 export default class DateTimeDrop extends Component {


### PR DESCRIPTION
Signed-off-by: Suhair Zain <suhairzain11@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes #1285 which displays the meridian as only am / pm instead of the expected AM / PM, according to the linked moment.js docs

#### Where should the reviewer start?
Check line 33 and 34 in DateTimeDrop.js

#### What testing has been done on this PR?
Manual testing as well as run the automated tests using `npm run test`.

#### How should this be manually tested?
Render a DateTime component with format `'M/D/YYYY h:mm A'`

#### What are the relevant issues?
#1285 

#### Screenshots (if appropriate)
![grommet](https://cloud.githubusercontent.com/assets/5249794/25073647/567831b4-2308-11e7-8716-d9b56e0cbd88.png)


#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
