### PR TITLE
fix: using DOM element in _listenForScroll() when the component's par…

### DIFF
--- a/src/js/components/Animate.js
+++ b/src/js/components/Animate.js
@@ -156,9 +156,9 @@ export default class Animate extends Component {
   }
 
   _listenForScroll () {
-    var scrollItem = this;
+    let scrollItem = this;
 
-    //If the component's parent is undefined, use the DOM element.
+    // if the component's parent is undefined, use the DOM element.
     if (!scrollItem.parentNode) {
       scrollItem = findDOMNode(scrollItem);
     }

--- a/src/js/components/Animate.js
+++ b/src/js/components/Animate.js
@@ -156,7 +156,14 @@ export default class Animate extends Component {
   }
 
   _listenForScroll () {
-    this._scrollParents = findScrollParents(this);
+    var scrollItem = this;
+
+    //If the component's parent is undefined, use the DOM element.
+    if (!scrollItem.parentNode) {
+      scrollItem = _reactDom.findDOMNode(scrollItem);
+    }
+
+    this._scrollParents = findScrollParents(scrollItem);
     this._scrollParents.forEach((scrollParent) => {
       scrollParent.addEventListener('scroll', this._checkScroll);
     });

--- a/src/js/components/Animate.js
+++ b/src/js/components/Animate.js
@@ -160,7 +160,7 @@ export default class Animate extends Component {
 
     //If the component's parent is undefined, use the DOM element.
     if (!scrollItem.parentNode) {
-      scrollItem = _reactDom.findDOMNode(scrollItem);
+      scrollItem = findDOMNode(scrollItem);
     }
 
     this._scrollParents = findScrollParents(scrollItem);


### PR DESCRIPTION
…ent is undefined
Signed-off-by: Erin O'Connell <obejda@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes an issue in which visible='scroll' animations were not triggered upon scrolling to the element (so the animated elements do not appear at all). 

Cause: In findScrollParents, var parent=element.parentNode. Parent was consistently undefined (‘element’ was the Animation component, but there was no parent node, despite my Animation component being nested in a Card component or within a plain div).  That function then returns the document, so scrolling doesn't trigger anything.

Fix: Finding the actual DOM node and getting its parent resolved the issue for me. I made it an ‘or’ statement since referencing the component rather than findDomNode is preferable when it works (I'm guessing it does work sometimes, since I didn't see this issue reported already). 

#### Where should the reviewer start?

#### What testing has been done on this PR?
I tested the change in my personal project and on a fresh installation from the Grommet CLI - I encountered the same issue in both projects and scrolling animation works after the change.

#### How should this be manually tested?
Use an animation with visible='scroll' with and without the change.

#### Any background context you want to provide?

Since animations appear to work upon scroll on the https://grommet.github.io/ site itself, there is a chance this could just be an implementation error on my part. Below is an example of how I used the component (if it does turn out to be just an implementation issue, adding an example to the docs would be appreciated!).

<Card align='center'>
	 <Animate
	   visible='scroll'
           enter={{animation: 'slide-down', duration: 1200, delay: 100}}
            keep={true}>
            	<div style={smallImgWrapper}>
                      <Image
                        src={image}
                        alt={imageTitle}
                        role='presentation'
                        style={smallImgStyle} />
                    </div>
          </Animate>
</Card>

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Compatible