### PR TITLE
Prevent dropbutton to close on props update without open prop

### DIFF
--- a/src/js/components/DropButton/DropButton.js
+++ b/src/js/components/DropButton/DropButton.js
@@ -17,7 +17,7 @@ class DropButton extends Component {
 
   componentWillReceiveProps({ open }) {
     const { showDrop } = this.state;
-    if (open !== showDrop) {
+    if (open !== undefined && open !== showDrop) {
       this.setState({ showDrop: open });
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
If you have a dynamic control or children, and you use the dropbutton without explicit `open` prop, the dropbutton will be closed because and the internal state gets overriden. 

#### What does this PR do?

With this PR the internal state will be used, unless open was provided.