### PR TITLE
Fix for React Router isActive deprecated warning

### DIFF
--- a/src/js/components/Anchor.js
+++ b/src/js/components/Anchor.js
@@ -59,8 +59,9 @@ export default class Anchor extends Component {
     let active;
     if (router && router.isActive) {
       active = router && router.isActive && 
-        path && router.isActive(path.path || path, {
-          indexLink: path.index
+        path && router.isActive({
+          pathname: path.path || path,
+          query: { indexLink: path.index }
         });
     } else if(router && matchPath) {
       active = !!matchPath(


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes the "Warning: [react-router] `isActive(pathname, query, indexOnly) is deprecated; use `isActive(location, indexOnly)` with a location descriptor instead. http://tiny.cc/router-isActivedeprecated"

#### Where should the reviewer start?
src/js/components/Anchor.js

#### What testing has been done on this PR?
Ran automated tests on commit

#### How should this be manually tested?
Render an Anchor element and check the console for any warnings
Then use the browser's inspector to check if the rendered <a/> tag has the grommetux-anchor--active class set to it if it's the active path.

#### Any background context you want to provide?
https://github.com/ReactTraining/react-router/blob/v2.8.1/upgrade-guides/v2.0.0.md/

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards Compatible