### PR TITLE
fix dateTime Icon when format set to 24 H

### DIFF
--- a/src/js/components/DateTime.js
+++ b/src/js/components/DateTime.js
@@ -28,7 +28,7 @@ const FORMATS = {
   m: 'minutes',
   s: 'seconds'
 };
-const TIME_REGEXP = new RegExp('[hmsa]');
+const TIME_REGEXP = new RegExp('[Hhmsa]');
 
 export default class DateTime extends Component {
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

It fixes icon in DateTimeComponent when format is set to "H" (24 hour)


#### Where should the reviewer start?

DateTime.js

#### What testing has been done on this PR?

manualy

#### How should this be manually tested?

set datetime format="H" and check if the icon is valid(timeIcon)



#### Do the grommet docs need to be updated?

nope

#### notes

It is probably the smallest PR ever but it was needed in my purpose
