### PR TITLE
Added interactivity to Meter

### DIFF
--- a/src/js/components/box/StyledBox.js
+++ b/src/js/components/box/StyledBox.js
@@ -162,6 +162,14 @@ const edgeStyle = (kind, data, theme) => {
   return '';
 };
 
+const ROUND_MAP = {
+  'full': '100%',
+};
+
+const roundStyle = css`
+  border-radius: ${props => ROUND_MAP[props.round] || props.theme.global.edgeSize[props.round]};
+`;
+
 const StyledBox = styled.div`
   display: flex;
 
@@ -177,6 +185,7 @@ const StyledBox = styled.div`
   ${props => props.justify && justifyStyle}
   ${props => props.margin && edgeStyle('margin', props.margin, props.theme)}
   ${props => props.pad && edgeStyle('padding', props.pad, props.theme)}
+  ${props => props.round && roundStyle}
   ${props => props.textAlign && textAlignStyle}
   ${props => props.wrap && wrapStyle}
 `;

--- a/src/js/components/box/__tests__/Box-test.js
+++ b/src/js/components/box/__tests__/Box-test.js
@@ -268,6 +268,20 @@ test('Box gridArea renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('Box round renders', () => {
+  const component = renderer.create(
+    <Grommet>
+      <Box round='xsmall' />
+      <Box round='small' />
+      <Box round='medium' />
+      <Box round='large' />
+      <Box round='full' />
+    </Grommet>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('Box tag renders', () => {
   const component = renderer.create(
     <Grommet>

--- a/src/js/components/box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/box/__tests__/__snapshots__/Box-test.js.snap
@@ -1778,6 +1778,117 @@ exports[`Box reverse renders 1`] = `
 </div>
 `;
 
+exports[`Box round renders 1`] = `
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  background-color: #FFFFFF;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 * {
+  box-sizing: inherit;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-radius: 6px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-radius: 12px;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-radius: 24px;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-radius: 48px;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-radius: 100%;
+}
+
+@media only screen and (min-width:481px) {
+  .c0 {
+    top: 0px;
+    bottom: 0px;
+    left: 0px;
+    right: 0px;
+    height: 100%;
+    width: 100%;
+    overflow: visible;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+    direction="column"
+  />
+  <div
+    className="c2"
+    direction="column"
+  />
+  <div
+    className="c3"
+    direction="column"
+  />
+  <div
+    className="c4"
+    direction="column"
+  />
+  <div
+    className="c5"
+    direction="column"
+  />
+</div>
+`;
+
 exports[`Box tag renders 1`] = `
 .c0 {
   font-family: 'Work Sans',Arial,sans-serif;

--- a/src/js/components/box/doc.js
+++ b/src/js/components/box/doc.js
@@ -112,6 +112,10 @@ export default Box => schema(Box, {
       PropTypes.bool,
       'Whether to reverse the order of the child components.',
     ],
+    round: [
+      PropTypes.oneOf(['xsmall', 'small', 'medium', 'large', 'full']),
+      'How much to round the corners.',
+    ],
     // separator - moved to border
     // size - removed, use basis
     tag: [

--- a/src/js/components/meter/Bar.js
+++ b/src/js/components/meter/Bar.js
@@ -14,15 +14,25 @@ export default class Bar extends Component {
     const height = parseMetricToInt(theme.global.edgeSize[thickness]);
     const mid = height / 2;
     const max = 100;
+    const someHighlight = (values || []).some(v => v.highlight);
 
     let start = 0;
     const paths = (values || []).map((valueArg, index) => {
-      const { value, label, color, ...rest } = valueArg;
+      const { color, highlight, label, onHover, value, ...rest } = valueArg;
+
       const key = `p-${index}`;
       const delta = (value * width) / max;
       const d = `M ${start},${mid} L ${start + delta},${mid}`;
       const colorName = color || `neutral-${index + 1}`;
+      let hoverProps;
+      if (onHover) {
+        hoverProps = {
+          onMouseOver: () => onHover(true),
+          onMouseLeave: () => onHover(false),
+        };
+      }
       start += delta;
+
       return (
         <path
           key={key}
@@ -31,6 +41,8 @@ export default class Bar extends Component {
           stroke={colorForName(colorName, theme)}
           strokeWidth={height}
           strokeLinecap={cap}
+          strokeOpacity={(someHighlight && !highlight) ? 0.5 : 1}
+          {...hoverProps}
           {...rest}
         />
       );

--- a/src/js/components/meter/Circle.js
+++ b/src/js/components/meter/Circle.js
@@ -18,11 +18,12 @@ export default class Circle extends Component {
     const radius = (width / 2) - (height / 2);
     const max = 100;
     const anglePer = (360 / max);
+    const someHighlight = (values || []).some(v => v.highlight);
 
     let startValue = 0;
     let startAngle = 0;
     const paths = (values || []).map((valueArg, index) => {
-      const { value, label, color, ...rest } = valueArg;
+      const { color, highlight, label, onHover, value, ...rest } = valueArg;
       const key = `p-${index}`;
       const colorName = color || `neutral-${index + 1}`;
 
@@ -33,8 +34,14 @@ export default class Circle extends Component {
         endAngle = Math.min(360,
           translateEndAngle(startAngle, anglePer, value));
       }
-
       const d = arcCommands(width / 2, width / 2, radius, startAngle, endAngle);
+      let hoverProps;
+      if (onHover) {
+        hoverProps = {
+          onMouseOver: () => onHover(true),
+          onMouseLeave: () => onHover(false),
+        };
+      }
       startValue += value;
       startAngle = endAngle;
 
@@ -46,6 +53,8 @@ export default class Circle extends Component {
           stroke={colorForName(colorName, theme)}
           strokeWidth={height}
           strokeLinecap={cap}
+          strokeOpacity={(someHighlight && !highlight) ? 0.5 : 1}
+          {...hoverProps}
           {...rest}
         />
       );

--- a/src/js/components/meter/__tests__/__snapshots__/Meter-test.js.snap
+++ b/src/js/components/meter/__tests__/__snapshots__/Meter-test.js.snap
@@ -51,6 +51,7 @@ exports[`Meter background renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap={undefined}
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -72,6 +73,7 @@ exports[`Meter background renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap={undefined}
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -94,6 +96,7 @@ exports[`Meter background renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="square"
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -116,6 +119,7 @@ exports[`Meter background renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="square"
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -173,6 +177,7 @@ exports[`Meter cap renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="square"
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -194,6 +199,7 @@ exports[`Meter cap renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="round"
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -216,6 +222,7 @@ exports[`Meter cap renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="square"
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -238,6 +245,7 @@ exports[`Meter cap renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="round"
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -309,6 +317,7 @@ exports[`Meter renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap={undefined}
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -366,6 +375,7 @@ exports[`Meter size renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap={undefined}
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -387,6 +397,7 @@ exports[`Meter size renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap={undefined}
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -408,6 +419,7 @@ exports[`Meter size renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap={undefined}
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -429,6 +441,7 @@ exports[`Meter size renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap={undefined}
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -450,6 +463,7 @@ exports[`Meter size renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap={undefined}
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -472,6 +486,7 @@ exports[`Meter size renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="square"
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -494,6 +509,7 @@ exports[`Meter size renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="square"
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -516,6 +532,7 @@ exports[`Meter size renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="square"
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -538,6 +555,7 @@ exports[`Meter size renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="square"
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -560,6 +578,7 @@ exports[`Meter size renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="square"
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -617,6 +636,7 @@ exports[`Meter thickness renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap={undefined}
+      strokeOpacity={1}
       strokeWidth={6}
     />
   </svg>
@@ -638,6 +658,7 @@ exports[`Meter thickness renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap={undefined}
+      strokeOpacity={1}
       strokeWidth={12}
     />
   </svg>
@@ -659,6 +680,7 @@ exports[`Meter thickness renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap={undefined}
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -680,6 +702,7 @@ exports[`Meter thickness renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap={undefined}
+      strokeOpacity={1}
       strokeWidth={48}
     />
   </svg>
@@ -701,6 +724,7 @@ exports[`Meter thickness renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap={undefined}
+      strokeOpacity={1}
       strokeWidth={96}
     />
   </svg>
@@ -723,6 +747,7 @@ exports[`Meter thickness renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="square"
+      strokeOpacity={1}
       strokeWidth={6}
     />
   </svg>
@@ -745,6 +770,7 @@ exports[`Meter thickness renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="square"
+      strokeOpacity={1}
       strokeWidth={12}
     />
   </svg>
@@ -767,6 +793,7 @@ exports[`Meter thickness renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="square"
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -789,6 +816,7 @@ exports[`Meter thickness renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="square"
+      strokeOpacity={1}
       strokeWidth={48}
     />
   </svg>
@@ -811,6 +839,7 @@ exports[`Meter thickness renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="square"
+      strokeOpacity={1}
       strokeWidth={96}
     />
   </svg>
@@ -868,6 +897,7 @@ exports[`Meter type renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap={undefined}
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>
@@ -890,6 +920,7 @@ exports[`Meter type renders 1`] = `
       fill="none"
       stroke="#DC2878"
       strokeLinecap="square"
+      strokeOpacity={1}
       strokeWidth={24}
     />
   </svg>

--- a/src/js/components/meter/doc.js
+++ b/src/js/components/meter/doc.js
@@ -29,11 +29,21 @@ export default Meter => schema(Meter, {
     values: [
       PropTypes.arrayOf(PropTypes.shape({
         color: PropTypes.string,
+        highlight: PropTypes.bool,
         label: PropTypes.string.isRequired, // for a11y
         onClick: PropTypes.func,
+        onHover: PropTypes.func,
         value: PropTypes.number.isRequired,
       })),
-      'Values to visualize',
+      `Array of value objects describing the data.
+      'value' is the actual numeric value.
+      'label' is a text string describing it.
+      'color' indicates the color name to use. If not specified a default one
+      will be chosen.
+      'onClick' will be called when the user clicks on it.
+      Set 'highlight' to call attention to it.
+      'onHover' will be called with a boolean argument indicating when the
+      user hovers onto or away from it.`,
     ],
   },
 });

--- a/src/js/components/stack/Stack.js
+++ b/src/js/components/stack/Stack.js
@@ -19,10 +19,9 @@ class Stack extends Component {
       return React.cloneElement(child, {
         style: {
           position: 'absolute',
-          top: '0px',
-          left: '0px',
-          right: '0px',
-          bottom: '0px',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
           overflow: 'hidden',
         },
       });

--- a/src/js/components/stack/__tests__/__snapshots__/Stack-test.js.snap
+++ b/src/js/components/stack/__tests__/__snapshots__/Stack-test.js.snap
@@ -46,12 +46,11 @@ exports[`Stack renders 1`] = `
     <div
       style={
         Object {
-          "bottom": "0px",
-          "left": "0px",
+          "left": "50%",
           "overflow": "hidden",
           "position": "absolute",
-          "right": "0px",
-          "top": "0px",
+          "top": "50%",
+          "transform": "translate(-50%, -50%)",
         }
       }
     >


### PR DESCRIPTION
#### What does this PR do?

Adds `highlight` and `onHover` to Meter values.
Adds `round` to Box.
Changes Stack to center stacked children.

#### Where should the reviewer start?

Meter.js

#### What testing has been done on this PR?

next-sample

#### How should this be manually tested?

next-sample

#### Any background context you want to provide?

no

#### What are the relevant issues?

none

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
