### PR TITLE
Allow columns to be individually sortable.

### DIFF
--- a/__tests__/components/TableHeader-test.js
+++ b/__tests__/components/TableHeader-test.js
@@ -18,4 +18,13 @@ describe('TableHeader', () => {
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('accepts options for sorting', () => {
+    const component = renderer.create(
+      <TableHeader labels={['first', ['second', { sortable: false }]]}
+        sortIndex={0} sortAscending={true} onSort={() => {}} />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/__tests__/components/__snapshots__/TableHeader-test.js.snap
+++ b/__tests__/components/__snapshots__/TableHeader-test.js.snap
@@ -1,5 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TableHeader accepts options for sorting 1`] = `
+<thead>
+  <tr>
+    <th>
+      <button
+        aria-label={undefined}
+        className="grommetux-button grommetux-button--fill grommetux-button--plain"
+        disabled={false}
+        href={undefined}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="button"
+      >
+        <div
+          className="grommetux-box grommetux-box--direction-row grommetux-box--justify-start grommetux-box--align-center grommetux-box--responsive grommetux-box--pad-between-small"
+          id={undefined}
+          onClick={undefined}
+          role={undefined}
+          style={Object {}}
+          tabIndex={undefined}
+        >
+          <span>
+            first
+          </span>
+          <svg
+            aria-label="link-down"
+            className="grommetux-control-icon grommetux-control-icon-link-down grommetux-control-icon--responsive"
+            height="24px"
+            role="img"
+            version="1.1"
+            viewBox="0 0 24 24"
+            width="24px"
+          >
+            <path
+              d="M12,2 L12,22 M3,11 L12,2 L21,11"
+              fill="none"
+              stroke="#000"
+              strokeWidth="2"
+              transform="matrix(1 0 0 -1 0 24)"
+            />
+          </svg>
+        </div>
+      </button>
+    </th>
+    <th>
+      <div
+        className="grommetux-box grommetux-box--direction-row grommetux-box--justify-start grommetux-box--align-center grommetux-box--responsive grommetux-box--pad-between-small"
+        id={undefined}
+        onClick={undefined}
+        role={undefined}
+        style={Object {}}
+        tabIndex={undefined}
+      >
+        <span>
+          second
+        </span>
+      </div>
+    </th>
+  </tr>
+</thead>
+`;
+
 exports[`TableHeader has correct default options 1`] = `
 <thead>
   <tr>

--- a/src/js/components/TableHeader.js
+++ b/src/js/components/TableHeader.js
@@ -24,8 +24,16 @@ export default class TableHeader extends Component {
     const { labels, onSort, sortAscending, sortIndex, ...props } = this.props;
 
     const cells = labels.map((label, index) => {
+      let content;
+      let options = {};
 
-      let content = label;
+      if (Array.isArray(label)) {
+        [content, options = {}] = label;
+      } else {
+        content = label;
+        options.sortable = !!onSort;
+      }
+
       if (sortIndex >= 0) {
         let sortIndicator;
         if (index === sortIndex) {
@@ -42,7 +50,7 @@ export default class TableHeader extends Component {
           </Box>
         );
 
-        if (onSort) {
+        if (options.sortable) {
           content = (
             <Button plain={true} fill={true}
               onClick={this._onSort.bind(this, index)}>
@@ -66,7 +74,10 @@ export default class TableHeader extends Component {
 }
 
 TableHeader.propTypes = {
-  labels: PropTypes.arrayOf(PropTypes.node).isRequired,
+  labels: PropTypes.arrayOf(PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.array
+  ])).isRequired,
   onSort: PropTypes.func, // (index, ascending?)
   sortAscending: PropTypes.bool,
   sortIndex: PropTypes.number


### PR DESCRIPTION
This closes #1176.

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Column labels should allow for an optional tuple to define a column header. The first item in the tuple is the column label. The second item is an options object which can contain a `sortable` boolean property which will disable sorting for the column it is defined for. If no options are passed the default is still to rely on the `onSort` value to enable the sorting UI.

#### What testing has been done on this PR?

I am currently using my fork in a project and can verify that his behavior is as described. There is also a new snapshot test to cover this.

#### How should this be manually tested?

```jsx
<TabelHeader onSort={() => {}} labels={['first', ['second', { sortable: false }]]} />
```

#### Any background context you want to provide?

Not all table columns can be sorted so there should be a backward compatible way to disable the sort icons and buttons for these.

#### What are the relevant issues?

#1176 

#### Do the grommet docs need to be updated?

Yes, but the change is backward compatible so it is not breaking and not critical.

#### Should this PR be mentioned in the release notes?

Yes.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
