### PR TITLE
Fix infinite eq false behavior

### DIFF
--- a/src/js/components/Carousel.js
+++ b/src/js/components/Carousel.js
@@ -224,7 +224,13 @@ export default class Carousel extends Component {
     const { children } = this.props;
     const { activeIndex } = this.state;
     const numSlides = children.length;
-    const index = (activeIndex + numSlides - 1) % numSlides;
+    let index = (activeIndex + numSlides - 1) % numSlides;
+
+    if (!this.props.infinite) {
+      if(activeIndex == 0) {
+        index = activeIndex;
+      }
+    }
 
     if(! this.props.hasOwnProperty('activeIndex')) {
       this.setState({
@@ -241,7 +247,13 @@ export default class Carousel extends Component {
     const { children } = this.props;
     const { activeIndex } = this.state;
     const numSlides = children.length;
-    const index = (activeIndex + 1) % numSlides;
+    let index = (activeIndex + 1) % numSlides;
+
+    if (!this.props.infinite) {
+      if(activeIndex == children.length - 1) {
+        index = activeIndex;
+      }
+    }
 
     if(! this.props.hasOwnProperty('activeIndex')) {
       this.setState({

--- a/src/js/components/Carousel.js
+++ b/src/js/components/Carousel.js
@@ -224,13 +224,8 @@ export default class Carousel extends Component {
     const { children } = this.props;
     const { activeIndex } = this.state;
     const numSlides = children.length;
-    let index = (activeIndex + numSlides - 1) % numSlides;
-
-    if (!this.props.infinite) {
-      if(activeIndex == 0) {
-        index = activeIndex;
-      }
-    }
+    const index = !this.props.infinite && activeIndex === 0 ? 
+      activeIndex : (activeIndex + numSlides - 1) % numSlides;
 
     if(! this.props.hasOwnProperty('activeIndex')) {
       this.setState({
@@ -247,13 +242,8 @@ export default class Carousel extends Component {
     const { children } = this.props;
     const { activeIndex } = this.state;
     const numSlides = children.length;
-    let index = (activeIndex + 1) % numSlides;
-
-    if (!this.props.infinite) {
-      if(activeIndex == children.length - 1) {
-        index = activeIndex;
-      }
-    }
+    const index = !this.props.infinite && activeIndex === children.length - 1 ?
+      activeIndex : (activeIndex + 1) % numSlides;
 
     if(! this.props.hasOwnProperty('activeIndex')) {
       this.setState({


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix #1327 and #1220 carousel infinite=false behavior so that it doesn't wrap
#### Where should the reviewer start?
https://grommet.github.io/docs/carousel/examples
#### What testing has been done on this PR?
mac/pc edge/chrome
#### How should this be manually tested?
https://grommet.github.io/docs/carousel/examples
#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Non-breaking