### PR TITLE
Allow href to be used in Menu items. Fixes GitHub issue #1761.

### DIFF
--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -143,6 +143,7 @@ class Menu extends Component {
                         this.onDropClose();
                       }
                     } : undefined}
+                    href={item.href}
                   >
                     <Box align='start' pad='small' direction='row'>
                       {item.icon}{item.label}

--- a/src/js/components/Menu/__tests__/Menu-test.js
+++ b/src/js/components/Menu/__tests__/Menu-test.js
@@ -38,7 +38,8 @@ describe('Menu', () => {
         label='Test'
         items={[
           { label: 'Item 1' },
-          { label: 'Item 2' },
+          { label: 'Item 2', onClick: () => {} },
+          { label: 'Item 3', href: '/test' },
         ]}
       />, {
         attachTo: document.body.firstChild,

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -63,9 +63,8 @@ exports[`Menu opens and closes on click 1`] = `
         </div>
       </button>
       <button
-        class="StyledButton-qbvYY hBnIRQ"
+        class="StyledButton-qbvYY eIJSCA"
         tabindex="0"
-        disabled=""
         type="button"
       >
         <div
@@ -75,6 +74,18 @@ exports[`Menu opens and closes on click 1`] = `
           Item 2
         </div>
       </button>
+      <a
+        class="StyledButton-kDOCUE iBrSOs"
+        tabindex="0"
+        href="/test"
+      >
+        <div
+          class="StyledBox-YaZNy bpXZSO"
+          direction="row"
+        >
+          Item 3
+        </div>
+      </a>
     </div>
   </div>
 </div>
@@ -97,6 +108,20 @@ exports[`Menu opens and closes on click 2`] = `
 
 @media only screen and (min-width:700px) {
   .hBnIRQ {
+    -webkit-transition: 0.1s ease-in-out;
+    transition: 0.1s ease-in-out;
+  }
+}
+
+@media only screen and (min-width:700px) {
+  .eIJSCA {
+    -webkit-transition: 0.1s ease-in-out;
+    transition: 0.1s ease-in-out;
+  }
+}
+
+@media only screen and (min-width:700px) {
+  .iBrSOs {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -283,6 +308,13 @@ exports[`Menu with dropAlign renders 2`] = `
 
 @media only screen and (min-width:700px) {
   .gyRZCS {
+    -webkit-transition: 0.1s ease-in-out;
+    transition: 0.1s ease-in-out;
+  }
+}
+
+@media only screen and (min-width:700px) {
+  .iBrSOs {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }


### PR DESCRIPTION
#### What does this PR do?

Adds `href` support for Menu items.

#### Where should the reviewer start?

Menu.js

#### What testing has been done on this PR?

Enhanced Menu tests to cover this. Manually tested via grommet-site.

#### How should this be manually tested?

grommet-site

#### Any background context you want to provide?

No.

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/1761

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible with 2.0.
