### PR TITLE
Add justify=around prop to Box

### DIFF
--- a/src/js/components/Box.js
+++ b/src/js/components/Box.js
@@ -315,7 +315,7 @@ Box.propTypes = {
   full: PropTypes.oneOf([true, 'horizontal', 'vertical', false]),
     // remove in 1.0?
   onClick: PropTypes.func,
-  justify: PropTypes.oneOf(['start', 'center', 'between', 'end']),
+  justify: PropTypes.oneOf(['start', 'center', 'between', 'end', 'around']),
   margin: PropTypes.oneOfType([
     PropTypes.oneOf(MARGIN_SIZES),
     PropTypes.shape({

--- a/src/scss/grommet-core/_objects.box.scss
+++ b/src/scss/grommet-core/_objects.box.scss
@@ -660,6 +660,10 @@
   justify-content: space-between;
 }
 
+.#{$grommet-namespace}box--justify-around {
+  justify-content: space-around;
+}
+
 .#{$grommet-namespace}box--justify-end {
   justify-content: flex-end;
 }


### PR DESCRIPTION
#### What does this PR do?

I noticed Box doesn't have a way to set `justify-content: space-around;`

This adds it.

#### Where should the reviewer start?

#### What testing has been done on this PR?

I'm using it locally

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

Yes, I've made https://github.com/grommet/grommet-docs/pull/264 for that.

#### Should this PR be mentioned in the release notes?
No, i wouldn't say so.

#### Is this change backwards compatible or is it a breaking change?
is backwards compatible.