### PR TITLE
Added button box prop

### DIFF
--- a/src/js/components/Button.js
+++ b/src/js/components/Button.js
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import CSSClassnames, { namespace } from '../utils/CSSClassnames';
 
+import Box from './Box';
+
 const CLASS_ROOT = CSSClassnames.BUTTON;
 
 function getHoverModifier(hoverIndicator) {
@@ -92,7 +94,7 @@ export default class Button extends Component {
 
   render () {
     const {
-      a11yTitle, accent, align, children, className, fill, hoverIndicator,
+      a11yTitle, accent, align, box, children, className, fill, hoverIndicator,
       href, icon, label, onClick, path, plain, primary, reverse, secondary,
       type, ...props
     } = this.props;
@@ -123,6 +125,7 @@ export default class Button extends Component {
     const classes = classnames(
       CLASS_ROOT,
       {
+        [`${CLASS_ROOT}--box`]: box,
         [`${CLASS_ROOT}--focus`]: this.state.focus,
         [`${CLASS_ROOT}--primary`]: primary,
         [`${CLASS_ROOT}--secondary`]: secondary,
@@ -132,8 +135,9 @@ export default class Button extends Component {
           !adjustedHref &&
           !['reset', 'submit'].includes(type),
         [`${CLASS_ROOT}--fill`]: fill,
-        [`${CLASS_ROOT}--plain`]: plain || Children.count(children) > 0 ||
-          (icon && ! label),
+        [`${CLASS_ROOT}--plain`]: (
+          plain || box || Children.count(children) > 0 || (icon && ! label)
+        ),
         [`${CLASS_ROOT}--align-${align}`]: align,
         [getHoverModifier(hoverIndicator)]: hoverIndicator
       },
@@ -142,17 +146,26 @@ export default class Button extends Component {
 
     let adjustedOnClick = (path && router ? this._onClick : onClick);
 
-    const Tag = adjustedHref ? 'a' : 'button';
+    let Tag = adjustedHref ? 'a' : 'button';
     let buttonType;
     if (!adjustedHref) {
       buttonType = type;
+    }
+
+    let boxProps;
+    if (box) {
+      // Let the root element of the Button be a Box element with tag prop
+      boxProps = {
+        tag: Tag
+      };
+      Tag = Box;
     }
 
     const first = reverse ? buttonLabel : buttonIcon;
     const second = reverse ? buttonIcon : buttonLabel;
 
     return (
-      <Tag {...props} href={adjustedHref} type={buttonType}
+      <Tag {...props} {...boxProps} href={adjustedHref} type={buttonType}
         className={classes} aria-label={a11yTitle}
         onClick={adjustedOnClick}
         disabled={
@@ -174,6 +187,7 @@ Button.propTypes = {
   a11yTitle: PropTypes.string,
   accent: PropTypes.bool,
   align: PropTypes.oneOf(['start', 'center', 'end']),
+  box: PropTypes.bool,
   fill: PropTypes.bool,
   hoverIndicator: PropTypes.oneOfType([
     PropTypes.oneOf(['background']),

--- a/src/scss/grommet-core/_objects.button.scss
+++ b/src/scss/grommet-core/_objects.button.scss
@@ -6,7 +6,10 @@ $button-horizontal-padding:
   round($inuit-base-spacing-unit) - $button-border-width;
 
 @mixin basic-button {
-  padding: $button-vertical-padding $button-horizontal-padding;
+  &:not(.#{$grommet-namespace}button--box) {
+    padding: $button-vertical-padding $button-horizontal-padding;
+  }
+  
   background-color: transparent;
   border: $button-border-width solid $button-border-color;
   border-radius: $border-radius;
@@ -122,8 +125,11 @@ $button-horizontal-padding:
   }
 }
 
-.#{$grommet-namespace}button--plain {
+.#{$grommet-namespace}button--plain:not(.#{$grommet-namespace}button--box) {
   padding: 0;
+}
+
+.#{$grommet-namespace}button--plain {
   width: auto;
   height: auto;
   min-width: 0;


### PR DESCRIPTION
#### What does this PR do?

The idea of this PR is to add `box` prop to Button.

#### Where should the reviewer start?

Button component

#### What testing has been done on this PR?

Manual

#### How should this be manually tested?

Add box prop to Button and validate if the children is a flexbox element

#### Any background context you want to provide?

Previously the children of a Button was not a flexbox element. So if you want more complex alignment you would need to put a box as the first children of the Button. This PR aims to avoid that wrapper.

#### Do the grommet docs need to be updated?

Yes

#### Should this PR be mentioned in the release notes?

Totally

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible