### PR TITLE
Enhance Heading to allow 'none' for top or bottom margin

### DIFF
--- a/src/js/components/Heading/StyledHeading.js
+++ b/src/js/components/Heading/StyledHeading.js
@@ -14,13 +14,22 @@ const marginStyle = (props) => {
       margin-bottom: ${margin};
     `;
   }
+  let result = '';
   if (props.margin.top) {
-    return `margin-top: ${props.theme.global.edgeSize[props.margin.top]};`;
+    if (props.margin.top === 'none') {
+      result += 'margin-top: 0;';
+    } else {
+      result += `margin-top: ${props.theme.global.edgeSize[props.margin.top]};`;
+    }
   }
   if (props.margin.bottom) {
-    return `margin-bottom: ${props.theme.global.edgeSize[props.margin.bottom]};`;
+    if (props.margin.bottom === 'none') {
+      result += 'margin-bottom: 0;';
+    } else {
+      result += `margin-bottom: ${props.theme.global.edgeSize[props.margin.bottom]};`;
+    }
   }
-  return '';
+  return result;
 };
 
 const sizeStyle = (props) => {

--- a/src/js/components/Heading/__tests__/Heading-test.js
+++ b/src/js/components/Heading/__tests__/Heading-test.js
@@ -70,6 +70,8 @@ test('Heading margin renders', () => {
       <Heading margin='none' />
       <Heading margin={{ bottom: 'small' }} />
       <Heading margin={{ top: 'small' }} />
+      <Heading margin={{ bottom: 'none' }} />
+      <Heading margin={{ top: 'none' }} />
     </Grommet>
   );
   const tree = component.toJSON();

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -136,6 +136,20 @@ exports[`Heading margin renders 1`] = `
   margin-top: 12px;
 }
 
+.c7 {
+  font-size: 48px;
+  line-height: 1.125;
+  font-weight: 300;
+  margin-bottom: 0;
+}
+
+.c8 {
+  font-size: 48px;
+  line-height: 1.125;
+  font-weight: 300;
+  margin-top: 0;
+}
+
 @media only screen and (min-width:481px) {
   .c0 {
     top: 0px;
@@ -168,6 +182,12 @@ exports[`Heading margin renders 1`] = `
   />
   <h1
     className="c6"
+  />
+  <h1
+    className="c7"
+  />
+  <h1
+    className="c8"
   />
 </div>
 `;

--- a/src/js/components/Heading/doc.js
+++ b/src/js/components/Heading/doc.js
@@ -15,8 +15,8 @@ export default Heading => schema(Heading, {
       PropTypes.oneOfType([
         PropTypes.oneOf(['none', 'small', 'medium', 'large']),
         PropTypes.shape({
-          bottom: PropTypes.oneOf(['small', 'medium', 'large']),
-          top: PropTypes.oneOf(['small', 'medium', 'large']),
+          bottom: PropTypes.oneOf(['none', 'small', 'medium', 'large']),
+          top: PropTypes.oneOf(['none', 'small', 'medium', 'large']),
         }),
       ]),
       `The amount of margin above and/or below the heading. An object can be


### PR DESCRIPTION
#### What does this PR do?

Adds support for 'none' as a value for top or bottom margin on Heading.

#### Where should the reviewer start?

Heading/doc.js

#### What testing has been done on this PR?

next-sample

#### How should this be manually tested?

next-sample

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

compatible