### PR TITLE
Add xsmall propType to SVGIcon #1324

### DIFF
--- a/src/js/components/SVGIcon.js
+++ b/src/js/components/SVGIcon.js
@@ -56,6 +56,7 @@ SVGIcon.defaultProps = {
 SVGIcon.propTypes = {
   a11yTitle: PropTypes.string,
   colorIndex: PropTypes.string,
-  size: PropTypes.oneOf(['small', 'medium', 'large', 'xlarge', 'huge']),
+  size: PropTypes.oneOf(['xsmall', 'small', 'medium', 'large', 'xlarge',
+    'huge']),
   type: PropTypes.oneOf(['control', 'logo', 'status'])
 };


### PR DESCRIPTION
#### What does this PR do?
Adds the 'xsmall' proptype to SVGIcon to fix issue #1324 

#### What testing has been done on this PR?
Manual - checking to see if it stops throwing a validation error when SVGIcon is used with size xsmall

#### How should this be manually tested?
Instantiate an SVGIcon with size xsmall and check the browser console for PropType errors - there shouldn't be any. [This codepen](https://codepen.io/marcelofs/pen/oWYexo?editors=0010) is a good start.

#### Any background context you want to provide?
The css classes are already generated, only the prop validation was missing

#### Do the grommet docs need to be updated?
No - the documentation for [Icon](https://grommet.github.io/docs/icon) already mentions the use of 'xsmall'. There doesn't seem to be documentation specific to SVGIcon.

#### Should this PR be mentioned in the release notes?
Probably not, its just a simple fix.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible