### PR TITLE
FIX_TABLE_HEADER_ROWS

### DIFF
--- a/__tests__/components/Table-test.js
+++ b/__tests__/components/Table-test.js
@@ -4,6 +4,8 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import Table from '../../src/js/components/Table';
+import TableHeader from '../../src/js/components/Table';
+import TableRow from '../../src/js/components/Table';
 
 // needed because this:
 // https://github.com/facebook/jest/issues/1353
@@ -38,6 +40,28 @@ describe('Table', () => {
               note 3
             </td>
           </tr>
+        </tbody>
+      </Table>
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('has mismatched headers and body columns', () => {
+    // Test covers case with one headerCell, but two row cells. Console logs
+    // error message, but nothing to assert.
+    const component = renderer.create(
+      <Table>
+        <TableHeader labels={['one']} />
+        <tbody>
+        <tr>
+          <td>
+            one
+          </td>
+          <td>
+            two - one too many
+          </td>
+        </tr>
         </tbody>
       </Table>
     );

--- a/__tests__/components/__snapshots__/Table-test.js.snap
+++ b/__tests__/components/__snapshots__/Table-test.js.snap
@@ -32,3 +32,32 @@ exports[`Table has correct default options 1`] = `
   </table>
 </div>
 `;
+
+exports[`Table has mismatched headers and body columns 1`] = `
+<div
+  className="grommetux-table">
+  <table
+    className="grommetux-table__table">
+    <div
+      className="grommetux-table"
+      labels={
+        Array [
+          "one",
+        ]
+      }>
+      <table
+        className="grommetux-table__table" />
+    </div>
+    <tbody>
+      <tr>
+        <td>
+          one
+        </td>
+        <td>
+          two - one too many
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;

--- a/src/js/components/Table.js
+++ b/src/js/components/Table.js
@@ -328,6 +328,12 @@ export default class Table extends Component {
         [].forEach.call(rows, (row) => {
           let incrementCount = 0;
           let headerIndex = 0;
+
+          if (row.cells.length !== headerCells.length) {
+            console.error(
+              'Table row cells do not match length of header cells.');
+          }
+
           [].forEach.call(row.cells, (cell) => {
             cell.setAttribute('data-th', (
               headerCells[headerIndex].innerText ||


### PR DESCRIPTION
#### What does this PR do?
Adds a little more error reporting for data mismatching between table header cells and row cells. See linked issue for more information.

#### Where should the reviewer start?
Pretty small change in the PR.

#### What testing has been done on this PR?
Light manual testing, in use with another application.

#### How should this be manually tested?
Chrome developer breakpoints, using notes in reproduction steps.

#### Any background context you want to provide?
none

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/1334

#### Screenshots (if appropriate)
none

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Probably not.

#### Is this change backwards compatible or is it a breaking change?
Backward compatible.