### PR TITLE
Removed prop duration to avoid invalid html attributes for Toast

### DIFF
--- a/__tests__/components/Toast-test.js
+++ b/__tests__/components/Toast-test.js
@@ -11,6 +11,7 @@ jest.mock('react-dom');
 
 describe('Toast', () => {
   it('has correct default options', () => {
+    document.body.innerHTML = '<div></div>';
     const component = renderer.create(
       <Toast>
         <span>

--- a/src/js/components/Toast.js
+++ b/src/js/components/Toast.js
@@ -59,6 +59,7 @@ class ToastContents extends Component {
     const { closing } = this.state;
 
     // removing context props to avoid invalid html attributes on prop transfer
+    delete rest.duration;
     delete rest.history;
     delete rest.intl;
     delete rest.router;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Removed prop duration to avoid invalid html attributes on prop transfer.
#### Where should the reviewer start?
`src/js/components/Toast.js`
#### What testing has been done on this PR?
None relevant.
#### How should this be manually tested?
1. Show a Toast.
2. See browser console.
3. Review that there is no any error messages related with **duration** prop.
#### Any background context you want to provide?
Browser console not showing any error message.
#### What are the relevant issues?
See #1811.
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/14350470/35357840-5a12a174-011a-11e8-9fa8-d2bf55ceac53.png)
#### Do the grommet docs need to be updated?
No.
#### Should this PR be mentioned in the release notes?
No.
#### Is this change backwards compatible or is it a breaking change?
It is backwards compatible.