### PR TITLE
do not show the menu's control if when expanded the menu doesn't over…

### DIFF
--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -505,7 +505,9 @@ export default class Menu extends Component {
         <Box ref={ref => this._controlRef = ref} {...props} className={classes}>
           <Button plain={true} reverse={true}
             a11yTitle={menuTitle} {...this._renderButtonProps()}
-            onClick={() => this.setState({state: 'expanded'})}
+            onClick={() => this.setState({
+              state: this.state.state !== 'expanded' ? 'expanded' : 'collapsed'
+            })}
             onFocus={this._onFocusControl} onBlur={this._onBlurControl} />
         </Box>
       );

--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -166,13 +166,23 @@ class MenuDrop extends Component {
     });
 
     let contents = [
-      React.cloneElement(control, {key: 'control', fill: true}),
       <Box {...restProps} key="nav" ref={ref => this.navContainerRef = ref}
         tag="nav" className={`${CLASS_ROOT}__contents`}
         primary={false}>
         {menuDropChildren}
       </Box>
     ];
+
+    // do not show the control if menu doesn't overlap with it when expanded
+    const showControl =
+        ('top' === dropAlign.top || 'bottom' === dropAlign.bottom) && 
+        ('left' === dropAlign.left || 'right' === dropAlign.right);
+    
+    if(showControl) {
+      contents.unshift(
+                  React.cloneElement(control, {key: 'control', fill: true}));
+    }
+
 
     if (dropAlign.bottom) {
       contents.reverse();


### PR DESCRIPTION
…lap with the control (e.g. when someone wants *only* the menu items to display below the control, ie top: bottom)

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
It fixes how Menu items are rendered when the expanded menu doesn't overlap with the control (e.g. when dropAlight={left:left, top: bottom}) 

#### Where should the reviewer start?

#### What testing has been done on this PR?
Manual

#### How should this be manually tested?
1. create a menu with a few items 
2. ensure to set dropAlign such that menu doesn't overlap with control, e.g. dropAlign={{ left: 'left', top: 'bottom' }}
3. check that all menu items are shown and work as expected, but the control itself isn't show as the first item

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/1208
https://github.com/grommet/grommet/issues/981

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
