### PR TITLE
Attempt to fix README test issues with Travis

### DIFF
--- a/src/js/components/__tests__/README-test.js
+++ b/src/js/components/__tests__/README-test.js
@@ -13,14 +13,9 @@ const FOLDER = path.resolve(__dirname, '../');
 test('README is updated', (done) => {
   const componentFolders = components(FOLDER);
   const readmeContent = {};
-  componentFolders.sort().forEach((component, index) => {
-    fs.readFile(path.join(FOLDER, component, 'README.md'), 'utf8', (err, data) => {
-      readmeContent[component] = data;
-
-      if (componentFolders.length === index + 1) {
-        expect(readmeContent).toMatchSnapshot();
-        done();
-      }
-    });
+  componentFolders.sort().forEach((component) => {
+    readmeContent[component] = fs.readFileSync(path.join(FOLDER, component, 'README.md'), 'utf8');
   });
+  expect(readmeContent).toMatchSnapshot();
+  done();
 });


### PR DESCRIPTION
#### What does this PR do?

serializes README file reading in the README test to avoid parallelization issues causing indeterminate snapshots.

#### Where should the reviewer start?

README-test.js

#### What testing has been done on this PR?

`npm run test`, waiting for Travis results.

#### How should this be manually tested?

`npm run test`

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
