### PR TITLE
bug fix #1419: incorrect focus on Menu when Layer opened from Menu

### DIFF
--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -333,7 +333,9 @@ export default class Menu extends Component {
   }
 
   _onOpen () {
-    this.setState({state: 'expanded'});
+    if(findDOMNode(this._controlRef).contains(document.activeElement)) {
+      this.setState({state: 'expanded'});
+    }
   }
 
   _onClose () {


### PR DESCRIPTION
#### What does this PR do?
Fixing issue #1419 with Menu holding focus on keyboard events after opening Layer on top

#### Where should the reviewer start?
src/js/components/Menu.js:336

#### What testing has been done on this PR?
I have tested with our production application:
1. Expand/Collapse Menu, then press `space` - Menu opens (though there is issue that first time space pressed it opens and immediately closes, second time it opens fine, but this issue is present in 1.5.1 as well and it is not this ticket)
2. Expand Menu, click item opening layer, press space - Menu does not open
3. Expand Menu, click item opening layer with TextInput, press space within TextInput - Menu does not open
4. Close Layer, press space - Menu opens again

#### How should this be manually tested?
As above

#### Any background context you want to provide?
There is codepen in the original issue

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/1419

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backcompatible
