### PR TITLE
Fixed DOM warnings for invalid property values

### DIFF
--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -54,9 +54,11 @@ class Box extends Component {
       a11yTitle,
       children,
       direction,
+      fill, // munged to avoid styled-components putting it in the DOM
       gap,
       tag,
       theme,
+      wrap, // munged to avoid styled-components putting it in the DOM
       ...rest
     } = this.props;
 
@@ -93,6 +95,8 @@ class Box extends Component {
       <StyledComponent
         aria-label={a11yTitle}
         direction={direction}
+        fillContainer={fill}
+        wrapContents={wrap}
         theme={theme}
         {...rest}
       >

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -312,13 +312,13 @@ const StyledBox = styled.div`
   ${props => props.direction && directionStyle}
   ${props => props.flex !== undefined && flexStyle}
   ${props => props.basis && basisStyle}
-  ${props => props.fill && fillStyle(props.fill)}
+  ${props => props.fillContainer && fillStyle(props.fillContainer)}
   ${props => props.gridArea && gridAreaStyle}
   ${props => props.justify && justifyStyle}
   ${props => (props.margin && edgeStyle('margin', props.margin, props.theme))}
   ${props => (props.pad && edgeStyle('padding', props.pad, props.theme))}
   ${props => props.round && roundStyle}
-  ${props => props.wrap && wrapStyle}
+  ${props => props.wrapContents && wrapStyle}
   ${props => props.responsive && responsiveStyle}
   ${props => props.overflow && `overflow: ${props.overflow};`}
   ${props => props.elevation && elevationStyle}

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -1901,25 +1901,21 @@ exports[`Box fill renders 1`] = `
       aria-label={undefined}
       className="c2"
       direction="column"
-      fill={true}
     />
     <div
       aria-label={undefined}
       className="c1"
       direction="column"
-      fill={false}
     />
     <div
       aria-label={undefined}
       className="c3"
       direction="column"
-      fill="horizontal"
     />
     <div
       aria-label={undefined}
       className="c4"
       direction="column"
-      fill="vertical"
     />
   </div>
 </div>
@@ -3016,13 +3012,11 @@ exports[`Box wrap renders 1`] = `
     aria-label={undefined}
     className="c1"
     direction="column"
-    wrap={true}
   />
   <div
     aria-label={undefined}
     className="c2"
     direction="column"
-    wrap={false}
   />
 </div>
 `;

--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -33,6 +33,7 @@ class Button extends Component {
       a11yTitle,
       children,
       icon,
+      fill, // munged to avoid styled-components putting it in the DOM
       focus,
       href,
       label,
@@ -73,6 +74,7 @@ class Button extends Component {
         aria-label={a11yTitle}
         disabled={disabled}
         icon={icon}
+        fillContainer={fill}
         focus={focus}
         href={href}
         label={label}

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -163,7 +163,7 @@ const StyledButton = styled.button`
     transition: 0.1s ease-in-out;
   `)}
   ${props => props.plain && plainStyle}
-  ${props => props.fill && fillStyle}
+  ${props => props.fillContainer && fillStyle}
   ${props => props.icon && !props.label && `
     padding: ${props.theme.global.edgeSize.small};
   `}

--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -138,7 +138,9 @@ class Calendar extends Component {
   onClickDay = dateString => () => {
     const { onSelect } = this.props;
     this.setState({ active: new Date(dateString) });
-    onSelect(dateString);
+    if (onSelect) {
+      onSelect(dateString);
+    }
   };
 
   render() {

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -48,11 +48,9 @@ exports[`play renders 1`] = `
       <div
         class="StyledBox-bStriS cMkvKv"
         direction="column"
-        fill="vertical"
       >
         <button
           class="StyledButton-gXzblK fBqgCo"
-          fill="true"
           disabled=""
           type="button"
         >
@@ -148,11 +146,9 @@ exports[`play renders 1`] = `
       <div
         class="StyledBox-bStriS cMkvKv"
         direction="column"
-        fill="vertical"
       >
         <button
           class="StyledButton-gXzblK dYRvzO"
-          fill="true"
           type="button"
         >
           <div
@@ -231,11 +227,9 @@ exports[`play renders 2`] = `
       <div
         class="StyledBox-bStriS cMkvKv"
         direction="column"
-        fill="vertical"
       >
         <button
           class="StyledButton-gXzblK dYRvzO"
-          fill="true"
           type="button"
         >
           <div
@@ -330,11 +324,9 @@ exports[`play renders 2`] = `
       <div
         class="StyledBox-bStriS cMkvKv"
         direction="column"
-        fill="vertical"
       >
         <button
           class="StyledButton-gXzblK fBqgCo"
-          fill="true"
           type="button"
           disabled=""
         >
@@ -762,7 +754,6 @@ exports[`renders 1`] = `
       aria-label={undefined}
       className="c5"
       direction="row"
-      fill={true}
       style={
         Object {
           "bottom": 0,
@@ -778,13 +769,11 @@ exports[`renders 1`] = `
         aria-label={undefined}
         className="c6"
         direction="column"
-        fill="vertical"
       >
         <button
           aria-label={undefined}
           className="c7"
           disabled={true}
-          fill="true"
           href={undefined}
           icon={undefined}
           label={undefined}
@@ -918,13 +907,11 @@ exports[`renders 1`] = `
         aria-label={undefined}
         className="c6"
         direction="column"
-        fill="vertical"
       >
         <button
           aria-label={undefined}
           className="c15"
           disabled={false}
-          fill="true"
           href={undefined}
           icon={undefined}
           label={undefined}


### PR DESCRIPTION
#### What does this PR do?

styled-components passes all legal DOM attributes into the DOM. Unfortunately, some of the values we use aren't valid in the DOM. These changes rename properties when calling the Styled* wrappers to avoid DOM injection. The Grommet API surface is unchanged.

#### Where should the reviewer start?

Box.js
Button.js

#### What testing has been done on this PR?

unit tests
grommet-site

#### How should this be manually tested?

grommet-site

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/1867
https://github.com/grommet/grommet/issues/1864

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible with v2
