### PR TITLE
Allow routed Anchor links to open in new tab via CMD + Click

### DIFF
--- a/src/js/components/Anchor.js
+++ b/src/js/components/Anchor.js
@@ -100,6 +100,11 @@ export default class Anchor extends Component {
   _onClick (event) {
     const { method, onClick, path, disabled } = this.props;
     const { router } = this.context;
+    const modifierKey = event.ctrlKey || event.metaKey;
+
+    if (modifierKey && !disabled && !onClick) {
+      return true;
+    }
 
     event.preventDefault();
 

--- a/src/js/components/Anchor.js
+++ b/src/js/components/Anchor.js
@@ -59,14 +59,14 @@ export default class Anchor extends Component {
     }
     let active;
     if (router && router.isActive) {
-      active = router && router.isActive && 
+      active = router && router.isActive &&
         path && router.isActive({
           pathname: path.path || path,
           query: { indexLink: path.index }
         });
     } else if(router && matchPath) {
       active = !!matchPath(
-        router.history.location.pathname, 
+        router.history.location.pathname,
         { path: path.path || path, exact: !!path.index }
       );
     }
@@ -87,7 +87,7 @@ export default class Anchor extends Component {
       const { router } = this.context;
       const active = matchPath ? (
         !!matchPath(
-          location.pathname, 
+          location.pathname,
           { path: path.path || path, exact: !!path.index }
         )
       ) : (
@@ -159,7 +159,7 @@ export default class Anchor extends Component {
         router.history.createHref(
           typeof target === 'string' ? { pathname: target } : target
         ) : href;
-    } 
+    }
 
     let classes = classnames(
       CLASS_ROOT,
@@ -186,7 +186,7 @@ export default class Anchor extends Component {
     const second = reverse ? anchorIcon : anchorChildren;
 
     const Component = tag;
-    
+
     return (
       <Component {...props} href={adjustedHref} className={classes}
         aria-label={a11yTitle} onClick={adjustedOnClick}>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Prevent JS to interfere with shortcuts to open a link in a new tab.

#### Where should the reviewer start?
this [diff](https://github.com/grommet/grommet/pull/1370/commits/cb51da2770ba84a81bc0157249068fa9b38f4346) on `src/js/components/Anchor.js`. 

#### What testing has been done on this PR?
`pre-commit` hooks + local testing

#### How should this be manually tested?
Linking the project and cmd+clicking some links

#### Any background context you want to provide?
I think it's frustrating for SPA's to break this native behavior.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No, it's just a fix.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backwards compatible.