### PR TITLE
Fixed issue #1399 - Number.isInteger is not supported in IE11. 

### DIFF
--- a/src/js/components/Accordion.js
+++ b/src/js/components/Accordion.js
@@ -17,7 +17,7 @@ export default class Accordion extends Component {
     this._onPanelChange = this._onPanelChange.bind(this);
 
     let active;
-    if (Number.isInteger(this.props.active)) {
+    if (typeof this.props.active === 'number') {
       active = [this.props.active];
     } else {
       active = this.props.active || [];

--- a/src/js/components/Accordion.js
+++ b/src/js/components/Accordion.js
@@ -17,6 +17,7 @@ export default class Accordion extends Component {
     this._onPanelChange = this._onPanelChange.bind(this);
 
     let active;
+    // active in state should always be an array
     if (typeof this.props.active === 'number') {
       active = [this.props.active];
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Uses typeof instead of Number.isInteger to determine if the active property is just a number that needs to be put into an array.

#### Where should the reviewer start?
Line 20 in Accordion.js

#### What testing has been done on this PR?
Verified that the Accordion displays without error in IE11 and Chrome.

#### How should this be manually tested?
See above.

#### Any background context you want to provide?
N/A

#### What are the relevant issues?
N/A

#### Screenshots (if appropriate)
N/A

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Not sure.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.
