### PR TITLE
Fix world map in IE11

### DIFF
--- a/__tests__/components/__snapshots__/WorldMap-test.js.snap
+++ b/__tests__/components/__snapshots__/WorldMap-test.js.snap
@@ -3,7 +3,7 @@
 exports[`WorldMap has correct default options 1`] = `
 <svg
   className="grommetux-world-map"
-  preserveAspectRatio="xMidYMid meet"
+  preserveAspectRatio="xMidYMin slice"
   version="1.1"
   viewBox="0 0 940 460"
   width="940px"
@@ -30,7 +30,7 @@ exports[`WorldMap renders place 1`] = `
 >
   <svg
     className="grommetux-world-map"
-    preserveAspectRatio="xMidYMid meet"
+    preserveAspectRatio="xMidYMin slice"
     version="1.1"
     viewBox="0 0 940 460"
     width="940px"
@@ -120,7 +120,7 @@ exports[`WorldMap renders place zoomed 1`] = `
 >
   <svg
     className="grommetux-world-map"
-    preserveAspectRatio="xMidYMid meet"
+    preserveAspectRatio="xMidYMin slice"
     version="1.1"
     viewBox="0 0 410 280"
     width="410px"

--- a/src/js/components/WorldMap.js
+++ b/src/js/components/WorldMap.js
@@ -555,7 +555,7 @@ export default class WorldMap extends Component {
       <svg {...props} {...interactiveProps}
         ref={(ref) => this._worldMapRef = ref}
         className={classes} version='1.1'
-        preserveAspectRatio='xMidYMid meet'
+        preserveAspectRatio='xMidYMin slice'
         width={`${width}px`}
         viewBox={`${x} ${y} ${width} ${height}`}>
         <g stroke='none' fill='none' fillRule='evenodd'>

--- a/src/scss/grommet-core/_objects.world-map.scss
+++ b/src/scss/grommet-core/_objects.world-map.scss
@@ -5,7 +5,8 @@
 
   // IE11 fix world map height
   @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-    padding-bottom: 49%;
+    // The padding value below comes from svg height / width
+    padding-bottom: 49%; // 460 / 940 = .489361702 rounding off to 49
     height: 1px;
   }
 }

--- a/src/scss/grommet-core/_objects.world-map.scss
+++ b/src/scss/grommet-core/_objects.world-map.scss
@@ -2,6 +2,12 @@
 
 .#{$grommet-namespace}world-map {
   width: 100%;
+
+  // IE11 fix world map height
+  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    padding-bottom: 49%;
+    height: 1px;
+  }
 }
 
 .#{$grommet-namespace}world-map__container {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
IE11 world map fixes:
- Fix height in IE11.
- Fix zoom in IE11.
- Fix mouse over in IE11.

#### What testing has been done on this PR?
✅ Chrome
✅ Firefox
✅ Safari
✅ Browser stack: IE11

#### How should this be manually tested?
Test this PR in the world map docs page: http://grommet.io/docs/world-map/

#### Screenshots (if appropriate)
&nbsp;  |  **Before:**  |  **After:**
:-------------:|:------------:|:-------------------------:
**Height**  |  ![image](https://user-images.githubusercontent.com/3210082/34515121-851afa2a-f025-11e7-84c8-f75a990d822d.png)  |  ![image](https://user-images.githubusercontent.com/3210082/34515130-8cc414e6-f025-11e7-963b-3c169593ffb2.png)
**Zoom**  |  ![image](https://user-images.githubusercontent.com/3210082/34515390-bd165824-f026-11e7-974a-80ee51a587ac.png)  |  ![image](https://user-images.githubusercontent.com/3210082/34515352-9835f82a-f026-11e7-94cf-16a981644031.png)
**Mouse Over**  |  ![worldmap-before](https://user-images.githubusercontent.com/3210082/34515366-a5b164bc-f026-11e7-8fa9-f69ea118f239.gif)  |  ![worldmap-after](https://user-images.githubusercontent.com/3210082/34515365-a5990d2c-f026-11e7-891b-199a899bb538.gif)







#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible. 