### PR TITLE
Prevent processing of tab characters if layer is hidden

### DIFF
--- a/src/js/components/Layer.js
+++ b/src/js/components/Layer.js
@@ -73,6 +73,8 @@ class LayerContents extends Component {
   }
 
   _processTab (event) {
+    const {hidden} = this.props;
+    if (hidden) return false;
     let items = this.containerRef.getElementsByTagName('*');
     items = filterByFocusable(items);
 

--- a/src/js/components/Layer.js
+++ b/src/js/components/Layer.js
@@ -74,7 +74,9 @@ class LayerContents extends Component {
 
   _processTab (event) {
     const {hidden} = this.props;
-    if (hidden) return false;
+    if (hidden) {
+      return;
+    }
     let items = this.containerRef.getElementsByTagName('*');
     items = filterByFocusable(items);
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Prevent Layer.js eating tab characters if hidden
#### Where should the reviewer start?
issue reported on Slack by aaronvasquez
#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?