### PR TITLE
Fix text input suggestions when array is empty. Closes #1549.

### DIFF
--- a/src/js/components/TextInput.js
+++ b/src/js/components/TextInput.js
@@ -125,7 +125,7 @@ export default class TextInput extends Component {
   _onInputChange (event) {
     const { onDOMChange, suggestions } = this.props;
 
-    if (suggestions && suggestions.length) {
+    if (suggestions && Array.isArray(suggestions)) {
       this.setState({
         activeSuggestionIndex: -1, announceChange: true, dropActive: true
       });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes a bug which would cause the suggestions not to show up if the initial suggestions array is empty. This issue is a bit confusing as we're checking the suggestions length before getting the new suggestions array from props. To avoid breaking any of the componentDidUpdate code I've added a looser check to the `_onInputChange` method.

#### What testing has been done on this PR?
I've tested this in the Grommet docs passing a variety of combinations of empty arrays at different stages of the filter process. I've also tested with screen reader and it appears to work well.

#### How should this be manually tested?
Test this branch in the grommet docs. To view the edge case pass an empty suggestions array to the TextInput on initial render, upon change add elements to this array. 
In `TextInputDoc.js`
```
const VALUES = [];
...
  _onDOMChange (event) {
    const suggestions = ['one', 'two'];
    this.setState({value: event.target.value, suggestions});
  }
```

#### What are the relevant issues?
#1549 Please review this issue and the corresponding codepens.

#### Do the grommet docs need to be updated?
Nope.

#### Should this PR be mentioned in the release notes?
Nope.

#### Is this change backwards compatible or is it a breaking change?
Yep.