### PR TITLE
Fixed an issue with Meter rounding

### DIFF
--- a/src/js/components/Meter/Bar.js
+++ b/src/js/components/Meter/Bar.js
@@ -55,7 +55,7 @@ export default class Bar extends Component {
         preserveAspectRatio='none'
         width={size === 'full' ? '100%' : width}
         height={height}
-        round={round ? { size } : undefined}
+        round={round ? { size: thickness } : undefined}
         theme={theme}
         {...rest}
       >


### PR DESCRIPTION
#### What does this PR do?

Meter outer element was setting the border-radius based on the size. It should be set based on thickness.

#### Where should the reviewer start?

Meter.js

#### What testing has been done on this PR?

grommet-site white-box

#### How should this be manually tested?

grommet-site white-box

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
