### PR TITLE
New property duration for Toast

### DIFF
--- a/src/js/components/Toast.js
+++ b/src/js/components/Toast.js
@@ -35,7 +35,7 @@ class ToastContents extends Component {
 
   componentDidMount () {
     announce(this._contentsRef.innerText);
-    this._timer = setTimeout(this._onClose, DURATION);
+    this._timer = setTimeout(this._onClose, this.props.duration);
   }
 
   componentWillUnmount () {
@@ -49,7 +49,7 @@ class ToastContents extends Component {
     this._timer = undefined;
     this.setState({ closing: true });
     if (onClose) {
-      // wait for the laeve animation to finish 
+      // wait for the laeve animation to finish
       setTimeout(onClose, ANIMATION_DURATION);
     }
   }
@@ -203,10 +203,12 @@ export default class Toast extends Component {
 
 Toast.propTypes = {
   onClose: PropTypes.func,
+  duration: PropTypes.number,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   status: PropTypes.string
 };
 
 Toast.defaultProps = {
+  duration: DURATION,
   size: 'medium'
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds a new property duration for Toast.
#### Where should the reviewer start?
`src/js/components/Toast.js`
#### What testing has been done on this PR?
None relevant.
#### How should this be manually tested?
Add a Toast with a different duration.
Example:
`<Toast duration="5000" ... />An example message</Toast>`
#### Any background context you want to provide?
Toast should use a variable duration.
#### What are the relevant issues?
See #1671 
#### Screenshots (if appropriate)
None relevant.
#### Do the grommet docs need to be updated?
Yes.
#### Should this PR be mentioned in the release notes?
Yes.
#### Is this change backwards compatible or is it a breaking change?
It is backwards compatible.