### PR TITLE
dropTarget changes

### DIFF
--- a/src/js/components/Diagram/README.md
+++ b/src/js/components/Diagram/README.md
@@ -15,14 +15,17 @@ import { Diagram } from 'grommet';
 **connections**
 
 Required. Array of objects describing the connections.
-      The 'fromId' and 'toId' must be DOM element ids.
+      The 'fromTarget' and 'toTarget' may be either DOM element ids or
+      React references.
       'offset' can be used to shift a bit to reduce the amount of overlap
-      with other connection lines
+      with other connection lines to make the lines easier to distinguish.
 
 ```
 [{
   color: string,
-  fromId: string,
+  fromTarget: 
+    string
+    object,
   label: string,
   offset: 
     xsmall
@@ -34,7 +37,9 @@ Required. Array of objects describing the connections.
     small
     medium
     large,
-  toId: string,
+  toTarget: 
+    string
+    object,
   type: 
     direct
     curved

--- a/src/js/components/Diagram/doc.js
+++ b/src/js/components/Diagram/doc.js
@@ -12,17 +12,24 @@ export default (Diagram) => {
   DocumentedDiagram.propTypes = {
     connections: PropTypes.arrayOf(PropTypes.shape({
       color: PropTypes.string,
-      fromId: PropTypes.string.isRequired,
+      fromTarget: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object,
+      ]).isRequired,
       label: PropTypes.string, // for accessibility
       offset: PropTypes.oneOf(['xsmall', 'small', 'medium', 'large']),
       thickness: PropTypes.oneOf(['xsmall', 'small', 'medium', 'large']),
-      toId: PropTypes.string.isRequired,
+      toTarget: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object,
+      ]).isRequired,
       type: PropTypes.oneOf(['direct', 'curved', 'rectilinear']),
     })).description(
       `Array of objects describing the connections.
-      The 'fromId' and 'toId' must be DOM element ids.
+      The 'fromTarget' and 'toTarget' may be either DOM element ids or
+      React references.
       'offset' can be used to shift a bit to reduce the amount of overlap
-      with other connection lines`
+      with other connection lines to make the lines easier to distinguish.`
     ).isRequired,
   };
 

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -32,8 +32,8 @@ class DropContainer extends Component {
   }
 
   addScrollListener = () => {
-    const { control } = this.props;
-    this.scrollParents = findScrollParents(control);
+    const { target } = this.props;
+    this.scrollParents = findScrollParents(target);
     this.scrollParents.forEach(scrollParent => scrollParent.addEventListener('scroll', this.place));
   }
 
@@ -63,9 +63,9 @@ class DropContainer extends Component {
     const windowWidth = window.innerWidth;
     const windowHeight = window.innerHeight;
 
-    const control = findDOMNode(this.props.control);
+    const target = findDOMNode(this.props.target);
     const container = findDOMNode(this.dropRef);
-    if (container && control) {
+    if (container && target) {
       // clear prior styling
       container.style.left = '';
       container.style.width = '';
@@ -73,12 +73,12 @@ class DropContainer extends Component {
       container.style.maxHeight = '';
 
       // get bounds
-      const controlRect = findVisibleParent(control).getBoundingClientRect();
+      const targetRect = findVisibleParent(target).getBoundingClientRect();
       const containerRect = container.getBoundingClientRect();
 
       // determine width
       const width = Math.min(
-        Math.max(controlRect.width, containerRect.width),
+        Math.max(targetRect.width, containerRect.width),
         windowWidth
       );
 
@@ -86,15 +86,15 @@ class DropContainer extends Component {
       let left;
       if (align.left) {
         if (align.left === 'left') {
-          left = controlRect.left;
+          left = targetRect.left;
         } else if (align.left === 'right') {
-          left = controlRect.left - width;
+          left = targetRect.left - width;
         }
       } else if (align.right) {
         if (align.right === 'left') {
-          left = controlRect.left - width;
+          left = targetRect.left - width;
         } else if (align.right === 'right') {
-          left = (controlRect.left + controlRect.width) - width;
+          left = (targetRect.left + targetRect.width) - width;
         }
       }
 
@@ -109,22 +109,22 @@ class DropContainer extends Component {
       let maxHeight;
       if (align.top) {
         if (align.top === 'top') {
-          top = controlRect.top;
-          maxHeight = Math.min(windowHeight - controlRect.top, windowHeight);
+          top = targetRect.top;
+          maxHeight = Math.min(windowHeight - targetRect.top, windowHeight);
         } else {
-          top = controlRect.bottom;
+          top = targetRect.bottom;
           maxHeight = Math.min(
-            windowHeight - controlRect.bottom,
-            windowHeight - controlRect.height
+            windowHeight - targetRect.bottom,
+            windowHeight - targetRect.height
           );
         }
       } else if (align.bottom) {
         if (align.bottom === 'bottom') {
-          top = controlRect.bottom - containerRect.height;
-          maxHeight = Math.max(controlRect.bottom, 0);
+          top = targetRect.bottom - containerRect.height;
+          maxHeight = Math.max(targetRect.bottom, 0);
         } else {
-          top = controlRect.top - containerRect.height;
-          maxHeight = Math.max(controlRect.top, 0);
+          top = targetRect.top - containerRect.height;
+          maxHeight = Math.max(targetRect.top, 0);
         }
       }
 
@@ -135,29 +135,29 @@ class DropContainer extends Component {
           // We put it below, but there's more room above, put it above
           if (align.top === 'bottom') {
             if (responsive) {
-              top = Math.max(controlRect.top - containerRect.height, 0);
+              top = Math.max(targetRect.top - containerRect.height, 0);
             }
-            maxHeight = controlRect.top;
+            maxHeight = targetRect.top;
           } else {
             if (responsive) {
-              top = Math.max(controlRect.bottom - containerRect.height, 0);
+              top = Math.max(targetRect.bottom - containerRect.height, 0);
             }
-            maxHeight = controlRect.bottom;
+            maxHeight = targetRect.bottom;
           }
         } else if (align.bottom && maxHeight < (windowHeight / 2)) {
           // We put it above but there's more room below, put it below
           if (align.bottom === 'bottom') {
             if (responsive) {
-              top = controlRect.top;
+              top = targetRect.top;
             }
             maxHeight = Math.min(windowHeight - top, windowHeight);
           } else {
             if (responsive) {
-              top = controlRect.bottom;
+              top = targetRect.bottom;
             }
             maxHeight = Math.min(
               windowHeight - top,
-              windowHeight - controlRect.height
+              windowHeight - targetRect.height
             );
           }
         }

--- a/src/js/components/Drop/README.md
+++ b/src/js/components/Drop/README.md
@@ -6,7 +6,7 @@ A drop container that opens next to a target.
 
 ```javascript
 import { Drop } from 'grommet';
-<Drop control={element}>...</Drop>
+<Drop target={reference}>...</Drop>
 ```
 
 ## Properties
@@ -35,22 +35,6 @@ How to align the drop with respect to the target element. Defaults to `{
 }
 ```
 
-**control**
-
-Required. Target container where the drop will be aligned.
-
-```
-object
-```
-
-**restrictFocus**
-
-Whether the drop should control focus.
-
-```
-boolean
-```
-
 **onClickOutside**
 
 Function that will be invoked when the user clicks outside the drop.
@@ -73,6 +57,22 @@ Whether to dynamically re-place when resized. Defaults to `true`.
 
 ```
 boolean
+```
+
+**restrictFocus**
+
+Whether the drop should control focus.
+
+```
+boolean
+```
+
+**target**
+
+Required. Target where the drop will be aligned to. This should be a React reference.
+
+```
+object
 ```
 
 **theme**

--- a/src/js/components/Drop/__tests__/Drop-test.js
+++ b/src/js/components/Drop/__tests__/Drop-test.js
@@ -25,7 +25,7 @@ class FakeInput extends Component {
     let drop;
     if (showDrop) {
       drop = (
-        <Drop id='drop-node' control={this.inputRef} {...rest}>
+        <Drop id='drop-node' target={this.inputRef} {...rest}>
           this is a test
         </Drop>
       );

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -5,6 +5,7 @@ exports[`Drop aligns left right top bottom 1`] = `
   class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="drop-node"
+  target="[object HTMLInputElement]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   this is a test
@@ -48,6 +49,7 @@ exports[`Drop aligns right left top top 1`] = `
   class="StyledDrop-bCWxPe fAkYxw"
   tabindex="-1"
   id="drop-node"
+  target="[object HTMLInputElement]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   this is a test
@@ -91,6 +93,7 @@ exports[`Drop aligns right right bottom top 1`] = `
   class="StyledDrop-bCWxPe cscpcq"
   tabindex="-1"
   id="drop-node"
+  target="[object HTMLInputElement]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   this is a test
@@ -134,6 +137,7 @@ exports[`Drop aligns right right bottom top 3`] = `
   class="StyledDrop-bCWxPe cscpcq"
   tabindex="-1"
   id="drop-node"
+  target="[object HTMLInputElement]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   this is a test
@@ -177,6 +181,7 @@ exports[`Drop aligns skips left random 1`] = `
   class="StyledDrop-bCWxPe hBYrcs"
   tabindex="-1"
   id="drop-node"
+  target="[object HTMLInputElement]"
   style="width: 0.1px; top: 0px; max-height: 768px;"
 >
   this is a test
@@ -220,6 +225,7 @@ exports[`Drop aligns skips right random 1`] = `
   class="StyledDrop-bCWxPe fAkYxw"
   tabindex="-1"
   id="drop-node"
+  target="[object HTMLInputElement]"
   style="width: 0.1px; max-height: 768px;"
 >
   this is a test
@@ -263,6 +269,7 @@ exports[`Drop mounts 1`] = `
   class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="drop-node"
+  target="[object HTMLInputElement]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   this is a test
@@ -306,6 +313,7 @@ exports[`Drop resizes 1`] = `
   class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="test"
+  target="[object HTMLInputElement]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
 >
   this is a test
@@ -349,6 +357,7 @@ exports[`Drop restrict focus 1`] = `
   class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="drop-node"
+  target="[object HTMLInputElement]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
 >
   this is a test
@@ -360,6 +369,7 @@ exports[`Drop restrict focus 2`] = `
   class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="drop-node"
+  target="[object HTMLInputElement]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
 >
   this is a test
@@ -411,6 +421,7 @@ exports[`Drop skips invalid align 1`] = `
   class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="drop-node"
+  target="[object HTMLInputElement]"
   style="width: 0.1px; max-height: 768px;"
 >
   this is a test

--- a/src/js/components/Drop/doc.js
+++ b/src/js/components/Drop/doc.js
@@ -8,7 +8,7 @@ export default (Drop) => {
     .description(
       'A drop container that opens next to a target.'
     ).usage(
-      'import { Drop } from \'grommet\';\n<Drop control={element}>...</Drop>'
+      'import { Drop } from \'grommet\';\n<Drop target={reference}>...</Drop>'
     );
 
   DocumentedDrop.propTypes = {
@@ -23,12 +23,6 @@ export default (Drop) => {
       top: 'top',
       left: 'left',
     }),
-    control: PropTypes.object.description(
-      'Target container where the drop will be aligned.'
-    ).isRequired,
-    restrictFocus: PropTypes.bool.description(
-      'Whether the drop should control focus.'
-    ),
     onClickOutside: PropTypes.func.description(
       'Function that will be invoked when the user clicks outside the drop.'
     ),
@@ -38,6 +32,12 @@ export default (Drop) => {
     responsive: PropTypes.bool
       .description('Whether to dynamically re-place when resized.')
       .defaultValue(true),
+    restrictFocus: PropTypes.bool.description(
+      'Whether the drop should control focus.'
+    ),
+    target: PropTypes.object.description(
+      'Target where the drop will be aligned to. This should be a React reference.'
+    ).isRequired,
     theme: PropTypes.object.description('Custom styles for Drop component.'),
   };
 

--- a/src/js/components/DropButton/DropButton.js
+++ b/src/js/components/DropButton/DropButton.js
@@ -53,7 +53,7 @@ class DropButton extends Component {
   }
 
   render() {
-    const { dropAlign, dropContent, id, open, theme, ...rest } = this.props;
+    const { dropAlign, dropContent, dropTarget, id, open, theme, ...rest } = this.props;
     const { show } = this.state;
 
     let drop;
@@ -65,7 +65,7 @@ class DropButton extends Component {
           id={id ? `${id}__drop` : undefined}
           restrictFocus={true}
           align={dropAlign}
-          control={this.buttonRef}
+          target={dropTarget || this.buttonRef}
           onClickOutside={this.onDropClose}
           onEsc={this.onDropClose}
         >

--- a/src/js/components/DropButton/README.md
+++ b/src/js/components/DropButton/README.md
@@ -9,7 +9,7 @@ A Button that when clicked will a Drop with the specified 'dropContent'.
 
 ```javascript
 import { DropButton } from 'grommet';
-<DropButton control={element}>{dropContents...}</DropButton>
+<DropButton dropContent={...} />
 ```
 
 ## Properties
@@ -52,6 +52,16 @@ Required. Content to put inside the Drop.
 
 ```
 element
+```
+
+**dropTarget**
+
+Target where the drop will be aligned to. This should be
+      a React reference. Typically, this is not required as the drop will be
+      aligned to the DropButton itself by default.
+
+```
+object
 ```
 
 **onClose**

--- a/src/js/components/DropButton/doc.js
+++ b/src/js/components/DropButton/doc.js
@@ -12,7 +12,7 @@ export default (DropButton) => {
       `
     ).usage(
       `import { DropButton } from 'grommet';
-<DropButton control={element}>{dropContents...}</DropButton>`
+<DropButton dropContent={...} />`
     );
 
   DocumentedDropButton.propTypes = {
@@ -31,6 +31,10 @@ export default (DropButton) => {
     dropContent: PropTypes.element.description(
       'Content to put inside the Drop.'
     ).isRequired,
+    dropTarget: PropTypes.object.description(
+      `Target where the drop will be aligned to. This should be
+      a React reference. Typically, this is not required as the drop will be
+      aligned to the DropButton itself by default.`),
     onClose: PropTypes.func.description('Callback for when the drop is closed'),
     onOpen: PropTypes.func.description('Callback for when the drop is opened'),
     open: PropTypes.bool.description(

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -74,6 +74,7 @@ class Menu extends Component {
   render() {
     const {
       dropAlign,
+      dropTarget,
       icon,
       items,
       label,
@@ -123,6 +124,7 @@ class Menu extends Component {
             {...rest}
             a11yTitle={messages.openMenu || 'Open Menu'}
             dropAlign={dropAlign}
+            dropTarget={dropTarget}
             open={open}
             onOpen={() => this.setState({ open: true })}
             onClose={() => this.setState({ open: false })}

--- a/src/js/components/Menu/README.md
+++ b/src/js/components/Menu/README.md
@@ -56,6 +56,16 @@ string
 }
 ```
 
+**dropTarget**
+
+Target where the drop will be aligned to. This should be
+      a React reference. Typically, this is not required as the drop will be
+      aligned to the Menu itself by default.
+
+```
+object
+```
+
 **icon**
 
 Indicates the icon shown as a control to open it.

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -5,6 +5,7 @@ exports[`Menu opens and closes on click 1`] = `
   class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="test-menu__drop"
+  target="[object Object]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   <div
@@ -206,6 +207,7 @@ exports[`Menu with dropAlign renders 1`] = `
   class="StyledDrop-bCWxPe fAkYxw"
   tabindex="-1"
   id="test-menu__drop"
+  target="[object Object]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   <div

--- a/src/js/components/Menu/doc.js
+++ b/src/js/components/Menu/doc.js
@@ -39,6 +39,10 @@ one of top or bottom should be specified.`
         ]),
       }),
     ]).description('Background color when drop is active'),
+    dropTarget: PropTypes.object.description(
+      `Target where the drop will be aligned to. This should be
+      a React reference. Typically, this is not required as the drop will be
+      aligned to the Menu itself by default.`),
     icon: PropTypes.node.description('Indicates the icon shown as a control to open it.'),
     items: PropTypes.arrayOf(PropTypes.object).description(
       `Menu items to be placed inside the drop down.

--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -38,7 +38,7 @@ function
 **dropAlign**
 
 How to align the drop. Defaults to `{
-  "top": "top",
+  "top": "bottom",
   "left": "left"
 }`.
 
@@ -81,6 +81,16 @@ Size of the options container inside the Select drop.
 
 ```
 string
+```
+
+**dropTarget**
+
+Target where the options drop will be aligned to. This should be
+      a React reference. Typically, this is not required as the drop will be
+      aligned to the Select itself by default.
+
+```
+object
 ```
 
 **focusIndicator**

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -11,6 +11,10 @@ import SelectContainer from './SelectContainer';
 import doc from './doc';
 
 class Select extends Component {
+  static defaultProps = {
+    dropAlign: { top: 'bottom', left: 'left' },
+  }
+
   state = { open: false }
 
   componentWillReceiveProps(nextProps) {
@@ -38,14 +42,15 @@ class Select extends Component {
 
   render() {
     const {
-      a11yTitle, children, onClose, placeholder, plain, value, ...rest
+      a11yTitle, children, dropAlign, dropTarget, onClose, placeholder, plain, value, ...rest
     } = this.props;
     const { open } = this.state;
 
     return (
       <Keyboard onDown={this.onOpen} onUp={this.onOpen}>
         <DropButton
-          dropAlign={{ top: 'bottom', left: 'left' }}
+          dropAlign={dropAlign}
+          dropTarget={dropTarget}
           {...rest}
           open={open}
           onOpen={this.onOpen}

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -5,6 +5,7 @@ exports[`Select closes drop on esc 1`] = `
   class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="test-select__drop"
+  target="[object Object]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   <div
@@ -316,6 +317,7 @@ exports[`Select mounts 3`] = `
   class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="test-select__drop"
+  target="[object Object]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   <div
@@ -567,6 +569,7 @@ exports[`Select mounts with complex options and children 3`] = `
   class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="test-select__drop"
+  target="[object Object]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   <div
@@ -660,6 +663,7 @@ exports[`Select mounts with search 1`] = `
   class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="test-select__drop"
+  target="[object Object]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   <div
@@ -791,6 +795,7 @@ exports[`Select mounts with search 4`] = `
   class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="test-select__drop"
+  target="[object Object]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   <div

--- a/src/js/components/Select/doc.js
+++ b/src/js/components/Select/doc.js
@@ -33,6 +33,10 @@ export default (Select) => {
     dropSize: PropTypes.string.description(
       'Size of the options container inside the Select drop.'
     ),
+    dropTarget: PropTypes.object.description(
+      `Target where the options drop will be aligned to. This should be
+      a React reference. Typically, this is not required as the drop will be
+      aligned to the Select itself by default.`),
     focusIndicator: PropTypes.bool.description(
       'Whether when \'plain\' it should receive a focus outline.'
     ),

--- a/src/js/components/TextInput/README.md
+++ b/src/js/components/TextInput/README.md
@@ -19,6 +19,40 @@ What text to start with in the input.
 string
 ```
 
+**dropAlign**
+
+How to align the drop. Defaults to `{
+  "top": "top",
+  "left": "left"
+}`.
+
+```
+{
+  top: 
+    top
+    bottom,
+  bottom: 
+    top
+    bottom,
+  right: 
+    left
+    right,
+  left: 
+    left
+    right
+}
+```
+
+**dropTarget**
+
+Target where any suggestions drop will be aligned to. This should be
+      a React reference. Typically, this is not required as the drop will be
+      aligned to the TextInput itself by default.
+
+```
+object
+```
+
 **id**
 
 The id attribute of the input.

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -28,6 +28,7 @@ class TextInput extends Component {
   }
 
   static defaultProps = {
+    dropAlign: { top: 'bottom', left: 'left' },
     messages: {
       enterSelect: '(Press Enter to Select)',
       suggestionsCount: 'suggestions available',
@@ -195,7 +196,10 @@ class TextInput extends Component {
   }
 
   render() {
-    const { defaultValue, id, plain, value, onFocus, onInput, onKeyDown, ...rest } = this.props;
+    const {
+      defaultValue, dropAlign, dropTarget, id, plain, value, onFocus, onInput, onKeyDown,
+      ...rest
+    } = this.props;
     delete rest.onInput; // se we can manage in onInputChange()
     const { showDrop } = this.state;
     // needed so that styled components does not invoke
@@ -206,9 +210,9 @@ class TextInput extends Component {
       drop = (
         <Drop
           id={id ? `text-input-drop__${id}` : undefined}
-          align={{ top: 'bottom', left: 'left' }}
+          align={dropAlign}
           responsive={false}
-          control={this.componentRef}
+          target={dropTarget || this.componentRef}
           onClickOutside={() => this.setState({ showDrop: false })}
           onEsc={() => this.setState({ showDrop: false })}
         >

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -5,6 +5,7 @@ exports[`TextInput closes suggestion drop 1`] = `
   class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="text-input-drop__item"
+  target="[object Object]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   <ol
@@ -130,6 +131,7 @@ exports[`TextInput mounts with complex suggestions 1`] = `
   class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="text-input-drop__item"
+  target="[object Object]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   <ol
@@ -209,6 +211,7 @@ exports[`TextInput mounts with suggestions 1`] = `
   class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="text-input-drop__item"
+  target="[object Object]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   <ol
@@ -288,6 +291,7 @@ exports[`TextInput selects suggestion 1`] = `
   class="StyledDrop-bCWxPe gcEofR"
   tabindex="-1"
   id="text-input-drop__item"
+  target="[object Object]"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
 >
   <ol

--- a/src/js/components/TextInput/doc.js
+++ b/src/js/components/TextInput/doc.js
@@ -14,6 +14,19 @@ export default (TextInput) => {
 
   DocumentedTextInput.propTypes = {
     defaultValue: PropTypes.string.description('What text to start with in the input.'),
+    dropAlign: PropTypes.shape({
+      top: PropTypes.oneOf(['top', 'bottom']),
+      bottom: PropTypes.oneOf(['top', 'bottom']),
+      right: PropTypes.oneOf(['left', 'right']),
+      left: PropTypes.oneOf(['left', 'right']),
+    }).description('How to align the drop.').defaultValue({
+      top: 'top',
+      left: 'left',
+    }),
+    dropTarget: PropTypes.object.description(
+      `Target where any suggestions drop will be aligned to. This should be
+      a React reference. Typically, this is not required as the drop will be
+      aligned to the TextInput itself by default.`),
     id: PropTypes.string.description('The id attribute of the input.'),
     focusIndicator: PropTypes.bool.description(
       'Whether the plain text input should receive a focus outline.'

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1068,14 +1068,17 @@ import { Diagram } from 'grommet';
 **connections**
 
 Required. Array of objects describing the connections.
-      The 'fromId' and 'toId' must be DOM element ids.
+      The 'fromTarget' and 'toTarget' may be either DOM element ids or
+      React references.
       'offset' can be used to shift a bit to reduce the amount of overlap
-      with other connection lines
+      with other connection lines to make the lines easier to distinguish.
 
 \`\`\`
 [{
   color: string,
-  fromId: string,
+  fromTarget: 
+    string
+    object,
   label: string,
   offset: 
     xsmall
@@ -1087,7 +1090,9 @@ Required. Array of objects describing the connections.
     small
     medium
     large,
-  toId: string,
+  toTarget: 
+    string
+    object,
   type: 
     direct
     curved
@@ -1152,7 +1157,7 @@ A drop container that opens next to a target.
 
 \`\`\`javascript
 import { Drop } from 'grommet';
-<Drop control={element}>...</Drop>
+<Drop target={reference}>...</Drop>
 \`\`\`
 
 ## Properties
@@ -1181,22 +1186,6 @@ How to align the drop with respect to the target element. Defaults to \`{
 }
 \`\`\`
 
-**control**
-
-Required. Target container where the drop will be aligned.
-
-\`\`\`
-object
-\`\`\`
-
-**restrictFocus**
-
-Whether the drop should control focus.
-
-\`\`\`
-boolean
-\`\`\`
-
 **onClickOutside**
 
 Function that will be invoked when the user clicks outside the drop.
@@ -1221,6 +1210,22 @@ Whether to dynamically re-place when resized. Defaults to \`true\`.
 boolean
 \`\`\`
 
+**restrictFocus**
+
+Whether the drop should control focus.
+
+\`\`\`
+boolean
+\`\`\`
+
+**target**
+
+Required. Target where the drop will be aligned to. This should be a React reference.
+
+\`\`\`
+object
+\`\`\`
+
 **theme**
 
 Custom styles for Drop component.
@@ -1240,7 +1245,7 @@ A Button that when clicked will a Drop with the specified 'dropContent'.
 
 \`\`\`javascript
 import { DropButton } from 'grommet';
-<DropButton control={element}>{dropContents...}</DropButton>
+<DropButton dropContent={...} />
 \`\`\`
 
 ## Properties
@@ -1283,6 +1288,16 @@ Required. Content to put inside the Drop.
 
 \`\`\`
 element
+\`\`\`
+
+**dropTarget**
+
+Target where the drop will be aligned to. This should be
+      a React reference. Typically, this is not required as the drop will be
+      aligned to the DropButton itself by default.
+
+\`\`\`
+object
 \`\`\`
 
 **onClose**
@@ -1899,6 +1914,16 @@ string
 }
 \`\`\`
 
+**dropTarget**
+
+Target where the drop will be aligned to. This should be
+      a React reference. Typically, this is not required as the drop will be
+      aligned to the Menu itself by default.
+
+\`\`\`
+object
+\`\`\`
+
 **icon**
 
 Indicates the icon shown as a control to open it.
@@ -2294,7 +2319,7 @@ function
 **dropAlign**
 
 How to align the drop. Defaults to \`{
-  \\"top\\": \\"top\\",
+  \\"top\\": \\"bottom\\",
   \\"left\\": \\"left\\"
 }\`.
 
@@ -2337,6 +2362,16 @@ Size of the options container inside the Select drop.
 
 \`\`\`
 string
+\`\`\`
+
+**dropTarget**
+
+Target where the options drop will be aligned to. This should be
+      a React reference. Typically, this is not required as the drop will be
+      aligned to the Select itself by default.
+
+\`\`\`
+object
 \`\`\`
 
 **focusIndicator**
@@ -2755,6 +2790,40 @@ What text to start with in the input.
 
 \`\`\`
 string
+\`\`\`
+
+**dropAlign**
+
+How to align the drop. Defaults to \`{
+  \\"top\\": \\"top\\",
+  \\"left\\": \\"left\\"
+}\`.
+
+\`\`\`
+{
+  top: 
+    top
+    bottom,
+  bottom: 
+    top
+    bottom,
+  right: 
+    left
+    right,
+  left: 
+    left
+    right
+}
+\`\`\`
+
+**dropTarget**
+
+Target where any suggestions drop will be aligned to. This should be
+      a React reference. Typically, this is not required as the drop will be
+      aligned to the TextInput itself by default.
+
+\`\`\`
+object
 \`\`\`
 
 **id**


### PR DESCRIPTION
#### What does this PR do?

Changed Drop to rename `control` to `target`.
Changed DropButton to add `dropTarget`.
Changed Menu to add `dropTarget`.
Changed Select to add `dropTarget`.
Changed TextInput to add `dropAlign` and `dropTarget`.
Changed Diagram `connections` to have object propeties `fromTarget` and `toTarget` instead of `fromId` and `toId`.

#### Where should the reviewer start?

changed doc.js files

#### What testing has been done on this PR?

unit tests
grommet-sandbox
grommet-site

#### How should this be manually tested?

grommet-sandbox

#### Any background context you want to provide?

Aligning on the term 'target' when referring to a related DOM element.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

BREAKING CHANGE in preparation for v2 beta.
