### PR TITLE
Changed WorldMap to rename selectColor to hoverColor

### DIFF
--- a/src/js/components/WorldMap/WorldMap.js
+++ b/src/js/components/WorldMap/WorldMap.js
@@ -269,6 +269,7 @@ class WorldMap extends Component {
   onMouseMove = (event) => {
     const { width } = this.state;
     // determine the map coordinates for where the mouse is
+    // containerRef uses the group so we can handle aspect ratio scaling
     const rect = findDOMNode(this.containerRef).getBoundingClientRect();
     const scale = rect.width / width; // since the SVG viewBox might be scaled
     const coords = [
@@ -283,7 +284,7 @@ class WorldMap extends Component {
   }
 
   render() {
-    const { color, onSelectPlace, selectColor, theme, ...rest } = this.props;
+    const { color, onSelectPlace, hoverColor, theme, ...rest } = this.props;
     delete rest.places;
     delete rest.continents;
     const {
@@ -356,7 +357,6 @@ class WorldMap extends Component {
     });
 
     // If the caller is interested in onSelectPlace changes, track where the
-    // user goes.
     let interactiveProps = {};
     if (onSelectPlace) {
       interactiveProps = {
@@ -380,7 +380,7 @@ class WorldMap extends Component {
           <path
             strokeLinecap='round'
             strokeWidth={parseMetricToNum(theme.worldMap.place.active)}
-            stroke={colorForName(selectColor || color || 'light-4', theme)}
+            stroke={colorForName(hoverColor || color || 'light-4', theme)}
             d={d}
           />
         </g>
@@ -389,7 +389,6 @@ class WorldMap extends Component {
 
     return (
       <StyledWorldMap
-        ref={(ref) => { this.containerRef = ref; }}
         viewBox={`${x} ${y} ${width} ${height}`}
         preserveAspectRatio='xMinYMin meet'
         width={width}
@@ -397,7 +396,12 @@ class WorldMap extends Component {
         {...interactiveProps}
         {...rest}
       >
-        <g stroke='none' fill='none' fillRule='evenodd'>
+        <g
+          ref={(ref) => { this.containerRef = ref; }}
+          stroke='none'
+          fill='none'
+          fillRule='evenodd'
+        >
           {continents}
         </g>
         {places}

--- a/src/js/components/WorldMap/doc.js
+++ b/src/js/components/WorldMap/doc.js
@@ -28,7 +28,8 @@ export default (WorldMap) => {
       onClick: PropTypes.func,
       onHover: PropTypes.func,
     })).description('Place details.'),
-    selectColor: PropTypes.string.description('Color when selecting.'),
+    hoverColor: PropTypes.string
+      .description('Color when hovering over places while selecting.'),
   };
 
   return DocumentedWorldMap;


### PR DESCRIPTION
#### What does this PR do?

Changed WorldMap to rename selectColor to hoverColor to align with terms like hoverIndicator in Button.

#### Where should the reviewer start?

WorldMap/doc.js

#### What testing has been done on this PR?

grommet-sandbox

#### How should this be manually tested?

grommet-sandbox

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

yes, automatic

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

BREAKING CHANGE

Replace `<WorldMap selectColor='' />` with `<WorldMap hoverColor='' />`.