### PR TITLE
Fix 'NaN' in Anchor docs schema

### DIFF
--- a/src/js/components/Anchor.js
+++ b/src/js/components/Anchor.js
@@ -235,7 +235,7 @@ schema(Anchor, {
     path: [
       PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
       'React-router path to navigate to when clicked.' +
-      ' Use path={{ path: '/', index: true }} if you want the Anchor to be' +
+      ' Use path={{ path: \'/\', index: true }} if you want the Anchor to be' +
       ' active only when the index route is current.'
     ],
     primary: [PropTypes.bool, 'Whether this is a primary anchor.'],


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Escape the single quotes in the `Anchor` schema docs.

#### Where should the reviewer start?
View the current [anchor docs](https://grommet.github.io/docs/anchor) and notice the incorrect doc string for the `path` prop:
> ...when clicked.**NaN** active only...

#### What testing has been done on this PR?
Built `grommet-docs` locally with modified `grommet` wc.

#### How should this be manually tested?
n/a

#### Any background context you want to provide?
n/a

#### What are the relevant issues?
n/a

#### Screenshots (if appropriate)
![before](https://user-images.githubusercontent.com/297461/28974076-236dfbe0-7903-11e7-83f9-cc6db5ce8a50.png)

![after](https://user-images.githubusercontent.com/297461/28974090-2cbd0c54-7903-11e7-89c3-dfd660abcf9d.png)


#### Do the grommet docs need to be updated?
Yes

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.