### PR TITLE
Hide text behind select__control

### DIFF
--- a/src/scss/grommet-core/_objects.select.scss
+++ b/src/scss/grommet-core/_objects.select.scss
@@ -42,6 +42,11 @@
   top: 50%;
   transform: translateY(-50%);
   right: quarter($inuit-base-spacing-unit);
+
+  // Hide text behind select__control
+  svg {
+    background-color: $background-color;
+  }
 }
 
 .#{$grommet-namespace}select__search {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix an issue where if the text inside a Select field was too long, it overlapped the select__control arrow

#### What testing has been done on this PR?
None. I actually have no idea if there would be any way to test this.

#### How should this be manually tested?
1. Create a Select field with a value longer than the width of the field.
2. See if the text overlaps the arrow.

#### Any background context you want to provide?
Here is a codepen illustrating the changes: https://codepen.io/Thuranel/pen/zdZeEq

#### Do the grommet docs need to be updated?
No

#### Is this change backwards compatible or is it a breaking change?
Should not break anything :)