### PR TITLE
Hot Spots

### DIFF
--- a/__tests__/components/HotSpots-test.js
+++ b/__tests__/components/HotSpots-test.js
@@ -1,0 +1,152 @@
+// (C) Copyright 2014-2017 Hewlett Packard Enterprise Development LP
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import HotSpots from '../../src/js/components/chart/HotSpots';
+
+// needed because this:
+// https://github.com/facebook/jest/issues/1353
+jest.mock('react-dom');
+
+describe('Hotspots', () => {
+  it('renders with correct widths for regular data', () => {
+    const component = renderer.create(
+      <HotSpots
+        count={0}
+        normalizedValues={[
+          [1, 2, 3]
+        ]}
+      />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with correct widths for data with beginning gaps', () => {
+    const component = renderer.create(
+      <HotSpots
+        count={0}
+        normalizedValues={[
+          [undefined, 1, 2]
+        ]}
+      />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with correct widths for data with end gaps', () => {
+    const component = renderer.create(
+      <HotSpots
+        count={0}
+        normalizedValues={[
+          [1, 2, undefined]
+        ]}
+      />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with correct widths for data with middle gaps', () => {
+    const component = renderer.create(
+      <HotSpots
+        count={0}
+        normalizedValues={[
+          [0, undefined, undefined, undefined, 1, undefined, undefined, 2]
+        ]}
+      />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with correct div widths for empty data', () => {
+    const component = renderer.create(
+      <HotSpots
+        count={0}
+        normalizedValues={[
+          []
+        ]}
+      />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with correct widths for merged data with beginning gaps', () => {
+    const component = renderer.create(
+      <HotSpots
+        count={0}
+        normalizedValues={[
+          [undefined, 2, 5, 56, 1, 6],
+          [undefined, 40, undefined, 6, 7, 1]
+        ]}
+      />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with correct widths for merged data with end gaps', () => {
+    const component = renderer.create(
+      <HotSpots
+        count={0}
+        normalizedValues={[
+          [2, 5, 56, 1, 6],
+          [40, undefined, 6, 7, 1, undefined]
+        ]}
+      />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with correct div widths for merged data without gaps', () => {
+    const component = renderer.create(
+      <HotSpots
+        count={0}
+        normalizedValues={[
+          [40, 43, 6, 7, 1, 0],
+          [2, 5, 56, 1, 6]
+        ]}
+      />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with correct widths for merged data with middle gaps', () => {
+    const component = renderer.create(
+      <HotSpots
+        count={0}
+        normalizedValues={[
+        [undefined, 1],
+	      [undefined, undefined, undefined, undefined]
+        ]}
+      />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with correct widths for merged data with all gaps', () => {
+    const component = renderer.create(
+      <HotSpots
+        count={0}
+        normalizedValues={[
+        [undefined, undefined],
+	      [undefined, undefined, undefined, undefined]
+        ]}
+      />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders with correct widths for merged data from multiple arrays', () => {
+    const component = renderer.create(
+      <HotSpots
+        count={0}
+        normalizedValues={[
+          [2, 5, undefined, undefined, 1, 6],
+          [40, undefined, undefined, undefined, 7, 1, undefined],
+          [8, undefined, undefined, 29, undefined, undefined, undefined, 1]
+        ]}
+      />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/__tests__/components/__snapshots__/HotSpots-test.js.snap
+++ b/__tests__/components/__snapshots__/HotSpots-test.js.snap
@@ -1,0 +1,732 @@
+exports[`Hotspots renders with correct div widths for empty data 1`] = `
+<div
+  aria-label="HotSpotsLabel"
+  className="grommetux-chart-hot-spots"
+  normalizedValues={
+    Array [
+      Array [],
+    ]
+  }
+  onBlur={[Function]}
+  onFocus={[Function]}
+  role="group"
+  style={
+    Object {
+      "padding": 8,
+    }
+  }
+  tabIndex="0" />
+`;
+
+exports[`Hotspots renders with correct div widths for merged data without gaps 1`] = `
+<div
+  aria-label="HotSpotsLabel"
+  className="grommetux-chart-hot-spots"
+  normalizedValues={
+    Array [
+      Array [
+        40,
+        43,
+        6,
+        7,
+        1,
+        0,
+      ],
+      Array [
+        2,
+        5,
+        56,
+        1,
+        6,
+      ],
+    ]
+  }
+  onBlur={[Function]}
+  onFocus={[Function]}
+  role="group"
+  style={
+    Object {
+      "padding": 8,
+    }
+  }
+  tabIndex="0">
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "10%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "20%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "20%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "20%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "20%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "10%",
+      }
+    } />
+</div>
+`;
+
+exports[`Hotspots renders with correct widths for data with beginning gaps 1`] = `
+<div
+  aria-label="HotSpotsLabel"
+  className="grommetux-chart-hot-spots"
+  normalizedValues={
+    Array [
+      Array [
+        undefined,
+        1,
+        2,
+      ],
+    ]
+  }
+  onBlur={[Function]}
+  onFocus={[Function]}
+  role="group"
+  style={
+    Object {
+      "padding": 8,
+    }
+  }
+  tabIndex="0">
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "75%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "25%",
+      }
+    } />
+</div>
+`;
+
+exports[`Hotspots renders with correct widths for data with end gaps 1`] = `
+<div
+  aria-label="HotSpotsLabel"
+  className="grommetux-chart-hot-spots"
+  normalizedValues={
+    Array [
+      Array [
+        1,
+        2,
+        undefined,
+      ],
+    ]
+  }
+  onBlur={[Function]}
+  onFocus={[Function]}
+  role="group"
+  style={
+    Object {
+      "padding": 8,
+    }
+  }
+  tabIndex="0">
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "25%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "75%",
+      }
+    } />
+</div>
+`;
+
+exports[`Hotspots renders with correct widths for data with middle gaps 1`] = `
+<div
+  aria-label="HotSpotsLabel"
+  className="grommetux-chart-hot-spots"
+  normalizedValues={
+    Array [
+      Array [
+        0,
+        undefined,
+        undefined,
+        undefined,
+        1,
+        undefined,
+        undefined,
+        2,
+      ],
+    ]
+  }
+  onBlur={[Function]}
+  onFocus={[Function]}
+  role="group"
+  style={
+    Object {
+      "padding": 8,
+    }
+  }
+  tabIndex="0">
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "28.571428571428573%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "50%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "21.42857142857143%",
+      }
+    } />
+</div>
+`;
+
+exports[`Hotspots renders with correct widths for merged data from multiple arrays 1`] = `
+<div
+  aria-label="HotSpotsLabel"
+  className="grommetux-chart-hot-spots"
+  normalizedValues={
+    Array [
+      Array [
+        8,
+        undefined,
+        undefined,
+        29,
+        undefined,
+        undefined,
+        undefined,
+        1,
+      ],
+      Array [
+        40,
+        undefined,
+        undefined,
+        undefined,
+        7,
+        1,
+        undefined,
+      ],
+      Array [
+        2,
+        5,
+        undefined,
+        undefined,
+        1,
+        6,
+      ],
+    ]
+  }
+  onBlur={[Function]}
+  onFocus={[Function]}
+  role="group"
+  style={
+    Object {
+      "padding": 8,
+    }
+  }
+  tabIndex="0">
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "7.142857142857143%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "21.42857142857143%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "21.42857142857143%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "14.285714285714286%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "21.42857142857143%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "14.285714285714278%",
+      }
+    } />
+</div>
+`;
+
+exports[`Hotspots renders with correct widths for merged data with all gaps 1`] = `
+<div
+  aria-label="HotSpotsLabel"
+  className="grommetux-chart-hot-spots"
+  normalizedValues={
+    Array [
+      Array [
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      ],
+      Array [
+        undefined,
+        undefined,
+      ],
+    ]
+  }
+  onBlur={[Function]}
+  onFocus={[Function]}
+  role="group"
+  style={
+    Object {
+      "padding": 8,
+    }
+  }
+  tabIndex="0" />
+`;
+
+exports[`Hotspots renders with correct widths for merged data with beginning gaps 1`] = `
+<div
+  aria-label="HotSpotsLabel"
+  className="grommetux-chart-hot-spots"
+  normalizedValues={
+    Array [
+      Array [
+        undefined,
+        2,
+        5,
+        56,
+        1,
+        6,
+      ],
+      Array [
+        undefined,
+        40,
+        undefined,
+        6,
+        7,
+        1,
+      ],
+    ]
+  }
+  onBlur={[Function]}
+  onFocus={[Function]}
+  role="group"
+  style={
+    Object {
+      "padding": 8,
+    }
+  }
+  tabIndex="0">
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "30%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "20%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "20%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "20%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "10%",
+      }
+    } />
+</div>
+`;
+
+exports[`Hotspots renders with correct widths for merged data with end gaps 1`] = `
+<div
+  aria-label="HotSpotsLabel"
+  className="grommetux-chart-hot-spots"
+  normalizedValues={
+    Array [
+      Array [
+        40,
+        undefined,
+        6,
+        7,
+        1,
+        undefined,
+      ],
+      Array [
+        2,
+        5,
+        56,
+        1,
+        6,
+      ],
+    ]
+  }
+  onBlur={[Function]}
+  onFocus={[Function]}
+  role="group"
+  style={
+    Object {
+      "padding": 8,
+    }
+  }
+  tabIndex="0">
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "10%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "20%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "20%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "20%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "30%",
+      }
+    } />
+</div>
+`;
+
+exports[`Hotspots renders with correct widths for merged data with middle gaps 1`] = `
+<div
+  aria-label="HotSpotsLabel"
+  className="grommetux-chart-hot-spots"
+  normalizedValues={
+    Array [
+      Array [
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      ],
+      Array [
+        undefined,
+        1,
+      ],
+    ]
+  }
+  onBlur={[Function]}
+  onFocus={[Function]}
+  role="group"
+  style={
+    Object {
+      "padding": 8,
+    }
+  }
+  tabIndex="0">
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "100%",
+      }
+    } />
+</div>
+`;
+
+exports[`Hotspots renders with correct widths for regular data 1`] = `
+<div
+  aria-label="HotSpotsLabel"
+  className="grommetux-chart-hot-spots"
+  normalizedValues={
+    Array [
+      Array [
+        1,
+        2,
+        3,
+      ],
+    ]
+  }
+  onBlur={[Function]}
+  onFocus={[Function]}
+  role="group"
+  style={
+    Object {
+      "padding": 8,
+    }
+  }
+  tabIndex="0">
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "25%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "50%",
+      }
+    } />
+  <div
+    aria-label={undefined}
+    className="grommetux-chart-hot-spots__band"
+    onClick={undefined}
+    onMouseOut={undefined}
+    onMouseOver={undefined}
+    role="row"
+    style={
+      Object {
+        "flexBasis": "25%",
+      }
+    } />
+</div>
+`;


### PR DESCRIPTION
#### What does this PR do?

My PR attempts to improve the process of determining the widths of the HotSpot's divs. Instead of the current method of creating equally sized divs for each data point, the PR extends the div widths of data points which are located next to gaps (i.e. undefined values in the data points array) such the div more accurately surrounds the data point. 

This behavior is accomplished by defining a new prop for the HotSpots component. The new prop is called normalizedValues and represents an array containing arrays of data points. The first operation that is required for this new method of gap-accounting div width calculation is to merge the normalizedValues into one array of data points, which will accurately gives us a representation of the gaps present within all of the data points we are given. Then we proceed to actually calculate the div widths. We start by creating a default basis which is set to 100 / (number of points in the merged data points array). The basis is extended for if there is a gap surrounded the data point. The widths are stored in an array named percentBasis. Lastly, in the render method we have to map the index of the percentBasis array (which may be shorter than the normalizedValues array due to the handling of gaps in the calculation of the widths) back to the index of normalizedValues. The mapping is performed with a map that is created by the _makeHotspotToIndexMapping method. The mapped index is then sent to onClick and onMouseOver. 

It should be noted that graphs with more than ~1000 data points using the version of HotSpots in this PR do not have a div for the last ~3 pixels of the graph. [Here is a screenshot illustrating the issue.](http://imgur.com/Qsygz32). The issue is a rare edge case that I have not found to actually impact user experience, since it is very difficult to actually notice the pixels missing when mousing over the region. 

#### Where should the reviewer start?

The reviewer should start by understanding the __calculateHotSpotWidths in the HotSpots.js file.

#### What testing has been done on this PR?

I have eleven unit tests cases verifying the calculation and merging operations. I do have more unit tests particularly for testing the functionality of componentWillReceiveProps and _makeHotspotToIndexMapping, but these tests would require the use of the enzyme testing utility so I have left them out for right now. 

#### How should this be manually tested?

After pulling the changes, hover over a chart using the HotSpots component and verify via hovering over the graph that the correct data points (i.e the one you're hovering over) are being presented. Also you can also check the actual div partitions with your browser's inspection tool.

#### Any background context you want to provide?

We were experiencing an issue with our use of the HotSpots component in Store Front Remote's performance graphs where hovering over a point on the graph did not actually select that point.

[Here is a screen shot of our graph using the original HotSpots.](http://imgur.com/BPPlQVe)
[Here is a screen shot of our graph using the version of HotSpots in the PR.](http://imgur.com/kmWNeVF)

#### What are the relevant issues?
Nothing that I could find in the issues list.

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

Probably not.
#### Should this PR be mentioned in the release notes?

Probably not.
#### Is this change backwards compatible or is it a breaking change?

Yes, this change is backwards compatible. The change in the div calculation is only used if the new non-required prop "noralizedValues" is provided. Otherwise the default method of using the count of the data points is used.