### PR TITLE
LoginForm: Add support for errors to be arbitrary JSX elements

### DIFF
--- a/__tests__/components/LoginForm-test.js
+++ b/__tests__/components/LoginForm-test.js
@@ -34,4 +34,24 @@ describe('LoginForm', () => {
     expect(onChangeFn.mock.calls.length).toBe(3);
     expect(onChangeFn.mock.calls[0][0].username).toBe('will@isthecoolest.com');
   });
+
+  it('renders errors properly with both string and JSX errors', () => {
+    const errors = [
+      'Some detailed error.',
+      (<span>
+        You need to use
+        <a href="#">some external resource</a>
+        to resolve this.
+      </span>)
+    ];
+    const component = renderer.create(
+      <LoginForm
+        onSubmit={() => {}}
+        errors={errors}
+      />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
 });

--- a/__tests__/components/__snapshots__/LoginForm-test.js.snap
+++ b/__tests__/components/__snapshots__/LoginForm-test.js.snap
@@ -90,3 +90,114 @@ exports[`LoginForm has correct default options 1`] = `
   </footer>
 </form>
 `;
+
+exports[`LoginForm renders errors properly with both string and JSX errors 1`] = `
+<form
+  className="grommetux-form grommetux-form--pad-medium grommetux-login-form"
+  onSubmit={[Function]}
+>
+  <div
+    className="grommetux-box grommetux-box--direction-column grommetux-box--align-center grommetux-box--responsive grommetux-box--pad-none"
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}
+  />
+  <fieldset>
+    <div
+      className="grommetux-form-field grommetux-form-field--text grommetux-form-field--size-medium"
+      onClick={[Function]}
+    >
+      <label
+        className="grommetux-form-field__label"
+        htmlFor="username"
+      >
+        <span>
+          Email
+        </span>
+      </label>
+      <span
+        className="grommetux-form-field__contents"
+      >
+        <input
+          onChange={[Function]}
+          type="email"
+          value=""
+        />
+      </span>
+    </div>
+    <div
+      className="grommetux-form-field grommetux-form-field--text grommetux-form-field--size-medium"
+      onClick={[Function]}
+    >
+      <label
+        className="grommetux-form-field__label"
+        htmlFor="password"
+      >
+        <span>
+          Password
+        </span>
+      </label>
+      <span
+        className="grommetux-form-field__contents"
+      >
+        <input
+          onChange={[Function]}
+          type="password"
+          value=""
+        />
+      </span>
+    </div>
+    <div
+      className="error"
+    >
+      <span>
+        Some detailed error.
+      </span>
+    </div>
+    <div
+      className="error"
+    >
+      <span>
+        You need to use
+        <a
+          href="#"
+        >
+          some external resource
+        </a>
+        to resolve this.
+      </span>
+    </div>
+  </fieldset>
+  <footer
+    className="grommetux-box grommetux-box--direction-column grommetux-box--align-stretch grommetux-box--pad-vertical-none grommetux-box--pad-between-medium grommetux-footer grommetux-footer--small"
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}
+  >
+    <button
+      aria-label={undefined}
+      className="grommetux-button grommetux-button--primary grommetux-button--fill"
+      disabled={false}
+      href={undefined}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      type="submit"
+    >
+      <span
+        className="grommetux-button__label"
+      >
+        <span>
+          Log In
+        </span>
+      </span>
+    </button>
+  </footer>
+</form>
+`;

--- a/src/js/components/LoginForm.js
+++ b/src/js/components/LoginForm.js
@@ -103,7 +103,7 @@ export default class LoginForm extends Component {
           </div>
         );
       }
-      return null;
+      return undefined;
     });
 
     let titleNode;

--- a/src/js/components/LoginForm.js
+++ b/src/js/components/LoginForm.js
@@ -90,15 +90,20 @@ export default class LoginForm extends Component {
     const center = ! align || 'stretch' === align || 'center' === align;
 
     const errorsNode = errors.map((error, index) => {
-      let errorComponent;
       if (error) {
-        errorComponent = (
+        let errorMessage;
+        if (React.isValidElement(error)) {
+          errorMessage = error;
+        } else {
+          errorMessage = <FormattedMessage id={error} defaultMessage={error} />;
+        }
+        return (
           <div key={index} className='error'>
-            <FormattedMessage id={error} defaultMessage={error} />
+            {errorMessage}
           </div>
         );
       }
-      return errorComponent;
+      return null;
     });
 
     let titleNode;
@@ -176,7 +181,10 @@ LoginForm.propTypes = {
     username: PropTypes.string,
     rememberMe: PropTypes.bool
   }),
-  errors: PropTypes.arrayOf(PropTypes.string),
+  errors: PropTypes.arrayOf(PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node
+  ])),
   forgotPassword: PropTypes.node,
   logo: PropTypes.node,
   onSubmit: PropTypes.func,


### PR DESCRIPTION
Signed-off-by: Mike Turley <mturley@hpe.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR adds the ability for the errors prop of LoginForm to contain arbitrary JSX elements, so a custom error can be rendered (e.g. one which contains a link to an external resource about the error).  Today that errors prop must be an array of strings, each of which is used as the id and defaultMessage of a FormattedMessage.  With this change, if any of the elements in that array is a JSX node (checked with `React.isValidElement()`) it is used as-is instead of being used in a FormattedMessage.

#### Where should the reviewer start?

LoginForm component

#### What testing has been done on this PR?

Testing in my own project, and also added a new snapshot test.

#### How should this be manually tested?

Try rendering a LoginForm with errors that contain both strings and JSX elements, and observe that both types of errors render properly with no console warnings.

#### Any background context you want to provide?

In our project, we need the ability to include a link in some of our login error messages, for example if the login failed due to an expired password, we direct the user to the HPE Passport profile page where they can change their password.  Today the errors array only accepts strings to be used as FormattedMessage ids (with no way to include FormattedMessage values), so we needed to either have some custom object accepted that would render the FormattedMessage differently, or allow arbitrary JSX so the application can decide how to render the error.  I decided that the latter choice would be more flexible.

#### What are the relevant issues?

I did not report any github issue about this, see above for a description of the issue.

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

Yes, the docs for LoginForm properties includes `errors          [{message}, ...]` , which should probably now read `errors          [{message|element}, ...]`

#### Should this PR be mentioned in the release notes?

¯\\\_(ツ)\_/¯

#### Is this change backwards compatible or is it a breaking change?

Backwards-compatible.  If you continue to pass only strings as errors, they will be treated the same as they were before (because `React.isValidElement('some string')` returns false).