### PR TITLE
Changed Chart to add onClick and onHover

### DIFF
--- a/src/js/components/Chart/Chart.js
+++ b/src/js/components/Chart/Chart.js
@@ -12,7 +12,7 @@ import doc from './doc';
 
 const renderBars = (values, bounds, scale, height) =>
   (values || []).map((valueArg, index) => {
-    const { label, value, ...rest } = valueArg;
+    const { label, onHover, value, ...rest } = valueArg;
 
     const key = `p-${index}`;
     const bottom = (value.length === 2 ? bounds[1][0] : value[1]);
@@ -23,31 +23,51 @@ const renderBars = (values, bounds, scale, height) =>
       ` L ${(value[0] - bounds[0][0]) * scale[0]},` +
       `${height - ((top - bounds[1][0]) * scale[1])}`;
 
+      let hoverProps;
+      if (onHover) {
+        hoverProps = {
+          onMouseOver: () => onHover(true),
+          onMouseLeave: () => onHover(false),
+        };
+      }
+
       return (
         <g key={key} fill='none'>
           <title>{label}</title>
-          <path d={d} {...rest} />
+          <path d={d} {...hoverProps} {...rest} />
         </g>
       );
     }
     return undefined;
   });
 
-const renderLine = (values, bounds, scale, height) => {
+const renderLine = (values, bounds, scale, height, { onClick, onHover }) => {
   let d = '';
   (values || []).forEach(({ value }, index) => {
     d += `${index ? ' L' : 'M'} ${(value[0] - bounds[0][0]) * scale[0]},` +
     `${height - ((value[1] - bounds[1][0]) * scale[1])}`;
   });
+
+  let hoverProps;
+  if (onHover) {
+    hoverProps = {
+      onMouseOver: () => onHover(true),
+      onMouseLeave: () => onHover(false),
+    };
+  }
+  let clickProps;
+  if (onClick) {
+    clickProps = { onClick };
+  }
+
   return (
     <g fill='none'>
-      <path d={d} />
+      <path d={d} {...hoverProps} {...clickProps} />
     </g>
   );
 };
 
-const renderArea = (values, bounds, scale, height, props) => {
-  const { color, theme } = props;
+const renderArea = (values, bounds, scale, height, { color, onClick, onHover, theme }) => {
   let d = '';
   (values || []).forEach(({ value }, index) => {
     const top = (value.length === 2 ? value[1] : value[2]);
@@ -60,9 +80,22 @@ const renderArea = (values, bounds, scale, height, props) => {
     `${height - ((bottom - bounds[1][0]) * scale[1])}`;
   });
   d += ' Z';
+
+  let hoverProps;
+  if (onHover) {
+    hoverProps = {
+      onMouseOver: () => onHover(true),
+      onMouseLeave: () => onHover(false),
+    };
+  }
+  let clickProps;
+  if (onClick) {
+    clickProps = { onClick };
+  }
+
   return (
     <g fill={colorForName(color, theme)}>
-      <path d={d} />
+      <path d={d} {...hoverProps} {...clickProps} />
     </g>
   );
 };
@@ -117,7 +150,7 @@ class Chart extends Component {
 
   render() {
     const {
-      color, round, size, theme, thickness, type, values, ...rest
+      color, onClick, onHover, round, size, theme, thickness, type, values, ...rest
     } = this.props;
     const { bounds, containerWidth, containerHeight } = this.state;
 
@@ -137,7 +170,7 @@ class Chart extends Component {
     if (type === 'bar') {
       contents = renderBars(values, bounds, scale, height);
     } else if (type === 'line') {
-      contents = renderLine(values, bounds, scale, height);
+      contents = renderLine(values, bounds, scale, height, this.props);
     } else if (type === 'area') {
       contents = renderArea(values, bounds, scale, height, this.props);
     }

--- a/src/js/components/Chart/README.md
+++ b/src/js/components/Chart/README.md
@@ -29,6 +29,25 @@ A color identifier to use for the graphic color. Defaults to `accent-1`.
 string
 ```
 
+**onClick**
+
+Called when the user clicks on it.
+      This is only available when the type is line or area.
+
+```
+function
+```
+
+**onHover**
+
+Called with a boolean argument
+      indicating when the user hovers onto or away from it.
+      This is only available when the type is line or area.
+
+```
+function
+```
+
 **round**
 
 Whether to round the line ends.
@@ -100,10 +119,13 @@ Required. Array of value objects describing the data.
       'value' is a tuple indicating the coordinate of the value or a triple
       indicating the x coordinate and a range of two y coordinates.
       'label' is a text string describing it.
+      'onHover' and 'onClick' only work when type='bar'.
 
 ```
 [{
   label: string,
+  onClick: function,
+  onHover: function,
   value: [number]
 }]
 ```

--- a/src/js/components/Chart/doc.js
+++ b/src/js/components/Chart/doc.js
@@ -17,6 +17,11 @@ export default (Chart) => {
     color: PropTypes.string.description(
       'A color identifier to use for the graphic color.'
     ).defaultValue('accent-1'),
+    onClick: PropTypes.func.description(`Called when the user clicks on it.
+      This is only available when the type is line or area.`),
+    onHover: PropTypes.func.description(`Called with a boolean argument
+      indicating when the user hovers onto or away from it.
+      This is only available when the type is line or area.`),
     round: PropTypes.bool.description('Whether to round the line ends.'),
     size: PropTypes.oneOfType([
       PropTypes.oneOf(
@@ -38,12 +43,15 @@ export default (Chart) => {
     ).defaultValue('bar'),
     values: PropTypes.arrayOf(PropTypes.shape({
       label: PropTypes.string, // for accessibility of bars
+      onClick: PropTypes.func,
+      onHover: PropTypes.func,
       value: PropTypes.arrayOf(PropTypes.number).isRequired,
     })).description(
       `Array of value objects describing the data.
       'value' is a tuple indicating the coordinate of the value or a triple
       indicating the x coordinate and a range of two y coordinates.
-      'label' is a text string describing it.`
+      'label' is a text string describing it.
+      'onHover' and 'onClick' only work when type='bar'.`
     ).isRequired,
   };
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -780,6 +780,25 @@ A color identifier to use for the graphic color. Defaults to \`accent-1\`.
 string
 \`\`\`
 
+**onClick**
+
+Called when the user clicks on it.
+      This is only available when the type is line or area.
+
+\`\`\`
+function
+\`\`\`
+
+**onHover**
+
+Called with a boolean argument
+      indicating when the user hovers onto or away from it.
+      This is only available when the type is line or area.
+
+\`\`\`
+function
+\`\`\`
+
 **round**
 
 Whether to round the line ends.
@@ -851,10 +870,13 @@ Required. Array of value objects describing the data.
       'value' is a tuple indicating the coordinate of the value or a triple
       indicating the x coordinate and a range of two y coordinates.
       'label' is a text string describing it.
+      'onHover' and 'onClick' only work when type='bar'.
 
 \`\`\`
 [{
   label: string,
+  onClick: function,
+  onHover: function,
   value: [number]
 }]
 \`\`\`


### PR DESCRIPTION
#### What does this PR do?

Adds `onClick` and `onHover` to Chart and each Chart `values` object.

#### Where should the reviewer start?

Chart/doc.js

#### What testing has been done on this PR?

grommet-site

#### How should this be manually tested?

grommet-site

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/1857

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible with v2.
