### PR TITLE
Added size and plain to TextInput

### DIFF
--- a/src/js/components/TextInput/StyledTextInput.js
+++ b/src/js/components/TextInput/StyledTextInput.js
@@ -5,8 +5,25 @@ import { focusStyle, inputStyle, parseMetricToInt } from '../utils';
 const placeholderColor = css`
   color: ${props => props.theme.global.placeholder.color};
 `;
+
+const sizeStyle = (props) => {
+  const data = props.theme.text[props.size];
+  return css`
+    font-size: ${data.size};
+    line-height: ${data.height};
+  `;
+};
+
+const plainStyle = css`
+  border: none;
+  width: 100%;
+`;
+
 const StyledTextInput = styled.input`
   ${inputStyle}
+
+  ${props => props.size && sizeStyle(props)}
+  ${props => props.plain && plainStyle}
 
   &::-webkit-input-placeholder {
     ${placeholderColor}
@@ -28,6 +45,10 @@ const StyledTextInput = styled.input`
   &:focus {
     ${focusStyle}
   }
+`;
+
+export const StyledTextInputContainer = styled.div`
+  ${props => props.plain && css`width: 100%`}
 `;
 
 const activeStyle = css`

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import { compose } from 'recompose';
 
-import StyledTextInput, { StyledSuggestion, StyledSuggestions } from './StyledTextInput';
+import StyledTextInput,
+  { StyledTextInputContainer, StyledSuggestion, StyledSuggestions } from './StyledTextInput';
 import { Button } from '../Button';
 import { Keyboard } from '../Keyboard';
 import { Drop } from '../Drop';
@@ -188,7 +189,7 @@ class TextInput extends Component {
       );
     }
     return (
-      <div>
+      <StyledTextInputContainer plain={rest.plain}>
         <Keyboard
           onEnter={onEnterSuggestionHandler}
           onEsc={() => this.setState({ showDrop: false })}
@@ -214,7 +215,7 @@ class TextInput extends Component {
           />
         </Keyboard>
         {drop}
-      </div>
+      </StyledTextInputContainer>
     );
   }
 }

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -76,7 +76,9 @@ exports[`TextInput calls onInput when input changes 1`] = `
 <div
   className="c0"
 >
-  <div>
+  <div
+    className=""
+  >
     <input
       autoComplete="off"
       className="c1"
@@ -171,7 +173,9 @@ exports[`TextInput handles next and previous without suggestion 1`] = `
 <div
   className="c0"
 >
-  <div>
+  <div
+    className=""
+  >
     <input
       autoComplete="off"
       className="c1"
@@ -266,7 +270,9 @@ exports[`TextInput renders 1`] = `
 <div
   className="c0"
 >
-  <div>
+  <div
+    className=""
+  >
     <input
       autoComplete="off"
       className="c1"
@@ -361,7 +367,9 @@ exports[`TextInput renders with complex suggestions 1`] = `
 <div
   className="c0"
 >
-  <div>
+  <div
+    className=""
+  >
     <input
       autoComplete="off"
       className="c1"
@@ -456,7 +464,9 @@ exports[`TextInput renders with suggestions 1`] = `
 <div
   className="c0"
 >
-  <div>
+  <div
+    className=""
+  >
     <input
       autoComplete="off"
       className="c1"
@@ -551,7 +561,9 @@ exports[`TextInput show suggestions on input change 1`] = `
 <div
   className="c0"
 >
-  <div>
+  <div
+    className=""
+  >
     <input
       autoComplete="off"
       className="c1"
@@ -646,7 +658,9 @@ exports[`TextInput show suggestions on input change 2`] = `
 <div
   className="c0"
 >
-  <div>
+  <div
+    className=""
+  >
     <input
       autoComplete="off"
       className="c1"

--- a/src/js/components/TextInput/doc.js
+++ b/src/js/components/TextInput/doc.js
@@ -26,6 +26,15 @@ export default TextInput => schema(TextInput, {
     placeholder: [
       PropTypes.string, 'Placeholder text to use when the input is empty.',
     ],
+    plain: [
+      PropTypes.bool,
+      `Whether this is a plain input with no border or padding.
+      Only use this when the containing context provides sufficient affordance`,
+    ],
+    size: [
+      PropTypes.oneOf(['small', 'medium', 'large', 'xlarge']),
+      'The size of the TextInput.',
+    ],
     suggestions: [
       PropTypes.arrayOf(
         PropTypes.oneOfType([


### PR DESCRIPTION
#### What does this PR do?

Adds `size` and `plain` to TextInput.

#### Where should the reviewer start?

TextInput/doc.js

#### What testing has been done on this PR?

next-sample and grommet-people-finder

#### How should this be manually tested?

next-sample

#### Any background context you want to provide?

This allows larger Search text input elements for search-centric UIs.

#### What are the relevant issues?

none

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

compatible