### PR TITLE
 Don't always set background color and text color in Grommet to avoid interfering with context

### DIFF
--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
@@ -6,7 +6,6 @@ exports[`Anchor disabled renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -53,7 +52,6 @@ exports[`Anchor focus renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -115,7 +113,6 @@ exports[`Anchor icon label renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -327,7 +324,6 @@ exports[`Anchor icon label renders 1`] = `
                   "#915591",
                 ],
                 "active": "rgba(221,221,221,0.5)",
-                "background": "#FFFFFF",
                 "black": "#000000",
                 "border": "rgba(0, 0, 0, 0.15)",
                 "brand": "#865CD6",
@@ -691,7 +687,6 @@ exports[`Anchor primary renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -936,7 +931,6 @@ exports[`Anchor primary renders 1`] = `
                   "#915591",
                 ],
                 "active": "rgba(221,221,221,0.5)",
-                "background": "#FFFFFF",
                 "black": "#000000",
                 "border": "rgba(0, 0, 0, 0.15)",
                 "brand": "#865CD6",
@@ -1318,7 +1312,6 @@ exports[`Anchor renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1366,7 +1359,6 @@ exports[`Anchor renders with children 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1416,7 +1408,6 @@ exports[`Anchor reverse icon label renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1628,7 +1619,6 @@ exports[`Anchor reverse icon label renders 1`] = `
                   "#915591",
                 ],
                 "active": "rgba(221,221,221,0.5)",
-                "background": "#FFFFFF",
                 "black": "#000000",
                 "border": "rgba(0, 0, 0, 0.15)",
                 "brand": "#865CD6",
@@ -1992,7 +1982,6 @@ exports[`Anchor warns about invalid icon render 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -2192,7 +2181,6 @@ exports[`Anchor warns about invalid icon render 1`] = `
                   "#915591",
                 ],
                 "active": "rgba(221,221,221,0.5)",
-                "background": "#FFFFFF",
                 "black": "#000000",
                 "border": "rgba(0, 0, 0, 0.15)",
                 "brand": "#865CD6",
@@ -2550,7 +2538,6 @@ exports[`Anchor warns about invalid label render 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/Anchor/__tests__/__snapshots__/RoutedAnchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/RoutedAnchor-test.js.snap
@@ -6,7 +6,6 @@ exports[`RoutedAnchor renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -6,7 +6,6 @@ exports[`Box align renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -135,7 +134,6 @@ exports[`Box alignContent renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -279,7 +277,6 @@ exports[`Box alignSelf renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -383,7 +380,6 @@ exports[`Box animation renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -689,7 +685,6 @@ exports[`Box background renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -886,7 +881,6 @@ exports[`Box basis renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1178,7 +1172,6 @@ exports[`Box border renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1431,7 +1424,6 @@ exports[`Box direction renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1489,7 +1481,6 @@ exports[`Box flex renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1611,7 +1602,6 @@ exports[`Box full renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1739,7 +1729,6 @@ exports[`Box gridArea renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1781,7 +1770,6 @@ exports[`Box justify renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1889,7 +1877,6 @@ exports[`Box justifySelf renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1945,7 +1932,6 @@ exports[`Box margin renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -2133,7 +2119,6 @@ exports[`Box pad renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -2321,7 +2306,6 @@ exports[`Box renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -2362,7 +2346,6 @@ exports[`Box reverse renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -2420,7 +2403,6 @@ exports[`Box round renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -2534,7 +2516,6 @@ exports[`Box tag renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -2575,7 +2556,6 @@ exports[`Box textAlign renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -2653,7 +2633,6 @@ exports[`Box wrap renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -12,6 +12,7 @@ const basicStyle = props => css`
 const primaryStyle = props => css`
   ${backgroundStyle(props.color || 'brand', props.theme)}
   border: none;
+  border-radius: ${props.theme.button.border.radius};
 
   // TODO: revisit this
   svg {

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -6,7 +6,6 @@ exports[`Button color renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -74,6 +73,7 @@ exports[`Button color renders 1`] = `
   background-color: #00CCEB;
   color: #333333;
   border: none;
+  border-radius: 5px;
   font-size: 1.1875rem;
   line-height: 24px;
   padding: 10px 10px;
@@ -160,7 +160,6 @@ exports[`Button disabled renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -231,7 +230,6 @@ exports[`Button focus renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -322,7 +320,6 @@ exports[`Button hoverIndicator as object renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -390,7 +387,6 @@ exports[`Button hoverIndicator as object with color renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -458,7 +454,6 @@ exports[`Button hoverIndicator as object with colorIndex renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -526,7 +521,6 @@ exports[`Button hoverIndicator as object with invalid color renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -594,7 +588,6 @@ exports[`Button hoverIndicator as object with invalid color renders 2`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -662,7 +655,6 @@ exports[`Button hoverIndicator as object with invalid colorIndex renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -730,7 +722,6 @@ exports[`Button hoverIndicator renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -798,7 +789,6 @@ exports[`Button href renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -878,7 +868,6 @@ exports[`Button icon label renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -986,7 +975,6 @@ exports[`Button primary renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1020,6 +1008,7 @@ exports[`Button primary renders 1`] = `
   background-color: #865CD6;
   color: rgba(255,255,255,0.85);
   border: none;
+  border-radius: 5px;
   font-size: 1.1875rem;
   line-height: 24px;
   padding: 10px 10px;
@@ -1076,7 +1065,6 @@ exports[`Button renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1166,7 +1154,6 @@ exports[`Button reverse icon label renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1274,7 +1261,6 @@ exports[`Button warns about invalid icon render 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1355,7 +1341,6 @@ exports[`Button warns about invalid label render 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/Button/__tests__/__snapshots__/RoutedButton-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/RoutedButton-test.js.snap
@@ -6,7 +6,6 @@ exports[`RoutedButton renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -6,7 +6,6 @@ exports[`Calendar date renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1587,7 +1586,6 @@ exports[`Calendar dates renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -3191,7 +3189,6 @@ exports[`Calendar disabled renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -4795,7 +4792,6 @@ exports[`Calendar renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -6376,7 +6372,6 @@ exports[`Calendar size renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
+++ b/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
@@ -6,7 +6,6 @@ exports[`Chart cap renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -106,7 +105,6 @@ exports[`Chart renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -175,7 +173,6 @@ exports[`Chart size renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -333,7 +330,6 @@ exports[`Chart thickness renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -491,7 +487,6 @@ exports[`Chart type renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -6,7 +6,6 @@ exports[`CheckBox checked renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -157,7 +156,6 @@ exports[`CheckBox disabled renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -345,7 +343,6 @@ exports[`CheckBox label renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -534,7 +531,6 @@ exports[`CheckBox renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -717,7 +713,6 @@ exports[`CheckBox reverse renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -871,7 +866,6 @@ exports[`CheckBox toggle renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
+++ b/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
@@ -172,7 +172,7 @@ exports[`Clock night renders 2`] = `
 
 exports[`Clock renders 1`] = `
 <div
-  class="StyledGrommet-gKbdxL kDQxAS"
+  class="StyledGrommet-gKbdxL dNFHPo"
 >
   <svg
     class="StyledClock-egFVkc cMDGwi"
@@ -223,7 +223,7 @@ exports[`Clock renders 1`] = `
 
 exports[`Clock renders 2`] = `
 <div
-  class="StyledGrommet-gKbdxL kDQxAS"
+  class="StyledGrommet-gKbdxL dNFHPo"
 >
   <svg
     class="StyledClock-egFVkc cMDGwi"

--- a/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
+++ b/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
@@ -172,7 +172,7 @@ exports[`Clock night renders 2`] = `
 
 exports[`Clock renders 1`] = `
 <div
-  class="StyledGrommet-gKbdxL dNFHPo"
+  class="StyledGrommet-gKbdxL kURDTi"
 >
   <svg
     class="StyledClock-egFVkc cMDGwi"
@@ -223,7 +223,7 @@ exports[`Clock renders 1`] = `
 
 exports[`Clock renders 2`] = `
 <div
-  class="StyledGrommet-gKbdxL dNFHPo"
+  class="StyledGrommet-gKbdxL kURDTi"
 >
   <svg
     class="StyledClock-egFVkc cMDGwi"

--- a/src/js/components/Diagram/__tests__/__snapshots__/Diagram-test.js.snap
+++ b/src/js/components/Diagram/__tests__/__snapshots__/Diagram-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Diagram color renders 1`] = `
 <div
-  class="StyledGrommet-gKbdxL dNFHPo"
+  class="StyledGrommet-gKbdxL kURDTi"
 >
   <div
     class="StyledStack-jtPAMP bgKQVO"
@@ -39,7 +39,7 @@ exports[`Diagram color renders 1`] = `
 
 exports[`Diagram offset renders 1`] = `
 <div
-  class="StyledGrommet-gKbdxL dNFHPo"
+  class="StyledGrommet-gKbdxL kURDTi"
 >
   <div
     class="StyledStack-jtPAMP bgKQVO"
@@ -76,7 +76,7 @@ exports[`Diagram offset renders 1`] = `
 
 exports[`Diagram renders 1`] = `
 <div
-  class="StyledGrommet-gKbdxL dNFHPo"
+  class="StyledGrommet-gKbdxL kURDTi"
 >
   <div
     class="StyledStack-jtPAMP bgKQVO"
@@ -113,7 +113,7 @@ exports[`Diagram renders 1`] = `
 
 exports[`Diagram thickness renders 1`] = `
 <div
-  class="StyledGrommet-gKbdxL dNFHPo"
+  class="StyledGrommet-gKbdxL kURDTi"
 >
   <div
     class="StyledStack-jtPAMP bgKQVO"
@@ -150,7 +150,7 @@ exports[`Diagram thickness renders 1`] = `
 
 exports[`Diagram type renders 1`] = `
 <div
-  class="StyledGrommet-gKbdxL dNFHPo"
+  class="StyledGrommet-gKbdxL kURDTi"
 >
   <div
     class="StyledStack-jtPAMP bgKQVO"

--- a/src/js/components/Diagram/__tests__/__snapshots__/Diagram-test.js.snap
+++ b/src/js/components/Diagram/__tests__/__snapshots__/Diagram-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Diagram color renders 1`] = `
 <div
-  class="StyledGrommet-gKbdxL kDQxAS"
+  class="StyledGrommet-gKbdxL dNFHPo"
 >
   <div
     class="StyledStack-jtPAMP bgKQVO"
@@ -39,7 +39,7 @@ exports[`Diagram color renders 1`] = `
 
 exports[`Diagram offset renders 1`] = `
 <div
-  class="StyledGrommet-gKbdxL kDQxAS"
+  class="StyledGrommet-gKbdxL dNFHPo"
 >
   <div
     class="StyledStack-jtPAMP bgKQVO"
@@ -76,7 +76,7 @@ exports[`Diagram offset renders 1`] = `
 
 exports[`Diagram renders 1`] = `
 <div
-  class="StyledGrommet-gKbdxL kDQxAS"
+  class="StyledGrommet-gKbdxL dNFHPo"
 >
   <div
     class="StyledStack-jtPAMP bgKQVO"
@@ -113,7 +113,7 @@ exports[`Diagram renders 1`] = `
 
 exports[`Diagram thickness renders 1`] = `
 <div
-  class="StyledGrommet-gKbdxL kDQxAS"
+  class="StyledGrommet-gKbdxL dNFHPo"
 >
   <div
     class="StyledStack-jtPAMP bgKQVO"
@@ -150,7 +150,7 @@ exports[`Diagram thickness renders 1`] = `
 
 exports[`Diagram type renders 1`] = `
 <div
-  class="StyledGrommet-gKbdxL kDQxAS"
+  class="StyledGrommet-gKbdxL dNFHPo"
 >
   <div
     class="StyledStack-jtPAMP bgKQVO"

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Drop aligns left right top bottom 1`] = `
 <div
-  class="StyledDrop-czaYBK jMwfOf"
+  class="StyledDrop-czaYBK bGWOnw"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -14,12 +14,11 @@ exports[`Drop aligns left right top bottom 1`] = `
 exports[`Drop aligns left right top bottom 2`] = `
 "
 
-.jMwfOf {
+.bGWOnw {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -43,14 +42,14 @@ exports[`Drop aligns left right top bottom 2`] = `
   animation-delay: 0.01s;
 }
 
-.jMwfOf * {
+.bGWOnw * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns right left top top 1`] = `
 <div
-  class="StyledDrop-czaYBK loJbGv"
+  class="StyledDrop-czaYBK jSLQCY"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -62,12 +61,11 @@ exports[`Drop aligns right left top top 1`] = `
 exports[`Drop aligns right left top top 2`] = `
 "
 
-.loJbGv {
+.jSLQCY {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -91,14 +89,14 @@ exports[`Drop aligns right left top top 2`] = `
   animation-delay: 0.01s;
 }
 
-.loJbGv * {
+.jSLQCY * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns right right bottom top 1`] = `
 <div
-  class="StyledDrop-czaYBK cmxywS"
+  class="StyledDrop-czaYBK kuvvDG"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -110,12 +108,11 @@ exports[`Drop aligns right right bottom top 1`] = `
 exports[`Drop aligns right right bottom top 2`] = `
 "
 
-.cmxywS {
+.kuvvDG {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -139,14 +136,14 @@ exports[`Drop aligns right right bottom top 2`] = `
   animation-delay: 0.01s;
 }
 
-.cmxywS * {
+.kuvvDG * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns right right bottom top 3`] = `
 <div
-  class="StyledDrop-czaYBK cmxywS"
+  class="StyledDrop-czaYBK kuvvDG"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -158,12 +155,11 @@ exports[`Drop aligns right right bottom top 3`] = `
 exports[`Drop aligns right right bottom top 4`] = `
 "
 
-.cmxywS {
+.kuvvDG {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -187,14 +183,14 @@ exports[`Drop aligns right right bottom top 4`] = `
   animation-delay: 0.01s;
 }
 
-.cmxywS * {
+.kuvvDG * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns skips left random 1`] = `
 <div
-  class="StyledDrop-czaYBK fgHsdl"
+  class="StyledDrop-czaYBK AyeHd"
   tabindex="-1"
   id="drop-node"
   style="width: 0.1px; top: 0px; max-height: 768px;"
@@ -206,12 +202,11 @@ exports[`Drop aligns skips left random 1`] = `
 exports[`Drop aligns skips left random 2`] = `
 "
 
-.fgHsdl {
+.AyeHd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -235,14 +230,14 @@ exports[`Drop aligns skips left random 2`] = `
   animation-delay: 0.01s;
 }
 
-.fgHsdl * {
+.AyeHd * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns skips right random 1`] = `
 <div
-  class="StyledDrop-czaYBK loJbGv"
+  class="StyledDrop-czaYBK jSLQCY"
   tabindex="-1"
   id="drop-node"
   style="width: 0.1px; max-height: 768px;"
@@ -254,12 +249,11 @@ exports[`Drop aligns skips right random 1`] = `
 exports[`Drop aligns skips right random 2`] = `
 "
 
-.loJbGv {
+.jSLQCY {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -283,14 +277,14 @@ exports[`Drop aligns skips right random 2`] = `
   animation-delay: 0.01s;
 }
 
-.loJbGv * {
+.jSLQCY * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop mounts 1`] = `
 <div
-  class="StyledDrop-czaYBK jMwfOf"
+  class="StyledDrop-czaYBK bGWOnw"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -302,12 +296,11 @@ exports[`Drop mounts 1`] = `
 exports[`Drop mounts 2`] = `
 "
 
-.jMwfOf {
+.bGWOnw {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -331,14 +324,14 @@ exports[`Drop mounts 2`] = `
   animation-delay: 0.01s;
 }
 
-.jMwfOf * {
+.bGWOnw * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop resizes 1`] = `
 <div
-  class="StyledDrop-czaYBK jMwfOf"
+  class="StyledDrop-czaYBK bGWOnw"
   tabindex="-1"
   id="test"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -350,12 +343,11 @@ exports[`Drop resizes 1`] = `
 exports[`Drop resizes 2`] = `
 "
 
-.jMwfOf {
+.bGWOnw {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -379,14 +371,14 @@ exports[`Drop resizes 2`] = `
   animation-delay: 0.01s;
 }
 
-.jMwfOf * {
+.bGWOnw * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop restrict focus 1`] = `
 <div
-  class="StyledDrop-czaYBK jMwfOf"
+  class="StyledDrop-czaYBK bGWOnw"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -397,7 +389,7 @@ exports[`Drop restrict focus 1`] = `
 
 exports[`Drop restrict focus 2`] = `
 <div
-  class="StyledDrop-czaYBK jMwfOf"
+  class="StyledDrop-czaYBK bGWOnw"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -409,12 +401,11 @@ exports[`Drop restrict focus 2`] = `
 exports[`Drop restrict focus 3`] = `
 "
 
-.jMwfOf {
+.bGWOnw {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -438,7 +429,7 @@ exports[`Drop restrict focus 3`] = `
   animation-delay: 0.01s;
 }
 
-.jMwfOf * {
+.bGWOnw * {
   box-sizing: inherit;
 }"
 `;
@@ -453,7 +444,7 @@ exports[`Drop restrict focus 4`] = `
 
 exports[`Drop skips invalid align 1`] = `
 <div
-  class="StyledDrop-czaYBK jMwfOf"
+  class="StyledDrop-czaYBK bGWOnw"
   tabindex="-1"
   id="drop-node"
   style="width: 0.1px; max-height: 768px;"
@@ -465,12 +456,11 @@ exports[`Drop skips invalid align 1`] = `
 exports[`Drop skips invalid align 2`] = `
 "
 
-.jMwfOf {
+.bGWOnw {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -494,14 +484,14 @@ exports[`Drop skips invalid align 2`] = `
   animation-delay: 0.01s;
 }
 
-.jMwfOf * {
+.bGWOnw * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop updates 1`] = `
 <div
-  class="StyledGrommet-gKbdxL kDQxAS"
+  class="StyledGrommet-gKbdxL dNFHPo"
 >
   <input />
 </div>

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Drop aligns left right top bottom 1`] = `
 <div
-  class="StyledDrop-czaYBK bGWOnw"
+  class="StyledDrop-czaYBK eZHhhX"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -14,7 +14,7 @@ exports[`Drop aligns left right top bottom 1`] = `
 exports[`Drop aligns left right top bottom 2`] = `
 "
 
-.bGWOnw {
+.eZHhhX {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -42,14 +42,14 @@ exports[`Drop aligns left right top bottom 2`] = `
   animation-delay: 0.01s;
 }
 
-.bGWOnw * {
+.eZHhhX * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns right left top top 1`] = `
 <div
-  class="StyledDrop-czaYBK jSLQCY"
+  class="StyledDrop-czaYBK bGmQVA"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -61,7 +61,7 @@ exports[`Drop aligns right left top top 1`] = `
 exports[`Drop aligns right left top top 2`] = `
 "
 
-.jSLQCY {
+.bGmQVA {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -89,14 +89,14 @@ exports[`Drop aligns right left top top 2`] = `
   animation-delay: 0.01s;
 }
 
-.jSLQCY * {
+.bGmQVA * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns right right bottom top 1`] = `
 <div
-  class="StyledDrop-czaYBK kuvvDG"
+  class="StyledDrop-czaYBK hgouJt"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -108,7 +108,7 @@ exports[`Drop aligns right right bottom top 1`] = `
 exports[`Drop aligns right right bottom top 2`] = `
 "
 
-.kuvvDG {
+.hgouJt {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -136,14 +136,14 @@ exports[`Drop aligns right right bottom top 2`] = `
   animation-delay: 0.01s;
 }
 
-.kuvvDG * {
+.hgouJt * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns right right bottom top 3`] = `
 <div
-  class="StyledDrop-czaYBK kuvvDG"
+  class="StyledDrop-czaYBK hgouJt"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -155,7 +155,7 @@ exports[`Drop aligns right right bottom top 3`] = `
 exports[`Drop aligns right right bottom top 4`] = `
 "
 
-.kuvvDG {
+.hgouJt {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -183,14 +183,14 @@ exports[`Drop aligns right right bottom top 4`] = `
   animation-delay: 0.01s;
 }
 
-.kuvvDG * {
+.hgouJt * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns skips left random 1`] = `
 <div
-  class="StyledDrop-czaYBK AyeHd"
+  class="StyledDrop-czaYBK gXwyMM"
   tabindex="-1"
   id="drop-node"
   style="width: 0.1px; top: 0px; max-height: 768px;"
@@ -202,7 +202,7 @@ exports[`Drop aligns skips left random 1`] = `
 exports[`Drop aligns skips left random 2`] = `
 "
 
-.AyeHd {
+.gXwyMM {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -230,14 +230,14 @@ exports[`Drop aligns skips left random 2`] = `
   animation-delay: 0.01s;
 }
 
-.AyeHd * {
+.gXwyMM * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns skips right random 1`] = `
 <div
-  class="StyledDrop-czaYBK jSLQCY"
+  class="StyledDrop-czaYBK bGmQVA"
   tabindex="-1"
   id="drop-node"
   style="width: 0.1px; max-height: 768px;"
@@ -249,7 +249,7 @@ exports[`Drop aligns skips right random 1`] = `
 exports[`Drop aligns skips right random 2`] = `
 "
 
-.jSLQCY {
+.bGmQVA {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -277,14 +277,14 @@ exports[`Drop aligns skips right random 2`] = `
   animation-delay: 0.01s;
 }
 
-.jSLQCY * {
+.bGmQVA * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop mounts 1`] = `
 <div
-  class="StyledDrop-czaYBK bGWOnw"
+  class="StyledDrop-czaYBK eZHhhX"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -296,7 +296,7 @@ exports[`Drop mounts 1`] = `
 exports[`Drop mounts 2`] = `
 "
 
-.bGWOnw {
+.eZHhhX {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -324,14 +324,14 @@ exports[`Drop mounts 2`] = `
   animation-delay: 0.01s;
 }
 
-.bGWOnw * {
+.eZHhhX * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop resizes 1`] = `
 <div
-  class="StyledDrop-czaYBK bGWOnw"
+  class="StyledDrop-czaYBK eZHhhX"
   tabindex="-1"
   id="test"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -343,7 +343,7 @@ exports[`Drop resizes 1`] = `
 exports[`Drop resizes 2`] = `
 "
 
-.bGWOnw {
+.eZHhhX {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -371,14 +371,14 @@ exports[`Drop resizes 2`] = `
   animation-delay: 0.01s;
 }
 
-.bGWOnw * {
+.eZHhhX * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop restrict focus 1`] = `
 <div
-  class="StyledDrop-czaYBK bGWOnw"
+  class="StyledDrop-czaYBK eZHhhX"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -389,7 +389,7 @@ exports[`Drop restrict focus 1`] = `
 
 exports[`Drop restrict focus 2`] = `
 <div
-  class="StyledDrop-czaYBK bGWOnw"
+  class="StyledDrop-czaYBK eZHhhX"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -401,7 +401,7 @@ exports[`Drop restrict focus 2`] = `
 exports[`Drop restrict focus 3`] = `
 "
 
-.bGWOnw {
+.eZHhhX {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -429,7 +429,7 @@ exports[`Drop restrict focus 3`] = `
   animation-delay: 0.01s;
 }
 
-.bGWOnw * {
+.eZHhhX * {
   box-sizing: inherit;
 }"
 `;
@@ -444,7 +444,7 @@ exports[`Drop restrict focus 4`] = `
 
 exports[`Drop skips invalid align 1`] = `
 <div
-  class="StyledDrop-czaYBK bGWOnw"
+  class="StyledDrop-czaYBK eZHhhX"
   tabindex="-1"
   id="drop-node"
   style="width: 0.1px; max-height: 768px;"
@@ -456,7 +456,7 @@ exports[`Drop skips invalid align 1`] = `
 exports[`Drop skips invalid align 2`] = `
 "
 
-.bGWOnw {
+.eZHhhX {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -484,14 +484,14 @@ exports[`Drop skips invalid align 2`] = `
   animation-delay: 0.01s;
 }
 
-.bGWOnw * {
+.eZHhhX * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop updates 1`] = `
 <div
-  class="StyledGrommet-gKbdxL dNFHPo"
+  class="StyledGrommet-gKbdxL kURDTi"
 >
   <input />
 </div>

--- a/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
+++ b/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
@@ -6,7 +6,6 @@ exports[`Grid align renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -78,7 +77,6 @@ exports[`Grid alignContent renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -168,7 +166,6 @@ exports[`Grid areas renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -210,7 +207,6 @@ exports[`Grid columns renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -243,7 +239,6 @@ exports[`Grid gap renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -358,7 +353,6 @@ exports[`Grid justify renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -430,7 +424,6 @@ exports[`Grid justifyContent renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -526,7 +519,6 @@ exports[`Grid renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -558,7 +550,6 @@ exports[`Grid rows renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -598,7 +589,6 @@ exports[`Grid tag renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
+++ b/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Grommet announces 1`] = `
 <div
-  class="StyledGrommet-gKbdxL kDQxAS"
+  class="StyledGrommet-gKbdxL dNFHPo"
 >
   <div>
     hi
@@ -32,7 +32,6 @@ exports[`Grommet hpe theme renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -57,7 +56,6 @@ exports[`Grommet renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
+++ b/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Grommet announces 1`] = `
 <div
-  class="StyledGrommet-gKbdxL dNFHPo"
+  class="StyledGrommet-gKbdxL kURDTi"
 >
   <div>
     hi

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -6,7 +6,6 @@ exports[`Heading level renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -70,7 +69,6 @@ exports[`Heading margin renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -186,7 +184,6 @@ exports[`Heading renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -220,7 +217,6 @@ exports[`Heading size renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -376,7 +372,6 @@ exports[`Heading textAlign renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -433,7 +428,6 @@ exports[`Heading truncate renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/Image/__tests__/__snapshots__/Image-test.js.snap
+++ b/src/js/components/Image/__tests__/__snapshots__/Image-test.js.snap
@@ -6,7 +6,6 @@ exports[`Image fit renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -54,7 +53,6 @@ exports[`Image renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/Keyboard/__tests__/__snapshots__/Keyboard-test.js.snap
+++ b/src/js/components/Keyboard/__tests__/__snapshots__/Keyboard-test.js.snap
@@ -6,7 +6,6 @@ exports[`Keyboard calls onKeyDown 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -35,7 +34,6 @@ exports[`Keyboard renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Layer aligns bottom 1`] = `
 <div
-  class="StyledLayer-EylWz cQEoYc"
+  class="StyledLayer-EylWz kvEpSi"
   id="bottom-test"
   tabindex="-1"
 >
@@ -188,12 +188,11 @@ exports[`Layer aligns bottom 2`] = `
 
 
 
-.cQEoYc {
+.kvEpSi {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -206,12 +205,12 @@ exports[`Layer aligns bottom 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.cQEoYc * {
+.kvEpSi * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .cQEoYc {
+  .kvEpSi {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -223,7 +222,7 @@ exports[`Layer aligns bottom 2`] = `
 
 exports[`Layer aligns left 1`] = `
 <div
-  class="StyledLayer-EylWz cQEoYc"
+  class="StyledLayer-EylWz kvEpSi"
   id="left-test"
   tabindex="-1"
 >
@@ -280,12 +279,11 @@ exports[`Layer aligns left 2`] = `
 
 
 
-.cQEoYc {
+.kvEpSi {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -298,12 +296,12 @@ exports[`Layer aligns left 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.cQEoYc * {
+.kvEpSi * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .cQEoYc {
+  .kvEpSi {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -315,7 +313,7 @@ exports[`Layer aligns left 2`] = `
 
 exports[`Layer aligns right 1`] = `
 <div
-  class="StyledLayer-EylWz cQEoYc"
+  class="StyledLayer-EylWz kvEpSi"
   id="right-test"
   tabindex="-1"
 >
@@ -414,12 +412,11 @@ exports[`Layer aligns right 2`] = `
 
 
 
-.cQEoYc {
+.kvEpSi {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -432,12 +429,12 @@ exports[`Layer aligns right 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.cQEoYc * {
+.kvEpSi * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .cQEoYc {
+  .kvEpSi {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -449,7 +446,7 @@ exports[`Layer aligns right 2`] = `
 
 exports[`Layer aligns top 1`] = `
 <div
-  class="StyledLayer-EylWz cQEoYc"
+  class="StyledLayer-EylWz kvEpSi"
   id="top-test"
   tabindex="-1"
 >
@@ -591,12 +588,11 @@ exports[`Layer aligns top 2`] = `
 
 
 
-.cQEoYc {
+.kvEpSi {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -609,12 +605,12 @@ exports[`Layer aligns top 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.cQEoYc * {
+.kvEpSi * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .cQEoYc {
+  .kvEpSi {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -626,7 +622,7 @@ exports[`Layer aligns top 2`] = `
 
 exports[`Layer hides 1`] = `
 <div
-  class="StyledLayer-EylWz dTHcZQ"
+  class="StyledLayer-EylWz jSjwWR"
   id="hidden-test"
   tabindex="-1"
 >
@@ -830,7 +826,7 @@ exports[`Layer hides 2`] = `
 
 
 @media only screen and (min-width:700px) {
-  .cQEoYc {
+  .kvEpSi {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -839,12 +835,11 @@ exports[`Layer hides 2`] = `
   }
 }
 
-.dTHcZQ {
+.jSjwWR {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -861,14 +856,14 @@ exports[`Layer hides 2`] = `
   position: fixed;
 }
 
-.dTHcZQ * {
+.jSjwWR * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Layer hides 3`] = `
 <div
-  class="StyledLayer-EylWz dTHcZQ"
+  class="StyledLayer-EylWz jSjwWR"
   id="hidden-test"
   tabindex="-1"
 >
@@ -1072,7 +1067,7 @@ exports[`Layer hides 4`] = `
 
 
 @media only screen and (min-width:700px) {
-  .cQEoYc {
+  .kvEpSi {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -1081,12 +1076,11 @@ exports[`Layer hides 4`] = `
   }
 }
 
-.dTHcZQ {
+.jSjwWR {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1103,7 +1097,7 @@ exports[`Layer hides 4`] = `
   position: fixed;
 }
 
-.dTHcZQ * {
+.jSjwWR * {
   box-sizing: inherit;
 }"
 `;
@@ -1144,7 +1138,7 @@ exports[`Layer is accessible 3`] = `
 
 exports[`Layer plain renders 1`] = `
 <div
-  class="StyledLayer-EylWz kTyGqG"
+  class="StyledLayer-EylWz fgLtjB"
   id="plain-test"
   tabindex="-1"
 >
@@ -1397,7 +1391,7 @@ exports[`Layer plain renders 2`] = `
 
 
 @media only screen and (min-width:700px) {
-  .cQEoYc {
+  .kvEpSi {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -1406,12 +1400,11 @@ exports[`Layer plain renders 2`] = `
   }
 }
 
-.kTyGqG {
+.fgLtjB {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1424,12 +1417,12 @@ exports[`Layer plain renders 2`] = `
   background-color: transparent;
 }
 
-.kTyGqG * {
+.fgLtjB * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .kTyGqG {
+  .fgLtjB {
     position: fixed;
     top: 0px;
     left: 0px;

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Layer aligns bottom 1`] = `
 <div
-  class="StyledLayer-EylWz kvEpSi"
+  class="StyledLayer-EylWz AjbAS"
   id="bottom-test"
   tabindex="-1"
 >
@@ -188,7 +188,7 @@ exports[`Layer aligns bottom 2`] = `
 
 
 
-.kvEpSi {
+.AjbAS {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -205,12 +205,12 @@ exports[`Layer aligns bottom 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.kvEpSi * {
+.AjbAS * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .kvEpSi {
+  .AjbAS {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -222,7 +222,7 @@ exports[`Layer aligns bottom 2`] = `
 
 exports[`Layer aligns left 1`] = `
 <div
-  class="StyledLayer-EylWz kvEpSi"
+  class="StyledLayer-EylWz AjbAS"
   id="left-test"
   tabindex="-1"
 >
@@ -279,7 +279,7 @@ exports[`Layer aligns left 2`] = `
 
 
 
-.kvEpSi {
+.AjbAS {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -296,12 +296,12 @@ exports[`Layer aligns left 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.kvEpSi * {
+.AjbAS * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .kvEpSi {
+  .AjbAS {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -313,7 +313,7 @@ exports[`Layer aligns left 2`] = `
 
 exports[`Layer aligns right 1`] = `
 <div
-  class="StyledLayer-EylWz kvEpSi"
+  class="StyledLayer-EylWz AjbAS"
   id="right-test"
   tabindex="-1"
 >
@@ -412,7 +412,7 @@ exports[`Layer aligns right 2`] = `
 
 
 
-.kvEpSi {
+.AjbAS {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -429,12 +429,12 @@ exports[`Layer aligns right 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.kvEpSi * {
+.AjbAS * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .kvEpSi {
+  .AjbAS {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -446,7 +446,7 @@ exports[`Layer aligns right 2`] = `
 
 exports[`Layer aligns top 1`] = `
 <div
-  class="StyledLayer-EylWz kvEpSi"
+  class="StyledLayer-EylWz AjbAS"
   id="top-test"
   tabindex="-1"
 >
@@ -588,7 +588,7 @@ exports[`Layer aligns top 2`] = `
 
 
 
-.kvEpSi {
+.AjbAS {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -605,12 +605,12 @@ exports[`Layer aligns top 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.kvEpSi * {
+.AjbAS * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .kvEpSi {
+  .AjbAS {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -622,7 +622,7 @@ exports[`Layer aligns top 2`] = `
 
 exports[`Layer hides 1`] = `
 <div
-  class="StyledLayer-EylWz jSjwWR"
+  class="StyledLayer-EylWz gwbVnu"
   id="hidden-test"
   tabindex="-1"
 >
@@ -826,7 +826,7 @@ exports[`Layer hides 2`] = `
 
 
 @media only screen and (min-width:700px) {
-  .kvEpSi {
+  .AjbAS {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -835,7 +835,7 @@ exports[`Layer hides 2`] = `
   }
 }
 
-.jSjwWR {
+.gwbVnu {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -856,14 +856,14 @@ exports[`Layer hides 2`] = `
   position: fixed;
 }
 
-.jSjwWR * {
+.gwbVnu * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Layer hides 3`] = `
 <div
-  class="StyledLayer-EylWz jSjwWR"
+  class="StyledLayer-EylWz gwbVnu"
   id="hidden-test"
   tabindex="-1"
 >
@@ -1067,7 +1067,7 @@ exports[`Layer hides 4`] = `
 
 
 @media only screen and (min-width:700px) {
-  .kvEpSi {
+  .AjbAS {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -1076,7 +1076,7 @@ exports[`Layer hides 4`] = `
   }
 }
 
-.jSjwWR {
+.gwbVnu {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -1097,7 +1097,7 @@ exports[`Layer hides 4`] = `
   position: fixed;
 }
 
-.jSjwWR * {
+.gwbVnu * {
   box-sizing: inherit;
 }"
 `;
@@ -1138,7 +1138,7 @@ exports[`Layer is accessible 3`] = `
 
 exports[`Layer plain renders 1`] = `
 <div
-  class="StyledLayer-EylWz fgLtjB"
+  class="StyledLayer-EylWz jOZKic"
   id="plain-test"
   tabindex="-1"
 >
@@ -1391,7 +1391,7 @@ exports[`Layer plain renders 2`] = `
 
 
 @media only screen and (min-width:700px) {
-  .kvEpSi {
+  .AjbAS {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -1400,7 +1400,7 @@ exports[`Layer plain renders 2`] = `
   }
 }
 
-.fgLtjB {
+.jOZKic {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -1417,12 +1417,12 @@ exports[`Layer plain renders 2`] = `
   background-color: transparent;
 }
 
-.fgLtjB * {
+.jOZKic * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .fgLtjB {
+  .jOZKic {
     position: fixed;
     top: 0px;
     left: 0px;

--- a/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
+++ b/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
@@ -6,7 +6,6 @@ exports[`Markdown renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Menu opens and closes on click 1`] = `
 <div
-  class="StyledDrop-czaYBK jMwfOf"
+  class="StyledDrop-czaYBK bGWOnw"
   tabindex="-1"
   id="menu-drop__test"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -129,12 +129,11 @@ exports[`Menu opens and closes on click 2`] = `
 
 
 
-.jMwfOf {
+.bGWOnw {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -158,7 +157,7 @@ exports[`Menu opens and closes on click 2`] = `
   animation-delay: 0.01s;
 }
 
-.jMwfOf * {
+.bGWOnw * {
   box-sizing: inherit;
 }"
 `;

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Menu opens and closes on click 1`] = `
 <div
-  class="StyledDrop-czaYBK bGWOnw"
+  class="StyledDrop-czaYBK eZHhhX"
   tabindex="-1"
   id="menu-drop__test"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -129,7 +129,7 @@ exports[`Menu opens and closes on click 2`] = `
 
 
 
-.bGWOnw {
+.eZHhhX {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -157,7 +157,7 @@ exports[`Menu opens and closes on click 2`] = `
   animation-delay: 0.01s;
 }
 
-.bGWOnw * {
+.eZHhhX * {
   box-sizing: inherit;
 }"
 `;

--- a/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
+++ b/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
@@ -6,7 +6,6 @@ exports[`Meter background renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -137,7 +136,6 @@ exports[`Meter renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -209,7 +207,6 @@ exports[`Meter round renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -310,7 +307,6 @@ exports[`Meter size renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -588,7 +584,6 @@ exports[`Meter thickness renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -866,7 +861,6 @@ exports[`Meter type renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.js.snap
+++ b/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.js.snap
@@ -6,7 +6,6 @@ exports[`Paragraph margin renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -94,7 +93,6 @@ exports[`Paragraph renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -127,7 +125,6 @@ exports[`Paragraph size renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -191,7 +188,6 @@ exports[`Paragraph textAlign renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
+++ b/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
@@ -6,7 +6,6 @@ exports[`RadioButton checked renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -156,7 +155,6 @@ exports[`RadioButton disabled renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -339,7 +337,6 @@ exports[`RadioButton label renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -528,7 +525,6 @@ exports[`RadioButton renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/RangeInput/StyledRangeInput.js
+++ b/src/js/components/RangeInput/StyledRangeInput.js
@@ -23,7 +23,7 @@ const rangeThumbStyle = css`
   height: ${props => props.theme.global.spacing};
   width: ${props => props.theme.global.spacing};
   overflow: visible;
-  background-color: ${props => (props.grommet.dark ? props.theme.global.colors.white : props.theme.global.colors.background)};
+  background-color: ${props => (props.grommet.dark ? props.theme.global.colors.dark[1] : props.theme.global.colors.white)};
   -webkit-appearance: none;
   cursor: pointer;
 `;
@@ -64,9 +64,9 @@ const StyledRangeInput = styled.input`
 
   &::-webkit-slider-thumb {
     ${rangeThumbStyle}
-    
+
     margin-top: -${props => Math.round(parseMetricToNum(props.theme.global.spacing) * 0.45)}px;
-    
+
     ${props => !props.disabled && css`
       &:hover {
         border-color: ${props.grommet.dark ? props.theme.global.colors.white : props.theme.global.hover.textColor};

--- a/src/js/components/RangeInput/StyledRangeInput.js
+++ b/src/js/components/RangeInput/StyledRangeInput.js
@@ -23,7 +23,7 @@ const rangeThumbStyle = css`
   height: ${props => props.theme.global.spacing};
   width: ${props => props.theme.global.spacing};
   overflow: visible;
-  background-color: ${props => (props.grommet.dark ? props.theme.global.colors.dark[1] : props.theme.global.colors.white)};
+  background-color: ${props => (props.grommet.dark ? props.theme.global.colors.black : props.theme.global.colors.white)};
   -webkit-appearance: none;
   cursor: pointer;
 `;

--- a/src/js/components/RangeInput/__tests__/__snapshots__/RangeInput-test.js.snap
+++ b/src/js/components/RangeInput/__tests__/__snapshots__/RangeInput-test.js.snap
@@ -6,7 +6,6 @@ exports[`RangeInput renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
+++ b/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SkipLink mounts 1`] = `
 <div
-  class="StyledLayer-EylWz dTHcZQ"
+  class="StyledLayer-EylWz jSjwWR"
   id="skip-links"
   tabindex="-1"
 >
@@ -73,12 +73,11 @@ exports[`SkipLink mounts 2`] = `
 
 
 
-.dTHcZQ {
+.jSjwWR {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -95,14 +94,14 @@ exports[`SkipLink mounts 2`] = `
   position: fixed;
 }
 
-.dTHcZQ * {
+.jSjwWR * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`SkipLink mounts 3`] = `
 <div
-  class="StyledLayer-EylWz cQEoYc"
+  class="StyledLayer-EylWz kvEpSi"
   id="skip-links"
   tabindex="-1"
 >
@@ -216,12 +215,11 @@ exports[`SkipLink mounts 4`] = `
 
 
 
-.cQEoYc {
+.kvEpSi {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -234,12 +232,12 @@ exports[`SkipLink mounts 4`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.cQEoYc * {
+.kvEpSi * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .cQEoYc {
+  .kvEpSi {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -258,7 +256,7 @@ exports[`SkipLink mounts 5`] = `
       hidden=""
     >
       <div
-        class="StyledLayer-EylWz dTHcZQ"
+        class="StyledLayer-EylWz jSjwWR"
         id="skip-links"
         tabindex="-1"
       >

--- a/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
+++ b/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SkipLink mounts 1`] = `
 <div
-  class="StyledLayer-EylWz jSjwWR"
+  class="StyledLayer-EylWz gwbVnu"
   id="skip-links"
   tabindex="-1"
 >
@@ -73,7 +73,7 @@ exports[`SkipLink mounts 2`] = `
 
 
 
-.jSjwWR {
+.gwbVnu {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -94,14 +94,14 @@ exports[`SkipLink mounts 2`] = `
   position: fixed;
 }
 
-.jSjwWR * {
+.gwbVnu * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`SkipLink mounts 3`] = `
 <div
-  class="StyledLayer-EylWz kvEpSi"
+  class="StyledLayer-EylWz AjbAS"
   id="skip-links"
   tabindex="-1"
 >
@@ -215,7 +215,7 @@ exports[`SkipLink mounts 4`] = `
 
 
 
-.kvEpSi {
+.AjbAS {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -232,12 +232,12 @@ exports[`SkipLink mounts 4`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.kvEpSi * {
+.AjbAS * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .kvEpSi {
+  .AjbAS {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -256,7 +256,7 @@ exports[`SkipLink mounts 5`] = `
       hidden=""
     >
       <div
-        class="StyledLayer-EylWz jSjwWR"
+        class="StyledLayer-EylWz gwbVnu"
         id="skip-links"
         tabindex="-1"
       >

--- a/src/js/components/Stack/__tests__/__snapshots__/Stack-test.js.snap
+++ b/src/js/components/Stack/__tests__/__snapshots__/Stack-test.js.snap
@@ -6,7 +6,6 @@ exports[`Stack anchor renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -264,7 +263,6 @@ exports[`Stack guidingChild renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -373,7 +371,6 @@ exports[`Stack renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -61,7 +61,7 @@ exports[`Tabs changes active index 1`] = `
 
 exports[`Tabs changes to second tab 1`] = `
 <div
-  className="StyledGrommet-gKbdxL kDQxAS"
+  className="StyledGrommet-gKbdxL dNFHPo"
 >
   <div
     role="tablist"
@@ -151,7 +151,7 @@ exports[`Tabs changes to second tab 1`] = `
 
 exports[`Tabs renders complex Tab title 1`] = `
 <div
-  className="StyledGrommet-gKbdxL kDQxAS"
+  className="StyledGrommet-gKbdxL dNFHPo"
 >
   <div
     role="tablist"
@@ -234,7 +234,7 @@ exports[`Tabs renders complex Tab title 1`] = `
 
 exports[`Tabs renders with Tab 1`] = `
 <div
-  className="StyledGrommet-gKbdxL kDQxAS"
+  className="StyledGrommet-gKbdxL dNFHPo"
 >
   <div
     role="tablist"
@@ -324,7 +324,7 @@ exports[`Tabs renders with Tab 1`] = `
 
 exports[`Tabs renders without Tab 1`] = `
 <div
-  className="StyledGrommet-gKbdxL kDQxAS"
+  className="StyledGrommet-gKbdxL dNFHPo"
 >
   <div
     role="tablist"

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -61,7 +61,7 @@ exports[`Tabs changes active index 1`] = `
 
 exports[`Tabs changes to second tab 1`] = `
 <div
-  className="StyledGrommet-gKbdxL dNFHPo"
+  className="StyledGrommet-gKbdxL kURDTi"
 >
   <div
     role="tablist"
@@ -151,7 +151,7 @@ exports[`Tabs changes to second tab 1`] = `
 
 exports[`Tabs renders complex Tab title 1`] = `
 <div
-  className="StyledGrommet-gKbdxL dNFHPo"
+  className="StyledGrommet-gKbdxL kURDTi"
 >
   <div
     role="tablist"
@@ -234,7 +234,7 @@ exports[`Tabs renders complex Tab title 1`] = `
 
 exports[`Tabs renders with Tab 1`] = `
 <div
-  className="StyledGrommet-gKbdxL dNFHPo"
+  className="StyledGrommet-gKbdxL kURDTi"
 >
   <div
     role="tablist"
@@ -324,7 +324,7 @@ exports[`Tabs renders with Tab 1`] = `
 
 exports[`Tabs renders without Tab 1`] = `
 <div
-  className="StyledGrommet-gKbdxL dNFHPo"
+  className="StyledGrommet-gKbdxL kURDTi"
 >
   <div
     role="tablist"

--- a/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
+++ b/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
@@ -6,7 +6,6 @@ exports[`Text color renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -40,7 +39,6 @@ exports[`Text margin renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -165,7 +163,6 @@ exports[`Text renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -199,7 +196,6 @@ exports[`Text size renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -277,7 +273,6 @@ exports[`Text tag renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -309,7 +304,6 @@ exports[`Text textAlign renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -360,7 +354,6 @@ exports[`Text truncate renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/TextArea/__tests__/__snapshots__/TextArea-test.js.snap
+++ b/src/js/components/TextArea/__tests__/__snapshots__/TextArea-test.js.snap
@@ -6,7 +6,6 @@ exports[`TextArea focusIndicator renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -78,7 +77,6 @@ exports[`TextArea placeholder renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -151,7 +149,6 @@ exports[`TextArea plain renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -211,7 +208,6 @@ exports[`TextArea renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`TextInput closes suggestion drop 1`] = `
 <div
-  class="StyledDrop-czaYBK jMwfOf"
+  class="StyledDrop-czaYBK bGWOnw"
   tabindex="-1"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -52,12 +52,11 @@ exports[`TextInput closes suggestion drop 2`] = `
 
 
 
-.jMwfOf {
+.bGWOnw {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -81,14 +80,14 @@ exports[`TextInput closes suggestion drop 2`] = `
   animation-delay: 0.01s;
 }
 
-.jMwfOf * {
+.bGWOnw * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`TextInput closes suggestion drop 3`] = `
 <div
-  class="StyledGrommet-gKbdxL kDQxAS"
+  class="StyledGrommet-gKbdxL dNFHPo"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-gOoAsL gBrQQI"
@@ -105,7 +104,7 @@ exports[`TextInput closes suggestion drop 3`] = `
 
 exports[`TextInput handles next and previous without suggestion 1`] = `
 <div
-  class="StyledGrommet-gKbdxL kDQxAS"
+  class="StyledGrommet-gKbdxL dNFHPo"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-gOoAsL gBrQQI"
@@ -134,7 +133,7 @@ exports[`TextInput mounts 1`] = `
 
 exports[`TextInput mounts with complex suggestions 1`] = `
 <div
-  class="StyledDrop-czaYBK jMwfOf"
+  class="StyledDrop-czaYBK bGWOnw"
   tabindex="-1"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -184,12 +183,11 @@ exports[`TextInput mounts with complex suggestions 2`] = `
 
 
 
-.jMwfOf {
+.bGWOnw {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -213,14 +211,14 @@ exports[`TextInput mounts with complex suggestions 2`] = `
   animation-delay: 0.01s;
 }
 
-.jMwfOf * {
+.bGWOnw * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`TextInput mounts with suggestions 1`] = `
 <div
-  class="StyledDrop-czaYBK jMwfOf"
+  class="StyledDrop-czaYBK bGWOnw"
   tabindex="-1"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -270,12 +268,11 @@ exports[`TextInput mounts with suggestions 2`] = `
 
 
 
-.jMwfOf {
+.bGWOnw {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -299,14 +296,14 @@ exports[`TextInput mounts with suggestions 2`] = `
   animation-delay: 0.01s;
 }
 
-.jMwfOf * {
+.bGWOnw * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`TextInput selects suggestion 1`] = `
 <div
-  class="StyledDrop-czaYBK jMwfOf"
+  class="StyledDrop-czaYBK bGWOnw"
   tabindex="-1"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -356,12 +353,11 @@ exports[`TextInput selects suggestion 2`] = `
 
 
 
-.jMwfOf {
+.bGWOnw {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -385,14 +381,14 @@ exports[`TextInput selects suggestion 2`] = `
   animation-delay: 0.01s;
 }
 
-.jMwfOf * {
+.bGWOnw * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`TextInput selects suggestion 3`] = `
 <div
-  class="StyledGrommet-gKbdxL kDQxAS"
+  class="StyledGrommet-gKbdxL dNFHPo"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-gOoAsL gCsbgz"

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`TextInput closes suggestion drop 1`] = `
 <div
-  class="StyledDrop-czaYBK bGWOnw"
+  class="StyledDrop-czaYBK eZHhhX"
   tabindex="-1"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -52,7 +52,7 @@ exports[`TextInput closes suggestion drop 2`] = `
 
 
 
-.bGWOnw {
+.eZHhhX {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -80,14 +80,14 @@ exports[`TextInput closes suggestion drop 2`] = `
   animation-delay: 0.01s;
 }
 
-.bGWOnw * {
+.eZHhhX * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`TextInput closes suggestion drop 3`] = `
 <div
-  class="StyledGrommet-gKbdxL dNFHPo"
+  class="StyledGrommet-gKbdxL kURDTi"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-gOoAsL gBrQQI"
@@ -104,7 +104,7 @@ exports[`TextInput closes suggestion drop 3`] = `
 
 exports[`TextInput handles next and previous without suggestion 1`] = `
 <div
-  class="StyledGrommet-gKbdxL dNFHPo"
+  class="StyledGrommet-gKbdxL kURDTi"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-gOoAsL gBrQQI"
@@ -133,7 +133,7 @@ exports[`TextInput mounts 1`] = `
 
 exports[`TextInput mounts with complex suggestions 1`] = `
 <div
-  class="StyledDrop-czaYBK bGWOnw"
+  class="StyledDrop-czaYBK eZHhhX"
   tabindex="-1"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -183,7 +183,7 @@ exports[`TextInput mounts with complex suggestions 2`] = `
 
 
 
-.bGWOnw {
+.eZHhhX {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -211,14 +211,14 @@ exports[`TextInput mounts with complex suggestions 2`] = `
   animation-delay: 0.01s;
 }
 
-.bGWOnw * {
+.eZHhhX * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`TextInput mounts with suggestions 1`] = `
 <div
-  class="StyledDrop-czaYBK bGWOnw"
+  class="StyledDrop-czaYBK eZHhhX"
   tabindex="-1"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -268,7 +268,7 @@ exports[`TextInput mounts with suggestions 2`] = `
 
 
 
-.bGWOnw {
+.eZHhhX {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -296,14 +296,14 @@ exports[`TextInput mounts with suggestions 2`] = `
   animation-delay: 0.01s;
 }
 
-.bGWOnw * {
+.eZHhhX * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`TextInput selects suggestion 1`] = `
 <div
-  class="StyledDrop-czaYBK bGWOnw"
+  class="StyledDrop-czaYBK eZHhhX"
   tabindex="-1"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -353,7 +353,7 @@ exports[`TextInput selects suggestion 2`] = `
 
 
 
-.bGWOnw {
+.eZHhhX {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -381,14 +381,14 @@ exports[`TextInput selects suggestion 2`] = `
   animation-delay: 0.01s;
 }
 
-.bGWOnw * {
+.eZHhhX * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`TextInput selects suggestion 3`] = `
 <div
-  class="StyledGrommet-gKbdxL dNFHPo"
+  class="StyledGrommet-gKbdxL kURDTi"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-gOoAsL gCsbgz"

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -6,7 +6,6 @@ exports[`Video autoPlay renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -475,7 +474,6 @@ exports[`Video controls renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1205,7 +1203,6 @@ exports[`Video fit renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -1894,7 +1891,6 @@ exports[`Video loop renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -2363,7 +2359,6 @@ exports[`Video mute renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -2832,7 +2827,6 @@ exports[`Video renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/WorldMap/__tests__/__snapshots__/WorldMap-test.js.snap
+++ b/src/js/components/WorldMap/__tests__/__snapshots__/WorldMap-test.js.snap
@@ -6,7 +6,6 @@ exports[`WorldMap color renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -139,7 +138,6 @@ exports[`WorldMap continents renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -281,7 +279,6 @@ exports[`WorldMap onSelectPlace renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -417,7 +414,6 @@ exports[`WorldMap places renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -564,7 +560,6 @@ exports[`WorldMap renders 1`] = `
   font-size: 1em;
   line-height: 1.5;
   color: #333333;
-  background-color: #FFFFFF;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/themes/vanilla.js
+++ b/src/js/themes/vanilla.js
@@ -48,7 +48,6 @@ export default deepFreeze({
     colors: {
       active: activeColor,
       accent: accentColors,
-      background: backgroundColor,
       black: '#000000',
       border: borderColor,
       brand: brandColor,
@@ -325,7 +324,7 @@ export default deepFreeze({
     `,
   },
   layer: {
-    backgroundColor: '#FFFFFF',
+    backgroundColor,
     border: {
       radius: '4px',
     },

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -78,7 +78,8 @@ export const baseStyle = css`
   line-height: ${props => (
     parseMetricToNum(props.theme.global.lineHeight) / parseMetricToNum(props.theme.global.font.size)
   )};
-  color: ${props => props.theme.global.colors.text};
+  ${props => props.theme.global.colors.text &&
+    `color: ${props.theme.global.colors.text};`}
   ${props => props.theme.global.colors.background &&
     `background-color: ${props.theme.global.colors.background};`}
 

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -53,19 +53,21 @@ export const backgroundStyle = (background, theme) => {
     }
     return undefined;
   }
-  if (background.lastIndexOf('url', 0) === 0) {
-    return css`
-      background: ${background} no-repeat center center;
-      background-size: cover;
-    `;
-  }
-  const color = colorForName(background, theme);
-  if (color) {
-    return css`
-      background-color: ${color};
-      color: ${colorIsDark(color) ?
-        theme.global.colors.darkBackground.text : theme.global.colors.text};
-    `;
+  if (background) {
+    if (background.lastIndexOf('url', 0) === 0) {
+      return css`
+        background: ${background} no-repeat center center;
+        background-size: cover;
+      `;
+    }
+    const color = colorForName(background, theme);
+    if (color) {
+      return css`
+        background-color: ${color};
+        color: ${colorIsDark(color) ?
+          theme.global.colors.darkBackground.text : theme.global.colors.text};
+      `;
+    }
   }
   return undefined;
 };
@@ -77,7 +79,8 @@ export const baseStyle = css`
     parseMetricToNum(props.theme.global.lineHeight) / parseMetricToNum(props.theme.global.font.size)
   )};
   color: ${props => props.theme.global.colors.text};
-  background-color: ${props => props.theme.global.colors.background};
+  ${props => props.theme.global.colors.background &&
+    `background-color: ${props.theme.global.colors.background};`}
 
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;


### PR DESCRIPTION
#### What does this PR do?

This change allows callers to use Grommet in an existing page without setting background and text colors to match, they will inherit from the context where the Grommet component is used.

#### Where should the reviewer start?

vanilla.js and styles.js

#### What testing has been done on this PR?

grommet-site Try screen where themes can be customized.

#### How should this be manually tested?

same

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

I consider the changes to be fixing a bug, so prior v2 behavior that depended on that, though unlikely, could be changed.