### PR TITLE
Added Heading.

### DIFF
--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -5,6 +5,7 @@ Object {
   "Box": [Function],
   "Button": [Function],
   "Grommet": [Function],
+  "Heading": [Function],
   "RoutedButton": [Function],
   "__esModule": true,
 }

--- a/src/js/components/heading/Heading.js
+++ b/src/js/components/heading/Heading.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+import { compose } from 'recompose';
+
+import StyledHeading from './StyledHeading';
+
+import { withTheme } from '../hocs';
+
+import doc from './doc';
+
+const styledComponents = {
+  div: StyledHeading,
+}; // tag -> styled component
+
+class Heading extends Component {
+  static defaultProps = {
+    level: 1,
+  };
+
+  render() {
+    const {
+      level,
+      ...rest
+    } = this.props;
+
+    const tag = `h${level}`;
+    let StyledComponent = styledComponents[tag];
+    if (!StyledComponent) {
+      StyledComponent = StyledHeading.withComponent(tag);
+      styledComponents[tag] = StyledComponent;
+    }
+
+    return (
+      <StyledComponent level={level} {...rest} />
+    );
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  doc(Heading);
+}
+
+export default compose(
+  withTheme,
+)(Heading);

--- a/src/js/components/heading/StyledHeading.js
+++ b/src/js/components/heading/StyledHeading.js
@@ -1,0 +1,61 @@
+import styled, { css } from 'styled-components';
+
+const marginStyle = (props) => {
+  if (typeof props.margin === 'string') {
+    if (props.margin === 'none') {
+      return `
+        margin-top: 0;
+        margin-bottom: 0;
+      `;
+    }
+    const margin = props.theme.global.edgeSize[props.margin];
+    return `
+      margin-top: ${margin};
+      margin-bottom: ${margin};
+    `;
+  }
+  if (props.margin.top) {
+    return `margin-top: ${props.theme.global.edgeSize[props.margin.top]};`;
+  }
+  if (props.margin.bottom) {
+    return `margin-bottom: ${props.theme.global.edgeSize[props.margin.bottom]};`;
+  }
+  return '';
+};
+
+const sizeStyle = (props) => {
+  // size is a combination of the level and size properties
+  const size = props.size || 'medium';
+  const data = props.theme.heading.level[props.level][size];
+  return css`
+    font-size: ${data.size};
+    line-height: ${data.height};
+  `;
+};
+
+const TEXT_ALIGN_MAP = {
+  center: 'center',
+  end: 'right',
+  start: 'left',
+};
+
+const textAlignStyle = css`
+  text-align: ${props => TEXT_ALIGN_MAP[props.textAlign]};
+`;
+
+const truncateStyle = `
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const StyledHeading = styled.h1`
+  ${props => sizeStyle(props)}
+  ${props => props.margin && marginStyle(props)}
+  ${props => props.textAlign && textAlignStyle}
+  ${props => props.truncate && truncateStyle}
+`;
+
+export default StyledHeading.extend`
+  ${props => props.theme.box && props.theme.box.extend}
+`;

--- a/src/js/components/heading/StyledHeading.js
+++ b/src/js/components/heading/StyledHeading.js
@@ -57,5 +57,5 @@ const StyledHeading = styled.h1`
 `;
 
 export default StyledHeading.extend`
-  ${props => props.theme.box && props.theme.box.extend}
+  ${props => props.theme.heading && props.theme.heading.extend}
 `;

--- a/src/js/components/heading/__tests__/Heading-test.js
+++ b/src/js/components/heading/__tests__/Heading-test.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import 'jest-styled-components';
+
+import { Grommet } from '../../grommet';
+import { Heading } from '../';
+
+test('Heading renders', () => {
+  const component = renderer.create(
+    <Grommet>
+      <Heading />
+    </Grommet>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Heading level renders', () => {
+  const component = renderer.create(
+    <Grommet>
+      <Heading level={1} />
+      <Heading level={2} />
+      <Heading level={3} />
+      <Heading level={4} />
+    </Grommet>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Heading size renders', () => {
+  const component = renderer.create(
+    <Grommet>
+      <Heading level={1} size='small' />
+      <Heading level={1} size='medium' />
+      <Heading level={1} size='large' />
+      <Heading level={2} size='small' />
+      <Heading level={2} size='medium' />
+      <Heading level={2} size='large' />
+      <Heading level={3} size='small' />
+      <Heading level={3} size='medium' />
+      <Heading level={3} size='large' />
+      <Heading level={4} size='small' />
+      <Heading level={4} size='medium' />
+      <Heading level={4} size='large' />
+    </Grommet>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Heading textAlign renders', () => {
+  const component = renderer.create(
+    <Grommet>
+      <Heading textAlign='start' />
+      <Heading textAlign='center' />
+      <Heading textAlign='end' />
+    </Grommet>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Heading margin renders', () => {
+  const component = renderer.create(
+    <Grommet>
+      <Heading margin='small' />
+      <Heading margin='medium' />
+      <Heading margin='large' />
+      <Heading margin='none' />
+      <Heading margin={{ bottom: 'small' }} />
+      <Heading margin={{ top: 'small' }} />
+    </Grommet>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+const LONG = 'a b c d e f g h i j k l m n o p q r s t u v w x y z';
+
+test('Heading truncate renders', () => {
+  const component = renderer.create(
+    <Grommet>
+      <Heading truncate={false}>{LONG}</Heading>
+      <Heading truncate={true}>{LONG}</Heading>
+    </Grommet>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/js/components/heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -1,0 +1,497 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Heading level renders 1`] = `
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  background-color: #FFFFFF;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  width: 100%;
+  max-width: 1152px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.c0 * {
+  box-sizing: inherit;
+}
+
+.c1 {
+  font-size: 48px;
+  line-height: 1.125;
+}
+
+.c2 {
+  font-size: 36px;
+  line-height: 1.23;
+}
+
+.c3 {
+  font-size: 24px;
+  line-height: 1.333;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 1.333;
+}
+
+@media only screen and (min-width:481px) {
+  .c0 {
+    top: 0px;
+    bottom: 0px;
+    left: 0px;
+    right: 0px;
+    height: 100%;
+    width: 100%;
+    overflow: visible;
+  }
+}
+
+<div
+  className="c0"
+>
+  <h1
+    className="c1"
+  />
+  <h2
+    className="c2"
+  />
+  <h3
+    className="c3"
+  />
+  <h4
+    className="c4"
+  />
+</div>
+`;
+
+exports[`Heading margin renders 1`] = `
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  background-color: #FFFFFF;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  width: 100%;
+  max-width: 1152px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.c0 * {
+  box-sizing: inherit;
+}
+
+.c1 {
+  font-size: 48px;
+  line-height: 1.125;
+  margin-top: 12px;
+  margin-bottom: 12px;
+}
+
+.c2 {
+  font-size: 48px;
+  line-height: 1.125;
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+
+.c3 {
+  font-size: 48px;
+  line-height: 1.125;
+  margin-top: 48px;
+  margin-bottom: 48px;
+}
+
+.c4 {
+  font-size: 48px;
+  line-height: 1.125;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c5 {
+  font-size: 48px;
+  line-height: 1.125;
+  margin-bottom: 12px;
+}
+
+.c6 {
+  font-size: 48px;
+  line-height: 1.125;
+  margin-top: 12px;
+}
+
+@media only screen and (min-width:481px) {
+  .c0 {
+    top: 0px;
+    bottom: 0px;
+    left: 0px;
+    right: 0px;
+    height: 100%;
+    width: 100%;
+    overflow: visible;
+  }
+}
+
+<div
+  className="c0"
+>
+  <h1
+    className="c1"
+  />
+  <h1
+    className="c2"
+  />
+  <h1
+    className="c3"
+  />
+  <h1
+    className="c4"
+  />
+  <h1
+    className="c5"
+  />
+  <h1
+    className="c6"
+  />
+</div>
+`;
+
+exports[`Heading renders 1`] = `
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  background-color: #FFFFFF;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  width: 100%;
+  max-width: 1152px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.c0 * {
+  box-sizing: inherit;
+}
+
+.c1 {
+  font-size: 48px;
+  line-height: 1.125;
+}
+
+@media only screen and (min-width:481px) {
+  .c0 {
+    top: 0px;
+    bottom: 0px;
+    left: 0px;
+    right: 0px;
+    height: 100%;
+    width: 100%;
+    overflow: visible;
+  }
+}
+
+<div
+  className="c0"
+>
+  <h1
+    className="c1"
+  />
+</div>
+`;
+
+exports[`Heading size renders 1`] = `
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  background-color: #FFFFFF;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  width: 100%;
+  max-width: 1152px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.c0 * {
+  box-sizing: inherit;
+}
+
+.c2 {
+  font-size: 48px;
+  line-height: 1.125;
+}
+
+.c1 {
+  font-size: 24px;
+  line-height: 1.333;
+}
+
+.c3 {
+  font-size: 96px;
+  line-height: 1.125;
+}
+
+.c5 {
+  font-size: 36px;
+  line-height: 1.23;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 1.333;
+}
+
+.c6 {
+  font-size: 48px;
+  line-height: 1.125;
+}
+
+.c8 {
+  font-size: 24px;
+  line-height: 1.333;
+}
+
+.c7 {
+  font-size: 18px;
+  line-height: 1.333;
+}
+
+.c9 {
+  font-size: 36px;
+  line-height: 1.23;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 1.333;
+}
+
+.c10 {
+  font-size: 16px;
+  line-height: 1.333;
+}
+
+.c12 {
+  font-size: 24px;
+  line-height: 1.333;
+}
+
+@media only screen and (min-width:481px) {
+  .c0 {
+    top: 0px;
+    bottom: 0px;
+    left: 0px;
+    right: 0px;
+    height: 100%;
+    width: 100%;
+    overflow: visible;
+  }
+}
+
+<div
+  className="c0"
+>
+  <h1
+    className="c1"
+    size="small"
+  />
+  <h1
+    className="c2"
+    size="medium"
+  />
+  <h1
+    className="c3"
+    size="large"
+  />
+  <h2
+    className="c4"
+    size="small"
+  />
+  <h2
+    className="c5"
+    size="medium"
+  />
+  <h2
+    className="c6"
+    size="large"
+  />
+  <h3
+    className="c7"
+    size="small"
+  />
+  <h3
+    className="c8"
+    size="medium"
+  />
+  <h3
+    className="c9"
+    size="large"
+  />
+  <h4
+    className="c10"
+    size="small"
+  />
+  <h4
+    className="c11"
+    size="medium"
+  />
+  <h4
+    className="c12"
+    size="large"
+  />
+</div>
+`;
+
+exports[`Heading textAlign renders 1`] = `
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  background-color: #FFFFFF;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  width: 100%;
+  max-width: 1152px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.c0 * {
+  box-sizing: inherit;
+}
+
+.c1 {
+  font-size: 48px;
+  line-height: 1.125;
+  text-align: left;
+}
+
+.c2 {
+  font-size: 48px;
+  line-height: 1.125;
+  text-align: center;
+}
+
+.c3 {
+  font-size: 48px;
+  line-height: 1.125;
+  text-align: right;
+}
+
+@media only screen and (min-width:481px) {
+  .c0 {
+    top: 0px;
+    bottom: 0px;
+    left: 0px;
+    right: 0px;
+    height: 100%;
+    width: 100%;
+    overflow: visible;
+  }
+}
+
+<div
+  className="c0"
+>
+  <h1
+    className="c1"
+  />
+  <h1
+    className="c2"
+  />
+  <h1
+    className="c3"
+  />
+</div>
+`;
+
+exports[`Heading truncate renders 1`] = `
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  background-color: #FFFFFF;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  width: 100%;
+  max-width: 1152px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.c0 * {
+  box-sizing: inherit;
+}
+
+.c1 {
+  font-size: 48px;
+  line-height: 1.125;
+}
+
+.c2 {
+  font-size: 48px;
+  line-height: 1.125;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media only screen and (min-width:481px) {
+  .c0 {
+    top: 0px;
+    bottom: 0px;
+    left: 0px;
+    right: 0px;
+    height: 100%;
+    width: 100%;
+    overflow: visible;
+  }
+}
+
+<div
+  className="c0"
+>
+  <h1
+    className="c1"
+  >
+    a b c d e f g h i j k l m n o p q r s t u v w x y z
+  </h1>
+  <h1
+    className="c2"
+  >
+    a b c d e f g h i j k l m n o p q r s t u v w x y z
+  </h1>
+</div>
+`;

--- a/src/js/components/heading/doc.js
+++ b/src/js/components/heading/doc.js
@@ -1,0 +1,42 @@
+import { schema, PropTypes } from 'react-desc';
+
+export default Heading => schema(Heading, {
+  description: 'A box.',
+  usage: `import { Heading } from 'grommet';
+  <Heading/>`,
+  props: {
+    level: [
+      PropTypes.oneOf([1, 2, 3, 4]),
+      `The heading level. It corresponds to the number after the 'H' for
+      the DOM tag. Set the level for semantic accuracy and accessibility.
+      The sizing can be further adjusted using the size property.`,
+    ],
+    margin: [
+      PropTypes.oneOfType([
+        PropTypes.oneOf(['none', 'small', 'medium', 'large']),
+        PropTypes.shape({
+          bottom: PropTypes.oneOf(['small', 'medium', 'large']),
+          top: PropTypes.oneOf(['small', 'medium', 'large']),
+        }),
+      ]),
+      `The amount of margin above and/or below the heading. An object can be
+      specified to distinguish top margin and bottom margin.`,
+    ],
+    size: [
+      PropTypes.oneOf(['small', 'medium', 'large']),
+      `The font size is primarily driven by the chosen tag. But, it can
+      be adjusted via this size property. The tag should be set for semantic
+      correctness and accessibility. This size property allows for stylistic
+      adjustments.`,
+    ],
+    textAlign: [
+      PropTypes.oneOf(['start', 'center', 'end']),
+      'How to align the text inside the heading.',
+    ],
+    truncate: [
+      PropTypes.bool,
+      `Restrict the text to a single line and truncate with ellipsis if it
+      is too long to all fit. Defaults to false.`,
+    ],
+  },
+});

--- a/src/js/components/heading/index.js
+++ b/src/js/components/heading/index.js
@@ -1,0 +1,5 @@
+import Heading from './Heading';
+
+export { default as Heading } from './Heading';
+
+export default Heading;

--- a/src/js/components/index.js
+++ b/src/js/components/index.js
@@ -1,3 +1,4 @@
 export * from './box';
 export * from './button';
 export * from './grommet';
+export * from './heading';

--- a/src/js/themes/vanilla.js
+++ b/src/js/themes/vanilla.js
@@ -142,4 +142,28 @@ export default {
     },
   },
   grommet: {},
+  heading: {
+    level: {
+      1: {
+        medium: { size: '48px', height: 1.125 },
+        small: { size: '24px', height: 1.333 },
+        large: { size: '96px', height: 1.125 },
+      },
+      2: {
+        medium: { size: '36px', height: 1.23 },
+        small: { size: '18px', height: 1.333 },
+        large: { size: '48px', height: 1.125 },
+      },
+      3: {
+        medium: { size: '24px', height: 1.333 },
+        small: { size: '18px', height: 1.333 },
+        large: { size: '36px', height: 1.23 },
+      },
+      4: {
+        medium: { size: '18px', height: 1.333 },
+        small: { size: '16px', height: 1.333 },
+        large: { size: '24px', height: 1.333 },
+      },
+    },
+  },
 };


### PR DESCRIPTION
The Heading differs from 1.0 in:

The `tag` property has been superseded by the `level` property.
There is a new `size` property to enable stylistic adjustment.
`margin` now supports an object allowing just top or bottom margin.
`strong` has been removed. Callers should use `<strong>`.
`uppercase` has been removed. Callers should use toUpperCase() when populating.