### PR TITLE
Remove Card's Markdown dependency. Closes #1550.

### DIFF
--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -9,7 +9,7 @@ import Box from './Box';
 import Label from './Label';
 import Heading from './Heading';
 import Headline from './Headline';
-import Markdown from './Markdown';
+import Paragraph from './Paragraph';
 import Anchor from './Anchor';
 import Layer from './Layer';
 import Video from './Video';
@@ -180,15 +180,14 @@ export default class Card extends Component {
     const { description, textSize } = this.props;
     let result = description;
     if (typeof description === 'string') {
-      console.warn(`Grommet Deprecation Notice: Card description's Markdown \
-support will be removed in Grommet's next major release.`);
-      const components = {
-        p: { props: {
-          margin: PARAGRAPH_MARGINS[textSize],
-          size: PARAGRAPH_SIZES[textSize]
-        } }
-      };
-      result = <Markdown components={components} content={description} />;
+      result = (
+        <Paragraph
+          margin={PARAGRAPH_MARGINS[textSize]}
+          size={PARAGRAPH_SIZES[textSize]} 
+        >
+          {description}
+        </Paragraph>
+      );
     }
     return result;
   }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR removes Card's Markdown component dependency. This reduces the Card component's size significantly. 

#### Where should the reviewer start?
Cloning this branch and using the docs in alias mode.

#### What testing has been done on this PR?
Cross browser testing, this does not introduce anything new to the dom as the Markdown component would eventually render a grommet Paragraph.

#### How should this be manually tested?
Test docs' Card example page.

#### What are the relevant issues?
#1550

#### Do the grommet docs need to be updated?
Yes, a PR for docs will follow removing the markdown deprecation notice.

#### Should this PR be mentioned in the release notes?
Potentially as it could be considered a breaking change if an app is using Markdown in a Card.

#### Is this change backwards compatible or is it a breaking change?
This is somewhat a breaking change. However, apps using Card's markdown support will simply render a markdown string and not throw errors. We've had a deprecation notice for a release cycle so users should be aware of the change at this point.