### PR TITLE
Fixed an issue with Select not placing the drop correctly when using a custom value element

### DIFF
--- a/src/js/components/Select.js
+++ b/src/js/components/Select.js
@@ -92,7 +92,7 @@ export default class Select extends Component {
 
       if (! inline) {
         // If this is inside a FormField, place the drop in reference to it.
-        const control = this.inputRef;
+        const control = this.valueRef || this.inputRef;
         this._drop = new Drop(control,
           this._renderOptions(`${CLASS_ROOT}__drop`), {
             align: { top: 'bottom', left: 'left' },
@@ -447,12 +447,13 @@ export default class Select extends Component {
 
       return (
         <div className={classes} onClick={this._onAddDrop}>
-          {shouldRenderElement && renderedValue}
+          {shouldRenderElement ?
+            <div ref={ref => this.valueRef = ref}>{renderedValue}</div> : null}
           <input {...restProps} ref={ref => this.inputRef = ref}
             type={shouldRenderElement ? 'hidden' : 'text'}
             className={`${INPUT} ${CLASS_ROOT}__input`}
             placeholder={placeHolder} readOnly={true}
-            value={renderedValue || ''} />
+            value={(!shouldRenderElement && renderedValue) || ''} />
           <Button className={`${CLASS_ROOT}__control`}
             a11yTitle={Intl.getMessage(intl, 'Select Icon')}
             icon={<CaretDownIcon />}

--- a/src/js/components/Select.js
+++ b/src/js/components/Select.js
@@ -366,16 +366,17 @@ export default class Select extends Component {
     if (options) {
       items = options.map((option, index) => {
         const selected = this._optionSelected(option, value);
+        let content = this._renderLabel(option);
         let classes = classnames(
           {
             [`${CLASS_ROOT}__option`]: true,
+            [`${CLASS_ROOT}__option--element`]: React.isValidElement(content),
             [`${CLASS_ROOT}__option--selected`]: selected,
             [`${CLASS_ROOT}__option--active`]:
               index === activeOptionIndex
           }
         );
 
-        let content = this._renderLabel(option);
         if (option && option.icon) {
           content = (
             <span>{option.icon} {content}</span>
@@ -447,8 +448,12 @@ export default class Select extends Component {
 
       return (
         <div className={classes} onClick={this._onAddDrop}>
-          {shouldRenderElement ?
-            <div ref={ref => this.valueRef = ref}>{renderedValue}</div> : null}
+          {shouldRenderElement ? (
+            <div ref={ref => this.valueRef = ref}
+              className={`${CLASS_ROOT}__value`}>
+              {renderedValue}
+            </div>
+          ) : null}
           <input {...restProps} ref={ref => this.inputRef = ref}
             type={shouldRenderElement ? 'hidden' : 'text'}
             className={`${INPUT} ${CLASS_ROOT}__input`}

--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -134,6 +134,10 @@ $colored-select-drop-caret: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB
     }
   }
 
+  > .#{$grommet-namespace}select:not(.#{$grommet-namespace}select--inline) .#{$grommet-namespace}select__value {
+    border: none;
+  }
+
   > input:not([type]),
   > input[type=text],
   > input[type=range],

--- a/src/scss/grommet-core/_objects.select.scss
+++ b/src/scss/grommet-core/_objects.select.scss
@@ -37,6 +37,13 @@
   display: none;
 }
 
+.#{$grommet-namespace}select__value {
+  // leave room for control
+  padding: quarter($inuit-base-spacing-unit) double($inuit-base-spacing-unit) quarter($inuit-base-spacing-unit) 0;
+  border: $input-border-width solid $border-color;
+  border-radius: $border-radius;
+}
+
 .#{$grommet-namespace}select__control {
   position: absolute;
   top: 50%;
@@ -73,6 +80,11 @@
     @include text();
     color: $text-color;
     padding: quarter($inuit-base-spacing-unit) $inuit-base-spacing-unit;
+
+    &.#{$grommet-namespace}select__option--element {
+      padding: quarter($inuit-base-spacing-unit) 0;
+    }
+
 
     &:hover,
     &--active {


### PR DESCRIPTION
#### What does this PR do?

Fixes a couple of issues with Select when the value property is a custom element.
One issue was how the Drop was being placed incorrectly.
The other issue was how the border was being rendered.

#### Where should the reviewer start?

Select.js

#### What testing has been done on this PR?

adding to grommet-docs example

#### How should this be manually tested?

#### Any background context you want to provide?

When setting the contained `input` element to `type='hidden'`, it doesn't get placed by the browser, and so the drop has no reference location to place itself by.

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/1784

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

sure

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
