### PR TITLE
Changed TextInput onDOMChange to onInput to align more with HTML spec

### DIFF
--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -24,7 +24,7 @@ class TextInput extends Component {
     showDrop: false,
   }
 
-  onInputChange() {
+  resetSuggestions() {
     const { suggestions } = this.props;
 
     if (suggestions && suggestions.length) {
@@ -129,7 +129,8 @@ class TextInput extends Component {
   }
 
   render() {
-    const { defaultValue, value, onKeyDown, ...rest } = this.props;
+    const { defaultValue, value, onInput, onKeyDown, ...rest } = this.props;
+    delete rest.onInput; // se we can manage in onInputChange()
     const { showDrop } = this.state;
     // needed so that styled components does not invoke
     // onSelect when text input is clicked
@@ -205,12 +206,9 @@ class TextInput extends Component {
             defaultValue={renderLabel(defaultValue)}
             value={renderLabel(value)}
             onInput={(event) => {
-              const { onDOMChange } = this.props;
-
-              this.onInputChange();
-
-              if (onDOMChange) {
-                onDOMChange(event);
+              this.resetSuggestions();
+              if (onInput) {
+                onInput(event);
               }
             }}
           />

--- a/src/js/components/TextInput/__tests__/TextInput-test.js
+++ b/src/js/components/TextInput/__tests__/TextInput-test.js
@@ -73,11 +73,11 @@ test('TextInput show suggestions on input change', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('TextInput calls onDOMChange when onInput is called', () => {
-  const onDOMChange = jest.fn();
+test('TextInput calls onInput when input changes', () => {
+  const onInput = jest.fn();
   const component = renderer.create(
     <Grommet>
-      <TextInput id='item' name='item' onDOMChange={onDOMChange} />
+      <TextInput id='item' name='item' onInput={onInput} />
     </Grommet>
   );
   const tree = component.toJSON();
@@ -85,7 +85,7 @@ test('TextInput calls onDOMChange when onInput is called', () => {
   const input = findAllByType(tree, 'input')[0];
   const fakeEvent = {};
   input.props.onInput(fakeEvent);
-  expect(onDOMChange).toBeCalledWith(fakeEvent);
+  expect(onInput).toBeCalledWith(fakeEvent);
 });
 
 test('TextInput closes suggestion drop', () => {

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TextInput calls onDOMChange when onInput is called 1`] = `
+exports[`TextInput calls onInput when input changes 1`] = `
 .c0 {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;

--- a/src/js/components/TextInput/doc.js
+++ b/src/js/components/TextInput/doc.js
@@ -14,14 +14,13 @@ export default TextInput => schema(TextInput, {
     name: [
       PropTypes.string, 'The name attribute of the input.',
     ],
-    // TODO: investigate to rename to onChange
-    onDOMChange: [
+    onInput: [
       PropTypes.func,
       'Function that will be called when the user types in the input.',
     ],
     onSelect: [
       PropTypes.func,
-      `Function that will be called when the user selects a suggestion. 
+      `Function that will be called when the user selects a suggestion.
       The suggestion contains the object chosen from the supplied suggestions.`,
     ],
     placeholder: [
@@ -37,7 +36,7 @@ export default TextInput => schema(TextInput, {
           PropTypes.string,
         ])
       ),
-      `Suggestions to show. It is recommended to avoid showing too many 
+      `Suggestions to show. It is recommended to avoid showing too many
       suggestions and instead rely on the user to type more.`,
     ],
     value: [


### PR DESCRIPTION
#### What does this PR do?

Changes the `onDOMChange` property to be `onInput`

#### Where should the reviewer start?

TextInput.js

#### What testing has been done on this PR?

next-sample

#### How should this be manually tested?

next-sample

#### Any background context you want to provide?

no

#### What are the relevant issues?

none

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

breaking change
