### PR TITLE
Fix plain Button icon/label rendering. Closes #1513.

### DIFF
--- a/__tests__/components/Button-test.js
+++ b/__tests__/components/Button-test.js
@@ -24,7 +24,9 @@ describe('Button', () => {
   });
   it('has correct plain={true} rendering', () => {
     const component = renderer.create(
-      <Button label='Test me' plain={true} />
+      <Button label='Test me' icon={<FakeIcon />} plain={true}>
+        Test Child
+      </Button>
     );
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();

--- a/__tests__/components/__snapshots__/Button-test.js.snap
+++ b/__tests__/components/__snapshots__/Button-test.js.snap
@@ -101,11 +101,7 @@ exports[`Button has correct plain={true} rendering 1`] = `
   onMouseUp={[Function]}
   type="button"
 >
-  <span
-    className="grommetux-button__label"
-  >
-    Test me
-  </span>
+  Test Child
 </button>
 `;
 

--- a/src/js/components/Button.js
+++ b/src/js/components/Button.js
@@ -107,12 +107,12 @@ export default class Button extends Component {
     const { router } = this.context;
 
     let buttonIcon;
-    if (icon) {
+    if (icon && !plain) {
       buttonIcon = <span className={`${CLASS_ROOT}__icon`}>{icon}</span>;
     }
 
     let buttonLabel;
-    if (label) {
+    if (label && !plain) {
       buttonLabel = <span className={`${CLASS_ROOT}__label`}>{label}</span>;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR allows Grommet to be a bit more opinionated regarding how the `plain` prop is handled in Button. Button will no longer render an icon or label if the `plain={true}` prop is passed to the Button.

#### What testing has been done on this PR?
Tested in docs and updated the Button tests to reflect the chance.

#### How should this be manually tested?
Docs using alias on this branch.

#### What are the relevant issues?
#1513 

#### Do the grommet docs need to be updated?
Yes they should be updated to reflect this change.

#### Should this PR be mentioned in the release notes?
👇

#### Is this change backwards compatible or is it a breaking change?
Potentially breaking if someone is using a plain Button with the icon/label prop - they will need to specifically pass these through as children now.