### PR TITLE
Use styled-components to generate keyframes

### DIFF
--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -800,7 +800,7 @@ exports[`Box background renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   max-width: 100%;
-  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==) no-repeat center center;
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==) no-repeat;
   background-position: center center;
   background-size: cover;
   color: #333333;
@@ -816,7 +816,7 @@ exports[`Box background renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   max-width: 100%;
-  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==) no-repeat center center;
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==) no-repeat;
   background-position: center center;
   background-size: cover;
   color: #FFFFFF;
@@ -832,7 +832,7 @@ exports[`Box background renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   max-width: 100%;
-  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==) no-repeat center center;
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==) no-repeat;
   background-position: top center;
   background-size: cover;
   color: inherit;

--- a/src/js/components/Clock/StyledClock.js
+++ b/src/js/components/Clock/StyledClock.js
@@ -1,4 +1,11 @@
-import styled, { css } from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
+
+
+const rotateKeyframe = keyframes`
+    100% {
+      transform: rotateZ(360deg);
+    }
+`;
 
 export const StyledCircle = styled.circle`
   stroke-width: ${props => props.theme.clock.circle.width};
@@ -18,7 +25,7 @@ export const StyledHour = styled.line`
   transition: stroke 1s ease-out;
 
   ${props => props.animate && `
-    animation: rotate 43200s infinite linear;
+    animation: ${rotateKeyframe} 43200s infinite linear;
   `}
 `;
 
@@ -28,7 +35,7 @@ export const StyledMinute = styled.line`
   transition: stroke 1s ease-out;
 
   ${props => props.animate && `
-    animation: rotate 3600s infinite steps(60);
+    animation: ${rotateKeyframe} 3600s infinite steps(60);
     animation-delay: 1s;
   `}
 `;
@@ -39,19 +46,13 @@ export const StyledSecond = styled.line`
   transition: stroke 1s ease-out;
 
   ${props => props.animate && `
-    animation: rotate 60s infinite steps(60);
+    animation: ${rotateKeyframe} 60s infinite steps(60);
   `}
 `;
 
 const StyledClock = styled.svg`
   width: ${props => props.theme.clock.size[props.size]};
   height: ${props => props.theme.clock.size[props.size]};
-
-  @keyframes rotate {
-    100% {
-      transform: rotateZ(360deg);
-    }
-  }
 `;
 
 export default StyledClock.extend`

--- a/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
+++ b/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Clock animates second hand 1`] = `
 <svg
-  class="StyledClock-bEPleQ xuTSy"
+  class="StyledClock-bEPleQ humySj"
   version="1.1"
   width="96"
   height="96"
@@ -49,7 +49,7 @@ exports[`Clock animates second hand 1`] = `
 
 exports[`Clock animates second hand 2`] = `
 <svg
-  class="StyledClock-bEPleQ xuTSy"
+  class="StyledClock-bEPleQ humySj"
   version="1.1"
   width="96"
   height="96"
@@ -96,7 +96,7 @@ exports[`Clock animates second hand 2`] = `
 
 exports[`Clock night renders 1`] = `
 <svg
-  class="StyledClock-bEPleQ xuTSy"
+  class="StyledClock-bEPleQ humySj"
   version="1.1"
   width="96"
   height="96"
@@ -134,7 +134,7 @@ exports[`Clock night renders 1`] = `
 
 exports[`Clock night renders 2`] = `
 <svg
-  class="StyledClock-bEPleQ xuTSy"
+  class="StyledClock-bEPleQ humySj"
   version="1.1"
   width="96"
   height="96"
@@ -175,7 +175,7 @@ exports[`Clock renders 1`] = `
   class="StyledGrommet-gGRXwz fbqGIt"
 >
   <svg
-    class="StyledClock-bEPleQ xuTSy"
+    class="StyledClock-bEPleQ humySj"
     version="1.1"
     width="96"
     height="96"
@@ -226,7 +226,7 @@ exports[`Clock renders 2`] = `
   class="StyledGrommet-gGRXwz fbqGIt"
 >
   <svg
-    class="StyledClock-bEPleQ xuTSy"
+    class="StyledClock-bEPleQ humySj"
     version="1.1"
     width="96"
     height="96"
@@ -242,7 +242,7 @@ exports[`Clock renders 2`] = `
       r="46"
     />
     <line
-      class="StyledClock__StyledSecond-oRaEs glIWSO"
+      class="StyledClock__StyledSecond-oRaEs dmRrQr"
       x1="48"
       y1="48"
       x2="48"
@@ -251,7 +251,7 @@ exports[`Clock renders 2`] = `
       stroke-linecap="round"
     />
     <line
-      class="StyledClock__StyledMinute-bDjMrZ Wfczg"
+      class="StyledClock__StyledMinute-bDjMrZ kLeTDM"
       x1="48"
       y1="48"
       x2="48"
@@ -260,7 +260,7 @@ exports[`Clock renders 2`] = `
       stroke-linecap="round"
     />
     <line
-      class="StyledClock__StyledHour-fpyVuK bIeIta"
+      class="StyledClock__StyledHour-fpyVuK bzoHew"
       x1="48"
       y1="48"
       x2="48"

--- a/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
+++ b/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
@@ -242,7 +242,7 @@ exports[`Clock renders 2`] = `
       r="46"
     />
     <line
-      class="StyledClock__StyledSecond-oRaEs dmRrQr"
+      class="StyledClock__StyledSecond-oRaEs kgjbvG"
       x1="48"
       y1="48"
       x2="48"
@@ -251,7 +251,7 @@ exports[`Clock renders 2`] = `
       stroke-linecap="round"
     />
     <line
-      class="StyledClock__StyledMinute-bDjMrZ kLeTDM"
+      class="StyledClock__StyledMinute-bDjMrZ iPvwyA"
       x1="48"
       y1="48"
       x2="48"
@@ -260,7 +260,7 @@ exports[`Clock renders 2`] = `
       stroke-linecap="round"
     />
     <line
-      class="StyledClock__StyledHour-fpyVuK bzoHew"
+      class="StyledClock__StyledHour-fpyVuK eQMuaB"
       x1="48"
       y1="48"
       x2="48"

--- a/src/js/components/Drop/StyledDrop.js
+++ b/src/js/components/Drop/StyledDrop.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 import { backgroundStyle, baseStyle } from '../../utils';
 
@@ -13,6 +13,18 @@ function getTransformOriginStyle(align) {
   }
   return `${vertical} ${horizontal}`;
 }
+
+const dropKeyFrames = keyframes`
+  0% {
+    opacity: 0.5;
+    transform: scale(0.8);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+`;
+
 const StyledDrop = styled.div`
   ${baseStyle}
 
@@ -20,7 +32,7 @@ const StyledDrop = styled.div`
   box-shadow: ${props => props.theme.global.drop.shadow};
   position: fixed;
   z-index: 20;
-  
+
   overflow: auto;
   outline: none;
 
@@ -30,20 +42,8 @@ const StyledDrop = styled.div`
 
   opacity: 0;
   transform-origin: ${props => getTransformOriginStyle(props.align)};
-  animation: grow-box 0.1s forwards;
+  animation:  ${dropKeyFrames} 0.1s forwards;
   animation-delay: 0.01s;
-
-  @keyframes grow-box {
-    0% {
-      opacity: 0.5;
-      transform: scale(0.8);
-    }
-
-    100% {
-      opacity: 1;
-      transform: scale(1);
-    }
-  }
 `;
 
 export default StyledDrop.extend`

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Drop aligns left right top bottom 1`] = `
 <div
-  class="StyledDrop-bCWxPe eRQUdY"
+  class="StyledDrop-bCWxPe hEiKPj"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -14,7 +14,7 @@ exports[`Drop aligns left right top bottom 1`] = `
 exports[`Drop aligns left right top bottom 2`] = `
 "
 
-.eRQUdY {
+.hEiKPj {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -36,20 +36,20 @@ exports[`Drop aligns left right top bottom 2`] = `
   -webkit-transform-origin: top left;
   -ms-transform-origin: top left;
   transform-origin: top left;
-  -webkit-animation: grow-box 0.1s forwards;
-  animation: grow-box 0.1s forwards;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
 }
 
-.eRQUdY * {
+.hEiKPj * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns right left top top 1`] = `
 <div
-  class="StyledDrop-bCWxPe flheEl"
+  class="StyledDrop-bCWxPe gSWhZw"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -61,7 +61,7 @@ exports[`Drop aligns right left top top 1`] = `
 exports[`Drop aligns right left top top 2`] = `
 "
 
-.flheEl {
+.gSWhZw {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -83,20 +83,20 @@ exports[`Drop aligns right left top top 2`] = `
   -webkit-transform-origin: top right;
   -ms-transform-origin: top right;
   transform-origin: top right;
-  -webkit-animation: grow-box 0.1s forwards;
-  animation: grow-box 0.1s forwards;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
 }
 
-.flheEl * {
+.gSWhZw * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns right right bottom top 1`] = `
 <div
-  class="StyledDrop-bCWxPe dnTOyg"
+  class="StyledDrop-bCWxPe jYGEAD"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -108,7 +108,7 @@ exports[`Drop aligns right right bottom top 1`] = `
 exports[`Drop aligns right right bottom top 2`] = `
 "
 
-.dnTOyg {
+.jYGEAD {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -130,20 +130,20 @@ exports[`Drop aligns right right bottom top 2`] = `
   -webkit-transform-origin: bottom right;
   -ms-transform-origin: bottom right;
   transform-origin: bottom right;
-  -webkit-animation: grow-box 0.1s forwards;
-  animation: grow-box 0.1s forwards;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
 }
 
-.dnTOyg * {
+.jYGEAD * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns right right bottom top 3`] = `
 <div
-  class="StyledDrop-bCWxPe dnTOyg"
+  class="StyledDrop-bCWxPe jYGEAD"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -155,7 +155,7 @@ exports[`Drop aligns right right bottom top 3`] = `
 exports[`Drop aligns right right bottom top 4`] = `
 "
 
-.dnTOyg {
+.jYGEAD {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -177,20 +177,20 @@ exports[`Drop aligns right right bottom top 4`] = `
   -webkit-transform-origin: bottom right;
   -ms-transform-origin: bottom right;
   transform-origin: bottom right;
-  -webkit-animation: grow-box 0.1s forwards;
-  animation: grow-box 0.1s forwards;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
 }
 
-.dnTOyg * {
+.jYGEAD * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns skips left random 1`] = `
 <div
-  class="StyledDrop-bCWxPe fTrLnY"
+  class="StyledDrop-bCWxPe tMsBQ"
   tabindex="-1"
   id="drop-node"
   style="width: 0.1px; top: 0px; max-height: 768px;"
@@ -202,7 +202,7 @@ exports[`Drop aligns skips left random 1`] = `
 exports[`Drop aligns skips left random 2`] = `
 "
 
-.fTrLnY {
+.tMsBQ {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -224,20 +224,20 @@ exports[`Drop aligns skips left random 2`] = `
   -webkit-transform-origin: bottom left;
   -ms-transform-origin: bottom left;
   transform-origin: bottom left;
-  -webkit-animation: grow-box 0.1s forwards;
-  animation: grow-box 0.1s forwards;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
 }
 
-.fTrLnY * {
+.tMsBQ * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns skips right random 1`] = `
 <div
-  class="StyledDrop-bCWxPe flheEl"
+  class="StyledDrop-bCWxPe gSWhZw"
   tabindex="-1"
   id="drop-node"
   style="width: 0.1px; max-height: 768px;"
@@ -249,7 +249,7 @@ exports[`Drop aligns skips right random 1`] = `
 exports[`Drop aligns skips right random 2`] = `
 "
 
-.flheEl {
+.gSWhZw {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -271,20 +271,20 @@ exports[`Drop aligns skips right random 2`] = `
   -webkit-transform-origin: top right;
   -ms-transform-origin: top right;
   transform-origin: top right;
-  -webkit-animation: grow-box 0.1s forwards;
-  animation: grow-box 0.1s forwards;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
 }
 
-.flheEl * {
+.gSWhZw * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop mounts 1`] = `
 <div
-  class="StyledDrop-bCWxPe eRQUdY"
+  class="StyledDrop-bCWxPe hEiKPj"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -296,7 +296,7 @@ exports[`Drop mounts 1`] = `
 exports[`Drop mounts 2`] = `
 "
 
-.eRQUdY {
+.hEiKPj {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -318,20 +318,20 @@ exports[`Drop mounts 2`] = `
   -webkit-transform-origin: top left;
   -ms-transform-origin: top left;
   transform-origin: top left;
-  -webkit-animation: grow-box 0.1s forwards;
-  animation: grow-box 0.1s forwards;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
 }
 
-.eRQUdY * {
+.hEiKPj * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop resizes 1`] = `
 <div
-  class="StyledDrop-bCWxPe eRQUdY"
+  class="StyledDrop-bCWxPe hEiKPj"
   tabindex="-1"
   id="test"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -343,7 +343,7 @@ exports[`Drop resizes 1`] = `
 exports[`Drop resizes 2`] = `
 "
 
-.eRQUdY {
+.hEiKPj {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -365,20 +365,20 @@ exports[`Drop resizes 2`] = `
   -webkit-transform-origin: top left;
   -ms-transform-origin: top left;
   transform-origin: top left;
-  -webkit-animation: grow-box 0.1s forwards;
-  animation: grow-box 0.1s forwards;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
 }
 
-.eRQUdY * {
+.hEiKPj * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`Drop restrict focus 1`] = `
 <div
-  class="StyledDrop-bCWxPe eRQUdY"
+  class="StyledDrop-bCWxPe hEiKPj"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -389,7 +389,7 @@ exports[`Drop restrict focus 1`] = `
 
 exports[`Drop restrict focus 2`] = `
 <div
-  class="StyledDrop-bCWxPe eRQUdY"
+  class="StyledDrop-bCWxPe hEiKPj"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -401,7 +401,7 @@ exports[`Drop restrict focus 2`] = `
 exports[`Drop restrict focus 3`] = `
 "
 
-.eRQUdY {
+.hEiKPj {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -423,13 +423,13 @@ exports[`Drop restrict focus 3`] = `
   -webkit-transform-origin: top left;
   -ms-transform-origin: top left;
   transform-origin: top left;
-  -webkit-animation: grow-box 0.1s forwards;
-  animation: grow-box 0.1s forwards;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
 }
 
-.eRQUdY * {
+.hEiKPj * {
   box-sizing: inherit;
 }"
 `;
@@ -444,7 +444,7 @@ exports[`Drop restrict focus 4`] = `
 
 exports[`Drop skips invalid align 1`] = `
 <div
-  class="StyledDrop-bCWxPe eRQUdY"
+  class="StyledDrop-bCWxPe hEiKPj"
   tabindex="-1"
   id="drop-node"
   style="width: 0.1px; max-height: 768px;"
@@ -456,7 +456,7 @@ exports[`Drop skips invalid align 1`] = `
 exports[`Drop skips invalid align 2`] = `
 "
 
-.eRQUdY {
+.hEiKPj {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -478,13 +478,13 @@ exports[`Drop skips invalid align 2`] = `
   -webkit-transform-origin: top left;
   -ms-transform-origin: top left;
   transform-origin: top left;
-  -webkit-animation: grow-box 0.1s forwards;
-  animation: grow-box 0.1s forwards;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
 }
 
-.eRQUdY * {
+.hEiKPj * {
   box-sizing: inherit;
 }"
 `;

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -1,6 +1,52 @@
-import styled, { css } from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 
 import { baseStyle, lapAndUp, palm } from '../../utils';
+
+const growBoxKeyframe = keyframes`
+  0% {
+    transform: translate(50%, 50%) scale(0.8);
+  }
+  100% {
+    transform: translate(50%, 50%) scale(1);
+  }
+`;
+
+const slideUpKeyframe = keyframes`
+  0% {
+    margin-bottom: -200px;
+  }
+  100% {
+    margin-bottom: 0px;
+  }
+`;
+
+const slideLeftKeyframe = keyframes`
+  0% {
+    left: -100%;
+  }
+  100% {
+    left: 0px;
+  }
+`;
+
+const slideRightKeyframe = keyframes`
+  0% {
+    right: -200px;
+  }
+  100% {
+    right: 0px;
+  }
+`;
+
+const slideDownKeyframe = keyframes`
+  0% {
+    top: -100vh;
+  }
+  100% {
+    top: 0px;
+  }
+
+`;
 
 const hiddenPositionStyle = css`
   left: -100%;
@@ -11,7 +57,7 @@ const hiddenPositionStyle = css`
 
 const StyledLayer = styled.div`
   ${baseStyle}
-  
+
   position: relative;
   z-index: 10;
   height: 100vh;
@@ -33,17 +79,7 @@ const leftPositionStyle = `
   bottom: 0px;
   left: 0px;
 
-  animation: slide-left 0.2s ease-in-out forwards;
-  
-  @keyframes slide-left {
-    0% {
-      left: -100%;
-    }
-
-    100% {
-      left: 0px;
-    }
-  }
+  animation: ${slideLeftKeyframe} 0.2s ease-in-out forwards;
 `;
 
 const rightPositionStyle = `
@@ -51,68 +87,26 @@ const rightPositionStyle = `
   bottom: 0px;
   right: 0px;
 
-  animation: slide-right 0.2s ease-in-out forwards;
-  
-  @keyframes slide-right {
-    0% {
-      right: -200px;
-    }
-
-    100% {
-      right: 0px;
-    }
-  }
+  animation: ${slideRightKeyframe} 0.2s ease-in-out forwards;
 `;
 
 const topPositionStyle = `
   left: 50%;
   transform: translateX(-50%);
-
-  animation: slide-down 0.2s ease-in-out forwards;
-  
-  @keyframes slide-down {
-    0% {
-      top: -100vh;
-    }
-  
-    100% {
-      top: 0px;
-    }
-  }
+  animation: ${slideDownKeyframe} 0.2s ease-in-out forwards;
 `;
 
 const bottomPositionStyle = `
   bottom: 0px;
   right: 50%;
   transform: translateX(50%);
-
-  animation: slide-up 0.2s ease-in-out forwards;
-  
-  @keyframes slide-up {
-    0% {
-      margin-bottom: -200px;
-    }
-  
-    100% {
-      margin-bottom: 0px;
-    }
-  }
+  animation: ${slideUpKeyframe} 0.2s ease-in-out forwards;
 `;
 
 const centerPositionStyle = css`
   bottom: 50%;
   right: 50%;
-  animation: grow-box 0.1s forwards;
-
-  @keyframes grow-box {
-    0% {
-      transform: translate(50%, 50%) scale(0.8);
-    }
-
-    100% {
-      transform: translate(50%, 50%) scale(1);
-    }
-  }
+  animation: ${growBoxKeyframe} 0.1s forwards;
 `;
 
 function getPositionStyle(props) {

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Layer aligns bottom 1`] = `
 <div
-  class="StyledLayer-ceZzeh jGmnWs"
+  class="StyledLayer-ceZzeh eJxHlH"
   id="bottom-test"
   tabindex="-1"
 >
@@ -17,7 +17,7 @@ exports[`Layer aligns bottom 1`] = `
 exports[`Layer aligns bottom 2`] = `
 "
 
-.jGmnWs {
+.eJxHlH {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -34,12 +34,12 @@ exports[`Layer aligns bottom 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.jGmnWs * {
+.eJxHlH * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .jGmnWs {
+  .eJxHlH {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -142,7 +142,7 @@ exports[`Layer aligns bottom 2`] = `
 
 exports[`Layer aligns left 1`] = `
 <div
-  class="StyledLayer-ceZzeh jGmnWs"
+  class="StyledLayer-ceZzeh eJxHlH"
   id="left-test"
   tabindex="-1"
 >
@@ -157,7 +157,7 @@ exports[`Layer aligns left 1`] = `
 exports[`Layer aligns left 2`] = `
 "
 
-.jGmnWs {
+.eJxHlH {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -174,12 +174,12 @@ exports[`Layer aligns left 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.jGmnWs * {
+.eJxHlH * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .jGmnWs {
+  .eJxHlH {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -213,7 +213,7 @@ exports[`Layer aligns left 2`] = `
 
 exports[`Layer aligns right 1`] = `
 <div
-  class="StyledLayer-ceZzeh jGmnWs"
+  class="StyledLayer-ceZzeh eJxHlH"
   id="right-test"
   tabindex="-1"
 >
@@ -228,7 +228,7 @@ exports[`Layer aligns right 1`] = `
 exports[`Layer aligns right 2`] = `
 "
 
-.jGmnWs {
+.eJxHlH {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -245,12 +245,12 @@ exports[`Layer aligns right 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.jGmnWs * {
+.eJxHlH * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .jGmnWs {
+  .eJxHlH {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -306,7 +306,7 @@ exports[`Layer aligns right 2`] = `
 
 exports[`Layer aligns top 1`] = `
 <div
-  class="StyledLayer-ceZzeh jGmnWs"
+  class="StyledLayer-ceZzeh eJxHlH"
   id="top-test"
   tabindex="-1"
 >
@@ -321,7 +321,7 @@ exports[`Layer aligns top 1`] = `
 exports[`Layer aligns top 2`] = `
 "
 
-.jGmnWs {
+.eJxHlH {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -338,12 +338,12 @@ exports[`Layer aligns top 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.jGmnWs * {
+.eJxHlH * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .jGmnWs {
+  .eJxHlH {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -438,7 +438,7 @@ exports[`Layer hides 2`] = `
 "
 
 @media only screen and (min-width:700px) {
-  .jGmnWs {
+  .eJxHlH {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -599,7 +599,7 @@ exports[`Layer hides 4`] = `
 "
 
 @media only screen and (min-width:700px) {
-  .jGmnWs {
+  .eJxHlH {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -778,7 +778,7 @@ exports[`Layer is accessible 3`] = `
 
 exports[`Layer plain renders 1`] = `
 <div
-  class="StyledLayer-ceZzeh elvjQE"
+  class="StyledLayer-ceZzeh jxhLXK"
   id="plain-test"
   tabindex="-1"
 >
@@ -794,7 +794,7 @@ exports[`Layer plain renders 2`] = `
 "
 
 @media only screen and (min-width:700px) {
-  .jGmnWs {
+  .eJxHlH {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -803,7 +803,7 @@ exports[`Layer plain renders 2`] = `
   }
 }
 
-.elvjQE {
+.jxhLXK {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -820,12 +820,12 @@ exports[`Layer plain renders 2`] = `
   background-color: transparent;
 }
 
-.elvjQE * {
+.jxhLXK * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .elvjQE {
+  .jxhLXK {
     position: fixed;
     top: 0px;
     left: 0px;

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -2,12 +2,12 @@
 
 exports[`Layer aligns bottom 1`] = `
 <div
-  class="StyledLayer-ceZzeh eJxHlH"
+  class="StyledLayer-ceZzeh jGmnWs"
   id="bottom-test"
   tabindex="-1"
 >
   <div
-    class="StyledLayer__StyledContainer-gBGbkw idryWu"
+    class="StyledLayer__StyledContainer-gBGbkw eAaVJF"
   >
     This is a layer
   </div>
@@ -17,7 +17,7 @@ exports[`Layer aligns bottom 1`] = `
 exports[`Layer aligns bottom 2`] = `
 "
 
-.eJxHlH {
+.jGmnWs {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -34,12 +34,12 @@ exports[`Layer aligns bottom 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.eJxHlH * {
+.jGmnWs * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .eJxHlH {
+  .jGmnWs {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -49,14 +49,14 @@ exports[`Layer aligns bottom 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .bmPnUS {
+  .jJppDO {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .bmPnUS {
+  .jJppDO {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -65,40 +65,20 @@ exports[`Layer aligns bottom 2`] = `
     top: 0px;
     bottom: 0px;
     left: 0px;
-    -webkit-animation: slide-left 0.2s ease-in-out forwards;
-    animation: slide-left 0.2s ease-in-out forwards;
+    -webkit-animation: hlTcuJ 0.2s ease-in-out forwards;
+    animation: hlTcuJ 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-left {
-    0% {
-      left: -100%;
-    }
-
-    100% {
-      left: 0px;
-    }
-}
-
-@keyframes slide-left {
-    0% {
-      left: -100%;
-    }
-
-    100% {
-      left: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
-  .iRwnXx {
+  .cfGsAU {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iRwnXx {
+  .cfGsAU {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -107,40 +87,20 @@ exports[`Layer aligns bottom 2`] = `
     top: 0px;
     bottom: 0px;
     right: 0px;
-    -webkit-animation: slide-right 0.2s ease-in-out forwards;
-    animation: slide-right 0.2s ease-in-out forwards;
+    -webkit-animation: vdrVB 0.2s ease-in-out forwards;
+    animation: vdrVB 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-right {
-    0% {
-      right: -200px;
-    }
-
-    100% {
-      right: 0px;
-    }
-}
-
-@keyframes slide-right {
-    0% {
-      right: -200px;
-    }
-
-    100% {
-      right: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
-  .fkperw {
+  .jpmyrr {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fkperw {
+  .jpmyrr {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -150,40 +110,20 @@ exports[`Layer aligns bottom 2`] = `
     -webkit-transform: translateX(-50%);
     -ms-transform: translateX(-50%);
     transform: translateX(-50%);
-    -webkit-animation: slide-down 0.2s ease-in-out forwards;
-    animation: slide-down 0.2s ease-in-out forwards;
+    -webkit-animation: fVNlMJ 0.2s ease-in-out forwards;
+    animation: fVNlMJ 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-down {
-    0% {
-      top: -100vh;
-    }
-
-    100% {
-      top: 0px;
-    }
-}
-
-@keyframes slide-down {
-    0% {
-      top: -100vh;
-    }
-
-    100% {
-      top: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
-  .idryWu {
+  .eAaVJF {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .idryWu {
+  .eAaVJF {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -194,40 +134,20 @@ exports[`Layer aligns bottom 2`] = `
     -webkit-transform: translateX(50%);
     -ms-transform: translateX(50%);
     transform: translateX(50%);
-    -webkit-animation: slide-up 0.2s ease-in-out forwards;
-    animation: slide-up 0.2s ease-in-out forwards;
+    -webkit-animation: ifqUGO 0.2s ease-in-out forwards;
+    animation: ifqUGO 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-up {
-    0% {
-      margin-bottom: -200px;
-    }
-
-    100% {
-      margin-bottom: 0px;
-    }
-}
-
-@keyframes slide-up {
-    0% {
-      margin-bottom: -200px;
-    }
-
-    100% {
-      margin-bottom: 0px;
-    }
-}
 }"
 `;
 
 exports[`Layer aligns left 1`] = `
 <div
-  class="StyledLayer-ceZzeh eJxHlH"
+  class="StyledLayer-ceZzeh jGmnWs"
   id="left-test"
   tabindex="-1"
 >
   <div
-    class="StyledLayer__StyledContainer-gBGbkw bmPnUS"
+    class="StyledLayer__StyledContainer-gBGbkw jJppDO"
   >
     This is a layer
   </div>
@@ -237,7 +157,7 @@ exports[`Layer aligns left 1`] = `
 exports[`Layer aligns left 2`] = `
 "
 
-.eJxHlH {
+.jGmnWs {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -254,12 +174,12 @@ exports[`Layer aligns left 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.eJxHlH * {
+.jGmnWs * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .eJxHlH {
+  .jGmnWs {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -269,14 +189,14 @@ exports[`Layer aligns left 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .bmPnUS {
+  .jJppDO {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .bmPnUS {
+  .jJppDO {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -285,40 +205,20 @@ exports[`Layer aligns left 2`] = `
     top: 0px;
     bottom: 0px;
     left: 0px;
-    -webkit-animation: slide-left 0.2s ease-in-out forwards;
-    animation: slide-left 0.2s ease-in-out forwards;
+    -webkit-animation: hlTcuJ 0.2s ease-in-out forwards;
+    animation: hlTcuJ 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-left {
-    0% {
-      left: -100%;
-    }
-
-    100% {
-      left: 0px;
-    }
-}
-
-@keyframes slide-left {
-    0% {
-      left: -100%;
-    }
-
-    100% {
-      left: 0px;
-    }
-}
 }"
 `;
 
 exports[`Layer aligns right 1`] = `
 <div
-  class="StyledLayer-ceZzeh eJxHlH"
+  class="StyledLayer-ceZzeh jGmnWs"
   id="right-test"
   tabindex="-1"
 >
   <div
-    class="StyledLayer__StyledContainer-gBGbkw iRwnXx"
+    class="StyledLayer__StyledContainer-gBGbkw cfGsAU"
   >
     This is a layer
   </div>
@@ -328,7 +228,7 @@ exports[`Layer aligns right 1`] = `
 exports[`Layer aligns right 2`] = `
 "
 
-.eJxHlH {
+.jGmnWs {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -345,12 +245,12 @@ exports[`Layer aligns right 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.eJxHlH * {
+.jGmnWs * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .eJxHlH {
+  .jGmnWs {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -360,14 +260,14 @@ exports[`Layer aligns right 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .bmPnUS {
+  .jJppDO {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .bmPnUS {
+  .jJppDO {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -376,40 +276,20 @@ exports[`Layer aligns right 2`] = `
     top: 0px;
     bottom: 0px;
     left: 0px;
-    -webkit-animation: slide-left 0.2s ease-in-out forwards;
-    animation: slide-left 0.2s ease-in-out forwards;
+    -webkit-animation: hlTcuJ 0.2s ease-in-out forwards;
+    animation: hlTcuJ 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-left {
-    0% {
-      left: -100%;
-    }
-
-    100% {
-      left: 0px;
-    }
-}
-
-@keyframes slide-left {
-    0% {
-      left: -100%;
-    }
-
-    100% {
-      left: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
-  .iRwnXx {
+  .cfGsAU {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iRwnXx {
+  .cfGsAU {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -418,40 +298,20 @@ exports[`Layer aligns right 2`] = `
     top: 0px;
     bottom: 0px;
     right: 0px;
-    -webkit-animation: slide-right 0.2s ease-in-out forwards;
-    animation: slide-right 0.2s ease-in-out forwards;
+    -webkit-animation: vdrVB 0.2s ease-in-out forwards;
+    animation: vdrVB 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-right {
-    0% {
-      right: -200px;
-    }
-
-    100% {
-      right: 0px;
-    }
-}
-
-@keyframes slide-right {
-    0% {
-      right: -200px;
-    }
-
-    100% {
-      right: 0px;
-    }
-}
 }"
 `;
 
 exports[`Layer aligns top 1`] = `
 <div
-  class="StyledLayer-ceZzeh eJxHlH"
+  class="StyledLayer-ceZzeh jGmnWs"
   id="top-test"
   tabindex="-1"
 >
   <div
-    class="StyledLayer__StyledContainer-gBGbkw fkperw"
+    class="StyledLayer__StyledContainer-gBGbkw jpmyrr"
   >
     This is a layer
   </div>
@@ -461,7 +321,7 @@ exports[`Layer aligns top 1`] = `
 exports[`Layer aligns top 2`] = `
 "
 
-.eJxHlH {
+.jGmnWs {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -478,12 +338,12 @@ exports[`Layer aligns top 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.eJxHlH * {
+.jGmnWs * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .eJxHlH {
+  .jGmnWs {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -493,14 +353,14 @@ exports[`Layer aligns top 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .bmPnUS {
+  .jJppDO {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .bmPnUS {
+  .jJppDO {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -509,40 +369,20 @@ exports[`Layer aligns top 2`] = `
     top: 0px;
     bottom: 0px;
     left: 0px;
-    -webkit-animation: slide-left 0.2s ease-in-out forwards;
-    animation: slide-left 0.2s ease-in-out forwards;
+    -webkit-animation: hlTcuJ 0.2s ease-in-out forwards;
+    animation: hlTcuJ 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-left {
-    0% {
-      left: -100%;
-    }
-
-    100% {
-      left: 0px;
-    }
-}
-
-@keyframes slide-left {
-    0% {
-      left: -100%;
-    }
-
-    100% {
-      left: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
-  .iRwnXx {
+  .cfGsAU {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iRwnXx {
+  .cfGsAU {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -551,40 +391,20 @@ exports[`Layer aligns top 2`] = `
     top: 0px;
     bottom: 0px;
     right: 0px;
-    -webkit-animation: slide-right 0.2s ease-in-out forwards;
-    animation: slide-right 0.2s ease-in-out forwards;
+    -webkit-animation: vdrVB 0.2s ease-in-out forwards;
+    animation: vdrVB 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-right {
-    0% {
-      right: -200px;
-    }
-
-    100% {
-      right: 0px;
-    }
-}
-
-@keyframes slide-right {
-    0% {
-      right: -200px;
-    }
-
-    100% {
-      right: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
-  .fkperw {
+  .jpmyrr {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fkperw {
+  .jpmyrr {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -594,29 +414,9 @@ exports[`Layer aligns top 2`] = `
     -webkit-transform: translateX(-50%);
     -ms-transform: translateX(-50%);
     transform: translateX(-50%);
-    -webkit-animation: slide-down 0.2s ease-in-out forwards;
-    animation: slide-down 0.2s ease-in-out forwards;
+    -webkit-animation: fVNlMJ 0.2s ease-in-out forwards;
+    animation: fVNlMJ 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-down {
-    0% {
-      top: -100vh;
-    }
-
-    100% {
-      top: 0px;
-    }
-}
-
-@keyframes slide-down {
-    0% {
-      top: -100vh;
-    }
-
-    100% {
-      top: 0px;
-    }
-}
 }"
 `;
 
@@ -638,7 +438,7 @@ exports[`Layer hides 2`] = `
 "
 
 @media only screen and (min-width:700px) {
-  .eJxHlH {
+  .jGmnWs {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -673,14 +473,14 @@ exports[`Layer hides 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .bmPnUS {
+  .jJppDO {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .bmPnUS {
+  .jJppDO {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -689,40 +489,20 @@ exports[`Layer hides 2`] = `
     top: 0px;
     bottom: 0px;
     left: 0px;
-    -webkit-animation: slide-left 0.2s ease-in-out forwards;
-    animation: slide-left 0.2s ease-in-out forwards;
+    -webkit-animation: hlTcuJ 0.2s ease-in-out forwards;
+    animation: hlTcuJ 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-left {
-    0% {
-      left: -100%;
-    }
-
-    100% {
-      left: 0px;
-    }
-}
-
-@keyframes slide-left {
-    0% {
-      left: -100%;
-    }
-
-    100% {
-      left: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
-  .iRwnXx {
+  .cfGsAU {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iRwnXx {
+  .cfGsAU {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -731,40 +511,20 @@ exports[`Layer hides 2`] = `
     top: 0px;
     bottom: 0px;
     right: 0px;
-    -webkit-animation: slide-right 0.2s ease-in-out forwards;
-    animation: slide-right 0.2s ease-in-out forwards;
+    -webkit-animation: vdrVB 0.2s ease-in-out forwards;
+    animation: vdrVB 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-right {
-    0% {
-      right: -200px;
-    }
-
-    100% {
-      right: 0px;
-    }
-}
-
-@keyframes slide-right {
-    0% {
-      right: -200px;
-    }
-
-    100% {
-      right: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
-  .fkperw {
+  .jpmyrr {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fkperw {
+  .jpmyrr {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -774,40 +534,20 @@ exports[`Layer hides 2`] = `
     -webkit-transform: translateX(-50%);
     -ms-transform: translateX(-50%);
     transform: translateX(-50%);
-    -webkit-animation: slide-down 0.2s ease-in-out forwards;
-    animation: slide-down 0.2s ease-in-out forwards;
+    -webkit-animation: fVNlMJ 0.2s ease-in-out forwards;
+    animation: fVNlMJ 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-down {
-    0% {
-      top: -100vh;
-    }
-
-    100% {
-      top: 0px;
-    }
-}
-
-@keyframes slide-down {
-    0% {
-      top: -100vh;
-    }
-
-    100% {
-      top: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
-  .idryWu {
+  .eAaVJF {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .idryWu {
+  .eAaVJF {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -818,29 +558,9 @@ exports[`Layer hides 2`] = `
     -webkit-transform: translateX(50%);
     -ms-transform: translateX(50%);
     transform: translateX(50%);
-    -webkit-animation: slide-up 0.2s ease-in-out forwards;
-    animation: slide-up 0.2s ease-in-out forwards;
+    -webkit-animation: ifqUGO 0.2s ease-in-out forwards;
+    animation: ifqUGO 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-up {
-    0% {
-      margin-bottom: -200px;
-    }
-
-    100% {
-      margin-bottom: 0px;
-    }
-}
-
-@keyframes slide-up {
-    0% {
-      margin-bottom: -200px;
-    }
-
-    100% {
-      margin-bottom: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
@@ -879,7 +599,7 @@ exports[`Layer hides 4`] = `
 "
 
 @media only screen and (min-width:700px) {
-  .eJxHlH {
+  .jGmnWs {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -914,14 +634,14 @@ exports[`Layer hides 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .bmPnUS {
+  .jJppDO {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .bmPnUS {
+  .jJppDO {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -930,40 +650,20 @@ exports[`Layer hides 4`] = `
     top: 0px;
     bottom: 0px;
     left: 0px;
-    -webkit-animation: slide-left 0.2s ease-in-out forwards;
-    animation: slide-left 0.2s ease-in-out forwards;
+    -webkit-animation: hlTcuJ 0.2s ease-in-out forwards;
+    animation: hlTcuJ 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-left {
-    0% {
-      left: -100%;
-    }
-
-    100% {
-      left: 0px;
-    }
-}
-
-@keyframes slide-left {
-    0% {
-      left: -100%;
-    }
-
-    100% {
-      left: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
-  .iRwnXx {
+  .cfGsAU {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iRwnXx {
+  .cfGsAU {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -972,40 +672,20 @@ exports[`Layer hides 4`] = `
     top: 0px;
     bottom: 0px;
     right: 0px;
-    -webkit-animation: slide-right 0.2s ease-in-out forwards;
-    animation: slide-right 0.2s ease-in-out forwards;
+    -webkit-animation: vdrVB 0.2s ease-in-out forwards;
+    animation: vdrVB 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-right {
-    0% {
-      right: -200px;
-    }
-
-    100% {
-      right: 0px;
-    }
-}
-
-@keyframes slide-right {
-    0% {
-      right: -200px;
-    }
-
-    100% {
-      right: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
-  .fkperw {
+  .jpmyrr {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fkperw {
+  .jpmyrr {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -1015,40 +695,20 @@ exports[`Layer hides 4`] = `
     -webkit-transform: translateX(-50%);
     -ms-transform: translateX(-50%);
     transform: translateX(-50%);
-    -webkit-animation: slide-down 0.2s ease-in-out forwards;
-    animation: slide-down 0.2s ease-in-out forwards;
+    -webkit-animation: fVNlMJ 0.2s ease-in-out forwards;
+    animation: fVNlMJ 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-down {
-    0% {
-      top: -100vh;
-    }
-
-    100% {
-      top: 0px;
-    }
-}
-
-@keyframes slide-down {
-    0% {
-      top: -100vh;
-    }
-
-    100% {
-      top: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
-  .idryWu {
+  .eAaVJF {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .idryWu {
+  .eAaVJF {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -1059,29 +719,9 @@ exports[`Layer hides 4`] = `
     -webkit-transform: translateX(50%);
     -ms-transform: translateX(50%);
     transform: translateX(50%);
-    -webkit-animation: slide-up 0.2s ease-in-out forwards;
-    animation: slide-up 0.2s ease-in-out forwards;
+    -webkit-animation: ifqUGO 0.2s ease-in-out forwards;
+    animation: ifqUGO 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-up {
-    0% {
-      margin-bottom: -200px;
-    }
-
-    100% {
-      margin-bottom: 0px;
-    }
-}
-
-@keyframes slide-up {
-    0% {
-      margin-bottom: -200px;
-    }
-
-    100% {
-      margin-bottom: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
@@ -1138,12 +778,12 @@ exports[`Layer is accessible 3`] = `
 
 exports[`Layer plain renders 1`] = `
 <div
-  class="StyledLayer-ceZzeh jxhLXK"
+  class="StyledLayer-ceZzeh elvjQE"
   id="plain-test"
   tabindex="-1"
 >
   <div
-    class="StyledLayer__StyledContainer-gBGbkw jDkaaP"
+    class="StyledLayer__StyledContainer-gBGbkw eQitpi"
   >
     This is a plain layer
   </div>
@@ -1154,7 +794,7 @@ exports[`Layer plain renders 2`] = `
 "
 
 @media only screen and (min-width:700px) {
-  .eJxHlH {
+  .jGmnWs {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -1163,7 +803,7 @@ exports[`Layer plain renders 2`] = `
   }
 }
 
-.jxhLXK {
+.elvjQE {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -1180,12 +820,12 @@ exports[`Layer plain renders 2`] = `
   background-color: transparent;
 }
 
-.jxhLXK * {
+.elvjQE * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .jxhLXK {
+  .elvjQE {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -1195,14 +835,14 @@ exports[`Layer plain renders 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .bmPnUS {
+  .jJppDO {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .bmPnUS {
+  .jJppDO {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -1211,40 +851,20 @@ exports[`Layer plain renders 2`] = `
     top: 0px;
     bottom: 0px;
     left: 0px;
-    -webkit-animation: slide-left 0.2s ease-in-out forwards;
-    animation: slide-left 0.2s ease-in-out forwards;
+    -webkit-animation: hlTcuJ 0.2s ease-in-out forwards;
+    animation: hlTcuJ 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-left {
-    0% {
-      left: -100%;
-    }
-
-    100% {
-      left: 0px;
-    }
-}
-
-@keyframes slide-left {
-    0% {
-      left: -100%;
-    }
-
-    100% {
-      left: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
-  .iRwnXx {
+  .cfGsAU {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iRwnXx {
+  .cfGsAU {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -1253,40 +873,20 @@ exports[`Layer plain renders 2`] = `
     top: 0px;
     bottom: 0px;
     right: 0px;
-    -webkit-animation: slide-right 0.2s ease-in-out forwards;
-    animation: slide-right 0.2s ease-in-out forwards;
+    -webkit-animation: vdrVB 0.2s ease-in-out forwards;
+    animation: vdrVB 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-right {
-    0% {
-      right: -200px;
-    }
-
-    100% {
-      right: 0px;
-    }
-}
-
-@keyframes slide-right {
-    0% {
-      right: -200px;
-    }
-
-    100% {
-      right: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
-  .fkperw {
+  .jpmyrr {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fkperw {
+  .jpmyrr {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -1296,40 +896,20 @@ exports[`Layer plain renders 2`] = `
     -webkit-transform: translateX(-50%);
     -ms-transform: translateX(-50%);
     transform: translateX(-50%);
-    -webkit-animation: slide-down 0.2s ease-in-out forwards;
-    animation: slide-down 0.2s ease-in-out forwards;
+    -webkit-animation: fVNlMJ 0.2s ease-in-out forwards;
+    animation: fVNlMJ 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-down {
-    0% {
-      top: -100vh;
-    }
-
-    100% {
-      top: 0px;
-    }
-}
-
-@keyframes slide-down {
-    0% {
-      top: -100vh;
-    }
-
-    100% {
-      top: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
-  .idryWu {
+  .eAaVJF {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .idryWu {
+  .eAaVJF {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -1340,29 +920,9 @@ exports[`Layer plain renders 2`] = `
     -webkit-transform: translateX(50%);
     -ms-transform: translateX(50%);
     transform: translateX(50%);
-    -webkit-animation: slide-up 0.2s ease-in-out forwards;
-    animation: slide-up 0.2s ease-in-out forwards;
+    -webkit-animation: ifqUGO 0.2s ease-in-out forwards;
+    animation: ifqUGO 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-up {
-    0% {
-      margin-bottom: -200px;
-    }
-
-    100% {
-      margin-bottom: 0px;
-    }
-}
-
-@keyframes slide-up {
-    0% {
-      margin-bottom: -200px;
-    }
-
-    100% {
-      margin-bottom: 0px;
-    }
-}
 }
 
 @media only screen and (max-width:699px) {
@@ -1383,14 +943,14 @@ exports[`Layer plain renders 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .jDkaaP {
+  .eQitpi {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jDkaaP {
+  .eQitpi {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -1398,36 +958,8 @@ exports[`Layer plain renders 2`] = `
     border-radius: none;
     bottom: 50%;
     right: 50%;
-    -webkit-animation: grow-box 0.1s forwards;
-    animation: grow-box 0.1s forwards;
+    -webkit-animation: ,ghNyyk,0.1s forwards;
+    animation: ,ghNyyk,0.1s forwards;
   }
-
-@-webkit-keyframes grow-box {
-    0% {
-      -webkit-transform: translate(50%,50%) scale(0.8);
-      -ms-transform: translate(50%,50%) scale(0.8);
-      transform: translate(50%,50%) scale(0.8);
-    }
-
-    100% {
-      -webkit-transform: translate(50%,50%) scale(1);
-      -ms-transform: translate(50%,50%) scale(1);
-      transform: translate(50%,50%) scale(1);
-    }
-}
-
-@keyframes grow-box {
-    0% {
-      -webkit-transform: translate(50%,50%) scale(0.8);
-      -ms-transform: translate(50%,50%) scale(0.8);
-      transform: translate(50%,50%) scale(0.8);
-    }
-
-    100% {
-      -webkit-transform: translate(50%,50%) scale(1);
-      -ms-transform: translate(50%,50%) scale(1);
-      transform: translate(50%,50%) scale(1);
-    }
-}
 }"
 `;

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Menu opens and closes on click 1`] = `
 <div
-  class="StyledDrop-bCWxPe eRQUdY"
+  class="StyledDrop-bCWxPe hEiKPj"
   tabindex="-1"
   id="menu-drop__test"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -122,7 +122,7 @@ exports[`Menu opens and closes on click 2`] = `
 
 
 
-.eRQUdY {
+.hEiKPj {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -144,13 +144,13 @@ exports[`Menu opens and closes on click 2`] = `
   -webkit-transform-origin: top left;
   -ms-transform-origin: top left;
   transform-origin: top left;
-  -webkit-animation: grow-box 0.1s forwards;
-  animation: grow-box 0.1s forwards;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
 }
 
-.eRQUdY * {
+.hEiKPj * {
   box-sizing: inherit;
 }"
 `;

--- a/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
+++ b/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
@@ -101,7 +101,7 @@ exports[`SkipLink mounts 2`] = `
 
 exports[`SkipLink mounts 3`] = `
 <div
-  class="StyledLayer-ceZzeh jGmnWs"
+  class="StyledLayer-ceZzeh eJxHlH"
   id="skip-links"
   tabindex="-1"
 >
@@ -155,7 +155,7 @@ exports[`SkipLink mounts 3`] = `
 exports[`SkipLink mounts 4`] = `
 "
 
-.jGmnWs {
+.eJxHlH {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -172,12 +172,12 @@ exports[`SkipLink mounts 4`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.jGmnWs * {
+.eJxHlH * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .jGmnWs {
+  .eJxHlH {
     position: fixed;
     top: 0px;
     left: 0px;

--- a/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
+++ b/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
@@ -101,12 +101,12 @@ exports[`SkipLink mounts 2`] = `
 
 exports[`SkipLink mounts 3`] = `
 <div
-  class="StyledLayer-ceZzeh eJxHlH"
+  class="StyledLayer-ceZzeh jGmnWs"
   id="skip-links"
   tabindex="-1"
 >
   <div
-    class="StyledLayer__StyledContainer-gBGbkw fkperw"
+    class="StyledLayer__StyledContainer-gBGbkw jpmyrr"
   >
     <div
       class="StyledBox-bStriS bZDKOr"
@@ -155,7 +155,7 @@ exports[`SkipLink mounts 3`] = `
 exports[`SkipLink mounts 4`] = `
 "
 
-.eJxHlH {
+.jGmnWs {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -172,12 +172,12 @@ exports[`SkipLink mounts 4`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.eJxHlH * {
+.jGmnWs * {
   box-sizing: inherit;
 }
 
 @media only screen and (min-width:700px) {
-  .eJxHlH {
+  .jGmnWs {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -204,14 +204,14 @@ exports[`SkipLink mounts 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fkperw {
+  .jpmyrr {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fkperw {
+  .jpmyrr {
     position: absolute;
     max-height: 100%;
     max-width: 100%;
@@ -221,29 +221,9 @@ exports[`SkipLink mounts 4`] = `
     -webkit-transform: translateX(-50%);
     -ms-transform: translateX(-50%);
     transform: translateX(-50%);
-    -webkit-animation: slide-down 0.2s ease-in-out forwards;
-    animation: slide-down 0.2s ease-in-out forwards;
+    -webkit-animation: fVNlMJ 0.2s ease-in-out forwards;
+    animation: fVNlMJ 0.2s ease-in-out forwards;
   }
-
-@-webkit-keyframes slide-down {
-    0% {
-      top: -100vh;
-    }
-
-    100% {
-      top: 0px;
-    }
-}
-
-@keyframes slide-down {
-    0% {
-      top: -100vh;
-    }
-
-    100% {
-      top: 0px;
-    }
-}
 }"
 `;
 

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`TextInput closes suggestion drop 1`] = `
 <div
-  class="StyledDrop-bCWxPe eRQUdY"
+  class="StyledDrop-bCWxPe hEiKPj"
   tabindex="-1"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -52,7 +52,7 @@ exports[`TextInput closes suggestion drop 2`] = `
 
 
 
-.eRQUdY {
+.hEiKPj {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -74,13 +74,13 @@ exports[`TextInput closes suggestion drop 2`] = `
   -webkit-transform-origin: top left;
   -ms-transform-origin: top left;
   transform-origin: top left;
-  -webkit-animation: grow-box 0.1s forwards;
-  animation: grow-box 0.1s forwards;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
 }
 
-.eRQUdY * {
+.hEiKPj * {
   box-sizing: inherit;
 }"
 `;
@@ -133,7 +133,7 @@ exports[`TextInput mounts 1`] = `
 
 exports[`TextInput mounts with complex suggestions 1`] = `
 <div
-  class="StyledDrop-bCWxPe eRQUdY"
+  class="StyledDrop-bCWxPe hEiKPj"
   tabindex="-1"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -183,7 +183,7 @@ exports[`TextInput mounts with complex suggestions 2`] = `
 
 
 
-.eRQUdY {
+.hEiKPj {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -205,20 +205,20 @@ exports[`TextInput mounts with complex suggestions 2`] = `
   -webkit-transform-origin: top left;
   -ms-transform-origin: top left;
   transform-origin: top left;
-  -webkit-animation: grow-box 0.1s forwards;
-  animation: grow-box 0.1s forwards;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
 }
 
-.eRQUdY * {
+.hEiKPj * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`TextInput mounts with suggestions 1`] = `
 <div
-  class="StyledDrop-bCWxPe eRQUdY"
+  class="StyledDrop-bCWxPe hEiKPj"
   tabindex="-1"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -268,7 +268,7 @@ exports[`TextInput mounts with suggestions 2`] = `
 
 
 
-.eRQUdY {
+.hEiKPj {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -290,20 +290,20 @@ exports[`TextInput mounts with suggestions 2`] = `
   -webkit-transform-origin: top left;
   -ms-transform-origin: top left;
   transform-origin: top left;
-  -webkit-animation: grow-box 0.1s forwards;
-  animation: grow-box 0.1s forwards;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
 }
 
-.eRQUdY * {
+.hEiKPj * {
   box-sizing: inherit;
 }"
 `;
 
 exports[`TextInput selects suggestion 1`] = `
 <div
-  class="StyledDrop-bCWxPe eRQUdY"
+  class="StyledDrop-bCWxPe hEiKPj"
   tabindex="-1"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -353,7 +353,7 @@ exports[`TextInput selects suggestion 2`] = `
 
 
 
-.eRQUdY {
+.hEiKPj {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -375,13 +375,13 @@ exports[`TextInput selects suggestion 2`] = `
   -webkit-transform-origin: top left;
   -ms-transform-origin: top left;
   transform-origin: top left;
-  -webkit-animation: grow-box 0.1s forwards;
-  animation: grow-box 0.1s forwards;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
 }
 
-.eRQUdY * {
+.hEiKPj * {
   box-sizing: inherit;
 }"
 `;


### PR DESCRIPTION
Otherwise they're global and can interfere with one another.

I discovered this when the `Drop` component failed to display after a `Layer` was rendered.  I tracked it down to them both sharing the `grow-box` keyframe, but `Layer`'s version didn't set the opacity to 1.

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Replaces all `@keyframes` with the `keyframe` function from `styled-components`

#### Where should the reviewer start?

#### What testing has been done on this PR?

Minimal, but I've verified that Drop works after rendering a Layer, which it didn't before.

#### How should this be manually tested?
verify that Drop, Layer, and Clock still work

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no

#### Should this PR be mentioned in the release notes?
no

#### Is this change backwards compatible or is it a breaking change?
backwards compatible