### PR TITLE
Added docs for sub components of Table

### DIFF
--- a/src/js/components/Table/doc.js
+++ b/src/js/components/Table/doc.js
@@ -27,6 +27,50 @@ export const docTableCell = (TableCell) => {
   return DocumentedTableCell;
 };
 
+export const docTableRow = (TableRow) => {
+  const DocumentedTableRow = describe(TableRow)
+    .description('A row of cells in a table.'
+    ).usage(
+      `import { TableRow } from 'grommet';
+<TableRow />`
+    );
+
+  return DocumentedTableRow;
+};
+
+export const docTableHeader = (TableHeader) => {
+  const DocumentedTableHeader = describe(TableHeader)
+    .description('The header of a table.'
+    ).usage(
+      `import { TableHeader } from 'grommet';
+<TableHeader />`
+    );
+
+  return DocumentedTableHeader;
+};
+
+export const docTableBody = (TableBody) => {
+  const DocumentedTableBody = describe(TableBody)
+    .description('The body of a table.'
+    ).usage(
+      `import { TableBody } from 'grommet';
+<TableBody />`
+    );
+
+  return DocumentedTableBody;
+};
+
+export const docTableFooter = (TableFooter) => {
+  const DocumentedTableFooter = describe(TableFooter)
+    .description('The footer of a table.'
+    ).usage(
+      `import { TableFooter } from 'grommet';
+<TableFooter />`
+    );
+
+  return DocumentedTableFooter;
+};
+
 export default (Table) => {
   const DocumentedTable = describe(Table)
     .availableAt(getAvailableAtBadge('Table'))


### PR DESCRIPTION
#### What does this PR do?

Adds documentation for TableHeader, TableFooter, TableBody, and TableRow.

#### Where should the reviewer start?

Table/doc.js

#### What testing has been done on this PR?

grommet-site

#### How should this be manually tested?

grommet-site

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible with v2
