### PR TITLE
Remove whitespace trimming of password in LoginForm

### DIFF
--- a/src/js/components/LoginForm.js
+++ b/src/js/components/LoginForm.js
@@ -74,7 +74,6 @@ export default class LoginForm extends Component {
     let { password, rememberMe, username } = this.state;
 
     username = username.trim();
-    password = password.trim();
 
     if (onSubmit) {
       onSubmit({username, password, rememberMe});


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR removes the trimming of the whitespace around the password field on the login form page.

#### Where should the reviewer start?
When a password that either starts or ends in spaces is submitted in the login form, previously the surrounding whitespace would be removed and the user's password would be submitted as something that they didn't intend to submit.

#### What testing has been done on this PR?
Submitting a password with whitespace around it no longer results in the whitespace being trimmed when the field is submitted.

#### How should this be manually tested?
When a password with whitespace surrounding it is submitted, the provided value should be observed to be unmodified after this PR, whereas before it would  modify the password that the user inputted.

#### Any background context you want to provide?
We have a bug against users who have passwords that start or end in spaces that are unable to login using the LoginForm. [There doesn't seem to be a good reason](https://security.stackexchange.com/questions/32691/why-not-allow-spaces-in-a-password) to enforce this as a password restriction, so it would be preferable if the UI didn't remove these whitespaces and allowed the user to login even if their password is surrounded by spaces.

#### What are the relevant issues?
If a user has a password that starts or ends with whitespace, then this will allow that user to use the login form. Previously, they would get rejected as their password would be trim'd behind the scenes.

#### Screenshots (if appropriate)
N/A

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
I don't think so

#### Is this change backwards compatible or is it a breaking change?
It is backwards compatible, all previously valid passwords will still work in addition to ones that have whitespace on either end.