### PR TITLE
Add React component support to Select's render()

### DIFF
--- a/__tests__/components/__snapshots__/Select-test.js.snap
+++ b/__tests__/components/__snapshots__/Select-test.js.snap
@@ -9,6 +9,7 @@ exports[`Select accepts initial value 1`] = `
     className="grommetux-input grommetux-select__input"
     placeholder={undefined}
     readOnly={true}
+    type="text"
     value="one"
   />
   <button
@@ -56,6 +57,7 @@ exports[`Select has correct default options 1`] = `
     className="grommetux-input grommetux-select__input"
     placeholder={undefined}
     readOnly={true}
+    type="text"
     value=""
   />
   <button

--- a/src/js/components/Select.js
+++ b/src/js/components/Select.js
@@ -392,7 +392,10 @@ export default class Select extends Component {
               onChange={this._onClickOption.bind(this, option)} />
           );
         } else {
-          itemOnClick = this._onClickOption.bind(this, option);
+          itemOnClick = (e) => {
+            e.stopPropagation();
+            this._onClickOption.bind(this, option)();
+          };
         }
 
         return (
@@ -435,13 +438,19 @@ export default class Select extends Component {
     if (inline) {
       return this._renderOptions(classes, restProps);
     } else {
+
+      const renderedValue = this._renderValue(value);
+      const shouldRenderElement  = React.isValidElement(renderedValue);
+
       return (
         <div ref={ref => this.componentRef = ref} className={classes}
           onClick={this._onAddDrop}>
+          { shouldRenderElement && renderedValue }
           <input {...restProps} ref={ref => this.inputRef = ref}
+            type={shouldRenderElement ? 'hidden' : 'text'}
             className={`${INPUT} ${CLASS_ROOT}__input`}
             placeholder={placeHolder} readOnly={true}
-            value={this._renderValue(value) || ''} />
+            value={renderedValue || ''} />
           <Button className={`${CLASS_ROOT}__control`}
             a11yTitle={Intl.getMessage(intl, 'Select Icon')}
             icon={<CaretDownIcon />}

--- a/src/js/components/Select.js
+++ b/src/js/components/Select.js
@@ -438,14 +438,13 @@ export default class Select extends Component {
     if (inline) {
       return this._renderOptions(classes, restProps);
     } else {
-
       const renderedValue = this._renderValue(value);
       const shouldRenderElement  = React.isValidElement(renderedValue);
 
       return (
         <div ref={ref => this.componentRef = ref} className={classes}
           onClick={this._onAddDrop}>
-          { shouldRenderElement && renderedValue }
+          {shouldRenderElement && renderedValue}
           <input {...restProps} ref={ref => this.inputRef = ref}
             type={shouldRenderElement ? 'hidden' : 'text'}
             className={`${INPUT} ${CLASS_ROOT}__input`}


### PR DESCRIPTION
## Changes

- Add React component support to Select's `render()`
- Stop `itemClick` event propagation which throws a React exception upon `Drop` dismiss.
- Fix tests to include `type="text"`

---

### What does this PR do?

> Grommet `Select` now supports render of valid React component JSX on `option.label` and `option.value` when rendering non-inline.

### Where should the reviewer start?

`Select.js`



### What testing has been done on this PR?

> The build passes all built-in tests within `__tests__`. I have updated the snapshot for two that initially did not pass. <br><br>I've `npm link`'ed it as a dependency in one of our internal systems at work. No functionality regressions that I can spot through basic hand-testing.



### How should this be manually tested?

> When providing options to `Select`, set `option.label` to a React component.



### What are the relevant issues?

#### Issue https://github.com/grommet/grommet/issues/1425



### Do the grommet docs need to be updated?

> Nope.

### Should this PR be mentioned in the release notes?

> Sure, up to y'all.



### Is this change backwards compatible or is it a breaking change?

> I do not believe this is a breaking change, as it will render the original `input` as before.



---

## Demo GIF

![screen recording 2017-07-14 at 12 57 am](https://user-images.githubusercontent.com/194885/28199193-d82fbdd0-6831-11e7-8e50-3f8c649c1116.gif)
