### PR TITLE
Fix timestamp ie moment

### DIFF
--- a/src/js/components/Timestamp.js
+++ b/src/js/components/Timestamp.js
@@ -42,15 +42,15 @@ export default class Timestamp extends Component {
     const dateObj = (typeof value === 'string') ? 
       moment(value).lang(locale) : value;
 
-      let dateFormat;
-      let yearFormat;
-      let monthFormat;
-      let dayFormat;
+    let dateFormat;
+    let yearFormat;
+    let monthFormat;
+    let dayFormat;
 
-      let timeFormat;
-      let hourFormat;
-      let minuteFormat;
-      let secondFormat;
+    let timeFormat;
+    let hourFormat;
+    let minuteFormat;
+    let secondFormat;
 
     if (_showField('date', fields)) {
       dateFormat = 'll';
@@ -74,38 +74,38 @@ export default class Timestamp extends Component {
       dateFormat = 'LL';
     }
 
-   if (_showField('time', fields)) {
-     timeFormat = 'LT';
-   } 
+    if (_showField('time', fields)) {
+      timeFormat = 'LT';
+    } 
 
-   if (!timeFormat) {
-     if (_showField('hour', fields) || _showField('hours', fields)) {
-       hourFormat = 'hh';
-     }
-    if (_showField('minute', fields) || _showField('minutes', fields)) {
-      minuteFormat = (hourFormat ? ':' : '') + 'mm';
+    if (!timeFormat) {
+      if (_showField('hour', fields) || _showField('hours', fields)) {
+        hourFormat = 'hh';
+      }
+      if (_showField('minute', fields) || _showField('minutes', fields)) {
+        minuteFormat = (hourFormat ? ':' : '') + 'mm';
+      }
+      if (_showField('second', fields) || _showField('seconds', fields)) {
+        secondFormat = (minuteFormat ? ':' : '') + 'ss';
+      }
+    } else if (_showField('second', fields) || _showField('seconds', fields)) {
+      timeFormat = 'LTS';
     }
-    if (_showField('second', fields) || _showField('seconds', fields)) {
-      secondFormat = (minuteFormat ? ':' : '') + 'ss';
+
+    if (!dateFormat) {
+      dateFormat = (
+        `${monthFormat || ''} ${dayFormat || ''} ${yearFormat || ''}`
+      );
     }
-   } else if (_showField('second', fields) || _showField('seconds', fields)) {
-     timeFormat = 'LTS';
-   }
 
-   if (!dateFormat) {
-     dateFormat = (
-       `${monthFormat || ''} ${dayFormat || ''} ${yearFormat || ''}`
-     );
-   }
+    if (!timeFormat) {
+      timeFormat = (
+        `${hourFormat || ''}${minuteFormat || ''}${secondFormat || ''}`
+      );
+    }
 
-   if (!timeFormat) {
-     timeFormat = (
-       `${hourFormat || ''}${minuteFormat || ''}${secondFormat || ''}`
-     );
-   }
-
-   const date = dateFormat !== '' ? dateObj.format(dateFormat) : undefined;
-   const time = timeFormat !== '' ? dateObj.format(timeFormat) : undefined;
+    const date = dateFormat !== '  ' ? dateObj.format(dateFormat) : undefined;
+    const time = timeFormat !== '' ? dateObj.format(timeFormat) : undefined;
 
     this.setState({ date, time });
   }
@@ -122,7 +122,6 @@ export default class Timestamp extends Component {
       },
       className
     );
-
 
     let dateElement;
     if (date) {

--- a/src/js/components/Timestamp.js
+++ b/src/js/components/Timestamp.js
@@ -1,22 +1,13 @@
-// (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2014-2017 Hewlett Packard Enterprise Development LP
 
 import React, { Component } from 'react';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { getCurrentLocale } from '../utils/Locale';
 import CSSClassnames from '../utils/CSSClassnames';
+import { getCurrentLocale } from '../utils/Locale';
 
 const CLASS_ROOT = CSSClassnames.TIMESTAMP;
-
-const FORMATS = {
-  year: 'numeric',
-  month: 'short',
-  'month-full': 'long',
-  day: 'numeric',
-  hour: '2-digit',
-  minute: '2-digit',
-  second: '2-digit'
-};
 
 function _showField(field, fields) {
   let result = true;
@@ -48,45 +39,73 @@ export default class Timestamp extends Component {
 
   _formatForLocale ({value, fields}) {
     const locale = getCurrentLocale();
-    const dateObj = (typeof value === 'string') ? new Date(value) : value;
-    let dateOptions = {};
-    let timeOptions = {};
+    const dateObj = (typeof value === 'string') ? 
+      moment(value).lang(locale) : value;
+
+      let dateFormat;
+      let yearFormat;
+      let monthFormat;
+      let dayFormat;
+
+      let timeFormat;
+      let hourFormat;
+      let minuteFormat;
+      let secondFormat;
 
     if (_showField('date', fields)) {
-      dateOptions.year = FORMATS.year;
-      dateOptions.month = FORMATS.month;
-      dateOptions.day = FORMATS.day;
-    }
-    if (_showField('year', fields)) {
-      dateOptions.year = FORMATS.year;
-    }
-    if (_showField('month', fields)) {
-      dateOptions.month = FORMATS.month;
-    } else if (_showField('month-full', fields)) {
-      dateOptions.month = FORMATS['month-full'];
-    }
-    if (_showField('day', fields)) {
-      dateOptions.day = FORMATS.day;
+      dateFormat = 'll';
     }
 
-    if (_showField('time', fields)) {
-      timeOptions.hour = FORMATS.hour;
-      timeOptions.minute = FORMATS.minute;
+    if (!dateFormat) {
+      if (_showField('year', fields)) {
+        yearFormat = 'YYYY';
+      }
+
+      if (_showField('month', fields)) {
+        monthFormat = 'MMM';
+      } else if (_showField('month-full', fields)) {
+        monthFormat = 'MMMM';
+      }
+
+      if (_showField('day', fields)) {
+        dayFormat = 'D';
+      }
+    } else if (_showField('month-full', fields)) {
+      dateFormat = 'LL';
     }
-    if (_showField('hour', fields) || _showField('hours', fields)) {
-      timeOptions.hour = FORMATS.hour;
-    }
+
+   if (_showField('time', fields)) {
+     timeFormat = 'LT';
+   } 
+
+   if (!timeFormat) {
+     if (_showField('hour', fields) || _showField('hours', fields)) {
+       hourFormat = 'hh';
+     }
     if (_showField('minute', fields) || _showField('minutes', fields)) {
-      timeOptions.minute = FORMATS.minute;
+      minuteFormat = (hourFormat ? ':' : '') + 'mm';
     }
     if (_showField('second', fields) || _showField('seconds', fields)) {
-      timeOptions.second = FORMATS.second;
+      secondFormat = (minuteFormat ? ':' : '') + 'ss';
     }
+   } else if (_showField('second', fields) || _showField('seconds', fields)) {
+     timeFormat = 'LTS';
+   }
 
-    const date = Object.keys(dateOptions).length > 0 ?
-      dateObj.toLocaleDateString(locale, dateOptions) : undefined;
-    const time = Object.keys(timeOptions).length > 0 ?
-      dateObj.toLocaleTimeString(locale, timeOptions) : undefined;
+   if (!dateFormat) {
+     dateFormat = (
+       `${monthFormat || ''} ${dayFormat || ''} ${yearFormat || ''}`
+     );
+   }
+
+   if (!timeFormat) {
+     timeFormat = (
+       `${hourFormat || ''}${minuteFormat || ''}${secondFormat || ''}`
+     );
+   }
+
+   const date = dateFormat !== '' ? dateObj.format(dateFormat) : undefined;
+   const time = timeFormat !== '' ? dateObj.format(timeFormat) : undefined;
 
     this.setState({ date, time });
   }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix issue #1224 Timestamp not working in IE/Edge and #1157 24hour time.
#### Where should the reviewer start?
In grommet-docs, chose 'minutes' or 'seconds' in Timestamp examples. 
#### What testing has been done on this PR?
IE/MAC, Chrome/Edge/IE/Firefox
#### How should this be manually tested?
In grommet-docs, chose 'minutes' or 'seconds' in Timestamp examples. 
#### Any background context you want to provide?
imports moment.js
#### What are the relevant issues?
may want to add http://momentjs.com/timezone/ to fix #835 Add display timezone
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
non-breaking.