### PR TITLE
The FormEdit icon needs to be localized

### DIFF
--- a/src/js/messages/icons/en-US.js
+++ b/src/js/messages/icons/en-US.js
@@ -162,6 +162,7 @@ export default {
   'folder-cycle': 'folder cycle', 
   'folder-open': 'folder open', 
   'folder': 'folder', 
+  'form-edit': 'form edit',
   'forward-ten': 'forward ten', 
   'gallery': 'gallery', 
   'gamepad': 'gamepad', 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
When using the FormEdit icon, the console fills up with the following message:

[React Intl] Missing message: "form-edit" for locale: "en-US", using default message as fallback.

That shouldn't happen.
#### Where should the reviewer start?
Create a page that has that icon.  See if you get the same message in your browser.

#### What testing has been done on this PR?
none

#### How should this be manually tested?
Create a page that has that icon.  See if you get the same message in your browser.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
