### PR TITLE
Pass the classname prop to the MenuDrop and child Box component

### DIFF
--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -179,6 +179,7 @@ class MenuDrop extends Component {
     }
 
     let classes = classnames(
+      this.props.className,
       `${CLASS_ROOT}__drop`,
       {
         [`${CLASS_ROOT}__drop--align-right`]: dropAlign.right,
@@ -430,6 +431,7 @@ export default class Menu extends Component {
 
     return (
       <MenuDrop {...boxProps} {...this.context}
+        className={this.props.className}
         dropAlign={this.props.dropAlign}
         size={this.props.size}
         onClick={onClick}

--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -179,9 +179,9 @@ class MenuDrop extends Component {
     }
 
     let classes = classnames(
-      `${this.props.className}__drop`,
       `${CLASS_ROOT}__drop`,
       {
+        [`${this.props.className}__drop`]: this.props.className,
         [`${CLASS_ROOT}__drop--align-right`]: dropAlign.right,
         [`${CLASS_ROOT}__drop--${size}`]: size
       }

--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -179,7 +179,7 @@ class MenuDrop extends Component {
     }
 
     let classes = classnames(
-      this.props.className,
+      `${this.props.className}__drop`,
       `${CLASS_ROOT}__drop`,
       {
         [`${CLASS_ROOT}__drop--align-right`]: dropAlign.right,


### PR DESCRIPTION
Signed-off-by: Sarah Allen <sarah@zooniverse.org>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This adds the classname prop to the `MenuDrop` and its child `Box` component. 

#### Where should the reviewer start?
Just a simple two line change in Menu.js

#### What testing has been done on this PR?
I didn't write any tests but didn't as it would seem more like testing React than the Grommet library, in my opinion. If the grommet team feels different, I am happy to write a simple unit test for this.

#### How should this be manually tested?
Create a `Menu` component with a `className` prop and check in the DOM using dev tools and React Dev Tools to see that the classname is applied to the div component that is inserted in the DOM body.

#### Any background context you want to provide?
I have a grommet `Menu` component that I'd like to slightly modify the styles for a specific use case. I can add a className to the parent `Menu` component as expected, but that class is not applied to the `MenuDrop` and its child `Box` component when it is opened. Currently, I have to write some styles targeting the `grommetux-menu__drop` class at a global level. This is because the `DropContents` component is inserted as a child of the DOM body tag. While targeting `grommeux-menu__drop` in the style sheet works, it is undesirable if I want to use the `Menu` elsewhere on my app with the base grommet styles.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible. Should be a minor version bump using semver.