### PR TITLE
Export passwordinput component

### DIFF
--- a/src/js/index-commonjs.js
+++ b/src/js/index-commonjs.js
@@ -57,6 +57,7 @@ var Grommet = {
   NumberInput: require('./components/NumberInput'),
   Object: require('./components/Object'),
   Paragraph: require('./components/Paragraph'),
+  PasswordInput: require('./components/PasswordInput'),
   Quote: require('./components/Quote'),
   RadioButton: require('./components/RadioButton'),
   Search: require('./components/Search'),

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -49,6 +49,7 @@ export { default as Notification } from './components/Notification';
 export { default as NumberInput } from './components/NumberInput';
 export { default as Object } from './components/Object';
 export { default as Paragraph } from './components/Paragraph';
+export { default as PasswordInput } from './components/PasswordInput';
 export { default as Quote } from './components/Quote';
 export { default as RadioButton } from './components/RadioButton';
 export { default as Search } from './components/Search';


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Export the recently added PasswordInput component (4d4ebd2fa5e71aac4d31f4bc9479048c567927a9) in src/js/index.js and src/js/index-commonjs.js files so the component is possible to import in external projects.

#### Where should the reviewer start?
Run tests, repeat 'manually tested'-step locally. Any other steps when exporting new components?

#### What testing has been done on this PR?
Tests ran, built project with gulp in accordance to [instructions](https://github.com/grommet/grommet/wiki/Building-Grommet) and tested that PasswordInput is available as an exported component.

#### How should this be manually tested?
I built the project using `gulp dist` before making the changes, and verified that importing the PasswordInput module was not possible, then repeated the process post-change and saw the component listed as a module. (See screenshot.)

#### Any background context you want to provide?
This is my first PR and I have very limited insight in the codebase. This change should be simple enough not to affect anything other than exposing a recently added component, but I'd love to hear that be verified.

#### What are the relevant issues?
N/A

#### Screenshots (if appropriate)
Before:
<img width="233" alt="before" src="https://user-images.githubusercontent.com/6001131/28517332-55a68340-7064-11e7-93e3-be26e97fb8c1.png">

After:
<img width="543" alt="after" src="https://user-images.githubusercontent.com/6001131/28517289-34d5a7fe-7064-11e7-8c3f-eaa79bd73be9.png">

#### Do the grommet docs need to be updated?
No, as far as I'm aware of. There already is documentation for the component and I can't see any other places that should be affected.

#### Should this PR be mentioned in the release notes?
I think so?

#### Is this change backwards compatible or is it a breaking change?
It should be backwards compatible, only exposing added functionality.