### PR TITLE
Video events propagation

### DIFF
--- a/src/js/components/Video.js
+++ b/src/js/components/Video.js
@@ -80,10 +80,10 @@ export default class Video extends Component {
     ];
 
     return videoEvents.reduce((previousValue, currentValue) => {
-      previousValue[currentValue] = () => {
+      previousValue[currentValue] = (e) => {
         if (currentValue in this.props
           && typeof this.props[currentValue] === 'function') {
-          this.props[currentValue]();
+          this.props[currentValue](e);
         }
         this._update();
       };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
video events parameters are propagated to event handlers.
#### Where should the reviewer start?
<Video onLoadedMetadata={this.onLoadedMetadata}>
  <source src='xxxx.mp4' type='video/mp4' />
</Video>
.... 
onLoadedMetadata = ({target}) => {
  console.log(target.duration)
}
#### Any background context you want to provide?
issue reported on slack channel by edward10
#### Is this change backwards compatible or is it a breaking change?
compatible