### PR TITLE
Russian translations for messages

### DIFF
--- a/src/js/messages/ru-RU.js
+++ b/src/js/messages/ru-RU.js
@@ -1,0 +1,136 @@
+// (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
+
+import iconMessages from './icons/en-US';
+
+export default {
+  IndexFilters: { // Did I understand the interpolation syntax?
+    filters: `{quantity, plural,
+      =0 {нет фильтров}
+      =1 {один фильтр}
+      other {# фильтры}
+    }`,
+  },
+  ...iconMessages,
+  Active: 'Активный',
+  Activate: 'Активировать',
+  Activated: 'Активирован',
+  Add: 'Добавить',
+  add: 'добавить',
+  Alerts: 'Уведомления',
+  All: 'Все',
+  ampm: 'ампм', // context?
+  Arc: 'Дуга',
+  AxisLabel: '{orientation} Ось',
+  area: 'зона',
+  Bar: 'Бар', // context?
+  bar: 'бар', // context?
+  Blank: 'Пустой',
+  Box: 'Ящик', // context?
+  Carousel: 'Карусель',
+  Category: 'Категория',
+  Circle: 'Круг',
+  Chart: 'Диаграмма',
+  Children: 'Дети',
+  Clear: 'Очистить',
+  Cleared: 'Очищенный',
+  Close: 'Закрыть',
+  'Close Menu': 'Закрыть меню',
+  Completed: 'Завершенный',
+  'Connects With': 'Соединяется с',
+  created: 'созданный',
+  Critical: 'Критический',
+  'Currently Active': 'Активный',
+  'Date Selector': 'Выбор даты',
+  'Date Time Icon': 'Выбор даты и времени',
+  day: 'день',
+  Disabled: 'Отключен',
+  Distribution: 'Распределение',
+  Email: 'Эл. адрес',
+  'Enter Select': 'Нажмите enter чтобы выбрать его',
+  Error: 'Ошибка',
+  Filter: 'Фильтр',
+  Footer: 'Нижний колонтитул', // Not 100% sure on this one
+  Grommet: 'Громмет',
+  HotSpotsLabel: 'HotSpots: нажмите клавиши со стрелками, чтобы взаимодействовать с ним.',
+  'GraphValues': 'График имеет {count} элементы. Наивысшее - {highest}, а наименьшее - {smallest}',
+  hour: 'час',
+  'Grommet Logo': 'Громмет Лого',
+  Layer: 'Слой',
+  List: 'Список',
+  line: 'линия',
+  Loading: 'Загружается',
+  loginInvalidPassword: 'Пожалуйста, укажите имя и пароль пользователя.',
+  'Log In': 'Авторизоваться',
+  Logout: 'Выйти',
+  'Main Content': 'Основное содержание',
+  Max: 'Максимум',
+  Menu: 'Меню',
+  Meter: 'метр',
+  Min: 'Минимум', // assming 'minimum'
+  minute: 'минута',
+  model: 'модель',
+  modified: 'модифицирован',
+  monitor: 'монитор',
+  month: 'месяц',
+  'Multi Select': 'Выбор из нескольких вариантов',
+  Name: 'Имя',
+  'Navigation Help': 'Используйте клавиши со стрелками для навигации',
+  'Next Month': 'Следующий месяц',
+  'Next Slide': 'Следующий слайд',
+  'No Relationship': 'Нет отношений',
+    'Notification': 'Уведомление',
+  OK: 'ОК',
+  Open: 'Открыть',
+  Parent: 'Родитель',
+  Parents: 'Родители',
+  Parts: 'Части',
+  Part: 'Часть',
+  Password: 'Пароль',
+  'Previous Month': 'Предыдущий Месяц',
+  'Previous Slide': 'Предыдущая Слайд',
+  'Previous Tiles': 'Предыдущие Плитки',
+  'Remember me': 'Запомни меня',
+  'Range Start': 'Начало Диапазона',
+  'Range End': 'Конец Диапазона',
+  Resource: 'Ресурс',
+  Running: 'Работает', // "working" -- fitting in context?
+  Search: 'Поиск',
+  'Match Results': `{count, plural,
+      =0 {Нет совпадения}
+      one {Есть одно совпадения}
+      other {Есть # совпадений}
+  }`,
+  second: 'второй', // as in sequence (number #2), not as in time (hour/minute/second) (might need conjugation based on context)
+  'Select Icon': 'Открыть селектор', // "open selector"
+  Selected: 'Selected',
+  'Selected Multiple': `{count, plural,
+      =0 {none}
+      one {# значение}
+      other {# значения}
+  }`,
+  'Skip to': 'Перейти к',
+  'Slide Number': ' Слайд {slideNumber}',
+  Sort: 'Сортировать',
+  Spinning: 'Прядильный', // not 100% sure on this
+  Spiral: 'Спираль',
+  State: 'Состояние',
+  Status: 'Статус',
+  Subtract: 'Вычитать',
+  SunBurst: 'SunBurst', // context?
+  'Tab Contents': 'Содержимое вкладки {activeTitle}',
+  Table: 'Таблица',
+  Tasks: 'Задания',
+  Tiles: 'Плитки',
+  Time: 'Время',
+  Title: 'Заглавие',
+  Today: 'Cегодня',
+  Topology: 'Топология',
+  Total: 'Всего',
+  Threshold: 'Порог',
+  Unknown: 'Неизвестный',
+  Username: 'Имя пользователя',
+  uri: 'унифицированный идентификатор ресурса', // no common abbreviation
+  Value: 'Стоимость',
+  Warning: 'Предупреждение',
+  year: 'год'
+};

--- a/src/js/messages/ru.js
+++ b/src/js/messages/ru.js
@@ -1,0 +1,1 @@
+export * from './ru-RU';


### PR DESCRIPTION
#### What does this PR do?
Adds Russian translations for messages.  

#### Where should the reviewer start?
The PR is submitted as a WIP, with comments that needs to be addressed throughout the file.  

#### What testing has been done on this PR?
None other than running test script.  

#### How should this be manually tested?
Address comments, let me know what I could do further.  

#### Any background context you want to provide?
This translation is done to the best of my ability. Russian is my mother tongue, but I haven't had a chance to practice it very often the last few years. I used the `en-US.js` translations as a base. Verified results with Google Translate and used contextual understanding to the best of my abilities. Results should be 90-95% reliable with possibility of minor mistakes. There's also a possibility that some conjugations are required if certain words are used in a context that is different from what I've managed to infer.

If this is received as something of interest, I could also do translations for /icons. I could also do translations for Norwegian, which would be much easier.

Also, I'm not sure how this fits into your 2.0 rewrite as I don't have much insight into the process other than the public Waffleboard and [this link](https://github.com/grommet/grommet/wiki/Why-Grommet-2.0%3F), but I hope and believe that as 2.0 focuses on DX, few alterations should be required here, if any.

#### What are the relevant issues?
N/A

#### Screenshots (if appropriate)
N/A

#### Do the grommet docs need to be updated?
Possibly. Nothing on localisation as far as I've seen, but that should probably be created.

#### Should this PR be mentioned in the release notes?
I would assume it's worth mentioning, if this PR gets to a state where it can be merged.

#### Is this change backwards compatible or is it a breaking change?
This should be backwards compatible.