### PR TITLE
Enhanced Chart to allow range for bar and area types.

### DIFF
--- a/src/js/components/Chart/Chart.js
+++ b/src/js/components/Chart/Chart.js
@@ -28,7 +28,7 @@ const renderBars = (values, bounds, scale, height) =>
         </g>
       );
     }
-    return null;
+    return undefined;
   });
 
 const renderLine = (values, bounds, scale, height) => {

--- a/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
+++ b/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
@@ -59,19 +59,7 @@ exports[`Chart cap renders 1`] = `
           sixty
         </title>
         <path
-          d="M NaN,NaN
-              L NaN,NaN"
-        />
-      </g>
-      <g
-        fill="none"
-      >
-        <title>
-          zero
-        </title>
-        <path
-          d="M NaN,NaN
-              L NaN,NaN"
+          d="M 384,192 L 384,0"
         />
       </g>
     </g>
@@ -95,9 +83,7 @@ exports[`Chart cap renders 1`] = `
         fill="none"
       >
         <path
-          d="M
-              NaN,NaN L
-              NaN,NaN"
+          d="M 0,192 L 384,0"
         />
       </g>
     </g>
@@ -121,7 +107,7 @@ exports[`Chart cap renders 1`] = `
         fill="#00CCEB"
       >
         <path
-          d="M 0,192M NaN,192 L NaN,NaN L NaN,NaNL NaN,192 Z"
+          d="M 0,192 L 384,0 L 384,192 L 0,192 Z"
         />
       </g>
     </g>
@@ -177,7 +163,7 @@ exports[`Chart renders 1`] = `
     <title />
     <g
       stroke="#00CCEB"
-      strokeLinecap="square"
+      strokeLinecap="butt"
       strokeLinejoin="miter"
       strokeWidth={24}
     />
@@ -193,7 +179,7 @@ exports[`Chart renders 1`] = `
     <title />
     <g
       stroke="#00CCEB"
-      strokeLinecap="square"
+      strokeLinecap="butt"
       strokeLinejoin="miter"
       strokeWidth={24}
     >
@@ -204,19 +190,7 @@ exports[`Chart renders 1`] = `
           sixty
         </title>
         <path
-          d="M NaN,NaN
-              L NaN,NaN"
-        />
-      </g>
-      <g
-        fill="none"
-      >
-        <title>
-          zero
-        </title>
-        <path
-          d="M NaN,NaN
-              L NaN,NaN"
+          d="M 384,192 L 384,0"
         />
       </g>
     </g>
@@ -272,7 +246,7 @@ exports[`Chart size renders 1`] = `
     <title />
     <g
       stroke="#00CCEB"
-      strokeLinecap="square"
+      strokeLinecap="butt"
       strokeLinejoin="miter"
       strokeWidth={24}
     >
@@ -283,19 +257,7 @@ exports[`Chart size renders 1`] = `
           sixty
         </title>
         <path
-          d="M NaN,NaN
-              L NaN,NaN"
-        />
-      </g>
-      <g
-        fill="none"
-      >
-        <title>
-          zero
-        </title>
-        <path
-          d="M NaN,NaN
-              L NaN,NaN"
+          d="M 96,96 L 96,0"
         />
       </g>
     </g>
@@ -311,7 +273,7 @@ exports[`Chart size renders 1`] = `
     <title />
     <g
       stroke="#00CCEB"
-      strokeLinecap="square"
+      strokeLinecap="butt"
       strokeLinejoin="miter"
       strokeWidth={24}
     >
@@ -322,19 +284,7 @@ exports[`Chart size renders 1`] = `
           sixty
         </title>
         <path
-          d="M NaN,NaN
-              L NaN,NaN"
-        />
-      </g>
-      <g
-        fill="none"
-      >
-        <title>
-          zero
-        </title>
-        <path
-          d="M NaN,NaN
-              L NaN,NaN"
+          d="M 192,192 L 192,0"
         />
       </g>
     </g>
@@ -350,7 +300,7 @@ exports[`Chart size renders 1`] = `
     <title />
     <g
       stroke="#00CCEB"
-      strokeLinecap="square"
+      strokeLinecap="butt"
       strokeLinejoin="miter"
       strokeWidth={24}
     >
@@ -361,19 +311,7 @@ exports[`Chart size renders 1`] = `
           sixty
         </title>
         <path
-          d="M NaN,NaN
-              L NaN,NaN"
-        />
-      </g>
-      <g
-        fill="none"
-      >
-        <title>
-          zero
-        </title>
-        <path
-          d="M NaN,NaN
-              L NaN,NaN"
+          d="M 384,384 L 384,0"
         />
       </g>
     </g>
@@ -389,7 +327,7 @@ exports[`Chart size renders 1`] = `
     <title />
     <g
       stroke="#00CCEB"
-      strokeLinecap="square"
+      strokeLinecap="butt"
       strokeLinejoin="miter"
       strokeWidth={24}
     >
@@ -400,19 +338,7 @@ exports[`Chart size renders 1`] = `
           sixty
         </title>
         <path
-          d="M NaN,NaN
-              L NaN,NaN"
-        />
-      </g>
-      <g
-        fill="none"
-      >
-        <title>
-          zero
-        </title>
-        <path
-          d="M NaN,NaN
-              L NaN,NaN"
+          d="M 768,768 L 768,0"
         />
       </g>
     </g>
@@ -428,7 +354,7 @@ exports[`Chart size renders 1`] = `
     <title />
     <g
       stroke="#00CCEB"
-      strokeLinecap="square"
+      strokeLinecap="butt"
       strokeLinejoin="miter"
       strokeWidth={24}
     >
@@ -439,19 +365,7 @@ exports[`Chart size renders 1`] = `
           sixty
         </title>
         <path
-          d="M NaN,NaN
-              L NaN,NaN"
-        />
-      </g>
-      <g
-        fill="none"
-      >
-        <title>
-          zero
-        </title>
-        <path
-          d="M NaN,NaN
-              L NaN,NaN"
+          d="M 1152,1152 L 1152,0"
         />
       </g>
     </g>
@@ -507,7 +421,7 @@ exports[`Chart thickness renders 1`] = `
     <title />
     <g
       stroke="#00CCEB"
-      strokeLinecap="square"
+      strokeLinecap="butt"
       strokeLinejoin="miter"
       strokeWidth={6}
     >
@@ -518,19 +432,7 @@ exports[`Chart thickness renders 1`] = `
           sixty
         </title>
         <path
-          d="M NaN,NaN
-              L NaN,NaN"
-        />
-      </g>
-      <g
-        fill="none"
-      >
-        <title>
-          zero
-        </title>
-        <path
-          d="M NaN,NaN
-              L NaN,NaN"
+          d="M 384,192 L 384,0"
         />
       </g>
     </g>
@@ -546,7 +448,7 @@ exports[`Chart thickness renders 1`] = `
     <title />
     <g
       stroke="#00CCEB"
-      strokeLinecap="square"
+      strokeLinecap="butt"
       strokeLinejoin="miter"
       strokeWidth={12}
     >
@@ -557,19 +459,7 @@ exports[`Chart thickness renders 1`] = `
           sixty
         </title>
         <path
-          d="M NaN,NaN
-              L NaN,NaN"
-        />
-      </g>
-      <g
-        fill="none"
-      >
-        <title>
-          zero
-        </title>
-        <path
-          d="M NaN,NaN
-              L NaN,NaN"
+          d="M 384,192 L 384,0"
         />
       </g>
     </g>
@@ -585,7 +475,7 @@ exports[`Chart thickness renders 1`] = `
     <title />
     <g
       stroke="#00CCEB"
-      strokeLinecap="square"
+      strokeLinecap="butt"
       strokeLinejoin="miter"
       strokeWidth={24}
     >
@@ -596,19 +486,7 @@ exports[`Chart thickness renders 1`] = `
           sixty
         </title>
         <path
-          d="M NaN,NaN
-              L NaN,NaN"
-        />
-      </g>
-      <g
-        fill="none"
-      >
-        <title>
-          zero
-        </title>
-        <path
-          d="M NaN,NaN
-              L NaN,NaN"
+          d="M 384,192 L 384,0"
         />
       </g>
     </g>
@@ -624,7 +502,7 @@ exports[`Chart thickness renders 1`] = `
     <title />
     <g
       stroke="#00CCEB"
-      strokeLinecap="square"
+      strokeLinecap="butt"
       strokeLinejoin="miter"
       strokeWidth={48}
     >
@@ -635,19 +513,7 @@ exports[`Chart thickness renders 1`] = `
           sixty
         </title>
         <path
-          d="M NaN,NaN
-              L NaN,NaN"
-        />
-      </g>
-      <g
-        fill="none"
-      >
-        <title>
-          zero
-        </title>
-        <path
-          d="M NaN,NaN
-              L NaN,NaN"
+          d="M 384,192 L 384,0"
         />
       </g>
     </g>
@@ -663,7 +529,7 @@ exports[`Chart thickness renders 1`] = `
     <title />
     <g
       stroke="#00CCEB"
-      strokeLinecap="square"
+      strokeLinecap="butt"
       strokeLinejoin="miter"
       strokeWidth={96}
     >
@@ -674,19 +540,7 @@ exports[`Chart thickness renders 1`] = `
           sixty
         </title>
         <path
-          d="M NaN,NaN
-              L NaN,NaN"
-        />
-      </g>
-      <g
-        fill="none"
-      >
-        <title>
-          zero
-        </title>
-        <path
-          d="M NaN,NaN
-              L NaN,NaN"
+          d="M 384,192 L 384,0"
         />
       </g>
     </g>
@@ -742,7 +596,7 @@ exports[`Chart type renders 1`] = `
     <title />
     <g
       stroke="#00CCEB"
-      strokeLinecap="square"
+      strokeLinecap="butt"
       strokeLinejoin="miter"
       strokeWidth={24}
     >
@@ -753,19 +607,7 @@ exports[`Chart type renders 1`] = `
           sixty
         </title>
         <path
-          d="M NaN,NaN
-              L NaN,NaN"
-        />
-      </g>
-      <g
-        fill="none"
-      >
-        <title>
-          zero
-        </title>
-        <path
-          d="M NaN,NaN
-              L NaN,NaN"
+          d="M 384,192 L 384,0"
         />
       </g>
     </g>
@@ -781,7 +623,7 @@ exports[`Chart type renders 1`] = `
     <title />
     <g
       stroke="#00CCEB"
-      strokeLinecap="square"
+      strokeLinecap="butt"
       strokeLinejoin="miter"
       strokeWidth={24}
     >
@@ -789,9 +631,7 @@ exports[`Chart type renders 1`] = `
         fill="none"
       >
         <path
-          d="M
-              NaN,NaN L
-              NaN,NaN"
+          d="M 384,0 L 0,192"
         />
       </g>
     </g>
@@ -807,7 +647,7 @@ exports[`Chart type renders 1`] = `
     <title />
     <g
       stroke="#00CCEB"
-      strokeLinecap="square"
+      strokeLinecap="butt"
       strokeLinejoin="miter"
       strokeWidth={24}
     >
@@ -815,7 +655,7 @@ exports[`Chart type renders 1`] = `
         fill="#00CCEB"
       >
         <path
-          d="M 0,192M NaN,192 L NaN,NaN L NaN,NaNL NaN,192 Z"
+          d="M 384,0 L 0,192 L 0,192 L 384,192 Z"
         />
       </g>
     </g>

--- a/src/js/components/Chart/doc.js
+++ b/src/js/components/Chart/doc.js
@@ -35,7 +35,7 @@ export default Chart => schema(Chart, {
     ],
     thickness: [
       PropTypes.oneOf(['xsmall', 'small', 'medium', 'large', 'xlarge']),
-      'The size of the lines or bars. Defaults to medium.',
+      'The width of the stroke. Defaults to medium.',
     ],
     title: [
       PropTypes.string, // .isRequired isn't working?
@@ -51,7 +51,8 @@ export default Chart => schema(Chart, {
         value: PropTypes.arrayOf(PropTypes.number).isRequired,
       })),
       `Array of value objects describing the data.
-      'value' is a tuple indicating the coordinate of the value.
+      'value' is a tuple indicating the coordinate of the value or a triple
+      indicating the x coordinate and a range of two y coordinates.
       'label' is a text string describing it.`,
     ],
   },


### PR DESCRIPTION
#### What does this PR do?

Allows Chart values to take a triple or tuple. When a triple, [x, y1, y2], the bar or area is drawn between y1 and y2 at x.

#### Where should the reviewer start?

Chart/doc.js

#### What testing has been done on this PR?

next-sample

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

compatible