### PR TITLE
Fix Menu Anchor path bug. Closes #1611.

### DIFF
--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -285,8 +285,13 @@ export default class Menu extends Component {
           document.removeEventListener('click', this._checkOnClose);
           document.removeEventListener('touchstart', this._checkOnClose);
           if (this._drop) {
-            this._drop.remove();
-            this._drop = undefined;
+            // When Menu is used with Anchor/paths the Drop removes too quickly
+            // and react looks for a DOM element which is gone. Adding a
+            // slight delay resolves this issue.
+            setTimeout(() => {
+              this._drop.remove();
+              this._drop = undefined;
+            }, 5);
           }
           break;
         case 'focused':


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes a bug in Menu which was causing React to throw an error. 
```
Uncaught Error: React DOM tree root should always have a node reference.
```
Stack trace:

invariant | @ | invariant.js?4599:44
-- | -- | --
getNodeFromInstance | @ | ReactDOMComponentTree.js?8ff5:172
didPutListener | @ | SimpleEventPlugin.js?6c81:209
putListener | @ | EventPluginHub.js?0f32:140
putListener | @ | ReactDOMComponent.js?ab8a:177
notifyAll | @ | CallbackQueue.js?f006:76
close | @ | ReactReconcileTransaction.js?ba2e:80
closeAll | @ | Transaction.js?f15f:209
perform | @ | Transaction.js?f15f:156
perform | @ | Transaction.js?f15f:143
perform | @ | ReactUpdates.js?8e6b:89
flushBatchedUpdates | @ | ReactUpdates.js?8e6b:172
closeAll | @ | Transaction.js?f15f:209
perform | @ | Transaction.js?f15f:156
batchedUpdates | @ | ReactDefaultBatchingStrategy.js?e9be:62
batchedUpdates | @ | ReactUpdates.js?8e6b:97
dispatchEvent | @ | ReactEventListener.js?944f:147

This error is thrown when an Anchor with a path prop is clicked within Menu. This PR adds a 5 ms delay to removing the drop which allows React to correctly traverse the DOM for the node. I can only assume this bug was introduced via dependencies updating as I could not nail down a specific piece of code which was causing this issue.

#### What testing has been done on this PR?
Tested in the docs using alias.

#### How should this be manually tested?
This branch using the following snippet:
```
<Menu label='menu'>
  <Anchor label='test' path='test' />
</Menu>
```

#### What are the relevant issues?
#1611 

#### Do the grommet docs need to be updated?
Nope.

#### Should this PR be mentioned in the release notes?
Nope.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.