### PR TITLE
Migrated from React.PropTypes to prop-types package, to support React 15.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lodash.zip": "^4.2.0",
     "markdown-to-jsx": "^5.0.0",
     "moment": "^2.13.0",
+    "prop-types": "^15.5.8",
     "react": "^15.3.0",
     "react-addons-transition-group": "^15.3.0",
     "react-desc": "^1.0.0",

--- a/src/js/components/Accordion.js
+++ b/src/js/components/Accordion.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import List from './List';
 
@@ -82,7 +83,7 @@ export default class Accordion extends Component {
       </List>
     );
   }
-};
+}
 
 Accordion.propTypes = {
   active: PropTypes.oneOfType([

--- a/src/js/components/AccordionPanel.js
+++ b/src/js/components/AccordionPanel.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Header from './Header';
 import Button from './Button';
@@ -68,7 +69,7 @@ export default class AccordionPanel extends Component {
       </div>
     );
   }
-};
+}
 
 AccordionPanel.propTypes = {
   a11yTitle: PropTypes.string,

--- a/src/js/components/Anchor.js
+++ b/src/js/components/Anchor.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
 import React, { Children, Component } from 'react';
+import ReactPropTypes from 'prop-types';
 import classnames from 'classnames';
 import { schema, PropTypes } from 'react-desc';
 import { matchPath } from 'react-router';
@@ -244,5 +245,5 @@ schema(Anchor, {
 });
 
 Anchor.contextTypes = {
-  router: React.PropTypes.object
+  router: ReactPropTypes.object
 };

--- a/src/js/components/Animate.js
+++ b/src/js/components/Animate.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import TransitionGroup from 'react-addons-transition-group';
 import classnames from 'classnames';
@@ -102,7 +103,7 @@ class AnimateChild extends Component {
     const style = { transitionDuration: `${duration || 0}ms` };
     return <div className={className} style={style}>{children}</div>;
   }
-};
+}
 
 AnimateChild.propTypes = {
   enter: PropTypes.shape({
@@ -207,7 +208,7 @@ export default class Animate extends Component {
       </TransitionGroup>
     );
   }
-};
+}
 
 const ANIMATIONS =
   ['fade', 'slide-up', 'slide-down', 'slide-left', 'slide-right', 'jiggle'];

--- a/src/js/components/App.js
+++ b/src/js/components/App.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { getCurrentLocale } from '../utils/Locale';
 import SkipLinks from './SkipLinks';

--- a/src/js/components/Article.js
+++ b/src/js/components/Article.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes, Children } from 'react';
+import React, { Component, Children } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import classnames from 'classnames';
 import Box from './Box';

--- a/src/js/components/Box.js
+++ b/src/js/components/Box.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import KeyboardAccelerators from '../utils/KeyboardAccelerators';
 import Intl from '../utils/Intl';

--- a/src/js/components/Button.js
+++ b/src/js/components/Button.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Children, Component, PropTypes } from 'react';
+import React, { Children, Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames, { namespace } from '../utils/CSSClassnames';
 
@@ -167,7 +168,7 @@ export default class Button extends Component {
       </Tag>
     );
   }
-};
+}
 
 Button.propTypes = {
   a11yTitle: PropTypes.string,

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 import Props from '../utils/Props';
@@ -253,7 +254,7 @@ export default class Card extends Component {
       </Box>
     );
   }
-};
+}
 
 Card.propTypes = {
   contentPad: Box.propTypes.pad,

--- a/src/js/components/Carousel.js
+++ b/src/js/components/Carousel.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box';
 import Tiles from './Tiles';

--- a/src/js/components/CheckBox.js
+++ b/src/js/components/CheckBox.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 

--- a/src/js/components/Collapsible.js
+++ b/src/js/components/Collapsible.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import TransitionGroup from 'react-addons-transition-group';
 import classnames from 'classnames';
@@ -54,7 +55,7 @@ class Collapse extends Component {
     );
     return <Box {...this.props} className={classes} />;
   }
-};
+}
 
 class Collapsible extends Component {
   render () {
@@ -70,7 +71,7 @@ class Collapsible extends Component {
       </Component>
     );
   }
-};
+}
 
 Collapsible.propTypes = {
   active: PropTypes.bool,

--- a/src/js/components/Columns.js
+++ b/src/js/components/Columns.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';

--- a/src/js/components/DateTime.js
+++ b/src/js/components/DateTime.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import moment from 'moment';
 import classnames from 'classnames';
 import KeyboardAccelerators from '../utils/KeyboardAccelerators';

--- a/src/js/components/DateTimeDrop.js
+++ b/src/js/components/DateTimeDrop.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import moment from 'moment';
 import Box from './Box';

--- a/src/js/components/Distribution.js
+++ b/src/js/components/Distribution.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import KeyboardAccelerators from '../utils/KeyboardAccelerators';

--- a/src/js/components/Footer.js
+++ b/src/js/components/Footer.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import Box from './Box';
@@ -124,7 +125,7 @@ export default class Footer extends Component {
       );
     }
   }
-};
+}
 
 Footer.propTypes = {
   fixed: PropTypes.bool,

--- a/src/js/components/Form.js
+++ b/src/js/components/Form.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 
@@ -30,7 +31,7 @@ export default class Form extends Component {
       </form>
     );
   }
-};
+}
 
 Form.propTypes = {
   compact: PropTypes.bool,

--- a/src/js/components/FormField.js
+++ b/src/js/components/FormField.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 

--- a/src/js/components/FormattedMessage.js
+++ b/src/js/components/FormattedMessage.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
 // NOTE: This component is a temporary wrapper of react-intl FormattedMessage
@@ -5,7 +6,7 @@
 // IntlProvider. The hope is that react-intl will change to obviate the
 // need for this component.
 
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 const GrommetFormattedMessage = (props, context) => (

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';

--- a/src/js/components/Heading.js
+++ b/src/js/components/Heading.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 

--- a/src/js/components/Headline.js
+++ b/src/js/components/Headline.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 
@@ -28,7 +29,7 @@ export default class Headline extends Component {
       </div>
     );
   }
-};
+}
 
 Headline.propTypes = {
   align: PropTypes.oneOf(['start', 'center', 'end']),

--- a/src/js/components/Hero.js
+++ b/src/js/components/Hero.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 import { smallSize } from '../utils/Responsive';

--- a/src/js/components/Image.js
+++ b/src/js/components/Image.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Label from './Label';
 import CSSClassnames from '../utils/CSSClassnames';
@@ -51,7 +52,7 @@ export default class Image extends Component {
       imgNode
     );
   }
-};
+}
 
 Image.propTypes = {
   align: PropTypes.shape({

--- a/src/js/components/Label.js
+++ b/src/js/components/Label.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 import { announce } from '../utils/Announcer';
@@ -41,7 +42,7 @@ export default class Label extends Component {
       </label>
     );
   }
-};
+}
 
 Label.propTypes = {
   align: PropTypes.oneOf(['start', 'center', 'end']),

--- a/src/js/components/Layer.js
+++ b/src/js/components/Layer.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import Button from './Button';

--- a/src/js/components/Legend.js
+++ b/src/js/components/Legend.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import FormattedMessage from './FormattedMessage';
 import List from './List';

--- a/src/js/components/List.js
+++ b/src/js/components/List.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import SpinningIcon from './icons/Spinning';
 import InfiniteScroll from '../utils/InfiniteScroll';

--- a/src/js/components/LoginForm.js
+++ b/src/js/components/LoginForm.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import Button from './Button';

--- a/src/js/components/Map.js
+++ b/src/js/components/Map.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';

--- a/src/js/components/Markdown.js
+++ b/src/js/components/Markdown.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2016 Hewlett Packard Enterprise Development LP
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Markdown from 'markdown-to-jsx';
 import deepAssign from 'deep-assign';
 import Paragraph from './Paragraph';

--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import classnames from 'classnames';
 import KeyboardAccelerators from '../utils/KeyboardAccelerators';

--- a/src/js/components/Meter.js
+++ b/src/js/components/Meter.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Responsive from '../utils/Responsive';
 import CSSClassnames from '../utils/CSSClassnames';

--- a/src/js/components/Notification.js
+++ b/src/js/components/Notification.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import classnames from 'classnames';
 import { FormattedDate } from 'react-intl';
@@ -204,7 +205,7 @@ export default class Notification extends Component {
       </Box>
     );
   }
-};
+}
 
 Notification.propTypes = {
   closer: PropTypes.oneOfType([

--- a/src/js/components/NumberInput.js
+++ b/src/js/components/NumberInput.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 import Button from './Button';

--- a/src/js/components/Object.js
+++ b/src/js/components/Object.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import CSSClassnames from '../utils/CSSClassnames';
 
 const CLASS_ROOT = CSSClassnames.OBJECT;

--- a/src/js/components/Paragraph.js
+++ b/src/js/components/Paragraph.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 
@@ -28,7 +29,7 @@ export default class Paragraph extends Component {
       </p>
     );
   }
-};
+}
 
 Paragraph.propTypes = {
   align: PropTypes.oneOf(['start', 'center', 'end']),

--- a/src/js/components/Quote.js
+++ b/src/js/components/Quote.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box';
 import Paragraph from './Paragraph';
@@ -54,7 +55,7 @@ export default class Quote extends Component {
       </Box>
     );
   }
-};
+}
 
 Quote.propTypes = {
   borderColorIndex: PropTypes.string,

--- a/src/js/components/RadioButton.js
+++ b/src/js/components/RadioButton.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 
@@ -28,7 +29,7 @@ export default class RadioButton extends Component {
       </label>
     );
   }
-};
+}
 
 RadioButton.propTypes = {
   checked: PropTypes.bool,

--- a/src/js/components/SVGIcon.js
+++ b/src/js/components/SVGIcon.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 import Intl from '../utils/Intl';
@@ -42,7 +43,7 @@ export default class SVGIcon extends Component {
       </svg>
     );
   }
-};
+}
 
 SVGIcon.contextTypes = {
   intl: PropTypes.object

--- a/src/js/components/Search.js
+++ b/src/js/components/Search.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import classnames from 'classnames';
 import KeyboardAccelerators from '../utils/KeyboardAccelerators';

--- a/src/js/components/SearchInput.js
+++ b/src/js/components/SearchInput.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import KeyboardAccelerators from '../utils/KeyboardAccelerators';
 import Drop from '../utils/Drop';

--- a/src/js/components/Select.js
+++ b/src/js/components/Select.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';

--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box';
 import CSSClassnames from '../utils/CSSClassnames';
@@ -26,7 +27,7 @@ export default class Sidebar extends Component {
       </Box>
     );
   }
-};
+}
 
 Sidebar.propTypes = {
   fixed: PropTypes.bool,

--- a/src/js/components/SkipLinkAnchor.js
+++ b/src/js/components/SkipLinkAnchor.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import CSSClassnames from '../utils/CSSClassnames';
 
 const CLASS_ROOT = CSSClassnames.SKIP_LINK_ANCHOR;
@@ -15,7 +16,7 @@ export default class SkipLinkAnchor extends Component {
       </a>
     );
   }
-};
+}
 
 SkipLinkAnchor.propTypes = {
   label: PropTypes.node.isRequired

--- a/src/js/components/SkipLinks.js
+++ b/src/js/components/SkipLinks.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import FormattedMessage from './FormattedMessage';
 import Box from './Box';
 import Layer from './Layer';

--- a/src/js/components/SocialShare.js
+++ b/src/js/components/SocialShare.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Anchor from './Anchor';
 import SocialTwitterIcon from './icons/base/SocialTwitter';
 import SocialFacebookIcon from './icons/base/SocialFacebook';
@@ -59,7 +60,7 @@ export default class SocialShare extends Component {
       <Anchor {...props} href={href} icon={socialIcon} target={target} />
     );
   }
-};
+}
 
 SocialShare.propTypes = {
   a11yTitle: PropTypes.string,

--- a/src/js/components/Split.js
+++ b/src/js/components/Split.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 import { smallSize } from '../utils/Responsive';
@@ -148,7 +149,7 @@ export default class Split extends Component {
 }
 
 Split.propTypes = {
-  children: PropTypes.arrayOf(React.PropTypes.node).isRequired,
+  children: PropTypes.arrayOf(PropTypes.node).isRequired,
   fixed: PropTypes.bool,
   flex: PropTypes.oneOf(['left', 'right', 'both']),
   onResponsive: PropTypes.func,

--- a/src/js/components/SunBurst.js
+++ b/src/js/components/SunBurst.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { baseUnit, translateEndAngle, arcCommands } from '../utils/Graphics';
 import CSSClassnames from '../utils/CSSClassnames';

--- a/src/js/components/Tab.js
+++ b/src/js/components/Tab.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Button from './Button';
 import CSSClassnames from '../utils/CSSClassnames';

--- a/src/js/components/Table.js
+++ b/src/js/components/Table.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import SpinningIcon from './icons/Spinning';
 import InfiniteScroll from '../utils/InfiniteScroll';

--- a/src/js/components/TableHeader.js
+++ b/src/js/components/TableHeader.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Button from './Button';
 import Box from './Box';
 import AscIcon from './icons/base/LinkDown';
@@ -62,7 +63,7 @@ export default class TableHeader extends Component {
       </thead>
     );
   }
-};
+}
 
 TableHeader.propTypes = {
   labels: PropTypes.arrayOf(PropTypes.node).isRequired,

--- a/src/js/components/TableRow.js
+++ b/src/js/components/TableRow.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 
@@ -24,7 +25,7 @@ export default class TableRow extends Component {
       </tr>
     );
   }
-};
+}
 
 TableRow.propTypes = {
   onClick: PropTypes.func

--- a/src/js/components/Tabs.js
+++ b/src/js/components/Tabs.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Intl from '../utils/Intl';
 import CSSClassnames from '../utils/CSSClassnames';

--- a/src/js/components/TextInput.js
+++ b/src/js/components/TextInput.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import KeyboardAccelerators from '../utils/KeyboardAccelerators';
 import Drop from '../utils/Drop';

--- a/src/js/components/Tile.js
+++ b/src/js/components/Tile.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Props from '../utils/Props';
 import Box from './Box';

--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes, Children } from 'react';
+import React, { Component, Children } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import classnames from 'classnames';
 import Props from '../utils/Props';

--- a/src/js/components/Timestamp.js
+++ b/src/js/components/Timestamp.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { getCurrentLocale } from '../utils/Locale';
 import CSSClassnames from '../utils/CSSClassnames';

--- a/src/js/components/Tip.js
+++ b/src/js/components/Tip.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box';
 import CSSClassnames from '../utils/CSSClassnames';

--- a/src/js/components/Title.js
+++ b/src/js/components/Title.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box';
 import Intl from '../utils/Intl';

--- a/src/js/components/Toast.js
+++ b/src/js/components/Toast.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import Button from './Button';

--- a/src/js/components/Topology.js
+++ b/src/js/components/Topology.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Children, Component, PropTypes } from 'react';
+import React, { Children, Component } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import classnames from 'classnames';
 import Status from './icons/Status';

--- a/src/js/components/Value.js
+++ b/src/js/components/Value.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 import { announce } from '../utils/Announcer';

--- a/src/js/components/Video.js
+++ b/src/js/components/Video.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
@@ -313,7 +314,7 @@ Video.propTypes = {
   shareHeadline: PropTypes.string,
   shareText: PropTypes.string,
   showControls: PropTypes.bool,
-  size: React.PropTypes.oneOf(['small', 'medium', 'large']),
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
   timeline: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string,
     time: PropTypes.number

--- a/src/js/components/WorldMap.js
+++ b/src/js/components/WorldMap.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../utils/CSSClassnames';
 import KeyboardAccelerators from '../utils/KeyboardAccelerators';

--- a/src/js/components/chart/Axis.js
+++ b/src/js/components/chart/Axis.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../utils/CSSClassnames';
 import Intl from '../../utils/Intl';
@@ -100,7 +101,7 @@ export default class Axis extends Component {
     );
   }
 
-};
+}
 
 Axis.contextTypes = {
   intl: PropTypes.object

--- a/src/js/components/chart/Base.js
+++ b/src/js/components/chart/Base.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes, Children } from 'react';
+import React, { Component, Children } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../utils/CSSClassnames';
 
@@ -64,7 +65,7 @@ export default class Base extends Component {
     );
   }
 
-};
+}
 
 Base.propTypes = {
   height: PropTypes.oneOf([

--- a/src/js/components/chart/Chart.js
+++ b/src/js/components/chart/Chart.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, Children, PropTypes } from 'react';
+import React, { Component, Children } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../utils/CSSClassnames';
 import Intl from '../../utils/Intl';
@@ -267,7 +268,7 @@ export default class Chart extends Component {
     );
   }
 
-};
+}
 
 Chart.contextTypes = {
   intl: PropTypes.object

--- a/src/js/components/chart/Graph.js
+++ b/src/js/components/chart/Graph.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../utils/CSSClassnames';
 import Intl from '../../utils/Intl';
@@ -246,7 +247,7 @@ export default class Graph extends Component {
     );
   }
 
-};
+}
 
 Graph.contextTypes = {
   intl: PropTypes.object

--- a/src/js/components/chart/Grid.js
+++ b/src/js/components/chart/Grid.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../utils/CSSClassnames';
 import { padding } from './utils';
@@ -51,7 +52,7 @@ export default class Grid extends Component {
     );
   }
 
-};
+}
 
 Grid.propTypes = {
   columns: PropTypes.number,

--- a/src/js/components/chart/HotSpots.js
+++ b/src/js/components/chart/HotSpots.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { padding } from './utils';
 import CSSClassnames from '../../utils/CSSClassnames';
@@ -128,7 +129,7 @@ export default class HotSpots extends Component {
     );
   }
 
-};
+}
 
 HotSpots.contextTypes = {
   intl: PropTypes.object

--- a/src/js/components/chart/Layers.js
+++ b/src/js/components/chart/Layers.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, Children, PropTypes } from 'react';
+import React, { Component, Children } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../utils/CSSClassnames';
 
@@ -38,7 +39,7 @@ export default class Layers extends Component {
     );
   }
 
-};
+}
 
 Layers.propTypes = {
   height: PropTypes.number, // only from Chart

--- a/src/js/components/chart/Marker.js
+++ b/src/js/components/chart/Marker.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../utils/CSSClassnames';
 import { graphValue, trackSize, padding } from './utils';
@@ -98,7 +99,7 @@ export default class Marker extends Component {
     );
   }
 
-};
+}
 
 // Need either count and index or value, min, and max
 Marker.propTypes = {

--- a/src/js/components/chart/MarkerLabel.js
+++ b/src/js/components/chart/MarkerLabel.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../utils/CSSClassnames';
 import Props from '../../utils/Props';
@@ -113,7 +114,7 @@ export default class MarkerLabel extends Component {
     );
   }
 
-};
+}
 
 // Need either count and index or value, min, and max
 MarkerLabel.propTypes = {

--- a/src/js/components/chart/Range.js
+++ b/src/js/components/chart/Range.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../utils/CSSClassnames';
 import DragIcon from '../icons/base/Drag';
@@ -227,7 +228,7 @@ export default class Range extends Component {
     );
   }
 
-};
+}
 
 Range.propTypes = {
   active: PropTypes.shape({

--- a/src/js/components/icons/Grommet.js
+++ b/src/js/components/icons/Grommet.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../utils/CSSClassnames';
 import Intl from '../../utils/Intl';
@@ -41,7 +42,7 @@ Grommet.defaultProps = {
 };
 
 Grommet.propTypes = {
-  a11yTitle: React.PropTypes.string,
+  a11yTitle: PropTypes.string,
   invert: PropTypes.bool,
-  size: React.PropTypes.oneOf(['small', 'medium', 'large', 'xlarge'])
+  size: PropTypes.oneOf(['small', 'medium', 'large', 'xlarge'])
 };

--- a/src/js/components/icons/Pulse.js
+++ b/src/js/components/icons/Pulse.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Add from './base/Add';
 import CSSClassnames from '../../utils/CSSClassnames';
 import classnames from 'classnames';

--- a/src/js/components/icons/Spinning.js
+++ b/src/js/components/icons/Spinning.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../utils/CSSClassnames';
 import Intl from '../../utils/Intl';

--- a/src/js/components/icons/Status.js
+++ b/src/js/components/icons/Status.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import OK from './status/OK';
 import CriticalStatus from './status/CriticalStatus';

--- a/src/js/components/icons/status/Blank.js
+++ b/src/js/components/icons/status/Blank.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../../utils/CSSClassnames';
 

--- a/src/js/components/icons/status/CriticalStatus.js
+++ b/src/js/components/icons/status/CriticalStatus.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../../utils/CSSClassnames';
 

--- a/src/js/components/icons/status/Disabled.js
+++ b/src/js/components/icons/status/Disabled.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../../utils/CSSClassnames';
 

--- a/src/js/components/icons/status/OK.js
+++ b/src/js/components/icons/status/OK.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../../utils/CSSClassnames';
 

--- a/src/js/components/icons/status/Unknown.js
+++ b/src/js/components/icons/status/Unknown.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../../utils/CSSClassnames';
 

--- a/src/js/components/icons/status/Warning.js
+++ b/src/js/components/icons/status/Warning.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames from '../../../utils/CSSClassnames';
 

--- a/src/js/components/meter/Graphic.js
+++ b/src/js/components/meter/Graphic.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import Intl from '../../utils/Intl';

--- a/src/js/components/meter/propTypes.js
+++ b/src/js/components/meter/propTypes.js
@@ -1,6 +1,4 @@
-// (C) Copyright 2014 Hewlett Packard Enterprise Development LP
-
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 
 export default {
   activeIndex: PropTypes.number,

--- a/src/js/components/meter/utils.js
+++ b/src/js/components/meter/utils.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { baseUnit } from '../../utils/Graphics';
 import CSSClassnames from '../../utils/CSSClassnames';
 
@@ -49,4 +50,4 @@ export function buildPath (itemIndex, commands, classes, onActivate,
       <path key={itemIndex} className={classes} d={commands} />
     );
   }
-};
+}

--- a/src/js/components/video/Controls.js
+++ b/src/js/components/video/Controls.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import Button from '../Button';

--- a/src/js/components/video/FullscreenButton.js
+++ b/src/js/components/video/FullscreenButton.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import Intl from '../../utils/Intl';
 import CSSClassnames from '../../utils/CSSClassnames';

--- a/src/js/components/video/PlayButton.js
+++ b/src/js/components/video/PlayButton.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Intl from '../../utils/Intl';
 import CSSClassnames from '../../utils/CSSClassnames';
 import Button from '../Button';

--- a/src/js/components/video/ProgressBar.js
+++ b/src/js/components/video/ProgressBar.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import Box from '../Box';

--- a/src/js/components/video/Share.js
+++ b/src/js/components/video/Share.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import Box from '../Box';
 import SocialShare from '../SocialShare';

--- a/src/js/components/video/Time.js
+++ b/src/js/components/video/Time.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import Box from '../Box';
 import Heading from '../Heading';

--- a/src/js/utils/Drop.js
+++ b/src/js/utils/Drop.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014 Hewlett Packard Enterprise Development LP
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { filterByFocusable, findScrollParents } from './DOM';
 import CSSClassnames from './CSSClassnames';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2152,7 +2152,7 @@ fb-watchman@^1.8.0, fb-watchman@^1.9.0:
   dependencies:
     bser "1.0.2"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
+fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.11"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.11.tgz#340b590b8a2278a01ef7467c07a16da9b753db24"
   dependencies:
@@ -5541,6 +5541,12 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.5.8:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
 
 proxy-addr@~1.1.3:
   version "1.1.3"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
From React 15.5.x, PropTypes has been moved to a separate package. Did the migration using JSCodeShift and a helper script. The src/js/components/icons/base folder has been omitted since it was mentioned that it was auto-generated.

#### What testing has been done on this PR?
Ran pre-commit tests

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/1303

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible