### PR TITLE
Remove unnecessary tabindexes

### DIFF
--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -61,11 +61,8 @@ class Button extends Component {
       ['reset', 'submit'].indexOf(type) === -1
     );
 
-    // tabIndex is needed because you may use button inside an svg
-    // without tabIndex it does not work in that scenario
     return (
       <Tag
-        tabIndex='0'
         {...rest}
         aria-label={a11yTitle}
         disabled={disabled}

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -120,7 +120,6 @@ exports[`Button color renders 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   >
     <span
@@ -142,7 +141,6 @@ exports[`Button color renders 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   >
     <span
@@ -216,7 +214,6 @@ exports[`Button disabled renders 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   />
 </div>
@@ -298,7 +295,6 @@ exports[`Button focus renders 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   >
     <span
@@ -368,7 +364,6 @@ exports[`Button hoverIndicator as object renders 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   >
     hoverIndicator
@@ -434,7 +429,6 @@ exports[`Button hoverIndicator as object with color renders 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   >
     hoverIndicator
@@ -500,7 +494,6 @@ exports[`Button hoverIndicator as object with colorIndex renders 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   >
     hoverIndicator
@@ -566,7 +559,6 @@ exports[`Button hoverIndicator as object with invalid color renders 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   >
     hoverIndicator
@@ -632,7 +624,6 @@ exports[`Button hoverIndicator as object with invalid color renders 2`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   >
     hoverIndicator
@@ -698,7 +689,6 @@ exports[`Button hoverIndicator as object with invalid colorIndex renders 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   >
     hoverIndicator
@@ -764,7 +754,6 @@ exports[`Button hoverIndicator renders 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   >
     hoverIndicator
@@ -843,7 +832,6 @@ exports[`Button href renders 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type={undefined}
   />
 </div>
@@ -936,7 +924,6 @@ exports[`Button icon label renders 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   >
     <span
@@ -1030,7 +1017,6 @@ exports[`Button primary renders 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   >
     <span
@@ -1117,7 +1103,6 @@ exports[`Button renders 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   >
     <span
@@ -1216,7 +1201,6 @@ exports[`Button reverse icon label renders 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   >
     <span
@@ -1300,7 +1284,6 @@ exports[`Button warns about invalid icon render 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   >
     <span
@@ -1370,7 +1353,6 @@ exports[`Button warns about invalid label render 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type="button"
   >
     <span

--- a/src/js/components/Button/__tests__/__snapshots__/RoutedButton-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/RoutedButton-test.js.snap
@@ -75,7 +75,6 @@ exports[`RoutedButton renders 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
-    tabIndex="0"
     type={undefined}
   >
     <span

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -226,7 +226,6 @@ exports[`Calendar date renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -269,7 +268,6 @@ exports[`Calendar date renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -541,7 +539,6 @@ exports[`Calendar dates renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -584,7 +581,6 @@ exports[`Calendar dates renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -856,7 +852,6 @@ exports[`Calendar disabled renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -899,7 +894,6 @@ exports[`Calendar disabled renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -1171,7 +1165,6 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -1214,7 +1207,6 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -1301,7 +1293,6 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -1344,7 +1335,6 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -1616,7 +1606,6 @@ exports[`Calendar renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -1659,7 +1648,6 @@ exports[`Calendar renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -2001,7 +1989,6 @@ exports[`Calendar size renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -2039,7 +2026,6 @@ exports[`Calendar size renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -2125,7 +2111,6 @@ exports[`Calendar size renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -2168,7 +2153,6 @@ exports[`Calendar size renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -2255,7 +2239,6 @@ exports[`Calendar size renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span
@@ -2298,7 +2281,6 @@ exports[`Calendar size renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <span

--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -54,7 +54,6 @@ class CheckBox extends Component {
         <StyledCheckBox theme={theme}>
           <StyledCheckBoxInput
             {...rest}
-            tabIndex='0'
             id={id}
             name={name}
             type='checkbox'

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -135,7 +135,6 @@ exports[`CheckBox checked renders 1`] = `
         id={undefined}
         name={undefined}
         onChange={undefined}
-        tabIndex="0"
         type="checkbox"
       />
       <div
@@ -291,7 +290,6 @@ exports[`CheckBox disabled renders 1`] = `
         id={undefined}
         name={undefined}
         onChange={undefined}
-        tabIndex="0"
         type="checkbox"
       />
       <div
@@ -323,7 +321,6 @@ exports[`CheckBox disabled renders 1`] = `
         id={undefined}
         name={undefined}
         onChange={undefined}
-        tabIndex="0"
         type="checkbox"
       />
       <div
@@ -484,7 +481,6 @@ exports[`CheckBox label renders 1`] = `
         id={undefined}
         name={undefined}
         onChange={undefined}
-        tabIndex="0"
         type="checkbox"
       />
       <div
@@ -519,7 +515,6 @@ exports[`CheckBox label renders 1`] = `
         id={undefined}
         name={undefined}
         onChange={undefined}
-        tabIndex="0"
         type="checkbox"
       />
       <div
@@ -678,7 +673,6 @@ exports[`CheckBox renders 1`] = `
         id={undefined}
         name={undefined}
         onChange={undefined}
-        tabIndex="0"
         type="checkbox"
       />
       <div
@@ -710,7 +704,6 @@ exports[`CheckBox renders 1`] = `
         id="test id"
         name="test name"
         onChange={undefined}
-        tabIndex="0"
         type="checkbox"
       />
       <div
@@ -866,7 +859,6 @@ exports[`CheckBox reverse renders 1`] = `
         id={undefined}
         name={undefined}
         onChange={undefined}
-        tabIndex="0"
         type="checkbox"
       />
       <div
@@ -1024,7 +1016,6 @@ exports[`CheckBox toggle renders 1`] = `
         id={undefined}
         name={undefined}
         onChange={undefined}
-        tabIndex="0"
         type="checkbox"
       />
       <span
@@ -1050,7 +1041,6 @@ exports[`CheckBox toggle renders 1`] = `
         id={undefined}
         name={undefined}
         onChange={undefined}
-        tabIndex="0"
         type="checkbox"
       />
       <span
@@ -1076,7 +1066,6 @@ exports[`CheckBox toggle renders 1`] = `
         id={undefined}
         name={undefined}
         onChange={undefined}
-        tabIndex="0"
         type="checkbox"
       />
       <span

--- a/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
+++ b/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
@@ -3,7 +3,6 @@
 exports[`DropButton closes 1`] = `
 <button
   class="StyledButton-gXzblK cfJbKA"
-  tabindex="0"
   aria-label="Open Drop"
   type="button"
 >
@@ -31,7 +30,6 @@ exports[`DropButton closes 3`] = `
 exports[`DropButton mounts 1`] = `
 <button
   class="StyledButton-gXzblK cfJbKA"
-  tabindex="0"
   aria-label="Open Drop"
   type="button"
 >
@@ -59,10 +57,9 @@ exports[`DropButton mounts 3`] = `
 exports[`DropButton mounts 4`] = `
 <button
   class="StyledButton-gXzblK cfJbKA"
-  tabindex="-1"
   aria-label="Open Drop"
   type="button"
-  data-g-tabindex="0"
+  tabindex="-1"
   id="test"
   open=""
 >

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -13,7 +13,6 @@ exports[`Menu opens and closes on click 1`] = `
   >
     <button
       class="StyledButton-gXzblK ioFkN"
-      tabindex="0"
       aria-label="Close Menu"
       type="button"
     >
@@ -51,7 +50,6 @@ exports[`Menu opens and closes on click 1`] = `
     >
       <button
         class="StyledButton-gXzblK eQPBtm"
-        tabindex="0"
         disabled=""
         type="button"
       >
@@ -64,7 +62,6 @@ exports[`Menu opens and closes on click 1`] = `
       </button>
       <button
         class="StyledButton-gXzblK khQPBH"
-        tabindex="0"
         type="button"
       >
         <div
@@ -76,7 +73,6 @@ exports[`Menu opens and closes on click 1`] = `
       </button>
       <a
         class="StyledButton-gXzblK khQPBH"
-        tabindex="0"
         href="/test"
       >
         <div
@@ -155,7 +151,6 @@ exports[`Menu renders 1`] = `
 <div>
   <button
     class="StyledButton-gXzblK cfJbKA"
-    tabindex="0"
     id="item"
     aria-label="Open Menu"
     type="button"
@@ -174,7 +169,6 @@ exports[`Menu with custom message renders 1`] = `
 <div>
   <button
     class="StyledButton-gXzblK cfJbKA"
-    tabindex="0"
     aria-label="Abrir Menu"
     type="button"
   >
@@ -212,11 +206,10 @@ exports[`Menu with custom message renders 1`] = `
 exports[`Menu with dropAlign renders 1`] = `
 <button
   class="StyledButton-gXzblK cfJbKA"
-  tabindex="-1"
   id="menu"
   aria-label="Open Menu"
   type="button"
-  data-g-tabindex="0"
+  tabindex="-1"
 >
   <div
     class="StyledBox-bStriS djNGoG"

--- a/src/js/components/RadioButton/RadioButton.js
+++ b/src/js/components/RadioButton/RadioButton.js
@@ -31,7 +31,6 @@ class RadioButton extends Component {
         <StyledRadioButton theme={theme}>
           <StyledRadioButtonInput
             {...rest}
-            tabIndex='0'
             id={id}
             name={name}
             type='radio'

--- a/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
+++ b/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
@@ -133,7 +133,6 @@ exports[`RadioButton checked renders 1`] = `
         id={undefined}
         name={undefined}
         onChange={undefined}
-        tabIndex="0"
         type="radio"
       />
       <div
@@ -288,7 +287,6 @@ exports[`RadioButton disabled renders 1`] = `
         id={undefined}
         name={undefined}
         onChange={undefined}
-        tabIndex="0"
         type="radio"
       />
       <div
@@ -321,7 +319,6 @@ exports[`RadioButton disabled renders 1`] = `
         id={undefined}
         name={undefined}
         onChange={undefined}
-        tabIndex="0"
         type="radio"
       />
       <div
@@ -476,7 +473,6 @@ exports[`RadioButton label renders 1`] = `
         id={undefined}
         name={undefined}
         onChange={undefined}
-        tabIndex="0"
         type="radio"
       />
       <div
@@ -512,7 +508,6 @@ exports[`RadioButton label renders 1`] = `
         id={undefined}
         name={undefined}
         onChange={undefined}
-        tabIndex="0"
         type="radio"
       />
       <div
@@ -670,7 +665,6 @@ exports[`RadioButton renders 1`] = `
         id={undefined}
         name={undefined}
         onChange={undefined}
-        tabIndex="0"
         type="radio"
       />
       <div
@@ -703,7 +697,6 @@ exports[`RadioButton renders 1`] = `
         id="test id"
         name="test name"
         onChange={undefined}
-        tabIndex="0"
         type="radio"
       />
       <div

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -19,7 +19,6 @@ exports[`Select closes drop on esc 1`] = `
     >
       <button
         class="StyledButton-gXzblK khQPBH"
-        tabindex="0"
         role="menuitem"
         type="button"
       >
@@ -36,7 +35,6 @@ exports[`Select closes drop on esc 1`] = `
       </button>
       <button
         class="StyledButton-gXzblK khQPBH"
-        tabindex="0"
         role="menuitem"
         type="button"
       >
@@ -308,7 +306,6 @@ exports[`Select mounts 3`] = `
     >
       <button
         class="StyledButton-gXzblK khQPBH"
-        tabindex="0"
         role="menuitem"
         type="button"
       >
@@ -325,7 +322,6 @@ exports[`Select mounts 3`] = `
       </button>
       <button
         class="StyledButton-gXzblK khQPBH"
-        tabindex="0"
         role="menuitem"
         type="button"
       >
@@ -387,7 +383,6 @@ exports[`Select mounts 5`] = `
 >
   <button
     class="StyledButton-gXzblK khQPBH"
-    tabindex="0"
     role="menuitem"
     type="button"
   >
@@ -404,7 +399,6 @@ exports[`Select mounts 5`] = `
   </button>
   <button
     class="StyledButton-gXzblK khQPBH"
-    tabindex="0"
     role="menuitem"
     type="button"
   >
@@ -541,7 +535,6 @@ exports[`Select mounts with complex options and children 3`] = `
     >
       <button
         class="StyledButton-gXzblK khQPBH"
-        tabindex="0"
         role="menuitem"
         type="button"
       >
@@ -551,7 +544,6 @@ exports[`Select mounts with complex options and children 3`] = `
       </button>
       <button
         class="StyledButton-gXzblK khQPBH"
-        tabindex="0"
         role="menuitem"
         type="button"
       >
@@ -631,7 +623,6 @@ exports[`Select mounts with search 1`] = `
     >
       <button
         class="StyledButton-gXzblK khQPBH"
-        tabindex="0"
         role="menuitem"
         type="button"
       >
@@ -648,7 +639,6 @@ exports[`Select mounts with search 1`] = `
       </button>
       <button
         class="StyledButton-gXzblK khQPBH"
-        tabindex="0"
         role="menuitem"
         type="button"
       >
@@ -744,7 +734,6 @@ exports[`Select mounts with search 4`] = `
     >
       <button
         class="StyledButton-gXzblK khQPBH"
-        tabindex="0"
         role="menuitem"
         type="button"
       >
@@ -761,7 +750,6 @@ exports[`Select mounts with search 4`] = `
       </button>
       <button
         class="StyledButton-gXzblK khQPBH"
-        tabindex="0"
         role="menuitem"
         type="button"
       >

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -10,7 +10,6 @@ exports[`Tabs changes active index 1`] = `
   >
     <button
       class="StyledButton-gXzblK cfJbKA"
-      tabindex="0"
       role="tab"
       aria-selected="true"
       aria-expanded="true"
@@ -31,7 +30,6 @@ exports[`Tabs changes active index 1`] = `
     </button>
     <button
       class="StyledButton-gXzblK cfJbKA"
-      tabindex="0"
       role="tab"
       aria-selected="false"
       aria-expanded="false"
@@ -88,7 +86,6 @@ exports[`Tabs changes to second tab 1`] = `
         onMouseOver={[Function]}
         onMouseUp={[Function]}
         role="tab"
-        tabIndex="0"
         type="button"
       >
         <div
@@ -121,7 +118,6 @@ exports[`Tabs changes to second tab 1`] = `
         onMouseOver={[Function]}
         onMouseUp={[Function]}
         role="tab"
-        tabIndex="0"
         type="button"
       >
         <div
@@ -178,7 +174,6 @@ exports[`Tabs renders complex Tab title 1`] = `
         onMouseOver={[Function]}
         onMouseUp={[Function]}
         role="tab"
-        tabIndex="0"
         type="button"
       >
         <div
@@ -208,7 +203,6 @@ exports[`Tabs renders complex Tab title 1`] = `
         onMouseOver={[Function]}
         onMouseUp={[Function]}
         role="tab"
-        tabIndex="0"
         type="button"
       >
         <div
@@ -261,7 +255,6 @@ exports[`Tabs renders with Tab 1`] = `
         onMouseOver={[Function]}
         onMouseUp={[Function]}
         role="tab"
-        tabIndex="0"
         type="button"
       >
         <div
@@ -295,7 +288,6 @@ exports[`Tabs renders with Tab 1`] = `
         onMouseOver={[Function]}
         onMouseUp={[Function]}
         role="tab"
-        tabIndex="0"
         type="button"
       >
         <div
@@ -352,7 +344,6 @@ exports[`Tabs sets on hover 1`] = `
   >
     <button
       class="StyledButton-gXzblK cfJbKA"
-      tabindex="0"
       role="tab"
       aria-selected="true"
       aria-expanded="true"
@@ -373,7 +364,6 @@ exports[`Tabs sets on hover 1`] = `
     </button>
     <button
       class="StyledButton-gXzblK cfJbKA"
-      tabindex="0"
       role="tab"
       aria-selected="false"
       aria-expanded="false"
@@ -411,7 +401,6 @@ exports[`Tabs sets on hover 2`] = `
   >
     <button
       class="StyledButton-gXzblK cfJbKA"
-      tabindex="0"
       role="tab"
       aria-selected="true"
       aria-expanded="true"
@@ -432,7 +421,6 @@ exports[`Tabs sets on hover 2`] = `
     </button>
     <button
       class="StyledButton-gXzblK cfJbKA"
-      tabindex="0"
       role="tab"
       aria-selected="false"
       aria-expanded="false"
@@ -470,7 +458,6 @@ exports[`Tabs sets on hover 3`] = `
   >
     <button
       class="StyledButton-gXzblK cfJbKA"
-      tabindex="0"
       role="tab"
       aria-selected="true"
       aria-expanded="true"
@@ -491,7 +478,6 @@ exports[`Tabs sets on hover 3`] = `
     </button>
     <button
       class="StyledButton-gXzblK cfJbKA"
-      tabindex="0"
       role="tab"
       aria-selected="false"
       aria-expanded="false"
@@ -529,7 +515,6 @@ exports[`Tabs sets on hover 4`] = `
   >
     <button
       class="StyledButton-gXzblK cfJbKA"
-      tabindex="0"
       role="tab"
       aria-selected="true"
       aria-expanded="true"
@@ -550,7 +535,6 @@ exports[`Tabs sets on hover 4`] = `
     </button>
     <button
       class="StyledButton-gXzblK cfJbKA"
-      tabindex="0"
       role="tab"
       aria-selected="false"
       aria-expanded="false"

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -13,7 +13,6 @@ exports[`TextInput closes suggestion drop 1`] = `
     <li>
       <button
         class="StyledButton-gXzblK dYRvzO"
-        tabindex="0"
         type="button"
       >
         <div
@@ -27,7 +26,6 @@ exports[`TextInput closes suggestion drop 1`] = `
     <li>
       <button
         class="StyledButton-gXzblK dYRvzO"
-        tabindex="0"
         type="button"
       >
         <div
@@ -140,7 +138,6 @@ exports[`TextInput mounts with complex suggestions 1`] = `
     <li>
       <button
         class="StyledButton-gXzblK dYRvzO"
-        tabindex="0"
         type="button"
       >
         <div
@@ -154,7 +151,6 @@ exports[`TextInput mounts with complex suggestions 1`] = `
     <li>
       <button
         class="StyledButton-gXzblK dYRvzO"
-        tabindex="0"
         type="button"
       >
         <div
@@ -221,7 +217,6 @@ exports[`TextInput mounts with suggestions 1`] = `
     <li>
       <button
         class="StyledButton-gXzblK dYRvzO"
-        tabindex="0"
         type="button"
       >
         <div
@@ -235,7 +230,6 @@ exports[`TextInput mounts with suggestions 1`] = `
     <li>
       <button
         class="StyledButton-gXzblK dYRvzO"
-        tabindex="0"
         type="button"
       >
         <div
@@ -302,7 +296,6 @@ exports[`TextInput selects suggestion 1`] = `
     <li>
       <button
         class="StyledButton-gXzblK dYRvzO"
-        tabindex="0"
         type="button"
       >
         <div
@@ -316,7 +309,6 @@ exports[`TextInput selects suggestion 1`] = `
     <li>
       <button
         class="StyledButton-gXzblK dYRvzO"
-        tabindex="0"
         type="button"
       >
         <div

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -343,7 +343,6 @@ exports[`Video autoPlay renders 1`] = `
           onFocus={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
-          tabIndex="0"
           type="button"
         >
           <span
@@ -452,7 +451,6 @@ exports[`Video autoPlay renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <div
@@ -894,7 +892,6 @@ exports[`Video controls renders 1`] = `
           onFocus={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
-          tabIndex="0"
           type="button"
         >
           <span
@@ -1003,7 +1000,6 @@ exports[`Video controls renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <div
@@ -1093,7 +1089,6 @@ exports[`Video controls renders 1`] = `
           onFocus={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
-          tabIndex="0"
           type="button"
         >
           <span
@@ -1203,7 +1198,6 @@ exports[`Video controls renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <div
@@ -1598,7 +1592,6 @@ exports[`Video fit renders 1`] = `
           onFocus={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
-          tabIndex="0"
           type="button"
         >
           <span
@@ -1707,7 +1700,6 @@ exports[`Video fit renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <div
@@ -1800,7 +1792,6 @@ exports[`Video fit renders 1`] = `
           onFocus={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
-          tabIndex="0"
           type="button"
         >
           <span
@@ -1909,7 +1900,6 @@ exports[`Video fit renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <div
@@ -2286,7 +2276,6 @@ exports[`Video loop renders 1`] = `
           onFocus={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
-          tabIndex="0"
           type="button"
         >
           <span
@@ -2395,7 +2384,6 @@ exports[`Video loop renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <div
@@ -2772,7 +2760,6 @@ exports[`Video mute renders 1`] = `
           onFocus={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
-          tabIndex="0"
           type="button"
         >
           <span
@@ -2881,7 +2868,6 @@ exports[`Video mute renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <div
@@ -3258,7 +3244,6 @@ exports[`Video renders 1`] = `
           onFocus={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}
-          tabIndex="0"
           type="button"
         >
           <span
@@ -3367,7 +3352,6 @@ exports[`Video renders 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
-            tabIndex="0"
             type="button"
           >
             <div


### PR DESCRIPTION
#### What does this PR do?

Changed Button, CheckBox, and RadioButton to not set tabindex.
The one area where this is needed is when they are embedded in an SVG, which is pretty rare. It will be the caller's responsibility to add it in that case.

#### Where should the reviewer start?

Button.js

#### What testing has been done on this PR?

unit testing

#### How should this be manually tested?

unit testing

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

essentially backwards compatible, unless they are being used inside an SVG.
