### PR TITLE
Fixed an issue with Toast status sizing.

### DIFF
--- a/src/scss/grommet-core/_objects.toast.scss
+++ b/src/scss/grommet-core/_objects.toast.scss
@@ -38,7 +38,7 @@
 
 .#{$grommet-namespace}toast__status {
   flex: 0 0 auto;
-  padding-left: $inuit-base-spacing-unit;
+  margin-left: $inuit-base-spacing-unit;
 }
 
 .#{$grommet-namespace}toast__contents {


### PR DESCRIPTION
Fixes GitHub issue #1733.

#### What does this PR do?

Uses margin instead of padding for the status icon inside Toast. The use of padding, coupled with `box-sizing: border` was causing the icon to be resized to account for the padding.

#### Where should the reviewer start?

One line change.

#### What testing has been done on this PR?

White box testing via grommet-docs.

#### How should this be manually tested?

Same as above.

#### Any background context you want to provide?

See earlier comments.

#### What are the relevant issues?

#1733 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
