### PR TITLE
Add IE11 Spinning support. Closes #1556.

### DIFF
--- a/src/scss/grommet-core/_objects.icon.scss
+++ b/src/scss/grommet-core/_objects.icon.scss
@@ -220,6 +220,22 @@ $spinning-dash: round($inuit-base-spacing-unit * 2 * 3.1416);
   }
 }
 
+@include keyframes(fadeOut) {
+  0% {
+    opacity: 1;
+    transform: rotate(0deg);
+  }
+
+  50% {
+    opacity: 0.75;
+  }
+
+  100% {
+    opacity: 1;
+    transform: rotate(360deg);
+  }
+}
+
 .#{$grommet-namespace}icon-spinning {
   width: $inuit-base-spacing-unit;
   height: $inuit-base-spacing-unit;
@@ -227,6 +243,11 @@ $spinning-dash: round($inuit-base-spacing-unit * 2 * 3.1416);
   stroke-dashoffset: 0;
   transform: rotate(90deg);
   @include animation('drawAndReverse 4s alternate infinite ease-in-out');
+  @media all and (-ms-high-contrast: none) {
+    transform: rotate(0deg);
+    stroke-dashoffset: 50;
+    @include animation('fadeOut 3s infinite linear');
+  }
 }
 
 .#{$grommet-namespace}icon-spinning--xsmall {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds support for IE11 to the Spinning component. 

#### Where should the reviewer start?
Viewing the branch in windows / IE11.

#### What testing has been done on this PR?
Windows 7 virtual machine.

#### Any background context you want to provide?
IE11 does not support animating stroke-dashoffset, from what I can tell the only way to animate stroke-dashoffset in IE11 is through Javascript manually adjusting the style value which doesn't seem like an elegant solution to me.

#### What are the relevant issues?
#1556. 

#### Screenshots (if appropriate)
![IE11 Spinning example](http://g.recordit.co/F7X61ws1eI.gif)

#### Do the grommet docs need to be updated?
Nope.

#### Should this PR be mentioned in the release notes?
Sure.

#### Is this change backwards compatible or is it a breaking change?
Yep!
