### PR TITLE
NEXT Stack refactor

### DIFF
--- a/src/js/components/Stack/Stack.js
+++ b/src/js/components/Stack/Stack.js
@@ -7,6 +7,8 @@ import { withTheme } from '../hocs';
 
 import doc from './doc';
 
+import styleMap from './styleMap';
+
 class Stack extends Component {
   static defaultProps = {
     anchor: 'center',
@@ -23,40 +25,8 @@ class Stack extends Component {
       const style = {
         position: 'absolute',
         overflow: 'hidden',
+        ...styleMap[anchor],
       };
-      if (anchor === 'center') {
-        style.top = '50%';
-        style.left = '50%';
-        style.transform = 'translate(-50%, -50%)';
-      } else if (anchor === 'left') {
-        style.top = '50%';
-        style.left = '0';
-        style.transform = 'translateY(-50%)';
-      } else if (anchor === 'right') {
-        style.top = '50%';
-        style.right = '0';
-        style.transform = 'translateY(-50%)';
-      } else if (anchor === 'top') {
-        style.top = '0';
-        style.right = '50%';
-        style.transform = 'translateX(-50%)';
-      } else if (anchor === 'bottom') {
-        style.top = '0';
-        style.right = '50%';
-        style.transform = 'translateX(-50%)';
-      } else if (anchor === 'top-left') {
-        style.top = '0';
-        style.left = '0';
-      } else if (anchor === 'bottom-left') {
-        style.bottom = '0';
-        style.left = '0';
-      } else if (anchor === 'top-right') {
-        style.top = '0';
-        style.right = '0';
-      } else if (anchor === 'bottom-right') {
-        style.bottom = '0';
-        style.right = '0';
-      }
       return React.cloneElement(child, { style });
     });
 

--- a/src/js/components/Stack/styleMap.js
+++ b/src/js/components/Stack/styleMap.js
@@ -1,0 +1,43 @@
+export default {
+  'center': {
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+  },
+  'left': {
+    top: '50%',
+    left: '0',
+    transform: 'translateY(-50%)',
+  },
+  'right': {
+    top: '50%',
+    right: '0',
+    transform: 'translateY(-50%)',
+  },
+  'top': {
+    top: '0',
+    right: '50%',
+    transform: 'translateX(-50%)',
+  },
+  'bottom': {
+    top: '0',
+    right: '50%',
+    transform: 'translateX(-50%)',
+  },
+  'top-left': {
+    top: '0',
+    left: '0',
+  },
+  'bottom-left': {
+    bottom: '0',
+    left: '0',
+  },
+  'top-right': {
+    top: '0',
+    right: '0',
+  },
+  'bottom-right': {
+    bottom: '0',
+    right: '0',
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Refactor's the NEXT stack component so that the style object is externalized into a Map.  This should make it easier to maintain and make the Stack component cleaner.

It might be a good idea to do this within the styled-component, but I will leave that for another PR.

#### Where should the reviewer start?
See the Diff

#### What testing has been done on this PR?
Tested with next-sample

#### How should this be manually tested?
Use the stack component and verify that the functionality is the same.

#### Any background context you want to provide?
N/A

#### What are the relevant issues?
N/A

#### Screenshots (if appropriate)
N/A

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible