### PR TITLE
Removed the label wrapping the radiobutton component (Issue #1436)

### DIFF
--- a/__tests__/components/__snapshots__/RadioButton-test.js.snap
+++ b/__tests__/components/__snapshots__/RadioButton-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RadioButton has correct default options 1`] = `
-<label
+<span
   className="grommetux-radio-button"
 >
   <input
@@ -20,5 +20,5 @@ exports[`RadioButton has correct default options 1`] = `
   >
     Choice
   </label>
-</label>
+</span>
 `;

--- a/__tests__/components/__snapshots__/Select-test.js.snap
+++ b/__tests__/components/__snapshots__/Select-test.js.snap
@@ -204,7 +204,7 @@ exports[`Select inline 1`] = `
       className="grommetux-select__option grommetux-select__option--selected"
       onClick={undefined}
     >
-      <label
+      <span
         className="grommetux-radio-button"
       >
         <input
@@ -223,13 +223,13 @@ exports[`Select inline 1`] = `
         >
           one
         </label>
-      </label>
+      </span>
     </li>
     <li
       className="grommetux-select__option"
       onClick={undefined}
     >
-      <label
+      <span
         className="grommetux-radio-button"
       >
         <input
@@ -248,7 +248,7 @@ exports[`Select inline 1`] = `
         >
           two
         </label>
-      </label>
+      </span>
     </li>
   </ol>
 </div>

--- a/src/js/components/RadioButton.js
+++ b/src/js/components/RadioButton.js
@@ -19,14 +19,14 @@ export default class RadioButton extends Component {
     );
 
     return (
-      <label className={classes}>
+      <span className={classes}>
         <input {...props} className={`${CLASS_ROOT}__input`}
           type="radio" />
         <span className={`${CLASS_ROOT}__control`} />
           <label htmlFor={props.id} className={`${CLASS_ROOT}__label`}>
             {label}
           </label>
-      </label>
+      </span>
     );
   }
 }


### PR DESCRIPTION
Changing the wrapper label of the Radiobutton component for a span tag to meet the WCAG requirement.
Updated the snapshots of the radiobutton.

Signed-off-by: jlevesque <jlevesque2109@gmail.com>

#### What does this PR do?
It removes the label tag wrapping the radiobutton component. Now the wcag requirements are met by having one label per form input.

#### What testing has been done on this PR?
The test coverage have been run.

#### Any background context you want to provide?
By using tools like react-axe, the exception is no longer thrown since the component has one label with a for attribut.

#### Is this change backwards compatible or is it a breaking change?
Compatible
