### PR TITLE
Fix Search onSelect when drop is not active.

### DIFF
--- a/src/js/components/Search.js
+++ b/src/js/components/Search.js
@@ -165,7 +165,7 @@ export default class Search extends Component {
 
   _onInputKeyDown (event) {
     const {
-      inline, onSelect, suggestions, activeSuggestionIndex, onKeyDown
+      inline, onSelect, suggestions, onKeyDown
     } = this.props;
     const enter = 13;
     const { dropActive } = this.state;
@@ -182,11 +182,8 @@ export default class Search extends Component {
       }
     }
     if (!dropActive && onSelect && event.keyCode === enter) {
-      const suggestion = suggestions[activeSuggestionIndex];
-
       onSelect({
-        target: this._inputRef || this._controlRef,
-        suggestion: suggestion
+        target: this._inputRef || this._controlRef
       }, false);
     }
     if (onKeyDown) {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR reverts a piece of commit fc03118970d4fc949609c85b832144abff0b1232 which was causing inline searches with no suggestions to throw an error when the enter key is pressed.

#### What testing has been done on this PR?
I've tested in the docs with a variation of Search components but I'm still not totally clear what the author had in mind for this code. It seems impossible to return a suggestion if the drop is not active.

#### How should this be manually tested?
Docs on this branch.

#### What are the relevant issues?
#1544

#### Do the grommet docs need to be updated?
Nope.

#### Should this PR be mentioned in the release notes?
Potentially due to the nature of not fully understanding the original implementation's intent.

#### Is this change backwards compatible or is it a breaking change?
I would assume so but as I've noted here, I don't quite understand what the author was trying to accomplish by returning a suggestion that wasn't there.
