### PR TITLE
Fixed base level self-referencing error

### DIFF
--- a/src/scss/grommet-core/_objects.animate.scss
+++ b/src/scss/grommet-core/_objects.animate.scss
@@ -15,7 +15,7 @@ $animation-duration: 1s;
   transition: all $animation-duration;
 }
 
-&.#{$grommet-namespace}animate__child--inactive {
+.#{$grommet-namespace}animate__child--inactive {
   pointer-events: none;
 }
 


### PR DESCRIPTION
I'm getting "Base-level rules cannot contain the parent-selector-referencing character '&'." compiling grommet with the sass gem, I think this might be a typo.

#### What does this PR do?

Fixes a typo.
