### PR TITLE
Clarify Anchor.js docs.

### DIFF
--- a/src/js/components/Anchor.js
+++ b/src/js/components/Anchor.js
@@ -215,7 +215,8 @@ schema(Anchor, {
       defaultProp: true
     }],
     disabled: [PropTypes.bool, 'Whether to disable the anchor.'],
-    href: [PropTypes.string, 'Hyperlink reference to place in the anchor.'],
+    href: [PropTypes.string, 'Hyperlink reference to place in the anchor. If'
+      + ' `path` prop is provided, `href` prop will be ignored.'],
     icon: [PropTypes.element, 'Icon element to place in the anchor.'],
     id: [PropTypes.string, 'Anchor identifier.'],
     label: [PropTypes.node, 'Label text to place in the anchor.'],


### PR DESCRIPTION
#### What does this PR do?

Explain that `path` supersedes the `href` prop if both are present.

#### Where should the reviewer start?

N/A

#### What testing has been done on this PR?

Manual testing to ensure accuracy of new docs.

#### How should this be manually tested?

Add both `href` and `path` props, with different values, to an `Anchor` component and notice that `href` prop is ignored.

#### Any background context you want to provide?

N/A

#### What are the relevant issues?

N/A

#### Screenshots (if appropriate)

N/A

#### Do the grommet docs need to be updated?

Done in this PR.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

N/A
