### PR TITLE
Set type='text' in TextInput

### DIFF
--- a/__tests__/components/__snapshots__/TextInput-test.js.snap
+++ b/__tests__/components/__snapshots__/TextInput-test.js.snap
@@ -9,6 +9,7 @@ exports[`TextInput can set autocomplete 1`] = `
   onFocus={[Function]}
   onKeyDown={[Function]}
   placeholder={undefined}
+  type="text"
   value={undefined}
 />
 `;
@@ -24,6 +25,7 @@ exports[`TextInput has correct default options 1`] = `
   onFocus={[Function]}
   onKeyDown={[Function]}
   placeholder={undefined}
+  type="text"
   value="one"
 />
 `;

--- a/src/js/components/TextInput.js
+++ b/src/js/components/TextInput.js
@@ -310,6 +310,7 @@ export default class TextInput extends Component {
     return (
       <input
         ref={ref => this.componentRef = ref}
+        type='text'
         autoComplete="off"
         {...props}
         className={classes}


### PR DESCRIPTION
#### What does this PR do?

Sets `type='text'` in TextInput.

#### Where should the reviewer start?

TextInput.js

#### What testing has been done on this PR?

Manual via grommet-docs and unit tests.

#### How should this be manually tested?

same

#### Any background context you want to provide?

no

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/1531

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
