### PR TITLE
Set width of Select, TextInput, and TextArea to always be 100%, filling their container

### DIFF
--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -98,11 +98,11 @@ exports[`Select closes drop on esc 3`] = `
     direction="row"
   >
     <div
-      class="StyledTextInput__StyledTextInputContainer-bPTWQl jYXZDG"
+      class="StyledTextInput__StyledTextInputContainer-bPTWQl hasTun"
     >
       <input
         type="text"
-        class="StyledTextInput-bzOzsW flduXy"
+        class="StyledTextInput-bzOzsW kYTHvL"
         id="select"
         autocomplete="off"
         style="cursor: pointer;"
@@ -148,11 +148,11 @@ exports[`Select closes drop on esc 4`] = `
     direction="row"
   >
     <div
-      class="StyledTextInput__StyledTextInputContainer-bPTWQl jYXZDG"
+      class="StyledTextInput__StyledTextInputContainer-bPTWQl hasTun"
     >
       <input
         type="text"
-        class="StyledTextInput-bzOzsW flduXy"
+        class="StyledTextInput-bzOzsW kYTHvL"
         id="select"
         autocomplete="off"
         style="cursor: pointer;"
@@ -198,11 +198,11 @@ exports[`Select mounts 1`] = `
     direction="row"
   >
     <div
-      class="StyledTextInput__StyledTextInputContainer-bPTWQl jYXZDG"
+      class="StyledTextInput__StyledTextInputContainer-bPTWQl hasTun"
     >
       <input
         type="text"
-        class="StyledTextInput-bzOzsW flduXy"
+        class="StyledTextInput-bzOzsW kYTHvL"
         id="select"
         autocomplete="off"
         style="cursor: pointer;"
@@ -248,11 +248,11 @@ exports[`Select mounts 2`] = `
     direction="row"
   >
     <div
-      class="StyledTextInput__StyledTextInputContainer-bPTWQl jYXZDG"
+      class="StyledTextInput__StyledTextInputContainer-bPTWQl hasTun"
     >
       <input
         type="text"
-        class="StyledTextInput-bzOzsW flduXy"
+        class="StyledTextInput-bzOzsW kYTHvL"
         id="select"
         autocomplete="off"
         style="cursor: pointer;"
@@ -428,11 +428,11 @@ exports[`Select mounts with complex options and children 1`] = `
     direction="row"
   >
     <div
-      class="StyledTextInput__StyledTextInputContainer-bPTWQl jYXZDG"
+      class="StyledTextInput__StyledTextInputContainer-bPTWQl hasTun"
     >
       <input
         type="text"
-        class="StyledTextInput-bzOzsW flduXy"
+        class="StyledTextInput-bzOzsW kYTHvL"
         id="select"
         autocomplete="off"
         style="cursor: pointer;"
@@ -478,11 +478,11 @@ exports[`Select mounts with complex options and children 2`] = `
     direction="row"
   >
     <div
-      class="StyledTextInput__StyledTextInputContainer-bPTWQl jYXZDG"
+      class="StyledTextInput__StyledTextInputContainer-bPTWQl hasTun"
     >
       <input
         type="text"
-        class="StyledTextInput-bzOzsW flduXy"
+        class="StyledTextInput-bzOzsW kYTHvL"
         id="select"
         autocomplete="off"
         style="cursor: pointer;"
@@ -599,11 +599,11 @@ exports[`Select mounts with search 1`] = `
     direction="column"
   >
     <div
-      class="StyledTextInput__StyledTextInputContainer-bPTWQl jYXZDG"
+      class="StyledTextInput__StyledTextInputContainer-bPTWQl hasTun"
     >
       <input
         type="search"
-        class="StyledTextInput-bzOzsW heLttg"
+        class="StyledTextInput-bzOzsW gkpwmV"
         autocomplete="off"
         value=""
       />
@@ -692,7 +692,7 @@ exports[`Select mounts with search 2`] = `
 exports[`Select mounts with search 3`] = `
 <input
   type="search"
-  class="StyledTextInput-bzOzsW heLttg"
+  class="StyledTextInput-bzOzsW gkpwmV"
   autocomplete="off"
   value=""
 />
@@ -709,11 +709,11 @@ exports[`Select mounts with search 4`] = `
     direction="column"
   >
     <div
-      class="StyledTextInput__StyledTextInputContainer-bPTWQl jYXZDG"
+      class="StyledTextInput__StyledTextInputContainer-bPTWQl hasTun"
     >
       <input
         type="search"
-        class="StyledTextInput-bzOzsW heLttg"
+        class="StyledTextInput-bzOzsW gkpwmV"
         autocomplete="off"
         value="a"
       />

--- a/src/js/components/TextArea/StyledTextArea.js
+++ b/src/js/components/TextArea/StyledTextArea.js
@@ -14,6 +14,7 @@ const plainStyle = css`
 
 const StyledTextArea = styled.textarea`
   ${inputStyle}
+  width: 100%;
 
   ${props => props.plain && plainStyle}
 

--- a/src/js/components/TextArea/__tests__/__snapshots__/TextArea-test.js.snap
+++ b/src/js/components/TextArea/__tests__/__snapshots__/TextArea-test.js.snap
@@ -26,6 +26,7 @@ exports[`TextArea focusIndicator renders 1`] = `
   color: inherit;
   font: inherit;
   margin: 0;
+  width: 100%;
 }
 
 .c1::-webkit-input-placeholder {
@@ -97,6 +98,7 @@ exports[`TextArea placeholder renders 1`] = `
   color: inherit;
   font: inherit;
   margin: 0;
+  width: 100%;
 }
 
 .c1::-webkit-input-placeholder {
@@ -169,6 +171,7 @@ exports[`TextArea plain renders 1`] = `
   color: inherit;
   font: inherit;
   margin: 0;
+  width: 100%;
   border: none;
   width: 100%;
   -webkit-appearance: none;
@@ -228,6 +231,7 @@ exports[`TextArea renders 1`] = `
   color: inherit;
   font: inherit;
   margin: 0;
+  width: 100%;
 }
 
 .c1::-webkit-input-placeholder {

--- a/src/js/components/TextInput/StyledTextInput.js
+++ b/src/js/components/TextInput/StyledTextInput.js
@@ -22,6 +22,7 @@ const plainStyle = css`
 
 const StyledTextInput = styled.input`
   ${inputStyle}
+  width: 100%;
 
   ${props => props.size && sizeStyle(props)}
   ${props => props.plain && plainStyle}
@@ -49,7 +50,7 @@ const StyledTextInput = styled.input`
 `;
 
 export const StyledTextInputContainer = styled.div`
-  ${props => props.plain && 'width: 100%'}
+  width: 100%;
 `;
 
 export const StyledSuggestions = styled.ol`

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -90,10 +90,10 @@ exports[`TextInput closes suggestion drop 3`] = `
   class="StyledGrommet-gGRXwz fbqGIt"
 >
   <div
-    class="StyledTextInput__StyledTextInputContainer-bPTWQl evFgGO"
+    class="StyledTextInput__StyledTextInputContainer-bPTWQl hasTun"
   >
     <input
-      class="StyledTextInput-bzOzsW gHwBkz"
+      class="StyledTextInput-bzOzsW gLwffh"
       id="item"
       autocomplete="off"
       name="item"
@@ -107,10 +107,10 @@ exports[`TextInput handles next and previous without suggestion 1`] = `
   class="StyledGrommet-gGRXwz fbqGIt"
 >
   <div
-    class="StyledTextInput__StyledTextInputContainer-bPTWQl evFgGO"
+    class="StyledTextInput__StyledTextInputContainer-bPTWQl hasTun"
   >
     <input
-      class="StyledTextInput-bzOzsW gHwBkz"
+      class="StyledTextInput-bzOzsW gLwffh"
       id="item"
       autocomplete="off"
       name="item"
@@ -121,10 +121,10 @@ exports[`TextInput handles next and previous without suggestion 1`] = `
 
 exports[`TextInput mounts 1`] = `
 <div
-  class="StyledTextInput__StyledTextInputContainer-bPTWQl evFgGO"
+  class="StyledTextInput__StyledTextInputContainer-bPTWQl hasTun"
 >
   <input
-    class="StyledTextInput-bzOzsW gHwBkz"
+    class="StyledTextInput-bzOzsW gLwffh"
     autocomplete="off"
     name="item"
   />
@@ -391,10 +391,10 @@ exports[`TextInput selects suggestion 3`] = `
   class="StyledGrommet-gGRXwz fbqGIt"
 >
   <div
-    class="StyledTextInput__StyledTextInputContainer-bPTWQl jYXZDG"
+    class="StyledTextInput__StyledTextInputContainer-bPTWQl hasTun"
   >
     <input
-      class="StyledTextInput-bzOzsW hxNRVC"
+      class="StyledTextInput-bzOzsW evRZOG"
       id="item"
       autocomplete="off"
       name="item"


### PR DESCRIPTION
#### What does this PR do?

See title

#### Where should the reviewer start?

StyledTextInput.js

#### What testing has been done on this PR?

grommet-site
grommet-ferret (with grommet-v1)

#### How should this be manually tested?

grommet-site

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

maybe

#### Is this change backwards compatible or is it a breaking change?

not behaviorally
