### PR TITLE
Aded object freeze to theme objects.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,8 @@
     "childContextTypes": true,
     "contextTypes": true,
     "state": true,
-    "Event": true
+    "Event": true,
+    "fail": true,
   },
   "rules": {
     "indent": "off",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,6 @@
     "styled-components": ">= 2.1.1"
   },
   "dependencies": {
-    "clone-deep": "^1.0.0",
-    "deep-assign": "^2.0.0",
     "grommet-icons": "^0.10.0",
     "markdown-to-jsx": "^5.4.2",
     "polished": "^1.3.0",

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -2,14 +2,13 @@ import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
 
 import PropTypes from 'prop-types';
-import deepAssign from 'deep-assign';
-import cloneDeep from 'clone-deep';
 
 import StyledDrop from './StyledDrop';
 
-import baseTheme from '../../themes/vanilla';
-
 import { findScrollParents } from '../utils';
+
+import baseTheme from '../../themes/vanilla';
+import { deepMerge } from '../../utils';
 
 class DropContainer extends Component {
   static childContextTypes = {
@@ -29,7 +28,7 @@ class DropContainer extends Component {
 
     return {
       ...this.context,
-      theme: contextTheme || deepAssign(cloneDeep(baseTheme), theme),
+      theme: contextTheme || deepMerge(baseTheme, theme),
     };
   }
 
@@ -198,14 +197,13 @@ class DropContainer extends Component {
     } = this.props;
     const { theme: contextTheme } = this.context;
 
-    const globalTheme = cloneDeep(baseTheme);
     return (
       <StyledDrop
         ref={(ref) => {
           this.componentRef = ref;
         }}
         {...rest}
-        theme={deepAssign(globalTheme, contextTheme, theme)}
+        theme={deepMerge(baseTheme, contextTheme, theme)}
       >
         {children}
       </StyledDrop>

--- a/src/js/components/Grommet/Grommet.js
+++ b/src/js/components/Grommet/Grommet.js
@@ -1,13 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import deepAssign from 'deep-assign';
-import cloneDeep from 'clone-deep';
 
 import StyledGrommet from './StyledGrommet';
 
-import baseTheme from '../../themes/vanilla';
-
 import doc from './doc';
+
+import baseTheme from '../../themes/vanilla';
+import { deepMerge } from '../../utils';
 
 class Grommet extends Component {
   static childContextTypes = {
@@ -23,11 +22,9 @@ class Grommet extends Component {
   getChildContext() {
     const { theme } = this.props;
 
-    const globalTheme = cloneDeep(baseTheme);
-
     return {
       grommet: {},
-      theme: deepAssign(globalTheme, theme),
+      theme: deepMerge(baseTheme, theme),
     };
   }
 
@@ -38,9 +35,8 @@ class Grommet extends Component {
       ...rest
     } = this.props;
 
-    const globalTheme = cloneDeep(baseTheme);
     return (
-      <StyledGrommet {...rest} theme={deepAssign(globalTheme, theme)}>
+      <StyledGrommet {...rest} theme={deepMerge(baseTheme, theme)}>
         {children}
       </StyledGrommet>
     );

--- a/src/js/components/Layer/Layer.js
+++ b/src/js/components/Layer/Layer.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { render, unmountComponentAtNode } from 'react-dom';
 
 import LayerContainer from './LayerContainer';
@@ -8,7 +9,13 @@ import doc from './doc';
 import { createContextProvider } from '../hocs';
 import { getNewContainer } from '../utils';
 
+import { deepMerge } from '../../utils';
+
 class Layer extends Component {
+  static contextTypes = {
+    grommet: PropTypes.object,
+    theme: PropTypes.object,
+  }
   static defaultProps = {
     align: 'center',
   }
@@ -38,7 +45,7 @@ class Layer extends Component {
   }
 
   renderLayer() {
-    const ContextProvider = createContextProvider(this.props.context);
+    const ContextProvider = createContextProvider(deepMerge(this.context, this.props.context));
     render(
       <ContextProvider>
         <LayerContainer {...this.props} />

--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -2,14 +2,13 @@ import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
 
 import PropTypes from 'prop-types';
-import deepAssign from 'deep-assign';
-import cloneDeep from 'clone-deep';
 
 import StyledLayer, { StyledContainer } from './StyledLayer';
 
 import { Keyboard } from '../Keyboard';
 
 import baseTheme from '../../themes/vanilla';
+import { deepMerge } from '../../utils';
 
 import { filterByFocusable, getBodyChildElements } from '../utils/DOM';
 
@@ -30,7 +29,7 @@ class LayerContainer extends Component {
 
     return {
       ...this.context,
-      theme: contextTheme || deepAssign(cloneDeep(baseTheme), theme),
+      theme: contextTheme || deepMerge(baseTheme, theme),
     };
   }
 
@@ -91,8 +90,7 @@ class LayerContainer extends Component {
     } = this.props;
     const { theme: contextTheme } = this.context;
 
-    const globalTheme = cloneDeep(baseTheme);
-    const localTheme = deepAssign(globalTheme, contextTheme, theme);
+    const localTheme = deepMerge(baseTheme, contextTheme, theme);
 
     return (
       <Keyboard onEsc={onEsc}>

--- a/src/js/components/Markdown/Markdown.js
+++ b/src/js/components/Markdown/Markdown.js
@@ -1,14 +1,14 @@
 import React, { Component } from 'react';
 import { compose } from 'recompose';
 import Markdown from 'markdown-to-jsx';
-import deepAssign from 'deep-assign';
+
+import doc from './doc';
 
 import { Heading } from '../Heading';
 import { Paragraph } from '../Paragraph';
-
 import { withTheme } from '../hocs';
 
-import doc from './doc';
+import { deepMerge } from '../../utils';
 
 class GrommetMarkdown extends Component {
   render() {
@@ -24,7 +24,7 @@ class GrommetMarkdown extends Component {
         return result;
       }, {});
 
-    const overrides = deepAssign({
+    const overrides = deepMerge({
       p: { component: Paragraph },
     }, heading, components);
 

--- a/src/js/components/hocs.js
+++ b/src/js/components/hocs.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import deepAssign from 'deep-assign';
+
+import { deepMerge } from '../utils';
 
 export function createContextProvider(context) {
   const childContextTypes = {};
@@ -94,7 +95,7 @@ export const withTheme = (WrappedComponent) => {
     render() {
       const { theme, ...rest } = this.props;
       const { theme: contextTheme } = this.context;
-      const localTheme = deepAssign({}, contextTheme, theme);
+      const localTheme = deepMerge(contextTheme, theme);
       return (
         <WrappedComponent theme={localTheme} {...rest} />
       );

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1,4 +1,6 @@
-export default {
+import { deepFreeze } from '../utils';
+
+export default deepFreeze({
   global: {
     colors: {
       accent: ['#2AD2C9', '#614767', '#ff8d6d'],
@@ -54,4 +56,4 @@ export default {
     },
     extend: 'letter-spacing: 0.04167em;',
   },
-};
+});

--- a/src/js/themes/vanilla.js
+++ b/src/js/themes/vanilla.js
@@ -3,6 +3,8 @@ import { css } from 'styled-components';
 
 import { colorForName } from '../components/utils';
 
+import { deepFreeze } from '../utils';
+
 const brandColor = '#865CD6';
 const accentColors = ['#00CCEB', '#FF7D28'];
 const neutralColors = ['#0A64A0', '#DC2878', '#501EB4', '#49516F'];
@@ -24,7 +26,7 @@ const baseSpacing = 24;
 
 const borderWidth = 2;
 
-export default {
+export default deepFreeze({
   global: {
     borderSize: {
       xsmall: '1px',
@@ -273,4 +275,4 @@ export default {
       background: rgba(0, 0, 0, 0.7),
     },
   },
-};
+});

--- a/src/js/utils/__tests__/__snapshots__/object-test.js.snap
+++ b/src/js/utils/__tests__/__snapshots__/object-test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Object freezes 1`] = `[TypeError: Cannot assign to read only property 'a' of object '#<Object>']`;
+
+exports[`Object merges deep 1`] = `
+Object {
+  "address": Object {
+    "city": "Mountain View",
+    "country": "US",
+  },
+  "age": "15",
+  "name": "Someone",
+  "profile": Object {
+    "username": "someone",
+  },
+}
+`;
+
+exports[`Object merges deep with freezed object 1`] = `
+Object {
+  "address": Object {
+    "city": "Mountain View",
+    "country": "US",
+  },
+  "age": "15",
+  "name": "someone else",
+  "profile": Object {
+    "username": "someone",
+  },
+}
+`;

--- a/src/js/utils/__tests__/object-test.js
+++ b/src/js/utils/__tests__/object-test.js
@@ -1,0 +1,59 @@
+import { deepFreeze, deepMerge } from '../';
+
+test('Object freezes', () => {
+  const obj = deepFreeze({ a: 'b' });
+
+  try {
+    obj.a = 'c';
+    fail('cannot change object');
+  } catch (e) {
+    expect(e).toMatchSnapshot();
+  }
+});
+
+test('Object merges deep', () => {
+  const obj = deepMerge(
+    {
+      name: 'Someone',
+      address: {
+        city: 'Palo Alto',
+      },
+    },
+    {
+      age: '15',
+      address: {
+        city: 'Mountain View',
+        country: 'US',
+      },
+      profile: {
+        username: 'someone',
+      },
+    }
+  );
+
+  expect(obj).toMatchSnapshot();
+});
+
+test('Object merges deep with freezed object', () => {
+  const obj = deepMerge(
+    deepFreeze({
+      name: 'Someone',
+      address: {
+        city: 'Palo Alto',
+      },
+    }),
+    deepFreeze({
+      name: 'someone else',
+      age: '15',
+      address: {
+        city: 'Mountain View',
+        country: 'US',
+      },
+      profile: {
+        username: 'someone',
+      },
+    }),
+  );
+
+  expect(obj).toMatchSnapshot();
+});

--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -1,0 +1,1 @@
+export * from './object';

--- a/src/js/utils/object.js
+++ b/src/js/utils/object.js
@@ -1,0 +1,35 @@
+export function isObject(item) {
+  return (item && typeof item === 'object' && !Array.isArray(item));
+}
+
+export function deepFreeze(obj) {
+  Object.keys(obj).forEach(
+    key => key && isObject(obj[key]) && Object.freeze(obj[key])
+  );
+  return Object.freeze(obj);
+}
+
+export function deepMerge(target, ...sources) {
+  if (!sources.length) {
+    return target;
+  }
+  // making sure to not change target (immutable)
+  const output = Object.assign({}, target);
+  const source = sources.shift();
+  if (isObject(output) && isObject(source)) {
+    Object.keys(source).forEach((key) => {
+      if (isObject(source[key])) {
+        if (!output[key]) {
+          output[key] = Object.assign({}, source[key]);
+        } else {
+          output[key] = deepMerge({}, output[key], source[key]);
+        }
+      } else {
+        output[key] = source[key];
+      }
+    });
+  }
+  return deepMerge(output, ...sources);
+}
+
+export default { deepFreeze, deepMerge, isObject };


### PR DESCRIPTION
This makes sure all theme objects will not be changed. Also removed deep clone and deep merge modules. `deep-merge` is deprecated so I decided to create a function that does the same job.