### PR TITLE
Fix IE Edge icon stroke and fill on dark backgrounds. Closes #1568.

### DIFF
--- a/src/scss/grommet-core/_objects.icon.scss
+++ b/src/scss/grommet-core/_objects.icon.scss
@@ -31,11 +31,13 @@ $icon-huge-size: round($inuit-base-spacing-unit * 12) !default;
       }
     }
 
-    *[stroke*="#"] {
+    *[stroke*="#"],
+    *[STROKE*="#"] {
       stroke: inherit;
     }
 
-    *[fill*="#"] {
+    *[fill*="#"],
+    *[FILL*="#"] {
       fill: inherit;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes a bug which was causing SVG icon strokes and fills not to adjust on dark background in IE Edge.

#### How should this be manually tested?
`/docs/anchor/examples?icon=true&label=true&animateIcon=true&href=true&c-background=dark` in Edge. 

#### What are the relevant issues?
#1568 

#### Screenshots (if appropriate)
**Edge in current build**
![29624564-65226e6a-87f7-11e7-8123-d814c1e2a87b](https://user-images.githubusercontent.com/5983843/29983045-1636d700-8f22-11e7-9c53-7c99bad47fb1.png)

**Edge after fix**
![screen shot 2017-09-01 at 2 26 02 pm](https://user-images.githubusercontent.com/5983843/29983048-181e94a4-8f22-11e7-960a-e703e30545ff.png)

#### Do the grommet docs need to be updated?
Nope

#### Should this PR be mentioned in the release notes?
Nope

#### Is this change backwards compatible or is it a breaking change?
Yep