### PR TITLE
Allow routed Button links to open in new tab via CMD + Click

### DIFF
--- a/src/js/components/Button.js
+++ b/src/js/components/Button.js
@@ -20,7 +20,7 @@ function getHoverModifier(hoverIndicator) {
         return `${CLASS_ROOT}--hover-background`;
       }
     } else if (typeof hoverIndicator === 'string') {
-      return (`${CLASS_ROOT}--hover-${hoverIndicator}`); 
+      return (`${CLASS_ROOT}--hover-${hoverIndicator}`);
     }
   }
 }

--- a/src/js/components/Button.js
+++ b/src/js/components/Button.js
@@ -43,6 +43,11 @@ export default class Button extends Component {
   _onClick (event) {
     const { method, onClick, path} = this.props;
     const { router } = this.context;
+    const modifierKey = event.ctrlKey || event.metaKey;
+
+    if (modifierKey && !disabled && !onClick) {
+      return true;
+    }
 
     event.preventDefault();
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

### related to #1370 

#### What does this PR do?
Prevent JS to interfere with shortcuts to open a link in a new tab.

#### Where should the reviewer start?
this [diff](https://github.com/grommet/grommet/pull/1373/commits/4d051e3462e0d7d2b396d14f2741b764079ca30c#diff-0839403ed3b1e347ea49e70ab82abca5) on `src/js/components/Button.js`. 

#### What testing has been done on this PR?
`pre-commit` hooks + local testing

#### How should this be manually tested?
Linking the project and cmd+clicking some buttons

#### Any background context you want to provide?
PR made to match Anchor behavior implemented in related PR

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No, it's just a fix.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backwards compatible.
