### PR TITLE
Change Heading to allow string level

### DIFF
--- a/src/js/components/Heading/Heading.js
+++ b/src/js/components/Heading/Heading.js
@@ -28,8 +28,9 @@ class Heading extends Component {
       styledComponents[tag] = StyledComponent;
     }
 
+    // enforce level to be a number
     return (
-      <StyledComponent level={level} {...rest} />
+      <StyledComponent level={+level} {...rest} />
     );
   }
 }

--- a/src/js/components/Heading/README.md
+++ b/src/js/components/Heading/README.md
@@ -22,6 +22,10 @@ The sizing can be further adjusted using the size property.
 2
 3
 4
+1
+2
+3
+4
 ```
 
 **margin**

--- a/src/js/components/Heading/__tests__/Heading-test.js
+++ b/src/js/components/Heading/__tests__/Heading-test.js
@@ -22,6 +22,10 @@ test('Heading level renders', () => {
       <Heading level={2} />
       <Heading level={3} />
       <Heading level={4} />
+      <Heading level='1' />
+      <Heading level='2' />
+      <Heading level='3' />
+      <Heading level='4' />
     </Grommet>
   );
   const tree = component.toJSON();

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -56,6 +56,18 @@ exports[`Heading level renders 1`] = `
   <h4
     className="c4"
   />
+  <h1
+    className="c1"
+  />
+  <h2
+    className="c2"
+  />
+  <h3
+    className="c3"
+  />
+  <h4
+    className="c4"
+  />
 </div>
 `;
 

--- a/src/js/components/Heading/doc.js
+++ b/src/js/components/Heading/doc.js
@@ -12,7 +12,7 @@ export default (Heading) => {
     );
 
   DocumentedHeading.propTypes = {
-    level: PropTypes.oneOf([1, 2, 3, 4]).description(
+    level: PropTypes.oneOf([1, 2, 3, 4, '1', '2', '3', '4']).description(
       `The heading level. It corresponds to the number after the 'H' for
 the DOM tag. Set the level for semantic accuracy and accessibility.
 The sizing can be further adjusted using the size property.`

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1469,6 +1469,10 @@ The sizing can be further adjusted using the size property.
 2
 3
 4
+1
+2
+3
+4
 \`\`\`
 
 **margin**


### PR DESCRIPTION
#### What does this PR do?

Change Heading to allow `level` to be passed as a string.

#### Where should the reviewer start?

Heading/doc.js

#### What testing has been done on this PR?

unit tests

#### How should this be manually tested?

unit tests

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible with v2