### PR TITLE
Revised how we use box-sizing style

### DIFF
--- a/src/js/components/Anchor/StyledAnchor.js
+++ b/src/js/components/Anchor/StyledAnchor.js
@@ -14,6 +14,7 @@ const disabledStyle = `
 `;
 
 const StyledAnchor = styled.a`
+  box-sizing: border-box;
   color: ${props =>
     (props.grommet && props.grommet.dark ? props.theme.global.colors.darkBackground.text
       : props.theme.anchor.color)};

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
@@ -13,11 +13,8 @@ exports[`Anchor disabled renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   color: #865CD6;
   text-decoration: none;
   cursor: pointer;
@@ -59,11 +56,8 @@ exports[`Anchor focus renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   color: #865CD6;
   text-decoration: none;
   cursor: pointer;
@@ -120,11 +114,8 @@ exports[`Anchor icon label renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   color: #865CD6;
   text-decoration: none;
   cursor: pointer;
@@ -694,10 +685,6 @@ exports[`Anchor primary renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c3 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -733,6 +720,7 @@ exports[`Anchor primary renders 1`] = `
 }
 
 .c1 {
+  box-sizing: border-box;
   color: #865CD6;
   text-decoration: none;
   cursor: pointer;
@@ -1319,11 +1307,8 @@ exports[`Anchor renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   color: #865CD6;
   text-decoration: none;
   cursor: pointer;
@@ -1366,11 +1351,8 @@ exports[`Anchor renders with children 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   color: #865CD6;
   text-decoration: none;
   cursor: pointer;
@@ -1415,11 +1397,8 @@ exports[`Anchor reverse icon label renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   color: #865CD6;
   text-decoration: none;
   cursor: pointer;
@@ -1989,11 +1968,8 @@ exports[`Anchor warns about invalid icon render 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   color: #865CD6;
   text-decoration: none;
   cursor: pointer;
@@ -2545,11 +2521,8 @@ exports[`Anchor warns about invalid label render 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   color: #865CD6;
   text-decoration: none;
   cursor: pointer;

--- a/src/js/components/Anchor/__tests__/__snapshots__/RoutedAnchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/RoutedAnchor-test.js.snap
@@ -13,11 +13,8 @@ exports[`RoutedAnchor renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   color: #865CD6;
   text-decoration: none;
   cursor: pointer;

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -361,6 +361,7 @@ const animationStyle = css`
 // NOTE: basis must be after flex! Otherwise, flex overrides basis
 const StyledBox = styled.div`
   display: flex;
+  box-sizing: border-box;
   ${props => !props.basis && 'max-width: 100%;'};
 
   ${props => props.align && alignStyle}

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -13,15 +13,12 @@ exports[`Box align renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -38,6 +35,7 @@ exports[`Box align renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -54,6 +52,7 @@ exports[`Box align renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
@@ -70,6 +69,7 @@ exports[`Box align renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -86,6 +86,7 @@ exports[`Box align renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -141,15 +142,12 @@ exports[`Box alignContent renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-content: flex-start;
   -ms-flex-line-pack: start;
@@ -165,6 +163,7 @@ exports[`Box alignContent renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -180,6 +179,7 @@ exports[`Box alignContent renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-content: between;
   -ms-flex-line-pack: between;
@@ -195,6 +195,7 @@ exports[`Box alignContent renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-content: around;
   -ms-flex-line-pack: around;
@@ -210,6 +211,7 @@ exports[`Box alignContent renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
@@ -225,6 +227,7 @@ exports[`Box alignContent renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-content: flex-end;
   -ms-flex-line-pack: end;
@@ -284,15 +287,12 @@ exports[`Box alignSelf renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
@@ -308,6 +308,7 @@ exports[`Box alignSelf renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-self: center;
   -ms-flex-item-align: center;
@@ -323,6 +324,7 @@ exports[`Box alignSelf renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -338,6 +340,7 @@ exports[`Box alignSelf renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
@@ -387,15 +390,12 @@ exports[`Box animation renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -411,6 +411,7 @@ exports[`Box animation renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -426,6 +427,7 @@ exports[`Box animation renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -443,6 +445,7 @@ exports[`Box animation renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -460,6 +463,7 @@ exports[`Box animation renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -477,6 +481,7 @@ exports[`Box animation renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -494,6 +499,7 @@ exports[`Box animation renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -511,6 +517,7 @@ exports[`Box animation renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -528,6 +535,7 @@ exports[`Box animation renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -545,6 +553,7 @@ exports[`Box animation renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -562,6 +571,7 @@ exports[`Box animation renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -580,6 +590,7 @@ exports[`Box animation renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -595,6 +606,7 @@ exports[`Box animation renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -692,15 +704,12 @@ exports[`Box background renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   background-color: #865CD6;
   color: #FFFFFF;
@@ -715,6 +724,7 @@ exports[`Box background renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   background-color: #00CCEB;
   color: #333333;
@@ -729,6 +739,7 @@ exports[`Box background renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   background-color: #0A64A0;
   color: #FFFFFF;
@@ -743,6 +754,7 @@ exports[`Box background renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   background-color: #F6F6F6;
   color: #333333;
@@ -757,6 +769,7 @@ exports[`Box background renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   background-color: #333333;
   color: #FFFFFF;
@@ -771,6 +784,7 @@ exports[`Box background renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   background-color: #FF324D;
   color: #FFFFFF;
@@ -785,6 +799,7 @@ exports[`Box background renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==) no-repeat center center;
   background-size: cover;
@@ -799,6 +814,7 @@ exports[`Box background renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==) no-repeat;
   background-position: center center;
@@ -815,6 +831,7 @@ exports[`Box background renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==) no-repeat;
   background-position: center center;
@@ -831,6 +848,7 @@ exports[`Box background renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==) no-repeat;
   background-position: top center;
@@ -911,15 +929,12 @@ exports[`Box basis renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -932,6 +947,7 @@ exports[`Box basis renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -944,6 +960,7 @@ exports[`Box basis renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   min-width: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -958,6 +975,7 @@ exports[`Box basis renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   min-width: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -972,6 +990,7 @@ exports[`Box basis renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   min-width: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -986,6 +1005,7 @@ exports[`Box basis renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   min-width: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -1000,6 +1020,7 @@ exports[`Box basis renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   min-width: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -1014,6 +1035,7 @@ exports[`Box basis renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   min-width: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -1028,6 +1050,7 @@ exports[`Box basis renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   min-width: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -1042,6 +1065,7 @@ exports[`Box basis renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   min-width: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -1056,6 +1080,7 @@ exports[`Box basis renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   min-width: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -1070,6 +1095,7 @@ exports[`Box basis renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   min-width: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -1084,6 +1110,7 @@ exports[`Box basis renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   min-width: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -1202,15 +1229,12 @@ exports[`Box border renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   border: solid 1px rgba(0,0,0,0.15);
   min-width: 0;
@@ -1224,6 +1248,7 @@ exports[`Box border renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   border-top: solid 1px rgba(0,0,0,0.15);
   border-bottom: solid 1px rgba(0,0,0,0.15);
@@ -1238,6 +1263,7 @@ exports[`Box border renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   border-left: solid 1px rgba(0,0,0,0.15);
   border-right: solid 1px rgba(0,0,0,0.15);
@@ -1252,6 +1278,7 @@ exports[`Box border renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   border-top: solid 1px rgba(0,0,0,0.15);
   min-width: 0;
@@ -1265,6 +1292,7 @@ exports[`Box border renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   border-left: solid 1px rgba(0,0,0,0.15);
   min-width: 0;
@@ -1278,6 +1306,7 @@ exports[`Box border renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.15);
   min-width: 0;
@@ -1291,6 +1320,7 @@ exports[`Box border renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   border-right: solid 1px rgba(0,0,0,0.15);
   min-width: 0;
@@ -1304,6 +1334,7 @@ exports[`Box border renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   border: solid 1px #00CCEB;
   min-width: 0;
@@ -1317,6 +1348,7 @@ exports[`Box border renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   border: solid 2px rgba(0,0,0,0.15);
   min-width: 0;
@@ -1330,6 +1362,7 @@ exports[`Box border renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   border: solid 4px rgba(0,0,0,0.15);
   min-width: 0;
@@ -1343,6 +1376,7 @@ exports[`Box border renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   border: solid 12px rgba(0,0,0,0.15);
   min-width: 0;
@@ -1356,6 +1390,7 @@ exports[`Box border renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   border: solid 24px rgba(0,0,0,0.15);
   min-width: 0;
@@ -1454,15 +1489,12 @@ exports[`Box direction renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1475,6 +1507,7 @@ exports[`Box direction renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -1511,15 +1544,12 @@ exports[`Box flex renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1532,6 +1562,7 @@ exports[`Box flex renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1547,6 +1578,7 @@ exports[`Box flex renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1562,6 +1594,7 @@ exports[`Box flex renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1577,6 +1610,7 @@ exports[`Box flex renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1632,15 +1666,12 @@ exports[`Box full renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1653,6 +1684,7 @@ exports[`Box full renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1670,6 +1702,7 @@ exports[`Box full renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1684,6 +1717,7 @@ exports[`Box full renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1699,6 +1733,7 @@ exports[`Box full renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1759,15 +1794,12 @@ exports[`Box gridArea renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1800,15 +1832,12 @@ exports[`Box justify renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1825,6 +1854,7 @@ exports[`Box justify renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1841,6 +1871,7 @@ exports[`Box justify renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1857,6 +1888,7 @@ exports[`Box justify renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1907,15 +1939,12 @@ exports[`Box justifySelf renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1962,15 +1991,12 @@ exports[`Box margin renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1984,6 +2010,7 @@ exports[`Box margin renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1997,6 +2024,7 @@ exports[`Box margin renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2010,6 +2038,7 @@ exports[`Box margin renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2024,6 +2053,7 @@ exports[`Box margin renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2038,6 +2068,7 @@ exports[`Box margin renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2051,6 +2082,7 @@ exports[`Box margin renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2064,6 +2096,7 @@ exports[`Box margin renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2077,6 +2110,7 @@ exports[`Box margin renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2149,15 +2183,12 @@ exports[`Box pad renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2171,6 +2202,7 @@ exports[`Box pad renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2184,6 +2216,7 @@ exports[`Box pad renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2197,6 +2230,7 @@ exports[`Box pad renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2211,6 +2245,7 @@ exports[`Box pad renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2225,6 +2260,7 @@ exports[`Box pad renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2238,6 +2274,7 @@ exports[`Box pad renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2251,6 +2288,7 @@ exports[`Box pad renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2264,6 +2302,7 @@ exports[`Box pad renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2336,15 +2375,12 @@ exports[`Box renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2376,15 +2412,12 @@ exports[`Box reverse renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2397,6 +2430,7 @@ exports[`Box reverse renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column-reverse;
@@ -2433,15 +2467,12 @@ exports[`Box round renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2455,6 +2486,7 @@ exports[`Box round renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2468,6 +2500,7 @@ exports[`Box round renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2481,6 +2514,7 @@ exports[`Box round renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2494,6 +2528,7 @@ exports[`Box round renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2546,15 +2581,12 @@ exports[`Box tag renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2586,15 +2618,12 @@ exports[`Box textAlign renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2608,6 +2637,7 @@ exports[`Box textAlign renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2621,6 +2651,7 @@ exports[`Box textAlign renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2663,15 +2694,12 @@ exports[`Box wrap renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2684,6 +2712,7 @@ exports[`Box wrap renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -116,6 +116,7 @@ const plainStyle = css`
 `;
 
 const StyledButton = styled.button`
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -13,11 +13,8 @@ exports[`Button color renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -52,6 +49,7 @@ exports[`Button color renders 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -167,11 +165,8 @@ exports[`Button disabled renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -237,11 +232,8 @@ exports[`Button focus renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -327,11 +319,8 @@ exports[`Button hoverIndicator as object renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -394,11 +383,8 @@ exports[`Button hoverIndicator as object with color renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -461,11 +447,8 @@ exports[`Button hoverIndicator as object with colorIndex renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -528,11 +511,8 @@ exports[`Button hoverIndicator as object with invalid color renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -595,11 +575,8 @@ exports[`Button hoverIndicator as object with invalid color renders 2`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -662,11 +639,8 @@ exports[`Button hoverIndicator as object with invalid colorIndex renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -729,11 +703,8 @@ exports[`Button hoverIndicator renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -796,11 +767,8 @@ exports[`Button href renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -875,11 +843,8 @@ exports[`Button icon label renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -982,11 +947,8 @@ exports[`Button primary renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -1072,11 +1034,8 @@ exports[`Button renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -1161,11 +1120,8 @@ exports[`Button reverse icon label renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -1268,11 +1224,8 @@ exports[`Button warns about invalid icon render 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -1348,11 +1301,8 @@ exports[`Button warns about invalid label render 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;

--- a/src/js/components/Button/__tests__/__snapshots__/RoutedButton-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/RoutedButton-test.js.snap
@@ -13,11 +13,8 @@ exports[`RoutedButton renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -13,10 +13,6 @@ exports[`Calendar date renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -54,6 +50,7 @@ exports[`Calendar date renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -66,6 +63,7 @@ exports[`Calendar date renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -86,6 +84,7 @@ exports[`Calendar date renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -98,6 +97,7 @@ exports[`Calendar date renders 1`] = `
 }
 
 .c6 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -116,6 +116,7 @@ exports[`Calendar date renders 1`] = `
 }
 
 .c13 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -136,6 +137,7 @@ exports[`Calendar date renders 1`] = `
 }
 
 .c16 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -1566,10 +1568,6 @@ exports[`Calendar dates renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -1607,6 +1605,7 @@ exports[`Calendar dates renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1619,6 +1618,7 @@ exports[`Calendar dates renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1639,6 +1639,7 @@ exports[`Calendar dates renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1651,6 +1652,7 @@ exports[`Calendar dates renders 1`] = `
 }
 
 .c6 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -1669,6 +1671,7 @@ exports[`Calendar dates renders 1`] = `
 }
 
 .c13 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -1689,6 +1692,7 @@ exports[`Calendar dates renders 1`] = `
 }
 
 .c17 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -3121,10 +3125,6 @@ exports[`Calendar disabled renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -3162,6 +3162,7 @@ exports[`Calendar disabled renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -3174,6 +3175,7 @@ exports[`Calendar disabled renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -3194,6 +3196,7 @@ exports[`Calendar disabled renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -3206,6 +3209,7 @@ exports[`Calendar disabled renders 1`] = `
 }
 
 .c6 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -3224,6 +3228,7 @@ exports[`Calendar disabled renders 1`] = `
 }
 
 .c13 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -3244,6 +3249,7 @@ exports[`Calendar disabled renders 1`] = `
 }
 
 .c17 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -4676,10 +4682,6 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -4717,6 +4719,7 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -4729,6 +4732,7 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -4749,6 +4753,7 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -4761,6 +4766,7 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
 }
 
 .c6 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -4779,6 +4785,7 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
 }
 
 .c13 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -4799,6 +4806,7 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
 }
 
 .c16 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -7489,10 +7497,6 @@ exports[`Calendar renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -7530,6 +7534,7 @@ exports[`Calendar renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -7542,6 +7547,7 @@ exports[`Calendar renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -7562,6 +7568,7 @@ exports[`Calendar renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -7574,6 +7581,7 @@ exports[`Calendar renders 1`] = `
 }
 
 .c6 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -7592,6 +7600,7 @@ exports[`Calendar renders 1`] = `
 }
 
 .c13 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -7612,6 +7621,7 @@ exports[`Calendar renders 1`] = `
 }
 
 .c16 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -9042,10 +9052,6 @@ exports[`Calendar size renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -9117,6 +9123,7 @@ exports[`Calendar size renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -9129,6 +9136,7 @@ exports[`Calendar size renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -9149,6 +9157,7 @@ exports[`Calendar size renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -9161,6 +9170,7 @@ exports[`Calendar size renders 1`] = `
 }
 
 .c6 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -9179,6 +9189,7 @@ exports[`Calendar size renders 1`] = `
 }
 
 .c13 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -9199,6 +9210,7 @@ exports[`Calendar size renders 1`] = `
 }
 
 .c16 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;

--- a/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
+++ b/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
@@ -13,10 +13,6 @@ exports[`Chart cap renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   max-width: 100%;
 }
@@ -112,10 +108,6 @@ exports[`Chart renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   max-width: 100%;
 }
@@ -178,10 +170,6 @@ exports[`Chart size renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c1 {
@@ -337,10 +325,6 @@ exports[`Chart thickness renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   max-width: 100%;
 }
@@ -492,10 +476,6 @@ exports[`Chart type renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c1 {

--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -48,6 +48,7 @@ export const StyledCheckBoxInput = styled.input`
 `;
 
 export const StyledCheckBoxBox = styled.div`
+  box-sizing: border-box;
   position: relative;
   top: -1px;
   display: inline-block;
@@ -60,6 +61,7 @@ export const StyledCheckBoxBox = styled.div`
   border-radius: ${props => props.theme.checkBox.border.radius};
 
   > svg {
+    box-sizing: border-box;
     position: absolute;
     top: -2px;
     left: -2px;
@@ -72,6 +74,7 @@ export const StyledCheckBoxBox = styled.div`
 `;
 
 export const StyledCheckBoxToggle = styled.span`
+  box-sizing: border-box;
   position: relative;
   vertical-align: middle;
   display: inline-block;
@@ -83,6 +86,7 @@ export const StyledCheckBoxToggle = styled.span`
 `;
 
 export const StyledCheckBoxKnob = styled.span`
+  box-sizing: border-box;
   position: absolute;
   top: -${props => props.theme.checkBox.border.width};
   left: -${props => props.theme.checkBox.border.width};

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -13,10 +13,6 @@ exports[`CheckBox checked renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -89,6 +85,7 @@ exports[`CheckBox checked renders 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   position: relative;
   top: -1px;
   display: inline-block;
@@ -102,6 +99,7 @@ exports[`CheckBox checked renders 1`] = `
 }
 
 .c3 > svg {
+  box-sizing: border-box;
   position: absolute;
   top: -2px;
   left: -2px;
@@ -163,10 +161,6 @@ exports[`CheckBox disabled renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -239,6 +233,7 @@ exports[`CheckBox disabled renders 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   position: relative;
   top: -1px;
   display: inline-block;
@@ -252,6 +247,7 @@ exports[`CheckBox disabled renders 1`] = `
 }
 
 .c3 > svg {
+  box-sizing: border-box;
   position: absolute;
   top: -2px;
   left: -2px;
@@ -350,10 +346,6 @@ exports[`CheckBox label renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -426,6 +418,7 @@ exports[`CheckBox label renders 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   position: relative;
   top: -1px;
   display: inline-block;
@@ -439,6 +432,7 @@ exports[`CheckBox label renders 1`] = `
 }
 
 .c3 > svg {
+  box-sizing: border-box;
   position: absolute;
   top: -2px;
   left: -2px;
@@ -538,10 +532,6 @@ exports[`CheckBox renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -614,6 +604,7 @@ exports[`CheckBox renders 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   position: relative;
   top: -1px;
   display: inline-block;
@@ -627,6 +618,7 @@ exports[`CheckBox renders 1`] = `
 }
 
 .c3 > svg {
+  box-sizing: border-box;
   position: absolute;
   top: -2px;
   left: -2px;
@@ -720,10 +712,6 @@ exports[`CheckBox reverse renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -796,6 +784,7 @@ exports[`CheckBox reverse renders 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   position: relative;
   top: -1px;
   display: inline-block;
@@ -809,6 +798,7 @@ exports[`CheckBox reverse renders 1`] = `
 }
 
 .c3 > svg {
+  box-sizing: border-box;
   position: absolute;
   top: -2px;
   left: -2px;
@@ -871,10 +861,6 @@ exports[`CheckBox toggle renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c1 {
@@ -949,6 +935,7 @@ exports[`CheckBox toggle renders 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   position: relative;
   vertical-align: middle;
   display: inline-block;
@@ -960,6 +947,7 @@ exports[`CheckBox toggle renders 1`] = `
 }
 
 .c4 {
+  box-sizing: border-box;
   position: absolute;
   top: -2px;
   left: -2px;

--- a/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
+++ b/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
@@ -172,7 +172,7 @@ exports[`Clock night renders 2`] = `
 
 exports[`Clock renders 1`] = `
 <div
-  class="StyledGrommet-gGRXwz fbqGIt"
+  class="StyledGrommet-gGRXwz DZGmZ"
 >
   <svg
     class="StyledClock-bEPleQ humySj"
@@ -223,7 +223,7 @@ exports[`Clock renders 1`] = `
 
 exports[`Clock renders 2`] = `
 <div
-  class="StyledGrommet-gGRXwz fbqGIt"
+  class="StyledGrommet-gGRXwz DZGmZ"
 >
   <svg
     class="StyledClock-bEPleQ humySj"

--- a/src/js/components/Diagram/__tests__/__snapshots__/Diagram-test.js.snap
+++ b/src/js/components/Diagram/__tests__/__snapshots__/Diagram-test.js.snap
@@ -2,23 +2,23 @@
 
 exports[`Diagram color renders 1`] = `
 <div
-  class="StyledGrommet-gGRXwz fbqGIt"
+  class="StyledGrommet-gGRXwz DZGmZ"
 >
   <div
     class="StyledStack-jqCQsC ewABiA"
   >
     <div
-      class="StyledBox-bStriS cpqHWx"
+      class="StyledBox-bStriS bDpPRE"
       direction="row"
       style="position: relative;"
     >
       <div
-        class="StyledBox-bStriS kyrQwD"
+        class="StyledBox-bStriS licPXK"
         id="1"
         direction="column"
       />
       <div
-        class="StyledBox-bStriS kyrQwD"
+        class="StyledBox-bStriS licPXK"
         id="2"
         direction="column"
       />
@@ -39,23 +39,23 @@ exports[`Diagram color renders 1`] = `
 
 exports[`Diagram offset renders 1`] = `
 <div
-  class="StyledGrommet-gGRXwz fbqGIt"
+  class="StyledGrommet-gGRXwz DZGmZ"
 >
   <div
     class="StyledStack-jqCQsC ewABiA"
   >
     <div
-      class="StyledBox-bStriS cpqHWx"
+      class="StyledBox-bStriS bDpPRE"
       direction="row"
       style="position: relative;"
     >
       <div
-        class="StyledBox-bStriS kyrQwD"
+        class="StyledBox-bStriS licPXK"
         id="1"
         direction="column"
       />
       <div
-        class="StyledBox-bStriS kyrQwD"
+        class="StyledBox-bStriS licPXK"
         id="2"
         direction="column"
       />
@@ -76,23 +76,23 @@ exports[`Diagram offset renders 1`] = `
 
 exports[`Diagram renders 1`] = `
 <div
-  class="StyledGrommet-gGRXwz fbqGIt"
+  class="StyledGrommet-gGRXwz DZGmZ"
 >
   <div
     class="StyledStack-jqCQsC ewABiA"
   >
     <div
-      class="StyledBox-bStriS cpqHWx"
+      class="StyledBox-bStriS bDpPRE"
       direction="row"
       style="position: relative;"
     >
       <div
-        class="StyledBox-bStriS kyrQwD"
+        class="StyledBox-bStriS licPXK"
         id="1"
         direction="column"
       />
       <div
-        class="StyledBox-bStriS kyrQwD"
+        class="StyledBox-bStriS licPXK"
         id="2"
         direction="column"
       />
@@ -113,23 +113,23 @@ exports[`Diagram renders 1`] = `
 
 exports[`Diagram thickness renders 1`] = `
 <div
-  class="StyledGrommet-gGRXwz fbqGIt"
+  class="StyledGrommet-gGRXwz DZGmZ"
 >
   <div
     class="StyledStack-jqCQsC ewABiA"
   >
     <div
-      class="StyledBox-bStriS cpqHWx"
+      class="StyledBox-bStriS bDpPRE"
       direction="row"
       style="position: relative;"
     >
       <div
-        class="StyledBox-bStriS kyrQwD"
+        class="StyledBox-bStriS licPXK"
         id="1"
         direction="column"
       />
       <div
-        class="StyledBox-bStriS kyrQwD"
+        class="StyledBox-bStriS licPXK"
         id="2"
         direction="column"
       />
@@ -150,23 +150,23 @@ exports[`Diagram thickness renders 1`] = `
 
 exports[`Diagram type renders 1`] = `
 <div
-  class="StyledGrommet-gGRXwz fbqGIt"
+  class="StyledGrommet-gGRXwz DZGmZ"
 >
   <div
     class="StyledStack-jqCQsC ewABiA"
   >
     <div
-      class="StyledBox-bStriS cpqHWx"
+      class="StyledBox-bStriS bDpPRE"
       direction="row"
       style="position: relative;"
     >
       <div
-        class="StyledBox-bStriS kyrQwD"
+        class="StyledBox-bStriS licPXK"
         id="1"
         direction="column"
       />
       <div
-        class="StyledBox-bStriS kyrQwD"
+        class="StyledBox-bStriS licPXK"
         id="2"
         direction="column"
       />

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Drop aligns left right top bottom 1`] = `
 <div
-  class="StyledDrop-bCWxPe hEiKPj"
+  class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -14,7 +14,7 @@ exports[`Drop aligns left right top bottom 1`] = `
 exports[`Drop aligns left right top bottom 2`] = `
 "
 
-.hEiKPj {
+.gcEofR {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -40,16 +40,12 @@ exports[`Drop aligns left right top bottom 2`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
-}
-
-.hEiKPj * {
-  box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns right left top top 1`] = `
 <div
-  class="StyledDrop-bCWxPe gSWhZw"
+  class="StyledDrop-bCWxPe fAkYxw"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -61,7 +57,7 @@ exports[`Drop aligns right left top top 1`] = `
 exports[`Drop aligns right left top top 2`] = `
 "
 
-.gSWhZw {
+.fAkYxw {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -87,16 +83,12 @@ exports[`Drop aligns right left top top 2`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
-}
-
-.gSWhZw * {
-  box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns right right bottom top 1`] = `
 <div
-  class="StyledDrop-bCWxPe jYGEAD"
+  class="StyledDrop-bCWxPe cscpcq"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -108,7 +100,7 @@ exports[`Drop aligns right right bottom top 1`] = `
 exports[`Drop aligns right right bottom top 2`] = `
 "
 
-.jYGEAD {
+.cscpcq {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -134,16 +126,12 @@ exports[`Drop aligns right right bottom top 2`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
-}
-
-.jYGEAD * {
-  box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns right right bottom top 3`] = `
 <div
-  class="StyledDrop-bCWxPe jYGEAD"
+  class="StyledDrop-bCWxPe cscpcq"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -155,7 +143,7 @@ exports[`Drop aligns right right bottom top 3`] = `
 exports[`Drop aligns right right bottom top 4`] = `
 "
 
-.jYGEAD {
+.cscpcq {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -181,16 +169,12 @@ exports[`Drop aligns right right bottom top 4`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
-}
-
-.jYGEAD * {
-  box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns skips left random 1`] = `
 <div
-  class="StyledDrop-bCWxPe tMsBQ"
+  class="StyledDrop-bCWxPe hBYrcs"
   tabindex="-1"
   id="drop-node"
   style="width: 0.1px; top: 0px; max-height: 768px;"
@@ -202,7 +186,7 @@ exports[`Drop aligns skips left random 1`] = `
 exports[`Drop aligns skips left random 2`] = `
 "
 
-.tMsBQ {
+.hBYrcs {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -228,16 +212,12 @@ exports[`Drop aligns skips left random 2`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
-}
-
-.tMsBQ * {
-  box-sizing: inherit;
 }"
 `;
 
 exports[`Drop aligns skips right random 1`] = `
 <div
-  class="StyledDrop-bCWxPe gSWhZw"
+  class="StyledDrop-bCWxPe fAkYxw"
   tabindex="-1"
   id="drop-node"
   style="width: 0.1px; max-height: 768px;"
@@ -249,7 +229,7 @@ exports[`Drop aligns skips right random 1`] = `
 exports[`Drop aligns skips right random 2`] = `
 "
 
-.gSWhZw {
+.fAkYxw {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -275,16 +255,12 @@ exports[`Drop aligns skips right random 2`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
-}
-
-.gSWhZw * {
-  box-sizing: inherit;
 }"
 `;
 
 exports[`Drop mounts 1`] = `
 <div
-  class="StyledDrop-bCWxPe hEiKPj"
+  class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -296,7 +272,7 @@ exports[`Drop mounts 1`] = `
 exports[`Drop mounts 2`] = `
 "
 
-.hEiKPj {
+.gcEofR {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -322,16 +298,12 @@ exports[`Drop mounts 2`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
-}
-
-.hEiKPj * {
-  box-sizing: inherit;
 }"
 `;
 
 exports[`Drop resizes 1`] = `
 <div
-  class="StyledDrop-bCWxPe hEiKPj"
+  class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="test"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -343,7 +315,7 @@ exports[`Drop resizes 1`] = `
 exports[`Drop resizes 2`] = `
 "
 
-.hEiKPj {
+.gcEofR {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -369,16 +341,12 @@ exports[`Drop resizes 2`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
-}
-
-.hEiKPj * {
-  box-sizing: inherit;
 }"
 `;
 
 exports[`Drop restrict focus 1`] = `
 <div
-  class="StyledDrop-bCWxPe hEiKPj"
+  class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -389,7 +357,7 @@ exports[`Drop restrict focus 1`] = `
 
 exports[`Drop restrict focus 2`] = `
 <div
-  class="StyledDrop-bCWxPe hEiKPj"
+  class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -401,7 +369,7 @@ exports[`Drop restrict focus 2`] = `
 exports[`Drop restrict focus 3`] = `
 "
 
-.hEiKPj {
+.gcEofR {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -427,10 +395,6 @@ exports[`Drop restrict focus 3`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
-}
-
-.hEiKPj * {
-  box-sizing: inherit;
 }"
 `;
 
@@ -444,7 +408,7 @@ exports[`Drop restrict focus 4`] = `
 
 exports[`Drop skips invalid align 1`] = `
 <div
-  class="StyledDrop-bCWxPe hEiKPj"
+  class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="drop-node"
   style="width: 0.1px; max-height: 768px;"
@@ -456,7 +420,7 @@ exports[`Drop skips invalid align 1`] = `
 exports[`Drop skips invalid align 2`] = `
 "
 
-.hEiKPj {
+.gcEofR {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -482,16 +446,12 @@ exports[`Drop skips invalid align 2`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
-}
-
-.hEiKPj * {
-  box-sizing: inherit;
 }"
 `;
 
 exports[`Drop updates 1`] = `
 <div
-  class="StyledGrommet-gGRXwz fbqGIt"
+  class="StyledGrommet-gGRXwz DZGmZ"
 >
   <input />
 </div>

--- a/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
+++ b/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DropButton closes 1`] = `
 <button
-  class="StyledButton-gXzblK eMXCzV"
+  class="StyledButton-gXzblK gWYNMT"
   tabindex="0"
   aria-label="Open Drop"
   type="button"
@@ -21,7 +21,7 @@ exports[`DropButton closes 2`] = `
 
 exports[`DropButton closes 3`] = `
 "@media only screen and (min-width:700px) {
-  .eMXCzV {
+  .gWYNMT {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -30,7 +30,7 @@ exports[`DropButton closes 3`] = `
 
 exports[`DropButton mounts 1`] = `
 <button
-  class="StyledButton-gXzblK eMXCzV"
+  class="StyledButton-gXzblK gWYNMT"
   tabindex="0"
   aria-label="Open Drop"
   type="button"
@@ -49,7 +49,7 @@ exports[`DropButton mounts 2`] = `
 
 exports[`DropButton mounts 3`] = `
 "@media only screen and (min-width:700px) {
-  .eMXCzV {
+  .gWYNMT {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -58,7 +58,7 @@ exports[`DropButton mounts 3`] = `
 
 exports[`DropButton mounts 4`] = `
 <button
-  class="StyledButton-gXzblK eMXCzV"
+  class="StyledButton-gXzblK gWYNMT"
   tabindex="-1"
   aria-label="Open Drop"
   type="button"
@@ -82,7 +82,7 @@ exports[`DropButton mounts 5`] = `
 
 exports[`DropButton mounts 6`] = `
 "@media only screen and (min-width:700px) {
-  .eMXCzV {
+  .gWYNMT {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }

--- a/src/js/components/Grid/StyledGrid.js
+++ b/src/js/components/Grid/StyledGrid.js
@@ -109,6 +109,7 @@ const areasStyle = (props) => {
 
 const StyledGrid = styled.div`
   display: grid;
+  box-sizing: border-box;
   height: 100%;
 
   ${props => props.align && alignStyle}

--- a/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
+++ b/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
@@ -13,12 +13,9 @@ exports[`Grid align renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -28,6 +25,7 @@ exports[`Grid align renders 1`] = `
 
 .c2 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -37,6 +35,7 @@ exports[`Grid align renders 1`] = `
 
 .c3 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -46,6 +45,7 @@ exports[`Grid align renders 1`] = `
 
 .c4 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -84,12 +84,9 @@ exports[`Grid alignContent renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-align-content: flex-start;
   -ms-flex-line-pack: start;
@@ -98,6 +95,7 @@ exports[`Grid alignContent renders 1`] = `
 
 .c2 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -106,6 +104,7 @@ exports[`Grid alignContent renders 1`] = `
 
 .c3 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-align-content: space-between;
   -ms-flex-line-pack: space-between;
@@ -114,6 +113,7 @@ exports[`Grid alignContent renders 1`] = `
 
 .c4 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-align-content: space-around;
   -ms-flex-line-pack: space-around;
@@ -122,6 +122,7 @@ exports[`Grid alignContent renders 1`] = `
 
 .c5 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-align-content: flex-end;
   -ms-flex-line-pack: end;
@@ -130,6 +131,7 @@ exports[`Grid alignContent renders 1`] = `
 
 .c6 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
@@ -173,12 +175,9 @@ exports[`Grid areas renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   grid-template-areas: "header main footer" "header sidebar footer" ". .";
   grid-template-columns: 75% 25%;
@@ -214,12 +213,9 @@ exports[`Grid columns renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   grid-template-columns: 50% 25% 25%;
 }
@@ -246,66 +242,72 @@ exports[`Grid gap renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   grid-gap: 12px 12px;
 }
 
 .c2 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   grid-gap: 24px 24px;
 }
 
 .c3 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   grid-gap: 48px 48px;
 }
 
 .c4 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   grid-row-gap: 12px;
 }
 
 .c5 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   grid-row-gap: 24px;
 }
 
 .c6 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   grid-row-gap: 48px;
 }
 
 .c7 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   grid-column-gap: 12px;
 }
 
 .c8 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   grid-column-gap: 24px;
 }
 
 .c9 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   grid-column-gap: 48px;
 }
 
 .c10 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   grid-row-gap: 12px;
   grid-column-gap: 24px;
@@ -360,12 +362,9 @@ exports[`Grid justify renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
@@ -375,6 +374,7 @@ exports[`Grid justify renders 1`] = `
 
 .c2 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -384,6 +384,7 @@ exports[`Grid justify renders 1`] = `
 
 .c3 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-box-pack: end;
   -webkit-justify-content: flex-end;
@@ -393,6 +394,7 @@ exports[`Grid justify renders 1`] = `
 
 .c4 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-box-pack: stretch;
   -webkit-justify-content: stretch;
@@ -431,12 +433,9 @@ exports[`Grid justifyContent renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
@@ -446,6 +445,7 @@ exports[`Grid justifyContent renders 1`] = `
 
 .c2 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -455,6 +455,7 @@ exports[`Grid justifyContent renders 1`] = `
 
 .c3 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
@@ -464,6 +465,7 @@ exports[`Grid justifyContent renders 1`] = `
 
 .c4 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-box-pack: space-around;
   -webkit-justify-content: space-around;
@@ -473,6 +475,7 @@ exports[`Grid justifyContent renders 1`] = `
 
 .c5 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-box-pack: end;
   -webkit-justify-content: flex-end;
@@ -482,6 +485,7 @@ exports[`Grid justifyContent renders 1`] = `
 
 .c6 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   -webkit-box-pack: stretch;
   -webkit-justify-content: stretch;
@@ -526,12 +530,9 @@ exports[`Grid renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
 }
 
@@ -557,12 +558,9 @@ exports[`Grid rows renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
   grid-template-rows: 192px 768px 384px;
 }
@@ -596,12 +594,9 @@ exports[`Grid tag renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: grid;
+  box-sizing: border-box;
   height: 100%;
 }
 

--- a/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
+++ b/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Grommet announces 1`] = `
 <div
-  class="StyledGrommet-gGRXwz fbqGIt"
+  class="StyledGrommet-gGRXwz DZGmZ"
 >
   <div>
     hi
@@ -39,10 +39,6 @@ exports[`Grommet hpe theme renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 <div
   className="c0"
 >
@@ -61,10 +57,6 @@ exports[`Grommet renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 <div

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -13,10 +13,6 @@ exports[`Heading level renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   font-size: 48px;
   line-height: 1.125;
@@ -74,10 +70,6 @@ exports[`Heading margin renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c1 {
@@ -191,10 +183,6 @@ exports[`Heading renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   font-size: 48px;
   line-height: 1.125;
@@ -222,10 +210,6 @@ exports[`Heading size renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c2 {
@@ -337,10 +321,6 @@ exports[`Heading textAlign renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   font-size: 48px;
   line-height: 1.125;
@@ -391,10 +371,6 @@ exports[`Heading truncate renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c1 {

--- a/src/js/components/Image/__tests__/__snapshots__/Image-test.js.snap
+++ b/src/js/components/Image/__tests__/__snapshots__/Image-test.js.snap
@@ -13,10 +13,6 @@ exports[`Image fit renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
@@ -58,10 +54,6 @@ exports[`Image renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 <div

--- a/src/js/components/Keyboard/__tests__/__snapshots__/Keyboard-test.js.snap
+++ b/src/js/components/Keyboard/__tests__/__snapshots__/Keyboard-test.js.snap
@@ -13,10 +13,6 @@ exports[`Keyboard calls onKeyDown 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 <div
   className="c0"
 >
@@ -39,10 +35,6 @@ exports[`Keyboard renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 <div

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Layer aligns bottom 1`] = `
 <div
-  class="StyledLayer-ceZzeh eJxHlH"
+  class="StyledLayer-ceZzeh bGwGvr"
   id="bottom-test"
   tabindex="-1"
 >
@@ -17,7 +17,7 @@ exports[`Layer aligns bottom 1`] = `
 exports[`Layer aligns bottom 2`] = `
 "
 
-.eJxHlH {
+.bGwGvr {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -34,12 +34,8 @@ exports[`Layer aligns bottom 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.eJxHlH * {
-  box-sizing: inherit;
-}
-
 @media only screen and (min-width:700px) {
-  .eJxHlH {
+  .bGwGvr {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -142,7 +138,7 @@ exports[`Layer aligns bottom 2`] = `
 
 exports[`Layer aligns left 1`] = `
 <div
-  class="StyledLayer-ceZzeh eJxHlH"
+  class="StyledLayer-ceZzeh bGwGvr"
   id="left-test"
   tabindex="-1"
 >
@@ -157,7 +153,7 @@ exports[`Layer aligns left 1`] = `
 exports[`Layer aligns left 2`] = `
 "
 
-.eJxHlH {
+.bGwGvr {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -174,12 +170,8 @@ exports[`Layer aligns left 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.eJxHlH * {
-  box-sizing: inherit;
-}
-
 @media only screen and (min-width:700px) {
-  .eJxHlH {
+  .bGwGvr {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -213,7 +205,7 @@ exports[`Layer aligns left 2`] = `
 
 exports[`Layer aligns right 1`] = `
 <div
-  class="StyledLayer-ceZzeh eJxHlH"
+  class="StyledLayer-ceZzeh bGwGvr"
   id="right-test"
   tabindex="-1"
 >
@@ -228,7 +220,7 @@ exports[`Layer aligns right 1`] = `
 exports[`Layer aligns right 2`] = `
 "
 
-.eJxHlH {
+.bGwGvr {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -245,12 +237,8 @@ exports[`Layer aligns right 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.eJxHlH * {
-  box-sizing: inherit;
-}
-
 @media only screen and (min-width:700px) {
-  .eJxHlH {
+  .bGwGvr {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -306,7 +294,7 @@ exports[`Layer aligns right 2`] = `
 
 exports[`Layer aligns top 1`] = `
 <div
-  class="StyledLayer-ceZzeh eJxHlH"
+  class="StyledLayer-ceZzeh bGwGvr"
   id="top-test"
   tabindex="-1"
 >
@@ -321,7 +309,7 @@ exports[`Layer aligns top 1`] = `
 exports[`Layer aligns top 2`] = `
 "
 
-.eJxHlH {
+.bGwGvr {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -338,12 +326,8 @@ exports[`Layer aligns top 2`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.eJxHlH * {
-  box-sizing: inherit;
-}
-
 @media only screen and (min-width:700px) {
-  .eJxHlH {
+  .bGwGvr {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -422,7 +406,7 @@ exports[`Layer aligns top 2`] = `
 
 exports[`Layer hides 1`] = `
 <div
-  class="StyledLayer-ceZzeh befYaj"
+  class="StyledLayer-ceZzeh gVCohQ"
   id="hidden-test"
   tabindex="-1"
 >
@@ -438,7 +422,7 @@ exports[`Layer hides 2`] = `
 "
 
 @media only screen and (min-width:700px) {
-  .eJxHlH {
+  .bGwGvr {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -447,7 +431,7 @@ exports[`Layer hides 2`] = `
   }
 }
 
-.befYaj {
+.gVCohQ {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -466,10 +450,6 @@ exports[`Layer hides 2`] = `
   right: 100%;
   z-index: -1;
   position: fixed;
-}
-
-.befYaj * {
-  box-sizing: inherit;
 }
 
 @media only screen and (max-width:699px) {
@@ -583,7 +563,7 @@ exports[`Layer hides 2`] = `
 
 exports[`Layer hides 3`] = `
 <div
-  class="StyledLayer-ceZzeh befYaj"
+  class="StyledLayer-ceZzeh gVCohQ"
   id="hidden-test"
   tabindex="-1"
 >
@@ -599,7 +579,7 @@ exports[`Layer hides 4`] = `
 "
 
 @media only screen and (min-width:700px) {
-  .eJxHlH {
+  .bGwGvr {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -608,7 +588,7 @@ exports[`Layer hides 4`] = `
   }
 }
 
-.befYaj {
+.gVCohQ {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -627,10 +607,6 @@ exports[`Layer hides 4`] = `
   right: 100%;
   z-index: -1;
   position: fixed;
-}
-
-.befYaj * {
-  box-sizing: inherit;
 }
 
 @media only screen and (max-width:699px) {
@@ -778,7 +754,7 @@ exports[`Layer is accessible 3`] = `
 
 exports[`Layer plain renders 1`] = `
 <div
-  class="StyledLayer-ceZzeh jxhLXK"
+  class="StyledLayer-ceZzeh jNReQX"
   id="plain-test"
   tabindex="-1"
 >
@@ -794,7 +770,7 @@ exports[`Layer plain renders 2`] = `
 "
 
 @media only screen and (min-width:700px) {
-  .eJxHlH {
+  .bGwGvr {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -803,7 +779,7 @@ exports[`Layer plain renders 2`] = `
   }
 }
 
-.jxhLXK {
+.jNReQX {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -820,12 +796,8 @@ exports[`Layer plain renders 2`] = `
   background-color: transparent;
 }
 
-.jxhLXK * {
-  box-sizing: inherit;
-}
-
 @media only screen and (min-width:700px) {
-  .jxhLXK {
+  .jNReQX {
     position: fixed;
     top: 0px;
     left: 0px;

--- a/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
+++ b/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
@@ -13,10 +13,6 @@ exports[`Markdown renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   font-size: 48px;
   line-height: 1.125;

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -2,27 +2,27 @@
 
 exports[`Menu opens and closes on click 1`] = `
 <div
-  class="StyledDrop-bCWxPe hEiKPj"
+  class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="menu-drop__test"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   <div
-    class="StyledBox-bStriS iSfEjW"
+    class="StyledBox-bStriS biDyjR"
     direction="column"
   >
     <button
-      class="StyledButton-gXzblK eMXCzV"
+      class="StyledButton-gXzblK gWYNMT"
       tabindex="0"
       aria-label="Close Menu"
       type="button"
     >
       <div
-        class="StyledBox-bStriS kZGdzl"
+        class="StyledBox-bStriS erqdbz"
         direction="row"
       >
         <div
-          class="StyledBox-bStriS kyUkeU"
+          class="StyledBox-bStriS cZkzQo"
           direction="column"
         >
           Test
@@ -46,41 +46,41 @@ exports[`Menu opens and closes on click 1`] = `
       </div>
     </button>
     <div
-      class="StyledBox-bStriS iSfEjW"
+      class="StyledBox-bStriS biDyjR"
       direction="column"
     >
       <button
-        class="StyledButton-gXzblK fmBjBd"
+        class="StyledButton-gXzblK hhpGCI"
         tabindex="0"
         disabled=""
         type="button"
       >
         <div
-          class="StyledBox-bStriS jtjnXL"
+          class="StyledBox-bStriS ezpILP"
           direction="row"
         >
           Item 1
         </div>
       </button>
       <button
-        class="StyledButton-gXzblK fXMbaK"
+        class="StyledButton-gXzblK dIqByu"
         tabindex="0"
         type="button"
       >
         <div
-          class="StyledBox-bStriS jtjnXL"
+          class="StyledBox-bStriS ezpILP"
           direction="row"
         >
           Item 2
         </div>
       </button>
       <a
-        class="StyledButton-gXzblK fXMbaK"
+        class="StyledButton-gXzblK dIqByu"
         tabindex="0"
         href="/test"
       >
         <div
-          class="StyledBox-bStriS jtjnXL"
+          class="StyledBox-bStriS ezpILP"
           direction="row"
         >
           Item 3
@@ -93,28 +93,28 @@ exports[`Menu opens and closes on click 1`] = `
 
 exports[`Menu opens and closes on click 2`] = `
 "@media only screen and (min-width:700px) {
-  .jYQWcg {
+  .cbZUvN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .eMXCzV {
+  .gWYNMT {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fmBjBd {
+  .hhpGCI {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fXMbaK {
+  .dIqByu {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -122,7 +122,7 @@ exports[`Menu opens and closes on click 2`] = `
 
 
 
-.hEiKPj {
+.gcEofR {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -148,24 +148,20 @@ exports[`Menu opens and closes on click 2`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
-}
-
-.hEiKPj * {
-  box-sizing: inherit;
 }"
 `;
 
 exports[`Menu renders 1`] = `
 <div>
   <button
-    class="StyledButton-gXzblK jYQWcg"
+    class="StyledButton-gXzblK cbZUvN"
     tabindex="0"
     id="item"
     aria-label="Open Menu"
     type="button"
   >
     <div
-      class="StyledBox-bStriS jtjnXL"
+      class="StyledBox-bStriS ezpILP"
       direction="row"
     >
       <svg />
@@ -177,17 +173,17 @@ exports[`Menu renders 1`] = `
 exports[`Menu with custom message renders 1`] = `
 <div>
   <button
-    class="StyledButton-gXzblK jYQWcg"
+    class="StyledButton-gXzblK cbZUvN"
     tabindex="0"
     aria-label="Abrir Menu"
     type="button"
   >
     <div
-      class="StyledBox-bStriS jtjnXL"
+      class="StyledBox-bStriS ezpILP"
       direction="row"
     >
       <div
-        class="StyledBox-bStriS kyUkeU"
+        class="StyledBox-bStriS cZkzQo"
         direction="column"
       >
         Test Icon
@@ -215,7 +211,7 @@ exports[`Menu with custom message renders 1`] = `
 
 exports[`Menu with dropAlign renders 1`] = `
 <button
-  class="StyledButton-gXzblK jYQWcg"
+  class="StyledButton-gXzblK cbZUvN"
   tabindex="-1"
   id="menu"
   aria-label="Open Menu"
@@ -223,11 +219,11 @@ exports[`Menu with dropAlign renders 1`] = `
   data-g-tabindex="0"
 >
   <div
-    class="StyledBox-bStriS jtjnXL"
+    class="StyledBox-bStriS ezpILP"
     direction="row"
   >
     <div
-      class="StyledBox-bStriS kyUkeU"
+      class="StyledBox-bStriS cZkzQo"
       direction="column"
     >
       Test
@@ -255,7 +251,8 @@ exports[`Menu with dropAlign renders 1`] = `
 exports[`Menu with dropAlign renders 2`] = `
 "
 
-.jYQWcg {
+.cbZUvN {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -271,35 +268,35 @@ exports[`Menu with dropAlign renders 2`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .jYQWcg {
+  .cbZUvN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .eMXCzV {
+  .gWYNMT {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fmBjBd {
+  .hhpGCI {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fXMbaK {
+  .dIqByu {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fYAaIT {
+  .bYclFl {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }

--- a/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
+++ b/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
@@ -13,10 +13,6 @@ exports[`Meter background renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   max-width: 100%;
 }
@@ -145,10 +141,6 @@ exports[`Meter renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   max-width: 100%;
 }
@@ -216,10 +208,6 @@ exports[`Meter round renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c2 {
@@ -318,10 +306,6 @@ exports[`Meter size renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c1 {
@@ -607,10 +591,6 @@ exports[`Meter thickness renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   max-width: 100%;
 }
@@ -892,10 +872,6 @@ exports[`Meter type renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c1 {

--- a/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.js.snap
+++ b/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.js.snap
@@ -13,10 +13,6 @@ exports[`Paragraph margin renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   font-size: 16px;
   line-height: 1.375;
@@ -100,10 +96,6 @@ exports[`Paragraph renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   font-size: 16px;
   line-height: 1.375;
@@ -130,10 +122,6 @@ exports[`Paragraph size renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c2 {
@@ -193,10 +181,6 @@ exports[`Paragraph textAlign renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c1 {

--- a/src/js/components/RadioButton/StyledRadioButton.js
+++ b/src/js/components/RadioButton/StyledRadioButton.js
@@ -44,6 +44,7 @@ export const StyledRadioButtonInput = styled.input`
 `;
 
 export const StyledRadioButtonButton = styled.div`
+  box-sizing: border-box;
   position: relative;
   top: -1px;
   display: inline-block;
@@ -56,6 +57,7 @@ export const StyledRadioButtonButton = styled.div`
   border-radius: ${props => props.theme.radioButton.border.radius};
 
   > svg {
+    box-sizing: border-box;
     position: absolute;
     top: -2px;
     left: -2px;

--- a/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
+++ b/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
@@ -13,10 +13,6 @@ exports[`RadioButton checked renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -88,6 +84,7 @@ exports[`RadioButton checked renders 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   position: relative;
   top: -1px;
   display: inline-block;
@@ -101,6 +98,7 @@ exports[`RadioButton checked renders 1`] = `
 }
 
 .c3 > svg {
+  box-sizing: border-box;
   position: absolute;
   top: -2px;
   left: -2px;
@@ -162,10 +160,6 @@ exports[`RadioButton disabled renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -237,6 +231,7 @@ exports[`RadioButton disabled renders 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   position: relative;
   top: -1px;
   display: inline-block;
@@ -250,6 +245,7 @@ exports[`RadioButton disabled renders 1`] = `
 }
 
 .c3 > svg {
+  box-sizing: border-box;
   position: absolute;
   top: -2px;
   left: -2px;
@@ -344,10 +340,6 @@ exports[`RadioButton label renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -419,6 +411,7 @@ exports[`RadioButton label renders 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   position: relative;
   top: -1px;
   display: inline-block;
@@ -432,6 +425,7 @@ exports[`RadioButton label renders 1`] = `
 }
 
 .c3 > svg {
+  box-sizing: border-box;
   position: absolute;
   top: -2px;
   left: -2px;
@@ -532,10 +526,6 @@ exports[`RadioButton renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -607,6 +597,7 @@ exports[`RadioButton renders 1`] = `
 }
 
 .c3 {
+  box-sizing: border-box;
   position: relative;
   top: -1px;
   display: inline-block;
@@ -620,6 +611,7 @@ exports[`RadioButton renders 1`] = `
 }
 
 .c3 > svg {
+  box-sizing: border-box;
   position: absolute;
   top: -2px;
   left: -2px;

--- a/src/js/components/RangeInput/StyledRangeInput.js
+++ b/src/js/components/RangeInput/StyledRangeInput.js
@@ -3,6 +3,7 @@ import styled, { css } from 'styled-components';
 import { focusStyle, parseMetricToNum } from '../../utils';
 
 const rangeTrackStyle = css`
+  box-sizing: border-box;
   width: 100%;
   height: ${props => props.theme.global.focus.border.width};
   background-color: ${
@@ -17,6 +18,7 @@ const rangeTrackStyle = css`
 `;
 
 const rangeThumbStyle = css`
+  box-sizing: border-box;
   position: relative;
   border: ${props => props.theme.global.control.border.width} solid ${props => (props.grommet.dark ? props.theme.global.colors.white : props.theme.global.colors.brand)};
   border-radius: ${props => props.theme.global.spacing};
@@ -36,6 +38,7 @@ const firefoxMicrosoftThumbStyle = css`
 `;
 
 const StyledRangeInput = styled.input`
+  box-sizing: border-box;
   position: relative;
   -webkit-appearance: none;
   border-color: transparent;

--- a/src/js/components/RangeInput/__tests__/__snapshots__/RangeInput-test.js.snap
+++ b/src/js/components/RangeInput/__tests__/__snapshots__/RangeInput-test.js.snap
@@ -13,11 +13,8 @@ exports[`RangeInput renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   position: relative;
   -webkit-appearance: none;
   border-color: transparent;
@@ -42,12 +39,14 @@ exports[`RangeInput renders 1`] = `
 }
 
 .c1::-webkit-slider-runnable-track {
+  box-sizing: border-box;
   width: 100%;
   height: 2px;
   background-color: rgba(51,51,51,0.2);
 }
 
 .c1::-webkit-slider-thumb {
+  box-sizing: border-box;
   position: relative;
   border: 2px solid #865CD6;
   border-radius: 24px;
@@ -65,12 +64,14 @@ exports[`RangeInput renders 1`] = `
 }
 
 .c1::-moz-range-track {
+  box-sizing: border-box;
   width: 100%;
   height: 2px;
   background-color: rgba(51,51,51,0.2);
 }
 
 .c1::-moz-range-thumb {
+  box-sizing: border-box;
   position: relative;
   border: 2px solid #865CD6;
   border-radius: 24px;
@@ -86,6 +87,7 @@ exports[`RangeInput renders 1`] = `
 }
 
 .c1::-ms-thumb {
+  box-sizing: border-box;
   position: relative;
   border: 2px solid #865CD6;
   border-radius: 24px;
@@ -109,6 +111,7 @@ exports[`RangeInput renders 1`] = `
 }
 
 .c1::-ms-track {
+  box-sizing: border-box;
   width: 100%;
   height: 2px;
   background-color: rgba(51,51,51,0.2);

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -2,29 +2,29 @@
 
 exports[`Select closes drop on esc 1`] = `
 <div
-  class="StyledBox-bStriS iSfEjW"
+  class="StyledBox-bStriS biDyjR"
   id="select-drop__select"
   direction="column"
 >
   <div
-    class="StyledBox-bStriS dkPsPN"
+    class="StyledBox-bStriS kTYZCw"
     overflow="auto"
     direction="column"
   >
     <div
-      class="StyledBox-bStriS kjpBUX"
+      class="StyledBox-bStriS iybkIn"
       role="menubar"
       tabindex="-1"
       direction="column"
     >
       <button
-        class="StyledButton-gXzblK fXMbaK"
+        class="StyledButton-gXzblK dIqByu"
         tabindex="0"
         role="menuitem"
         type="button"
       >
         <div
-          class="StyledBox-bStriS hPDWZy"
+          class="StyledBox-bStriS hYyHvw"
           direction="column"
         >
           <span
@@ -35,13 +35,13 @@ exports[`Select closes drop on esc 1`] = `
         </div>
       </button>
       <button
-        class="StyledButton-gXzblK fXMbaK"
+        class="StyledButton-gXzblK dIqByu"
         tabindex="0"
         role="menuitem"
         type="button"
       >
         <div
-          class="StyledBox-bStriS hPDWZy"
+          class="StyledBox-bStriS hYyHvw"
           direction="column"
         >
           <span
@@ -59,11 +59,12 @@ exports[`Select closes drop on esc 1`] = `
 exports[`Select closes drop on esc 2`] = `
 "
 
-.iSfEjW {
+.biDyjR {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -72,14 +73,14 @@ exports[`Select closes drop on esc 2`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .eMXCzV {
+  .gWYNMT {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fXMbaK {
+  .dIqByu {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -88,12 +89,12 @@ exports[`Select closes drop on esc 2`] = `
 
 exports[`Select closes drop on esc 3`] = `
 <button
-  class="StyledButton-gXzblK eMXCzV"
+  class="StyledButton-gXzblK gWYNMT"
   aria-label="undefined"
   type="button"
 >
   <div
-    class="StyledBox-bStriS gIBvIW"
+    class="StyledBox-bStriS dXYgCY"
     aria-hidden="true"
     direction="row"
   >
@@ -102,7 +103,7 @@ exports[`Select closes drop on esc 3`] = `
     >
       <input
         type="text"
-        class="StyledTextInput-bzOzsW flduXy"
+        class="StyledTextInput-bzOzsW eWBxmM"
         id="select"
         autocomplete="off"
         style="cursor: pointer;"
@@ -111,7 +112,7 @@ exports[`Select closes drop on esc 3`] = `
       />
     </div>
     <div
-      class="StyledBox-bStriS bwImBZ"
+      class="StyledBox-bStriS eHityG"
       style="min-width: auto;"
       direction="column"
     >
@@ -138,12 +139,12 @@ exports[`Select closes drop on esc 3`] = `
 
 exports[`Select closes drop on esc 4`] = `
 <button
-  class="StyledButton-gXzblK eMXCzV"
+  class="StyledButton-gXzblK gWYNMT"
   aria-label="undefined"
   type="button"
 >
   <div
-    class="StyledBox-bStriS gIBvIW"
+    class="StyledBox-bStriS dXYgCY"
     aria-hidden="true"
     direction="row"
   >
@@ -152,7 +153,7 @@ exports[`Select closes drop on esc 4`] = `
     >
       <input
         type="text"
-        class="StyledTextInput-bzOzsW flduXy"
+        class="StyledTextInput-bzOzsW eWBxmM"
         id="select"
         autocomplete="off"
         style="cursor: pointer;"
@@ -161,7 +162,7 @@ exports[`Select closes drop on esc 4`] = `
       />
     </div>
     <div
-      class="StyledBox-bStriS bwImBZ"
+      class="StyledBox-bStriS eHityG"
       style="min-width: auto;"
       direction="column"
     >
@@ -188,12 +189,12 @@ exports[`Select closes drop on esc 4`] = `
 
 exports[`Select mounts 1`] = `
 <button
-  class="StyledButton-gXzblK eMXCzV"
+  class="StyledButton-gXzblK gWYNMT"
   aria-label="undefined"
   type="button"
 >
   <div
-    class="StyledBox-bStriS gIBvIW"
+    class="StyledBox-bStriS dXYgCY"
     aria-hidden="true"
     direction="row"
   >
@@ -202,7 +203,7 @@ exports[`Select mounts 1`] = `
     >
       <input
         type="text"
-        class="StyledTextInput-bzOzsW flduXy"
+        class="StyledTextInput-bzOzsW eWBxmM"
         id="select"
         autocomplete="off"
         style="cursor: pointer;"
@@ -211,7 +212,7 @@ exports[`Select mounts 1`] = `
       />
     </div>
     <div
-      class="StyledBox-bStriS bwImBZ"
+      class="StyledBox-bStriS eHityG"
       style="min-width: auto;"
       direction="column"
     >
@@ -238,12 +239,12 @@ exports[`Select mounts 1`] = `
 
 exports[`Select mounts 2`] = `
 <button
-  class="StyledButton-gXzblK eMXCzV"
+  class="StyledButton-gXzblK gWYNMT"
   aria-label="undefined"
   type="button"
 >
   <div
-    class="StyledBox-bStriS gIBvIW"
+    class="StyledBox-bStriS dXYgCY"
     aria-hidden="true"
     direction="row"
   >
@@ -252,7 +253,7 @@ exports[`Select mounts 2`] = `
     >
       <input
         type="text"
-        class="StyledTextInput-bzOzsW flduXy"
+        class="StyledTextInput-bzOzsW eWBxmM"
         id="select"
         autocomplete="off"
         style="cursor: pointer;"
@@ -261,7 +262,7 @@ exports[`Select mounts 2`] = `
       />
     </div>
     <div
-      class="StyledBox-bStriS bwImBZ"
+      class="StyledBox-bStriS eHityG"
       style="min-width: auto;"
       direction="column"
     >
@@ -288,29 +289,29 @@ exports[`Select mounts 2`] = `
 
 exports[`Select mounts 3`] = `
 <div
-  class="StyledBox-bStriS iSfEjW"
+  class="StyledBox-bStriS biDyjR"
   id="select-drop__select"
   direction="column"
 >
   <div
-    class="StyledBox-bStriS dkPsPN"
+    class="StyledBox-bStriS kTYZCw"
     overflow="auto"
     direction="column"
   >
     <div
-      class="StyledBox-bStriS kjpBUX"
+      class="StyledBox-bStriS iybkIn"
       role="menubar"
       tabindex="-1"
       direction="column"
     >
       <button
-        class="StyledButton-gXzblK fXMbaK"
+        class="StyledButton-gXzblK dIqByu"
         tabindex="0"
         role="menuitem"
         type="button"
       >
         <div
-          class="StyledBox-bStriS hPDWZy"
+          class="StyledBox-bStriS hYyHvw"
           direction="column"
         >
           <span
@@ -321,13 +322,13 @@ exports[`Select mounts 3`] = `
         </div>
       </button>
       <button
-        class="StyledButton-gXzblK fXMbaK"
+        class="StyledButton-gXzblK dIqByu"
         tabindex="0"
         role="menuitem"
         type="button"
       >
         <div
-          class="StyledBox-bStriS hPDWZy"
+          class="StyledBox-bStriS hYyHvw"
           direction="column"
         >
           <span
@@ -345,11 +346,12 @@ exports[`Select mounts 3`] = `
 exports[`Select mounts 4`] = `
 "
 
-.iSfEjW {
+.biDyjR {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -358,14 +360,14 @@ exports[`Select mounts 4`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .eMXCzV {
+  .gWYNMT {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fXMbaK {
+  .dIqByu {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -374,19 +376,19 @@ exports[`Select mounts 4`] = `
 
 exports[`Select mounts 5`] = `
 <div
-  class="StyledBox-bStriS kjpBUX"
+  class="StyledBox-bStriS iybkIn"
   role="menubar"
   tabindex="-1"
   direction="column"
 >
   <button
-    class="StyledButton-gXzblK fXMbaK"
+    class="StyledButton-gXzblK dIqByu"
     tabindex="0"
     role="menuitem"
     type="button"
   >
     <div
-      class="StyledBox-bStriS hPDWZy"
+      class="StyledBox-bStriS hYyHvw"
       direction="column"
     >
       <span
@@ -397,13 +399,13 @@ exports[`Select mounts 5`] = `
     </div>
   </button>
   <button
-    class="StyledButton-gXzblK fXMbaK"
+    class="StyledButton-gXzblK dIqByu"
     tabindex="0"
     role="menuitem"
     type="button"
   >
     <div
-      class="StyledBox-bStriS hPDWZy"
+      class="StyledBox-bStriS hYyHvw"
       direction="column"
     >
       <span
@@ -418,12 +420,12 @@ exports[`Select mounts 5`] = `
 
 exports[`Select mounts with complex options and children 1`] = `
 <button
-  class="StyledButton-gXzblK eMXCzV"
+  class="StyledButton-gXzblK gWYNMT"
   aria-label="undefined"
   type="button"
 >
   <div
-    class="StyledBox-bStriS gIBvIW"
+    class="StyledBox-bStriS dXYgCY"
     aria-hidden="true"
     direction="row"
   >
@@ -432,7 +434,7 @@ exports[`Select mounts with complex options and children 1`] = `
     >
       <input
         type="text"
-        class="StyledTextInput-bzOzsW flduXy"
+        class="StyledTextInput-bzOzsW eWBxmM"
         id="select"
         autocomplete="off"
         style="cursor: pointer;"
@@ -441,7 +443,7 @@ exports[`Select mounts with complex options and children 1`] = `
       />
     </div>
     <div
-      class="StyledBox-bStriS bwImBZ"
+      class="StyledBox-bStriS eHityG"
       style="min-width: auto;"
       direction="column"
     >
@@ -468,12 +470,12 @@ exports[`Select mounts with complex options and children 1`] = `
 
 exports[`Select mounts with complex options and children 2`] = `
 <button
-  class="StyledButton-gXzblK eMXCzV"
+  class="StyledButton-gXzblK gWYNMT"
   aria-label="undefined"
   type="button"
 >
   <div
-    class="StyledBox-bStriS gIBvIW"
+    class="StyledBox-bStriS dXYgCY"
     aria-hidden="true"
     direction="row"
   >
@@ -482,7 +484,7 @@ exports[`Select mounts with complex options and children 2`] = `
     >
       <input
         type="text"
-        class="StyledTextInput-bzOzsW flduXy"
+        class="StyledTextInput-bzOzsW eWBxmM"
         id="select"
         autocomplete="off"
         style="cursor: pointer;"
@@ -491,7 +493,7 @@ exports[`Select mounts with complex options and children 2`] = `
       />
     </div>
     <div
-      class="StyledBox-bStriS bwImBZ"
+      class="StyledBox-bStriS eHityG"
       style="min-width: auto;"
       direction="column"
     >
@@ -518,23 +520,23 @@ exports[`Select mounts with complex options and children 2`] = `
 
 exports[`Select mounts with complex options and children 3`] = `
 <div
-  class="StyledBox-bStriS iSfEjW"
+  class="StyledBox-bStriS biDyjR"
   id="select-drop__select"
   direction="column"
 >
   <div
-    class="StyledBox-bStriS dkPsPN"
+    class="StyledBox-bStriS kTYZCw"
     overflow="auto"
     direction="column"
   >
     <div
-      class="StyledBox-bStriS kjpBUX"
+      class="StyledBox-bStriS iybkIn"
       role="menubar"
       tabindex="-1"
       direction="column"
     >
       <button
-        class="StyledButton-gXzblK fXMbaK"
+        class="StyledButton-gXzblK dIqByu"
         tabindex="0"
         role="menuitem"
         type="button"
@@ -544,7 +546,7 @@ exports[`Select mounts with complex options and children 3`] = `
         </span>
       </button>
       <button
-        class="StyledButton-gXzblK fXMbaK"
+        class="StyledButton-gXzblK dIqByu"
         tabindex="0"
         role="menuitem"
         type="button"
@@ -561,11 +563,12 @@ exports[`Select mounts with complex options and children 3`] = `
 exports[`Select mounts with complex options and children 4`] = `
 "
 
-.iSfEjW {
+.biDyjR {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -574,14 +577,14 @@ exports[`Select mounts with complex options and children 4`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .eMXCzV {
+  .gWYNMT {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fXMbaK {
+  .dIqByu {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -590,12 +593,12 @@ exports[`Select mounts with complex options and children 4`] = `
 
 exports[`Select mounts with search 1`] = `
 <div
-  class="StyledBox-bStriS iSfEjW"
+  class="StyledBox-bStriS biDyjR"
   id="select-drop__select"
   direction="column"
 >
   <div
-    class="StyledBox-bStriS cbPlPJ"
+    class="StyledBox-bStriS kIiIQk"
     direction="column"
   >
     <div
@@ -603,31 +606,31 @@ exports[`Select mounts with search 1`] = `
     >
       <input
         type="search"
-        class="StyledTextInput-bzOzsW heLttg"
+        class="StyledTextInput-bzOzsW fNMAEl"
         autocomplete="off"
         value=""
       />
     </div>
   </div>
   <div
-    class="StyledBox-bStriS dkPsPN"
+    class="StyledBox-bStriS kTYZCw"
     overflow="auto"
     direction="column"
   >
     <div
-      class="StyledBox-bStriS kjpBUX"
+      class="StyledBox-bStriS iybkIn"
       role="menubar"
       tabindex="-1"
       direction="column"
     >
       <button
-        class="StyledButton-gXzblK fXMbaK"
+        class="StyledButton-gXzblK dIqByu"
         tabindex="0"
         role="menuitem"
         type="button"
       >
         <div
-          class="StyledBox-bStriS hPDWZy"
+          class="StyledBox-bStriS hYyHvw"
           direction="column"
         >
           <span
@@ -638,13 +641,13 @@ exports[`Select mounts with search 1`] = `
         </div>
       </button>
       <button
-        class="StyledButton-gXzblK fXMbaK"
+        class="StyledButton-gXzblK dIqByu"
         tabindex="0"
         role="menuitem"
         type="button"
       >
         <div
-          class="StyledBox-bStriS hPDWZy"
+          class="StyledBox-bStriS hYyHvw"
           direction="column"
         >
           <span
@@ -662,11 +665,12 @@ exports[`Select mounts with search 1`] = `
 exports[`Select mounts with search 2`] = `
 "
 
-.iSfEjW {
+.biDyjR {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -675,14 +679,14 @@ exports[`Select mounts with search 2`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .eMXCzV {
+  .gWYNMT {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fXMbaK {
+  .dIqByu {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -692,7 +696,7 @@ exports[`Select mounts with search 2`] = `
 exports[`Select mounts with search 3`] = `
 <input
   type="search"
-  class="StyledTextInput-bzOzsW heLttg"
+  class="StyledTextInput-bzOzsW fNMAEl"
   autocomplete="off"
   value=""
 />
@@ -700,12 +704,12 @@ exports[`Select mounts with search 3`] = `
 
 exports[`Select mounts with search 4`] = `
 <div
-  class="StyledBox-bStriS iSfEjW"
+  class="StyledBox-bStriS biDyjR"
   id="select-drop__select"
   direction="column"
 >
   <div
-    class="StyledBox-bStriS cbPlPJ"
+    class="StyledBox-bStriS kIiIQk"
     direction="column"
   >
     <div
@@ -713,31 +717,31 @@ exports[`Select mounts with search 4`] = `
     >
       <input
         type="search"
-        class="StyledTextInput-bzOzsW heLttg"
+        class="StyledTextInput-bzOzsW fNMAEl"
         autocomplete="off"
         value="a"
       />
     </div>
   </div>
   <div
-    class="StyledBox-bStriS dkPsPN"
+    class="StyledBox-bStriS kTYZCw"
     overflow="auto"
     direction="column"
   >
     <div
-      class="StyledBox-bStriS kjpBUX"
+      class="StyledBox-bStriS iybkIn"
       role="menubar"
       tabindex="-1"
       direction="column"
     >
       <button
-        class="StyledButton-gXzblK fXMbaK"
+        class="StyledButton-gXzblK dIqByu"
         tabindex="0"
         role="menuitem"
         type="button"
       >
         <div
-          class="StyledBox-bStriS hPDWZy"
+          class="StyledBox-bStriS hYyHvw"
           direction="column"
         >
           <span
@@ -748,13 +752,13 @@ exports[`Select mounts with search 4`] = `
         </div>
       </button>
       <button
-        class="StyledButton-gXzblK fXMbaK"
+        class="StyledButton-gXzblK dIqByu"
         tabindex="0"
         role="menuitem"
         type="button"
       >
         <div
-          class="StyledBox-bStriS hPDWZy"
+          class="StyledBox-bStriS hYyHvw"
           direction="column"
         >
           <span
@@ -772,11 +776,12 @@ exports[`Select mounts with search 4`] = `
 exports[`Select mounts with search 5`] = `
 "
 
-.iSfEjW {
+.biDyjR {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -785,14 +790,14 @@ exports[`Select mounts with search 5`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .eMXCzV {
+  .gWYNMT {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fXMbaK {
+  .dIqByu {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }

--- a/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
+++ b/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SkipLink mounts 1`] = `
 <div
-  class="StyledLayer-ceZzeh befYaj"
+  class="StyledLayer-ceZzeh gVCohQ"
   id="skip-links"
   tabindex="-1"
 >
@@ -10,7 +10,7 @@ exports[`SkipLink mounts 1`] = `
     class="StyledLayer__StyledContainer-gBGbkw emuypU"
   >
     <div
-      class="StyledBox-bStriS bZDKOr"
+      class="StyledBox-bStriS lfaLpu"
       direction="column"
     >
       <h2
@@ -20,15 +20,15 @@ exports[`SkipLink mounts 1`] = `
         :
       </h2>
       <div
-        class="StyledBox-bStriS etiTqg"
+        class="StyledBox-bStriS clkleN"
         direction="row"
       >
         <div
-          class="StyledBox-bStriS gqXbJX"
+          class="StyledBox-bStriS dVyTyq"
           direction="column"
         >
           <a
-            class="StyledAnchor-hcnTIZ cnvuhs"
+            class="StyledAnchor-hcnTIZ kwSIan"
             label="Main Content"
             href="#main"
           >
@@ -36,11 +36,11 @@ exports[`SkipLink mounts 1`] = `
           </a>
         </div>
         <div
-          class="StyledBox-bStriS gqXbJX"
+          class="StyledBox-bStriS dVyTyq"
           direction="column"
         >
           <a
-            class="StyledAnchor-hcnTIZ cnvuhs"
+            class="StyledAnchor-hcnTIZ kwSIan"
             label="Footer"
             href="#footer"
           >
@@ -56,7 +56,7 @@ exports[`SkipLink mounts 1`] = `
 exports[`SkipLink mounts 2`] = `
 "
 
-.befYaj {
+.gVCohQ {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -75,10 +75,6 @@ exports[`SkipLink mounts 2`] = `
   right: 100%;
   z-index: -1;
   position: fixed;
-}
-
-.befYaj * {
-  box-sizing: inherit;
 }
 
 @media only screen and (max-width:699px) {
@@ -101,7 +97,7 @@ exports[`SkipLink mounts 2`] = `
 
 exports[`SkipLink mounts 3`] = `
 <div
-  class="StyledLayer-ceZzeh eJxHlH"
+  class="StyledLayer-ceZzeh bGwGvr"
   id="skip-links"
   tabindex="-1"
 >
@@ -109,7 +105,7 @@ exports[`SkipLink mounts 3`] = `
     class="StyledLayer__StyledContainer-gBGbkw jpmyrr"
   >
     <div
-      class="StyledBox-bStriS bZDKOr"
+      class="StyledBox-bStriS lfaLpu"
       direction="column"
     >
       <h2
@@ -119,15 +115,15 @@ exports[`SkipLink mounts 3`] = `
         :
       </h2>
       <div
-        class="StyledBox-bStriS etiTqg"
+        class="StyledBox-bStriS clkleN"
         direction="row"
       >
         <div
-          class="StyledBox-bStriS gqXbJX"
+          class="StyledBox-bStriS dVyTyq"
           direction="column"
         >
           <a
-            class="StyledAnchor-hcnTIZ kAqUau"
+            class="StyledAnchor-hcnTIZ gUtwfp"
             label="Main Content"
             href="#main"
           >
@@ -135,11 +131,11 @@ exports[`SkipLink mounts 3`] = `
           </a>
         </div>
         <div
-          class="StyledBox-bStriS gqXbJX"
+          class="StyledBox-bStriS dVyTyq"
           direction="column"
         >
           <a
-            class="StyledAnchor-hcnTIZ cnvuhs"
+            class="StyledAnchor-hcnTIZ kwSIan"
             label="Footer"
             href="#footer"
           >
@@ -155,7 +151,7 @@ exports[`SkipLink mounts 3`] = `
 exports[`SkipLink mounts 4`] = `
 "
 
-.eJxHlH {
+.bGwGvr {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -172,12 +168,8 @@ exports[`SkipLink mounts 4`] = `
   background-color: rgba(0,0,0,0.5);
 }
 
-.eJxHlH * {
-  box-sizing: inherit;
-}
-
 @media only screen and (min-width:700px) {
-  .eJxHlH {
+  .bGwGvr {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -236,7 +228,7 @@ exports[`SkipLink mounts 5`] = `
       hidden=""
     >
       <div
-        class="StyledLayer-ceZzeh befYaj"
+        class="StyledLayer-ceZzeh gVCohQ"
         id="skip-links"
         tabindex="-1"
       >
@@ -244,7 +236,7 @@ exports[`SkipLink mounts 5`] = `
           class="StyledLayer__StyledContainer-gBGbkw emuypU"
         >
           <div
-            class="StyledBox-bStriS bZDKOr"
+            class="StyledBox-bStriS lfaLpu"
             direction="column"
           >
             <h2
@@ -254,15 +246,15 @@ exports[`SkipLink mounts 5`] = `
               :
             </h2>
             <div
-              class="StyledBox-bStriS etiTqg"
+              class="StyledBox-bStriS clkleN"
               direction="row"
             >
               <div
-                class="StyledBox-bStriS gqXbJX"
+                class="StyledBox-bStriS dVyTyq"
                 direction="column"
               >
                 <a
-                  class="StyledAnchor-hcnTIZ cnvuhs"
+                  class="StyledAnchor-hcnTIZ kwSIan"
                   label="Main Content"
                   href="#main"
                 >
@@ -270,11 +262,11 @@ exports[`SkipLink mounts 5`] = `
                 </a>
               </div>
               <div
-                class="StyledBox-bStriS gqXbJX"
+                class="StyledBox-bStriS dVyTyq"
                 direction="column"
               >
                 <a
-                  class="StyledAnchor-hcnTIZ cnvuhs"
+                  class="StyledAnchor-hcnTIZ kwSIan"
                   label="Footer"
                   href="#footer"
                 >

--- a/src/js/components/Stack/__tests__/__snapshots__/Stack-test.js.snap
+++ b/src/js/components/Stack/__tests__/__snapshots__/Stack-test.js.snap
@@ -13,10 +13,6 @@ exports[`Stack anchor renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   position: relative;
 }
@@ -270,10 +266,6 @@ exports[`Stack guidingChild renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   position: relative;
 }
@@ -376,10 +368,6 @@ exports[`Stack renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c1 {

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -5,11 +5,11 @@ exports[`Tabs changes active index 1`] = `
   role="tablist"
 >
   <div
-    class="StyledBox-bStriS edKAPy"
+    class="StyledBox-bStriS kaGovm"
     direction="row"
   >
     <button
-      class="StyledButton-gXzblK jYQWcg"
+      class="StyledButton-gXzblK cbZUvN"
       tabindex="0"
       role="tab"
       aria-selected="true"
@@ -17,7 +17,7 @@ exports[`Tabs changes active index 1`] = `
       type="button"
     >
       <div
-        class="StyledBox-bStriS jttQdi"
+        class="StyledBox-bStriS hvvwbh"
         direction="column"
       >
         <span
@@ -30,7 +30,7 @@ exports[`Tabs changes active index 1`] = `
       </div>
     </button>
     <button
-      class="StyledButton-gXzblK jYQWcg"
+      class="StyledButton-gXzblK cbZUvN"
       tabindex="0"
       role="tab"
       aria-selected="false"
@@ -38,7 +38,7 @@ exports[`Tabs changes active index 1`] = `
       type="button"
     >
       <div
-        class="StyledBox-bStriS daYSDH"
+        class="StyledBox-bStriS eYeWaC"
         direction="column"
       >
         <span
@@ -61,21 +61,21 @@ exports[`Tabs changes active index 1`] = `
 
 exports[`Tabs changes to second tab 1`] = `
 <div
-  className="StyledGrommet-gGRXwz fbqGIt"
+  className="StyledGrommet-gGRXwz DZGmZ"
 >
   <div
     role="tablist"
   >
     <div
       aria-label={undefined}
-      className="StyledBox-bStriS edKAPy"
+      className="StyledBox-bStriS kaGovm"
       direction="row"
     >
       <button
         aria-expanded={false}
         aria-label={undefined}
         aria-selected={false}
-        className="StyledButton-gXzblK jYQWcg"
+        className="StyledButton-gXzblK cbZUvN"
         disabled={false}
         href={undefined}
         icon={undefined}
@@ -93,7 +93,7 @@ exports[`Tabs changes to second tab 1`] = `
       >
         <div
           aria-label={undefined}
-          className="StyledBox-bStriS daYSDH"
+          className="StyledBox-bStriS eYeWaC"
           direction="column"
         >
           <span
@@ -108,7 +108,7 @@ exports[`Tabs changes to second tab 1`] = `
         aria-expanded={true}
         aria-label={undefined}
         aria-selected={true}
-        className="StyledButton-gXzblK jYQWcg"
+        className="StyledButton-gXzblK cbZUvN"
         disabled={false}
         href={undefined}
         icon={undefined}
@@ -126,7 +126,7 @@ exports[`Tabs changes to second tab 1`] = `
       >
         <div
           aria-label={undefined}
-          className="StyledBox-bStriS jttQdi"
+          className="StyledBox-bStriS hvvwbh"
           direction="column"
         >
           <span
@@ -151,21 +151,21 @@ exports[`Tabs changes to second tab 1`] = `
 
 exports[`Tabs renders complex Tab title 1`] = `
 <div
-  className="StyledGrommet-gGRXwz fbqGIt"
+  className="StyledGrommet-gGRXwz DZGmZ"
 >
   <div
     role="tablist"
   >
     <div
       aria-label={undefined}
-      className="StyledBox-bStriS edKAPy"
+      className="StyledBox-bStriS kaGovm"
       direction="row"
     >
       <button
         aria-expanded={true}
         aria-label={undefined}
         aria-selected={true}
-        className="StyledButton-gXzblK jYQWcg"
+        className="StyledButton-gXzblK cbZUvN"
         disabled={false}
         href={undefined}
         icon={undefined}
@@ -183,7 +183,7 @@ exports[`Tabs renders complex Tab title 1`] = `
       >
         <div
           aria-label={undefined}
-          className="StyledBox-bStriS jttQdi"
+          className="StyledBox-bStriS hvvwbh"
           direction="column"
         >
           <div>
@@ -195,7 +195,7 @@ exports[`Tabs renders complex Tab title 1`] = `
         aria-expanded={false}
         aria-label={undefined}
         aria-selected={false}
-        className="StyledButton-gXzblK jYQWcg"
+        className="StyledButton-gXzblK cbZUvN"
         disabled={false}
         href={undefined}
         icon={undefined}
@@ -213,7 +213,7 @@ exports[`Tabs renders complex Tab title 1`] = `
       >
         <div
           aria-label={undefined}
-          className="StyledBox-bStriS daYSDH"
+          className="StyledBox-bStriS eYeWaC"
           direction="column"
         >
           <div>
@@ -234,21 +234,21 @@ exports[`Tabs renders complex Tab title 1`] = `
 
 exports[`Tabs renders with Tab 1`] = `
 <div
-  className="StyledGrommet-gGRXwz fbqGIt"
+  className="StyledGrommet-gGRXwz DZGmZ"
 >
   <div
     role="tablist"
   >
     <div
       aria-label={undefined}
-      className="StyledBox-bStriS edKAPy"
+      className="StyledBox-bStriS kaGovm"
       direction="row"
     >
       <button
         aria-expanded={true}
         aria-label={undefined}
         aria-selected={true}
-        className="StyledButton-gXzblK jYQWcg"
+        className="StyledButton-gXzblK cbZUvN"
         disabled={false}
         href={undefined}
         icon={undefined}
@@ -266,7 +266,7 @@ exports[`Tabs renders with Tab 1`] = `
       >
         <div
           aria-label={undefined}
-          className="StyledBox-bStriS jttQdi"
+          className="StyledBox-bStriS hvvwbh"
           direction="column"
         >
           <span
@@ -282,7 +282,7 @@ exports[`Tabs renders with Tab 1`] = `
         aria-expanded={false}
         aria-label={undefined}
         aria-selected={false}
-        className="StyledButton-gXzblK jYQWcg"
+        className="StyledButton-gXzblK cbZUvN"
         disabled={false}
         href={undefined}
         icon={undefined}
@@ -300,7 +300,7 @@ exports[`Tabs renders with Tab 1`] = `
       >
         <div
           aria-label={undefined}
-          className="StyledBox-bStriS daYSDH"
+          className="StyledBox-bStriS eYeWaC"
           direction="column"
         >
           <span
@@ -324,14 +324,14 @@ exports[`Tabs renders with Tab 1`] = `
 
 exports[`Tabs renders without Tab 1`] = `
 <div
-  className="StyledGrommet-gGRXwz fbqGIt"
+  className="StyledGrommet-gGRXwz DZGmZ"
 >
   <div
     role="tablist"
   >
     <div
       aria-label={undefined}
-      className="StyledBox-bStriS edKAPy"
+      className="StyledBox-bStriS kaGovm"
       direction="row"
     />
     <div
@@ -347,11 +347,11 @@ exports[`Tabs sets on hover 1`] = `
   role="tablist"
 >
   <div
-    class="StyledBox-bStriS edKAPy"
+    class="StyledBox-bStriS kaGovm"
     direction="row"
   >
     <button
-      class="StyledButton-gXzblK jYQWcg"
+      class="StyledButton-gXzblK cbZUvN"
       tabindex="0"
       role="tab"
       aria-selected="true"
@@ -359,7 +359,7 @@ exports[`Tabs sets on hover 1`] = `
       type="button"
     >
       <div
-        class="StyledBox-bStriS jttQdi"
+        class="StyledBox-bStriS hvvwbh"
         direction="column"
       >
         <span
@@ -372,7 +372,7 @@ exports[`Tabs sets on hover 1`] = `
       </div>
     </button>
     <button
-      class="StyledButton-gXzblK jYQWcg"
+      class="StyledButton-gXzblK cbZUvN"
       tabindex="0"
       role="tab"
       aria-selected="false"
@@ -380,7 +380,7 @@ exports[`Tabs sets on hover 1`] = `
       type="button"
     >
       <div
-        class="StyledBox-bStriS daYSDH"
+        class="StyledBox-bStriS eYeWaC"
         direction="column"
       >
         <span
@@ -406,11 +406,11 @@ exports[`Tabs sets on hover 2`] = `
   role="tablist"
 >
   <div
-    class="StyledBox-bStriS edKAPy"
+    class="StyledBox-bStriS kaGovm"
     direction="row"
   >
     <button
-      class="StyledButton-gXzblK jYQWcg"
+      class="StyledButton-gXzblK cbZUvN"
       tabindex="0"
       role="tab"
       aria-selected="true"
@@ -418,7 +418,7 @@ exports[`Tabs sets on hover 2`] = `
       type="button"
     >
       <div
-        class="StyledBox-bStriS jttQdi"
+        class="StyledBox-bStriS hvvwbh"
         direction="column"
       >
         <span
@@ -431,7 +431,7 @@ exports[`Tabs sets on hover 2`] = `
       </div>
     </button>
     <button
-      class="StyledButton-gXzblK jYQWcg"
+      class="StyledButton-gXzblK cbZUvN"
       tabindex="0"
       role="tab"
       aria-selected="false"
@@ -439,7 +439,7 @@ exports[`Tabs sets on hover 2`] = `
       type="button"
     >
       <div
-        class="StyledBox-bStriS iuoQfu"
+        class="StyledBox-bStriS hUGKo"
         direction="column"
       >
         <span
@@ -465,11 +465,11 @@ exports[`Tabs sets on hover 3`] = `
   role="tablist"
 >
   <div
-    class="StyledBox-bStriS edKAPy"
+    class="StyledBox-bStriS kaGovm"
     direction="row"
   >
     <button
-      class="StyledButton-gXzblK jYQWcg"
+      class="StyledButton-gXzblK cbZUvN"
       tabindex="0"
       role="tab"
       aria-selected="true"
@@ -477,7 +477,7 @@ exports[`Tabs sets on hover 3`] = `
       type="button"
     >
       <div
-        class="StyledBox-bStriS jttQdi"
+        class="StyledBox-bStriS hvvwbh"
         direction="column"
       >
         <span
@@ -490,7 +490,7 @@ exports[`Tabs sets on hover 3`] = `
       </div>
     </button>
     <button
-      class="StyledButton-gXzblK jYQWcg"
+      class="StyledButton-gXzblK cbZUvN"
       tabindex="0"
       role="tab"
       aria-selected="false"
@@ -498,7 +498,7 @@ exports[`Tabs sets on hover 3`] = `
       type="button"
     >
       <div
-        class="StyledBox-bStriS iuoQfu"
+        class="StyledBox-bStriS hUGKo"
         direction="column"
       >
         <span
@@ -524,11 +524,11 @@ exports[`Tabs sets on hover 4`] = `
   role="tablist"
 >
   <div
-    class="StyledBox-bStriS edKAPy"
+    class="StyledBox-bStriS kaGovm"
     direction="row"
   >
     <button
-      class="StyledButton-gXzblK jYQWcg"
+      class="StyledButton-gXzblK cbZUvN"
       tabindex="0"
       role="tab"
       aria-selected="true"
@@ -536,7 +536,7 @@ exports[`Tabs sets on hover 4`] = `
       type="button"
     >
       <div
-        class="StyledBox-bStriS jttQdi"
+        class="StyledBox-bStriS hvvwbh"
         direction="column"
       >
         <span
@@ -549,7 +549,7 @@ exports[`Tabs sets on hover 4`] = `
       </div>
     </button>
     <button
-      class="StyledButton-gXzblK jYQWcg"
+      class="StyledButton-gXzblK cbZUvN"
       tabindex="0"
       role="tab"
       aria-selected="false"
@@ -557,7 +557,7 @@ exports[`Tabs sets on hover 4`] = `
       type="button"
     >
       <div
-        class="StyledBox-bStriS daYSDH"
+        class="StyledBox-bStriS eYeWaC"
         direction="column"
       >
         <span

--- a/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
+++ b/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
@@ -13,10 +13,6 @@ exports[`Text color renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   font-size: 16px;
   line-height: 1.375;
@@ -44,10 +40,6 @@ exports[`Text margin renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c1 {
@@ -170,10 +162,6 @@ exports[`Text renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   font-size: 16px;
   line-height: 1.375;
@@ -201,10 +189,6 @@ exports[`Text size renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c3 {
@@ -280,10 +264,6 @@ exports[`Text tag renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   font-size: 16px;
   line-height: 1.375;
@@ -309,10 +289,6 @@ exports[`Text textAlign renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c1 {
@@ -359,10 +335,6 @@ exports[`Text truncate renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c1 {

--- a/src/js/components/TextArea/__tests__/__snapshots__/TextArea-test.js.snap
+++ b/src/js/components/TextArea/__tests__/__snapshots__/TextArea-test.js.snap
@@ -13,11 +13,8 @@ exports[`TextArea focusIndicator renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   padding: 11px;
   border: 1px solid rgba(0,0,0,0.15);
   border-radius: 4px;
@@ -84,11 +81,8 @@ exports[`TextArea placeholder renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   padding: 11px;
   border: 1px solid rgba(0,0,0,0.15);
   border-radius: 4px;
@@ -156,11 +150,8 @@ exports[`TextArea plain renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   padding: 11px;
   border: 1px solid rgba(0,0,0,0.15);
   border-radius: 4px;
@@ -215,11 +206,8 @@ exports[`TextArea renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
+  box-sizing: border-box;
   padding: 11px;
   border: 1px solid rgba(0,0,0,0.15);
   border-radius: 4px;

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`TextInput closes suggestion drop 1`] = `
 <div
-  class="StyledDrop-bCWxPe hEiKPj"
+  class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -12,12 +12,12 @@ exports[`TextInput closes suggestion drop 1`] = `
   >
     <li>
       <button
-        class="StyledButton-gXzblK evsvQl"
+        class="StyledButton-gXzblK jEvpLS"
         tabindex="0"
         type="button"
       >
         <div
-          class="StyledBox-bStriS hPDWZy"
+          class="StyledBox-bStriS hYyHvw"
           direction="column"
         >
           test
@@ -26,12 +26,12 @@ exports[`TextInput closes suggestion drop 1`] = `
     </li>
     <li>
       <button
-        class="StyledButton-gXzblK evsvQl"
+        class="StyledButton-gXzblK jEvpLS"
         tabindex="0"
         type="button"
       >
         <div
-          class="StyledBox-bStriS hPDWZy"
+          class="StyledBox-bStriS hYyHvw"
           direction="column"
         >
           test1
@@ -44,7 +44,7 @@ exports[`TextInput closes suggestion drop 1`] = `
 
 exports[`TextInput closes suggestion drop 2`] = `
 "@media only screen and (min-width:700px) {
-  .evsvQl {
+  .jEvpLS {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -52,7 +52,7 @@ exports[`TextInput closes suggestion drop 2`] = `
 
 
 
-.hEiKPj {
+.gcEofR {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -78,22 +78,18 @@ exports[`TextInput closes suggestion drop 2`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
-}
-
-.hEiKPj * {
-  box-sizing: inherit;
 }"
 `;
 
 exports[`TextInput closes suggestion drop 3`] = `
 <div
-  class="StyledGrommet-gGRXwz fbqGIt"
+  class="StyledGrommet-gGRXwz DZGmZ"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-bPTWQl evFgGO"
   >
     <input
-      class="StyledTextInput-bzOzsW gHwBkz"
+      class="StyledTextInput-bzOzsW krEHmh"
       id="item"
       autocomplete="off"
       name="item"
@@ -104,13 +100,13 @@ exports[`TextInput closes suggestion drop 3`] = `
 
 exports[`TextInput handles next and previous without suggestion 1`] = `
 <div
-  class="StyledGrommet-gGRXwz fbqGIt"
+  class="StyledGrommet-gGRXwz DZGmZ"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-bPTWQl evFgGO"
   >
     <input
-      class="StyledTextInput-bzOzsW gHwBkz"
+      class="StyledTextInput-bzOzsW krEHmh"
       id="item"
       autocomplete="off"
       name="item"
@@ -124,7 +120,7 @@ exports[`TextInput mounts 1`] = `
   class="StyledTextInput__StyledTextInputContainer-bPTWQl evFgGO"
 >
   <input
-    class="StyledTextInput-bzOzsW gHwBkz"
+    class="StyledTextInput-bzOzsW krEHmh"
     autocomplete="off"
     name="item"
   />
@@ -133,7 +129,7 @@ exports[`TextInput mounts 1`] = `
 
 exports[`TextInput mounts with complex suggestions 1`] = `
 <div
-  class="StyledDrop-bCWxPe hEiKPj"
+  class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -143,12 +139,12 @@ exports[`TextInput mounts with complex suggestions 1`] = `
   >
     <li>
       <button
-        class="StyledButton-gXzblK evsvQl"
+        class="StyledButton-gXzblK jEvpLS"
         tabindex="0"
         type="button"
       >
         <div
-          class="StyledBox-bStriS hPDWZy"
+          class="StyledBox-bStriS hYyHvw"
           direction="column"
         >
           test
@@ -157,12 +153,12 @@ exports[`TextInput mounts with complex suggestions 1`] = `
     </li>
     <li>
       <button
-        class="StyledButton-gXzblK evsvQl"
+        class="StyledButton-gXzblK jEvpLS"
         tabindex="0"
         type="button"
       >
         <div
-          class="StyledBox-bStriS hPDWZy"
+          class="StyledBox-bStriS hYyHvw"
           direction="column"
         >
           test1
@@ -175,7 +171,7 @@ exports[`TextInput mounts with complex suggestions 1`] = `
 
 exports[`TextInput mounts with complex suggestions 2`] = `
 "@media only screen and (min-width:700px) {
-  .evsvQl {
+  .jEvpLS {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -183,7 +179,7 @@ exports[`TextInput mounts with complex suggestions 2`] = `
 
 
 
-.hEiKPj {
+.gcEofR {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -209,16 +205,12 @@ exports[`TextInput mounts with complex suggestions 2`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
-}
-
-.hEiKPj * {
-  box-sizing: inherit;
 }"
 `;
 
 exports[`TextInput mounts with suggestions 1`] = `
 <div
-  class="StyledDrop-bCWxPe hEiKPj"
+  class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -228,12 +220,12 @@ exports[`TextInput mounts with suggestions 1`] = `
   >
     <li>
       <button
-        class="StyledButton-gXzblK evsvQl"
+        class="StyledButton-gXzblK jEvpLS"
         tabindex="0"
         type="button"
       >
         <div
-          class="StyledBox-bStriS hPDWZy"
+          class="StyledBox-bStriS hYyHvw"
           direction="column"
         >
           test
@@ -242,12 +234,12 @@ exports[`TextInput mounts with suggestions 1`] = `
     </li>
     <li>
       <button
-        class="StyledButton-gXzblK evsvQl"
+        class="StyledButton-gXzblK jEvpLS"
         tabindex="0"
         type="button"
       >
         <div
-          class="StyledBox-bStriS hPDWZy"
+          class="StyledBox-bStriS hYyHvw"
           direction="column"
         >
           test1
@@ -260,7 +252,7 @@ exports[`TextInput mounts with suggestions 1`] = `
 
 exports[`TextInput mounts with suggestions 2`] = `
 "@media only screen and (min-width:700px) {
-  .evsvQl {
+  .jEvpLS {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -268,7 +260,7 @@ exports[`TextInput mounts with suggestions 2`] = `
 
 
 
-.hEiKPj {
+.gcEofR {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -294,16 +286,12 @@ exports[`TextInput mounts with suggestions 2`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
-}
-
-.hEiKPj * {
-  box-sizing: inherit;
 }"
 `;
 
 exports[`TextInput selects suggestion 1`] = `
 <div
-  class="StyledDrop-bCWxPe hEiKPj"
+  class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -313,12 +301,12 @@ exports[`TextInput selects suggestion 1`] = `
   >
     <li>
       <button
-        class="StyledButton-gXzblK evsvQl"
+        class="StyledButton-gXzblK jEvpLS"
         tabindex="0"
         type="button"
       >
         <div
-          class="StyledBox-bStriS hPDWZy"
+          class="StyledBox-bStriS hYyHvw"
           direction="column"
         >
           test
@@ -327,12 +315,12 @@ exports[`TextInput selects suggestion 1`] = `
     </li>
     <li>
       <button
-        class="StyledButton-gXzblK evsvQl"
+        class="StyledButton-gXzblK jEvpLS"
         tabindex="0"
         type="button"
       >
         <div
-          class="StyledBox-bStriS hPDWZy"
+          class="StyledBox-bStriS hYyHvw"
           direction="column"
         >
           test1
@@ -345,7 +333,7 @@ exports[`TextInput selects suggestion 1`] = `
 
 exports[`TextInput selects suggestion 2`] = `
 "@media only screen and (min-width:700px) {
-  .evsvQl {
+  .jEvpLS {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -353,7 +341,7 @@ exports[`TextInput selects suggestion 2`] = `
 
 
 
-.hEiKPj {
+.gcEofR {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -379,22 +367,18 @@ exports[`TextInput selects suggestion 2`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
-}
-
-.hEiKPj * {
-  box-sizing: inherit;
 }"
 `;
 
 exports[`TextInput selects suggestion 3`] = `
 <div
-  class="StyledGrommet-gGRXwz fbqGIt"
+  class="StyledGrommet-gGRXwz DZGmZ"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-bPTWQl jYXZDG"
   >
     <input
-      class="StyledTextInput-bzOzsW hxNRVC"
+      class="StyledTextInput-bzOzsW fYpLVJ"
       id="item"
       autocomplete="off"
       name="item"

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -13,10 +13,6 @@ exports[`Video autoPlay renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -56,6 +52,7 @@ exports[`Video autoPlay renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -78,6 +75,7 @@ exports[`Video autoPlay renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -97,6 +95,7 @@ exports[`Video autoPlay renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -112,6 +111,7 @@ exports[`Video autoPlay renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -126,6 +126,7 @@ exports[`Video autoPlay renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -139,6 +140,7 @@ exports[`Video autoPlay renders 1`] = `
 }
 
 .c5 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -160,6 +162,7 @@ exports[`Video autoPlay renders 1`] = `
 }
 
 .c15 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -481,10 +484,6 @@ exports[`Video controls renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -556,6 +555,7 @@ exports[`Video controls renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -578,6 +578,7 @@ exports[`Video controls renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -597,6 +598,7 @@ exports[`Video controls renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -612,6 +614,7 @@ exports[`Video controls renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -626,6 +629,7 @@ exports[`Video controls renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -643,6 +647,7 @@ exports[`Video controls renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -659,6 +664,7 @@ exports[`Video controls renders 1`] = `
 }
 
 .c5 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -680,6 +686,7 @@ exports[`Video controls renders 1`] = `
 }
 
 .c15 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -1211,10 +1218,6 @@ exports[`Video fit renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -1254,6 +1257,7 @@ exports[`Video fit renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1276,6 +1280,7 @@ exports[`Video fit renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1295,6 +1300,7 @@ exports[`Video fit renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1310,6 +1316,7 @@ exports[`Video fit renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1324,6 +1331,7 @@ exports[`Video fit renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -1337,6 +1345,7 @@ exports[`Video fit renders 1`] = `
 }
 
 .c5 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -1358,6 +1367,7 @@ exports[`Video fit renders 1`] = `
 }
 
 .c15 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -1899,10 +1909,6 @@ exports[`Video loop renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -1942,6 +1948,7 @@ exports[`Video loop renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1964,6 +1971,7 @@ exports[`Video loop renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1983,6 +1991,7 @@ exports[`Video loop renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -1998,6 +2007,7 @@ exports[`Video loop renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2012,6 +2022,7 @@ exports[`Video loop renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -2025,6 +2036,7 @@ exports[`Video loop renders 1`] = `
 }
 
 .c5 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -2046,6 +2058,7 @@ exports[`Video loop renders 1`] = `
 }
 
 .c15 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -2367,10 +2380,6 @@ exports[`Video mute renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -2410,6 +2419,7 @@ exports[`Video mute renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2432,6 +2442,7 @@ exports[`Video mute renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2451,6 +2462,7 @@ exports[`Video mute renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2466,6 +2478,7 @@ exports[`Video mute renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2480,6 +2493,7 @@ exports[`Video mute renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -2493,6 +2507,7 @@ exports[`Video mute renders 1`] = `
 }
 
 .c5 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -2514,6 +2529,7 @@ exports[`Video mute renders 1`] = `
 }
 
 .c15 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -2835,10 +2851,6 @@ exports[`Video renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -2878,6 +2890,7 @@ exports[`Video renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2900,6 +2913,7 @@ exports[`Video renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2919,6 +2933,7 @@ exports[`Video renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2934,6 +2949,7 @@ exports[`Video renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   min-width: 0;
   -webkit-flex-direction: column;
@@ -2948,6 +2964,7 @@ exports[`Video renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  box-sizing: border-box;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -2961,6 +2978,7 @@ exports[`Video renders 1`] = `
 }
 
 .c5 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;
@@ -2982,6 +3000,7 @@ exports[`Video renders 1`] = `
 }
 
 .c15 {
+  box-sizing: border-box;
   cursor: pointer;
   outline: none;
   font: inherit;

--- a/src/js/components/WorldMap/__tests__/__snapshots__/WorldMap-test.js.snap
+++ b/src/js/components/WorldMap/__tests__/__snapshots__/WorldMap-test.js.snap
@@ -13,10 +13,6 @@ exports[`WorldMap color renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   width: 100%;
 }
@@ -143,10 +139,6 @@ exports[`WorldMap continents renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c1 {
@@ -286,10 +278,6 @@ exports[`WorldMap onSelectPlace renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c0 * {
-  box-sizing: inherit;
-}
-
 .c1 {
   width: 100%;
 }
@@ -419,10 +407,6 @@ exports[`WorldMap places renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c1 {
@@ -565,10 +549,6 @@ exports[`WorldMap renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c0 * {
-  box-sizing: inherit;
 }
 
 .c1 {

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -89,10 +89,6 @@ export const baseStyle = css`
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-
-  * {
-    box-sizing: inherit;
-  }
 `;
 
 // focus also supports clickable elements inside svg
@@ -117,6 +113,7 @@ export const focusStyle = css`
 `;
 
 export const inputStyle = css`
+  box-sizing: border-box;
   padding: ${props => (
     (parseMetricToNum(props.theme.global.spacing) / 2) -
     parseMetricToNum(props.theme.global.input.border.width)


### PR DESCRIPTION
#### What does this PR do?

Moves box-sizing styles to just components that need them instead of to all descendants of Grommet, Layer, and Drop.

#### Where should the reviewer start?

styles.js

#### What testing has been done on this PR?

grommet-site

#### How should this be manually tested?

anything

#### Any background context you want to provide?

This reduces the chance of us interfering with styles in non-grommet elements contained inside grommet components.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible with v2
