### PR TITLE
Set `full` to `true` if `fit` is defined.

### DIFF
--- a/src/js/components/Image.js
+++ b/src/js/components/Image.js
@@ -18,7 +18,9 @@ export default class Image extends Component {
       {
         [`${CLASS_ROOT}--${size}`]: size,
         [`${CLASS_ROOT}--${fit}`]: fit,
-        [`${CLASS_ROOT}--full`]: (fit ? true : (typeof full === 'boolean' && full)),
+        [`${CLASS_ROOT}--full`]: (
+          fit ? true : (typeof full === 'boolean' && full)
+        ),
         [`${CLASS_ROOT}--full-${full}`]: typeof full === 'string',
         [`${CLASS_ROOT}--mask`]: mask,
         [`${CLASS_ROOT}--align-top`]: align && align.top,

--- a/src/js/components/Image.js
+++ b/src/js/components/Image.js
@@ -18,7 +18,7 @@ export default class Image extends Component {
       {
         [`${CLASS_ROOT}--${size}`]: size,
         [`${CLASS_ROOT}--${fit}`]: fit,
-        [`${CLASS_ROOT}--full`]: (typeof full === 'boolean' && full),
+        [`${CLASS_ROOT}--full`]: (fit ? true : (typeof full === 'boolean' && full)),
         [`${CLASS_ROOT}--full-${full}`]: typeof full === 'string',
         [`${CLASS_ROOT}--mask`]: mask,
         [`${CLASS_ROOT}--align-top`]: align && align.top,


### PR DESCRIPTION
According to the docs, this is what the component should do:

- https://grommet.github.io/docs/image

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Sets `full` type to `true` if `fit` prop is defined.

#### Where should the reviewer start?

It's a one-line change, so this will be obvious. 

#### What testing has been done on this PR?

0 testing. 

#### How should this be manually tested?

Set the prop `fit` and not the prop `full` on an Image component. Then, with `react-dev-tools`, check the props of the `Image` component and see if it has the prop `full` set to `true`.

#### Any background context you want to provide?

[Docs][1] says this is how this is supposed to work.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

[1]: https://grommet.github.io/docs/image