### PR TITLE
Fix Anchor adjustedOnClick bug. Closes #1585 Closes #1552.

### DIFF
--- a/src/js/components/Anchor.js
+++ b/src/js/components/Anchor.js
@@ -196,7 +196,7 @@ export default class Anchor extends Component {
         aria-label={a11yTitle} onClick={(event, ...args) => {
           if (disabled) {
             event.preventDefault();
-          } else {
+          } else if (adjustedOnClick) {
             adjustedOnClick(event, ...args);
           }
         }}>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes #1585 

#### What testing has been done on this PR?
Docs

#### How should this be manually tested?
Docs

#### Any background context you want to provide?
#1585

#### What are the relevant issues?
Currently when only an href is passed to an Anchor with no onClick handler we receive an error.
```
Uncaught TypeError: Cannot read property 'apply' of undefined
```

#### Do the grommet docs need to be updated?
Yes, the AnchorDocs need the onClick handler updated. I will send a PR for that shortly.

#### Should this PR be mentioned in the release notes?
Nope.

#### Is this change backwards compatible or is it a breaking change?
Compatible