### PR TITLE
Fix compact Form checkbox/radio button overflow bug. Closes #1338.

### DIFF
--- a/src/scss/grommet-core/_objects.form.scss
+++ b/src/scss/grommet-core/_objects.form.scss
@@ -75,6 +75,19 @@
   max-width: $compact-form-width;
 
   // Fixes a bug in Windows which causes overflow.
-  .#{$grommet-namespace}check-box__label { width: calc(100% - 36px); }
-  .#{$grommet-namespace}radio-button__label { width: calc(100% - 36px); }
+  label.#{$grommet-namespace}check-box {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  label.#{$grommet-namespace}radio-button {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    .#{$grommet-namespace}radio-button__control {
+      min-width: 24px;
+    }
+  }
 }

--- a/src/scss/grommet-core/_objects.form.scss
+++ b/src/scss/grommet-core/_objects.form.scss
@@ -87,7 +87,7 @@
     align-items: center;
 
     .#{$grommet-namespace}radio-button__control {
-      min-width: 24px;
+      min-width: $inuit-base-spacing-unit;
     }
   }
 }

--- a/src/scss/grommet-core/_objects.form.scss
+++ b/src/scss/grommet-core/_objects.form.scss
@@ -73,4 +73,8 @@
 
 .#{$grommet-namespace}form--compact {
   max-width: $compact-form-width;
+
+  // Fixes a bug in Windows which causes overflow.
+  .#{$grommet-namespace}check-box__label { width: calc(100% - 36px); }
+  .#{$grommet-namespace}radio-button__label { width: calc(100% - 36px); }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes a compact Form overflow bug seen in Windows based machines.

#### What testing has been done on this PR?
Tested on Windows 10 / Chrome

#### What are the relevant issues?
#1338 

#### Screenshots (if appropriate)
**Before**
![f45eb6ec-3013-11e7-95f1-310560cd593b](https://user-images.githubusercontent.com/5983843/30340925-283b921c-97c2-11e7-9624-171ad5d1957a.png)

### After
![screen shot 2017-09-12 at 2 05 14 pm](https://user-images.githubusercontent.com/5983843/30341277-706465f4-97c3-11e7-9c0c-9556415093c8.png)

#### Do the grommet docs need to be updated?
Nope.

#### Should this PR be mentioned in the release notes?
Nope.

#### Is this change backwards compatible or is it a breaking change?
This change is backward compatible.