### PR TITLE
Fix Tile select bug. Closes #1250.

### DIFF
--- a/__tests__/components/Tiles-test.js
+++ b/__tests__/components/Tiles-test.js
@@ -28,4 +28,21 @@ describe('Tiles', () => {
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+  it('renders selected tiles', () => {
+    const component = renderer.create(
+      <Tiles selected={[0, 1]}>
+        <Tile>
+          First
+        </Tile>
+        <Tile>
+          Second
+        </Tile>
+        <Tile>
+          Third
+        </Tile>
+      </Tiles>
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/__tests__/components/__snapshots__/Tiles-test.js.snap
+++ b/__tests__/components/__snapshots__/Tiles-test.js.snap
@@ -41,3 +41,45 @@ exports[`Tiles has correct default options 1`] = `
   </div>
 </div>
 `;
+
+exports[`Tiles renders selected tiles 1`] = `
+<div
+  className="grommetux-box grommetux-box--direction-row grommetux-box--justify-start grommetux-box--responsive grommetux-box--pad-small grommetux-box--wrap grommetux-tiles grommetux-tiles--flush"
+  id={undefined}
+  onClick={undefined}
+  role={undefined}
+  style={Object {}}
+  tabIndex={undefined}
+>
+  <div
+    className="grommetux-box grommetux-box--direction-column grommetux-box--align-center grommetux-box--responsive grommetux-box--pad-none grommetux-tile grommetux-tile--selected grommetux-none-hover-color-index-disabled grommetux-tile--hover-border-small"
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}
+  >
+    First
+  </div>
+  <div
+    className="grommetux-box grommetux-box--direction-column grommetux-box--align-center grommetux-box--responsive grommetux-box--pad-none grommetux-tile grommetux-tile--selected grommetux-none-hover-color-index-disabled grommetux-tile--hover-border-small"
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}
+  >
+    Second
+  </div>
+  <div
+    className="grommetux-box grommetux-box--direction-column grommetux-box--align-center grommetux-box--responsive grommetux-box--pad-none grommetux-tile grommetux-none-hover-color-index-disabled grommetux-tile--hover-border-small"
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}
+  >
+    Third
+  </div>
+</div>
+`;

--- a/src/js/components/Tile.js
+++ b/src/js/components/Tile.js
@@ -14,7 +14,7 @@ export default class Tile extends Component {
 
   render () {
     const { children, className, onClick, wide, status,
-      hoverStyle, hoverColorIndex, hoverBorder, hoverBorderSize
+      hoverStyle, hoverColorIndex, hoverBorder, hoverBorderSize, selected
     } = this.props;
     const restProps = Props.omit(this.props, Object.keys(Tile.propTypes));
 
@@ -28,6 +28,7 @@ export default class Tile extends Component {
       className,
       {
         [`${CLASS_ROOT}--status-${statusClass}`]: status,
+        [`${CLASS_ROOT}--selected`]: selected,
         [`${CLASS_ROOT}--wide`]: wide,
         [`${CLASS_ROOT}--selectable`]: onClick,
         [`${NAMESPACE}${hoverStyle}${(hoverStyle == 'border') ?
@@ -53,6 +54,7 @@ Tile.propTypes = {
   hoverColorIndex: PropTypes.string,
   hoverBorder: PropTypes.bool,
   hoverBorderSize: PropTypes.oneOf(['small', 'medium', 'large']),
+  selected: PropTypes.bool,
   wide: PropTypes.bool, /// remove in 1.0? Box.basis='full'
   ...Box.propTypes
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes two issues. First, when a Tile is set to `selected={true}` [it would not render selected](https://codepen.io/karatechops/pen/jGErod?editors=0010). Secondly, when a colorIndex is defined on a tile and the tile is part of the `selected` array passed to Tiles [it does not render as selected](https://codepen.io/ezzatron/pen/gmvKBE).

#### What testing has been done on this PR?
Tested in the docs.

#### How should this be manually tested?
This branch in the docs with the following snippet
```
<Tiles fill selectable flush={false} colorIndex='light-2' selected={[ 0, 2 ]}>
  <Tile colorIndex='light-1'>0</Tile>
  <Tile colorIndex='light-1'>1</Tile>
  <Tile>2</Tile>
</Tiles>
```
or
```
<Tiles fill selectable flush={false} colorIndex='light-2'>
  <Tile colorIndex='light-1'>0</Tile>
  <Tile colorIndex='light-1'>1</Tile>
  <Tile selected>2</Tile>
</Tiles>
```

#### Any background context you want to provide?
Tiles is currently appending the DOM with selected classes using utility functions, this approach is causing race conditions or the classes to be overwritten when components re-render. These utils were written 2+ years ago, we've learned a lot about how to apply classes since then. These days touching the DOM, especially the `classList`, with React is more of a last ditch effort and we rely on triggering re-renders to adjust our data and classes. Tiles could very much so benefit from a refactor but this late in 1.x I don't believe it's worth it. 

I've left in a few of the DOM adjusting utils and fixed the issue bugs. I did not want to disrupt too much of the code.

#### What are the relevant issues?
#1250

#### Do the grommet docs need to be updated?
Nope.

#### Should this PR be mentioned in the release notes?
Nope.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.