### PR TITLE
Added guidingChild to Stack. Adjusted Box border widths in vanilla theme.

### DIFF
--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
@@ -287,8 +287,8 @@ exports[`Anchor icon label renders 1`] = `
                 "duration": "1s",
               },
               "borderSize": Object {
-                "large": "6px",
-                "medium": "3px",
+                "large": "12px",
+                "medium": "4px",
                 "small": "2px",
                 "xlarge": "24px",
                 "xsmall": "1px",
@@ -863,8 +863,8 @@ exports[`Anchor primary renders 1`] = `
                 "duration": "1s",
               },
               "borderSize": Object {
-                "large": "6px",
-                "medium": "3px",
+                "large": "12px",
+                "medium": "4px",
                 "small": "2px",
                 "xlarge": "24px",
                 "xsmall": "1px",
@@ -1522,8 +1522,8 @@ exports[`Anchor reverse icon label renders 1`] = `
                 "duration": "1s",
               },
               "borderSize": Object {
-                "large": "6px",
-                "medium": "3px",
+                "large": "12px",
+                "medium": "4px",
                 "small": "2px",
                 "xlarge": "24px",
                 "xsmall": "1px",
@@ -2053,8 +2053,8 @@ exports[`Anchor warns about invalid icon render 1`] = `
                 "duration": "1s",
               },
               "borderSize": Object {
-                "large": "6px",
-                "medium": "3px",
+                "large": "12px",
+                "medium": "4px",
                 "small": "2px",
                 "xlarge": "24px",
                 "xsmall": "1px",

--- a/src/js/components/Box/__tests__/Box-test.js
+++ b/src/js/components/Box/__tests__/Box-test.js
@@ -299,7 +299,13 @@ test('Box border renders', () => {
       <Box border='left' />
       <Box border='bottom' />
       <Box border='right' />
-      <Box border={{ color: 'accent-1', side: 'all', size: 'medium' }} />
+      <Box border={{ color: 'accent-1' }} />,
+      <Box border={{ side: 'all' }} />
+      <Box border={{ size: 'xsmall' }} />
+      <Box border={{ size: 'small' }} />
+      <Box border={{ size: 'medium' }} />
+      <Box border={{ size: 'large' }} />
+      <Box border={{ size: 'xlarge' }} />
     </Grommet>
   );
   const tree = component.toJSON();

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -1089,7 +1089,59 @@ exports[`Box border renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   max-width: 100%;
-  border: solid 3px #00CCEB;
+  border: solid 1px #00CCEB;
+  min-width: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  max-width: 100%;
+  border: solid 2px rgba(0,0,0,0.15);
+  min-width: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  max-width: 100%;
+  border: solid 4px rgba(0,0,0,0.15);
+  min-width: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  max-width: 100%;
+  border: solid 12px rgba(0,0,0,0.15);
+  min-width: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  max-width: 100%;
+  border: solid 24px rgba(0,0,0,0.15);
   min-width: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -1137,6 +1189,37 @@ exports[`Box border renders 1`] = `
   <div
     aria-label={undefined}
     className="c8"
+    direction="column"
+  />
+  ,
+  <div
+    aria-label={undefined}
+    className="c1"
+    direction="column"
+  />
+  <div
+    aria-label={undefined}
+    className="c1"
+    direction="column"
+  />
+  <div
+    aria-label={undefined}
+    className="c9"
+    direction="column"
+  />
+  <div
+    aria-label={undefined}
+    className="c10"
+    direction="column"
+  />
+  <div
+    aria-label={undefined}
+    className="c11"
+    direction="column"
+  />
+  <div
+    aria-label={undefined}
+    className="c12"
     direction="column"
   />
 </div>

--- a/src/js/components/Stack/README.md
+++ b/src/js/components/Stack/README.md
@@ -14,7 +14,7 @@ import { Stack } from 'grommet';
 **anchor**
 
 Where to anchor children from. If not specified, children fill the
-first child's area.
+guiding child's area.
 
 ```
 center
@@ -26,5 +26,16 @@ top-left
 bottom-left
 top-right
 bottom-right
+```
+
+**guidingChild**
+
+Which child to guide layout from. All other children will be positioned
+      within that area. Defaults to `first`.
+
+```
+number
+first
+last
 ```
   

--- a/src/js/components/Stack/Stack.js
+++ b/src/js/components/Stack/Stack.js
@@ -9,16 +9,28 @@ import styleMap from './styleMap';
 
 class Stack extends Component {
   render() {
-    const { anchor, children, ...rest } = this.props;
+    const { anchor, children, guidingChild, ...rest } = this.props;
 
     // make all children but the first absolutely positioned
+    const lastIndex = React.Children.count(children) - 1;
+    let guidingIndex = guidingChild;
+    if (guidingIndex === 'first' || !guidingIndex) {
+      guidingIndex = 0;
+    } else if (guidingIndex === 'last') {
+      guidingIndex = lastIndex;
+    }
     const styledChildren = React.Children.map(children, (child, index) => {
-      if (index === 0) {
-        return child;
-      }
-
       if (child) {
+        if (index === guidingIndex) {
+          const style = {
+            ...(child.props || {}).style,
+            position: 'relative',
+          };
+          return cloneElement(child, { style });
+        }
+
         const style = {
+          ...(child.props || {}).style,
           position: 'absolute',
           overflow: 'hidden',
           ...styleMap[anchor || 'fill'],

--- a/src/js/components/Stack/__tests__/Stack-test.js
+++ b/src/js/components/Stack/__tests__/Stack-test.js
@@ -5,12 +5,27 @@ import 'jest-styled-components';
 import { Grommet } from '../../Grommet';
 import { Stack } from '../';
 
-const CONTENTS = [<div key={1}>first</div>, <div key={2}>second</div>];
+const CONTENTS = [
+  <div key={1}>first</div>,
+  <div key={2}>second</div>,
+];
 
 test('Stack renders', () => {
   const component = renderer.create(
     <Grommet>
       <Stack>{CONTENTS}</Stack>
+    </Grommet>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Stack guidingChild renders', () => {
+  const component = renderer.create(
+    <Grommet>
+      <Stack guidingChild='first'>{CONTENTS}</Stack>
+      <Stack guidingChild='last'>{CONTENTS}</Stack>
+      <Stack guidingChild={0}>{CONTENTS}</Stack>
     </Grommet>
   );
   const tree = component.toJSON();

--- a/src/js/components/Stack/__tests__/__snapshots__/Stack-test.js.snap
+++ b/src/js/components/Stack/__tests__/__snapshots__/Stack-test.js.snap
@@ -28,7 +28,13 @@ exports[`Stack anchor renders 1`] = `
   <div
     className="c1"
   >
-    <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
       first
     </div>
     <div
@@ -48,7 +54,13 @@ exports[`Stack anchor renders 1`] = `
   <div
     className="c1"
   >
-    <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
       first
     </div>
     <div
@@ -68,7 +80,13 @@ exports[`Stack anchor renders 1`] = `
   <div
     className="c1"
   >
-    <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
       first
     </div>
     <div
@@ -88,7 +106,13 @@ exports[`Stack anchor renders 1`] = `
   <div
     className="c1"
   >
-    <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
       first
     </div>
     <div
@@ -108,7 +132,13 @@ exports[`Stack anchor renders 1`] = `
   <div
     className="c1"
   >
-    <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
       first
     </div>
     <div
@@ -128,7 +158,13 @@ exports[`Stack anchor renders 1`] = `
   <div
     className="c1"
   >
-    <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
       first
     </div>
     <div
@@ -147,7 +183,13 @@ exports[`Stack anchor renders 1`] = `
   <div
     className="c1"
   >
-    <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
       first
     </div>
     <div
@@ -166,7 +208,13 @@ exports[`Stack anchor renders 1`] = `
   <div
     className="c1"
   >
-    <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
       first
     </div>
     <div
@@ -185,7 +233,13 @@ exports[`Stack anchor renders 1`] = `
   <div
     className="c1"
   >
-    <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
       first
     </div>
     <div
@@ -195,6 +249,115 @@ exports[`Stack anchor renders 1`] = `
           "overflow": "hidden",
           "position": "absolute",
           "right": "0",
+        }
+      }
+    >
+      second
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Stack guidingChild renders 1`] = `
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  background-color: #FFFFFF;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c0 * {
+  box-sizing: inherit;
+}
+
+.c1 {
+  position: relative;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
+      first
+    </div>
+    <div
+      style={
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    >
+      second
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      style={
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    >
+      first
+    </div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
+      second
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
+      first
+    </div>
+    <div
+      style={
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
         }
       }
     >
@@ -232,7 +395,13 @@ exports[`Stack renders 1`] = `
   <div
     className="c1"
   >
-    <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
       first
     </div>
     <div

--- a/src/js/components/Stack/doc.js
+++ b/src/js/components/Stack/doc.js
@@ -20,8 +20,15 @@ export default (Stack) => {
       ]
     ).description(
       `Where to anchor children from. If not specified, children fill the
-first child's area.`
+guiding child's area.`
     ),
+    guidingChild: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.oneOf(['first', 'last']),
+    ]).description(
+      `Which child to guide layout from. All other children will be positioned
+      within that area.`
+    ).defaultValue('first'),
   };
 
   return DocumentedStack;

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -17,7 +17,7 @@ exports[`Tabs changes active index 1`] = `
       type="button"
     >
       <div
-        class="StyledBox-YaZNy hVgGWk"
+        class="StyledBox-YaZNy cVzNWb"
         direction="column"
       >
         <span
@@ -38,7 +38,7 @@ exports[`Tabs changes active index 1`] = `
       type="button"
     >
       <div
-        class="StyledBox-YaZNy eeXmpG"
+        class="StyledBox-YaZNy kLBzNE"
         direction="column"
       >
         <span
@@ -93,7 +93,7 @@ exports[`Tabs changes to second tab 1`] = `
       >
         <div
           aria-label={undefined}
-          className="StyledBox-YaZNy eeXmpG"
+          className="StyledBox-YaZNy kLBzNE"
           direction="column"
         >
           <span
@@ -126,7 +126,7 @@ exports[`Tabs changes to second tab 1`] = `
       >
         <div
           aria-label={undefined}
-          className="StyledBox-YaZNy hVgGWk"
+          className="StyledBox-YaZNy cVzNWb"
           direction="column"
         >
           <span
@@ -183,7 +183,7 @@ exports[`Tabs renders complex Tab title 1`] = `
       >
         <div
           aria-label={undefined}
-          className="StyledBox-YaZNy hVgGWk"
+          className="StyledBox-YaZNy cVzNWb"
           direction="column"
         >
           <div>
@@ -213,7 +213,7 @@ exports[`Tabs renders complex Tab title 1`] = `
       >
         <div
           aria-label={undefined}
-          className="StyledBox-YaZNy eeXmpG"
+          className="StyledBox-YaZNy kLBzNE"
           direction="column"
         >
           <div>
@@ -266,7 +266,7 @@ exports[`Tabs renders with Tab 1`] = `
       >
         <div
           aria-label={undefined}
-          className="StyledBox-YaZNy hVgGWk"
+          className="StyledBox-YaZNy cVzNWb"
           direction="column"
         >
           <span
@@ -300,7 +300,7 @@ exports[`Tabs renders with Tab 1`] = `
       >
         <div
           aria-label={undefined}
-          className="StyledBox-YaZNy eeXmpG"
+          className="StyledBox-YaZNy kLBzNE"
           direction="column"
         >
           <span
@@ -359,7 +359,7 @@ exports[`Tabs sets on hover 1`] = `
       type="button"
     >
       <div
-        class="StyledBox-YaZNy hVgGWk"
+        class="StyledBox-YaZNy cVzNWb"
         direction="column"
       >
         <span
@@ -380,7 +380,7 @@ exports[`Tabs sets on hover 1`] = `
       type="button"
     >
       <div
-        class="StyledBox-YaZNy eeXmpG"
+        class="StyledBox-YaZNy kLBzNE"
         direction="column"
       >
         <span
@@ -418,7 +418,7 @@ exports[`Tabs sets on hover 2`] = `
       type="button"
     >
       <div
-        class="StyledBox-YaZNy hVgGWk"
+        class="StyledBox-YaZNy cVzNWb"
         direction="column"
       >
         <span
@@ -439,7 +439,7 @@ exports[`Tabs sets on hover 2`] = `
       type="button"
     >
       <div
-        class="StyledBox-YaZNy fkyuKu"
+        class="StyledBox-YaZNy cVdybV"
         direction="column"
       >
         <span
@@ -477,7 +477,7 @@ exports[`Tabs sets on hover 3`] = `
       type="button"
     >
       <div
-        class="StyledBox-YaZNy hVgGWk"
+        class="StyledBox-YaZNy cVzNWb"
         direction="column"
       >
         <span
@@ -498,7 +498,7 @@ exports[`Tabs sets on hover 3`] = `
       type="button"
     >
       <div
-        class="StyledBox-YaZNy fkyuKu"
+        class="StyledBox-YaZNy cVdybV"
         direction="column"
       >
         <span
@@ -536,7 +536,7 @@ exports[`Tabs sets on hover 4`] = `
       type="button"
     >
       <div
-        class="StyledBox-YaZNy hVgGWk"
+        class="StyledBox-YaZNy cVzNWb"
         direction="column"
       >
         <span
@@ -557,7 +557,7 @@ exports[`Tabs sets on hover 4`] = `
       type="button"
     >
       <div
-        class="StyledBox-YaZNy eeXmpG"
+        class="StyledBox-YaZNy kLBzNE"
         direction="column"
       >
         <span

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -370,6 +370,11 @@ exports[`Video autoPlay renders 1`] = `
                 className="c11"
                 height={12}
                 preserveAspectRatio="none"
+                style={
+                  Object {
+                    "position": "relative",
+                  }
+                }
                 viewBox="0 0 288 12"
                 width="100%"
               >
@@ -896,6 +901,11 @@ exports[`Video controls renders 1`] = `
                 className="c11"
                 height={12}
                 preserveAspectRatio="none"
+                style={
+                  Object {
+                    "position": "relative",
+                  }
+                }
                 viewBox="0 0 288 12"
                 width="100%"
               >
@@ -1090,6 +1100,11 @@ exports[`Video controls renders 1`] = `
                 className="c11"
                 height={12}
                 preserveAspectRatio="none"
+                style={
+                  Object {
+                    "position": "relative",
+                  }
+                }
                 viewBox="0 0 288 12"
                 width="100%"
               >
@@ -1572,6 +1587,11 @@ exports[`Video fit renders 1`] = `
                 className="c11"
                 height={12}
                 preserveAspectRatio="none"
+                style={
+                  Object {
+                    "position": "relative",
+                  }
+                }
                 viewBox="0 0 288 12"
                 width="100%"
               >
@@ -1769,6 +1789,11 @@ exports[`Video fit renders 1`] = `
                 className="c11"
                 height={12}
                 preserveAspectRatio="none"
+                style={
+                  Object {
+                    "position": "relative",
+                  }
+                }
                 viewBox="0 0 288 12"
                 width="100%"
               >
@@ -2233,6 +2258,11 @@ exports[`Video loop renders 1`] = `
                 className="c11"
                 height={12}
                 preserveAspectRatio="none"
+                style={
+                  Object {
+                    "position": "relative",
+                  }
+                }
                 viewBox="0 0 288 12"
                 width="100%"
               >
@@ -2697,6 +2727,11 @@ exports[`Video mute renders 1`] = `
                 className="c11"
                 height={12}
                 preserveAspectRatio="none"
+                style={
+                  Object {
+                    "position": "relative",
+                  }
+                }
                 viewBox="0 0 288 12"
                 width="100%"
               >
@@ -3161,6 +3196,11 @@ exports[`Video renders 1`] = `
                 className="c11"
                 height={12}
                 preserveAspectRatio="none"
+                style={
+                  Object {
+                    "position": "relative",
+                  }
+                }
                 viewBox="0 0 288 12"
                 width="100%"
               >

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -2033,7 +2033,7 @@ import { Stack } from 'grommet';
 **anchor**
 
 Where to anchor children from. If not specified, children fill the
-first child's area.
+guiding child's area.
 
 \`\`\`
 center
@@ -2045,6 +2045,17 @@ top-left
 bottom-left
 top-right
 bottom-right
+\`\`\`
+
+**guidingChild**
+
+Which child to guide layout from. All other children will be positioned
+      within that area. Defaults to \`first\`.
+
+\`\`\`
+number
+first
+last
 \`\`\`
   ",
   "Tabs": "## Tabs

--- a/src/js/themes/vanilla.js
+++ b/src/js/themes/vanilla.js
@@ -34,8 +34,8 @@ export default deepFreeze({
     borderSize: {
       xsmall: '1px',
       small: '2px',
-      medium: `${baseSpacing / 8}px`,
-      large: `${baseSpacing / 4}px`,
+      medium: `${baseSpacing / 6}px`,
+      large: `${baseSpacing / 2}px`,
       xlarge: `${baseSpacing}px`,
     },
     breakpoints: {


### PR DESCRIPTION
#### What does this PR do?

Adds `guidingChild` to Stack to allow controlling which child drives the layout.
Adjusted default theme Box border thicknesses.

#### Where should the reviewer start?

Stack/doc.js

#### What testing has been done on this PR?

new grommet-site

#### How should this be manually tested?

grommet-site

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

Automatic.

#### Should this PR be mentioned in the release notes?

Sure.

#### Is this change backwards compatible or is it a breaking change?

Essentially compatible.