### PR TITLE
Fixed an issue with Select not closing the Drop

### DIFF
--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -43,6 +43,14 @@ Whether the button expands to fill all of the available width and height.
 boolean
 ```
 
+**focusIndicator**
+
+Whether when 'plain' it should receive a focus outline.
+
+```
+boolean
+```
+
 **hoverIndicator**
 
 The hover indicator to apply when the user is mousing over the

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -111,7 +111,7 @@ const plainStyle = css`
   border: none;
   padding: 0;
 
-  ${props => props.focus && plainFocusStyle}
+  ${props => props.focus && props.focusIndicator && plainFocusStyle}
 `;
 
 const StyledButton = styled.button`
@@ -152,7 +152,7 @@ const StyledButton = styled.button`
       `padding: ${props.theme.button.padding.vertical} ${props.theme.button.padding.horizontal};`
     )
   )}
-  ${props => props.focus && focusStyle}
+  ${props => props.focus && (!props.plain || props.focusIndicator) && focusStyle}
   ${lapAndUp(`
     transition: 0.1s ease-in-out;
   `)}

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -32,6 +32,9 @@ export default (Button) => {
     fill: PropTypes.bool.description(
       'Whether the button expands to fill all of the available width and height.'
     ),
+    focusIndicator: PropTypes.bool.description(
+      'Whether when \'plain\' it should receive a focus outline.'
+    ),
     hoverIndicator: PropTypes.oneOfType([
       PropTypes.oneOf(['background']),
       PropTypes.shape({

--- a/src/js/components/Drop/README.md
+++ b/src/js/components/Drop/README.md
@@ -71,9 +71,7 @@ function
 
 **responsive**
 
-Whether to dynamically re-place when resized. Defaults to `{
-  "defaultProp": true
-}`.
+Whether to dynamically re-place when resized. Defaults to `true`.
 
 ```
 boolean

--- a/src/js/components/Drop/doc.js
+++ b/src/js/components/Drop/doc.js
@@ -30,15 +30,15 @@ export default (Drop) => {
       `Whether text should be rendered right to left or not. Defaults to
       inherit from the document context.`
     ),
-    restrictFocus: PropTypes.bool.description('Whether the drop should control focus.'),
+    restrictFocus: PropTypes.bool.description(
+      'Whether the drop should control focus.'
+    ),
     onClose: PropTypes.func.description(
       'Function that will be invoked when the user clicks outside the drop area.'
     ),
     responsive: PropTypes.bool
       .description('Whether to dynamically re-place when resized.')
-      .defaultValue({
-        defaultProp: true,
-      }),
+      .defaultValue(true),
     theme: PropTypes.object.description('Custom styles for Drop component.'),
   };
 

--- a/src/js/components/DropButton/README.md
+++ b/src/js/components/DropButton/README.md
@@ -1,6 +1,7 @@
 ## DropButton
 A control that when clicked will render its children in a drop layer.
-When opened, the drop will control the focus so that the contents behind it are not focusable.
+When opened, the drop will control the focus so that the contents behind it
+are not focusable.
       
 
 [![](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=dropbutton&module=%2Fsrc%2FDropButton.js)
@@ -15,7 +16,8 @@ import { DropButton } from 'grommet';
 
 **a11yTitle**
 
-Custom title to be used by screen readers.
+Custom title to be used by
+screen readers.
 
 ```
 string
@@ -23,7 +25,8 @@ string
 
 **control**
 
-Required. React node to open/close the drop content.
+Required. React node to open/close the
+drop content.
 
 ```
 element

--- a/src/js/components/DropButton/doc.js
+++ b/src/js/components/DropButton/doc.js
@@ -7,7 +7,8 @@ export default (DropButton) => {
     .availableAt(getAvailableAtBadge('DropButton'))
     .description(
       `A control that when clicked will render its children in a drop layer.
-When opened, the drop will control the focus so that the contents behind it are not focusable.
+When opened, the drop will control the focus so that the contents behind it
+are not focusable.
       `
     ).usage(
       `import { DropButton } from 'grommet';
@@ -15,12 +16,12 @@ When opened, the drop will control the focus so that the contents behind it are 
     );
 
   DocumentedDropButton.propTypes = {
-    a11yTitle: PropTypes.string.description('Custom title to be used by screen readers.'),
-    control: PropTypes.element.description('React node to open/close the drop content.').isRequired,
+    a11yTitle: PropTypes.string.description(`Custom title to be used by
+screen readers.`),
+    control: PropTypes.element.description(`React node to open/close the
+drop content.`).isRequired,
     onClose: PropTypes.func.description('Callback for when the drop is closed'),
-    open: PropTypes.bool.description(
-      'Whether the drop should be open or not.'
-    ),
+    open: PropTypes.bool.description('Whether the drop should be open or not.'),
   };
 
   return DocumentedDropButton;

--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -59,6 +59,14 @@ Size of the options container inside the Select drop.
 string
 ```
 
+**focusIndicator**
+
+Whether when 'plain' it should receive a focus outline.
+
+```
+boolean
+```
+
 **onChange**
 
 Function that will be called when the user selects an option.

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -10,6 +10,20 @@ import SelectContainer from './SelectContainer';
 import doc from './doc';
 
 class Select extends Component {
+  state = {}
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.value !== nextProps.value) {
+      this.closeDrop = true;
+    }
+  }
+
+  componentDidUpdate() {
+    if (this.closeDrop) {
+      this.closeDrop = false;
+    }
+  }
+
   selectControl = () => {
     const { placeholder, plain, value, ...rest } = this.props;
     delete rest.children;
@@ -35,7 +49,11 @@ class Select extends Component {
         justify='between'
       >
         {content}
-        <Box margin={{ horizontal: 'small' }} flex={false}>
+        <Box
+          margin={{ horizontal: 'small' }}
+          flex={false}
+          style={{ minWidth: 'auto' }}
+        >
           <FormDown />
         </Box>
       </Box>
@@ -43,15 +61,22 @@ class Select extends Component {
   }
 
   render() {
-    const { a11yTitle, background, onClose, open, tabIndex, value } = this.props;
+    const {
+      a11yTitle, background, focusIndicator, onBlur, onClose, onFocus, open,
+      plain, tabIndex, value,
+    } = this.props;
     return (
       <DropButton
-        open={open}
+        open={open || this.closeDrop ? false : undefined}
         tabIndex={tabIndex}
         a11yTitle={`${a11yTitle}${typeof value === 'string' ? `, ${value}` : ''}`}
         background={background}
+        plain={plain}
+        focusIndicator={focusIndicator}
         control={this.selectControl()}
         onClose={onClose}
+        onFocus={onFocus}
+        onBlur={onBlur}
       >
         <SelectContainer {...this.props} />
       </DropButton>

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -112,6 +112,7 @@ exports[`Select closes drop on esc 3`] = `
     </div>
     <div
       class="StyledBox-YaZNy fnEUqy"
+      style="min-width: auto;"
       direction="column"
     >
       <svg
@@ -161,6 +162,7 @@ exports[`Select closes drop on esc 4`] = `
     </div>
     <div
       class="StyledBox-YaZNy fnEUqy"
+      style="min-width: auto;"
       direction="column"
     >
       <svg
@@ -210,6 +212,7 @@ exports[`Select mounts 1`] = `
     </div>
     <div
       class="StyledBox-YaZNy fnEUqy"
+      style="min-width: auto;"
       direction="column"
     >
       <svg
@@ -259,6 +262,7 @@ exports[`Select mounts 2`] = `
     </div>
     <div
       class="StyledBox-YaZNy fnEUqy"
+      style="min-width: auto;"
       direction="column"
     >
       <svg
@@ -438,6 +442,7 @@ exports[`Select mounts with complex options and children 1`] = `
     </div>
     <div
       class="StyledBox-YaZNy fnEUqy"
+      style="min-width: auto;"
       direction="column"
     >
       <svg
@@ -487,6 +492,7 @@ exports[`Select mounts with complex options and children 2`] = `
     </div>
     <div
       class="StyledBox-YaZNy fnEUqy"
+      style="min-width: auto;"
       direction="column"
     >
       <svg

--- a/src/js/components/Select/doc.js
+++ b/src/js/components/Select/doc.js
@@ -24,6 +24,9 @@ export default (Select) => {
     dropSize: PropTypes.string.description(
       'Size of the options container inside the Select drop.'
     ),
+    focusIndicator: PropTypes.bool.description(
+      'Whether when \'plain\' it should receive a focus outline.'
+    ),
     onChange: PropTypes.func.description(
       'Function that will be called when the user selects an option.'
     ),

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -535,6 +535,14 @@ Whether the button expands to fill all of the available width and height.
 boolean
 \`\`\`
 
+**focusIndicator**
+
+Whether when 'plain' it should receive a focus outline.
+
+\`\`\`
+boolean
+\`\`\`
+
 **hoverIndicator**
 
 The hover indicator to apply when the user is mousing over the
@@ -1079,9 +1087,7 @@ function
 
 **responsive**
 
-Whether to dynamically re-place when resized. Defaults to \`{
-  \\"defaultProp\\": true
-}\`.
+Whether to dynamically re-place when resized. Defaults to \`true\`.
 
 \`\`\`
 boolean
@@ -1097,7 +1103,8 @@ object
   ",
   "DropButton": "## DropButton
 A control that when clicked will render its children in a drop layer.
-When opened, the drop will control the focus so that the contents behind it are not focusable.
+When opened, the drop will control the focus so that the contents behind it
+are not focusable.
       
 
 [![](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=dropbutton&module=%2Fsrc%2FDropButton.js)
@@ -1112,7 +1119,8 @@ import { DropButton } from 'grommet';
 
 **a11yTitle**
 
-Custom title to be used by screen readers.
+Custom title to be used by
+screen readers.
 
 \`\`\`
 string
@@ -1120,7 +1128,8 @@ string
 
 **control**
 
-Required. React node to open/close the drop content.
+Required. React node to open/close the
+drop content.
 
 \`\`\`
 element
@@ -2047,6 +2056,14 @@ Size of the options container inside the Select drop.
 
 \`\`\`
 string
+\`\`\`
+
+**focusIndicator**
+
+Whether when 'plain' it should receive a focus outline.
+
+\`\`\`
+boolean
 \`\`\`
 
 **onChange**


### PR DESCRIPTION
#### What does this PR do?

Fixed an issue with Select not closing the Drop when the use selects an item.
Also fixed an issue with how the form drop down icon was being rendered in Select.
Also added a `focusIndicator` to both Select and Button to allow using them in more diverse form field contexts. This is similar to how TextInput and TextArea have `focusIndicator`.

#### Where should the reviewer start?

doc.js files

#### What testing has been done on this PR?

grommet-site

#### How should this be manually tested?

grommet-site

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible with v2
