### PR TITLE
Fix core font for grommet-theme Toast

### DIFF
--- a/src/js/components/Toast.js
+++ b/src/js/components/Toast.js
@@ -65,6 +65,7 @@ class ToastContents extends Component {
     delete rest.store;
 
     const classNames = classnames(
+      'grommet',
       CLASS_ROOT, {
         [`${CLASS_ROOT}--${size}`]: size,
         [`${CLASS_ROOT}--closing`]: closing

--- a/src/scss/grommet-core/_objects.icon.scss
+++ b/src/scss/grommet-core/_objects.icon.scss
@@ -124,7 +124,7 @@ $icon-huge-size: round($inuit-base-spacing-unit * 12) !default;
     fill: map-get($brand-status-colors, unknown);
 
     #{$dark-background-context} {
-      @include icon-color($colored-status-color);
+      fill: icon-color($colored-status-color);
     }
   }
 

--- a/src/scss/grommet-core/_settings.font.scss
+++ b/src/scss/grommet-core/_settings.font.scss
@@ -1,7 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-$brand-font-family: Arial, sans-serif !default;
-$brand-large-number-font-family: Arial, sans-serif !default;
+$brand-font-family: 'Work Sans', Arial, sans-serif !default;
+$brand-large-number-font-family: 'Work Sans', Arial, sans-serif !default;
 $code-font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Liberation Mono', monospace !default;
 
 $text-font-weight: 300 !default;

--- a/src/scss/grommet-core/_settings.font.scss
+++ b/src/scss/grommet-core/_settings.font.scss
@@ -1,7 +1,7 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-$brand-font-family: 'Work Sans', Arial, sans-serif !default;
-$brand-large-number-font-family: 'Work Sans', Arial, sans-serif !default;
+$brand-font-family: Arial, sans-serif !default;
+$brand-large-number-font-family: Arial, sans-serif !default;
 $code-font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Liberation Mono', monospace !default;
 
 $text-font-weight: 300 !default;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?  Adds 'Work Sans' to core font as needed to reach Toast when vanilla theme

#### Where should the reviewer start?  http://grommet.io/docs/toast  Fixed: wrong-font only when theme=grommet


