### PR TITLE
Video events propagation

### DIFF
--- a/src/js/components/Video/Video.js
+++ b/src/js/components/Video/Video.js
@@ -118,10 +118,10 @@ class Video extends Component {
 
     return videoEvents.reduce((previousValue, currentValue) => {
       const nextValue = { ...previousValue };
-      nextValue[currentValue] = () => {
+      nextValue[currentValue] = (e) => {
         if (currentValue in this.props
           && typeof this.props[currentValue] === 'function') {
-          this.props[currentValue]();
+          this.props[currentValue](e);
         }
         this.update();
       };


### PR DESCRIPTION
What does this PR do?

video events parameters are propagated to event handlers.

Where should the reviewer start?
.... onLoadedMetadata = ({target}) => { console.log(target.duration) } #### Any background context you want to provide? issue reported on slack channel by edward10 #### Is this change backwards compatible or is it a breaking change? compatible