### PR TITLE
Fixed an issue with dark background Box

### DIFF
--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -42,6 +42,14 @@ export const backgroundStyle = (background, theme) => {
           };
         `;
       }
+    } else if (background.dark === false) {
+      return css`
+        color: ${theme.global.colors.text};
+      `;
+    } else if (background.dark) {
+      return css`
+        color: ${theme.global.colors.darkBackground.text};
+      `;
     }
     return undefined;
   }


### PR DESCRIPTION
#### What does this PR do?

When using `<Box background={{ dark: false }} />`, the color style wasn't being set correctly. If the `background` had a `color` or `image`, it was working fine.

#### Where should the reviewer start?

utils/styles.js

#### What testing has been done on this PR?

grommet-weather app

#### How should this be manually tested?

grommet-site?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
