### PR TITLE
BREAKING CHANGE: Icons in the theme as opposed as embbeded in the code.

### DIFF
--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'recompose';
 
-import { LinkNext } from 'grommet-icons';
-
 import { withFocus, withTheme } from '../hocs';
 
 import StyledAnchor, { StyledIcon } from './StyledAnchor';
@@ -44,8 +42,9 @@ class Anchor extends Component {
     if (icon) {
       anchorIcon = icon;
     } else if (primary) {
+      const Icon = theme.anchor.icons.primary;
       anchorIcon = (
-        <LinkNext color={primary ? 'brand' : undefined} />
+        <Icon color={primary ? 'brand' : undefined} />
       );
     }
 

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
@@ -164,6 +164,9 @@ exports[`Anchor icon label renders 1`] = `
                 [Function],
               ],
               "fontWeight": 600,
+              "icons": Object {
+                "primary": [Function],
+              },
               "textDecoration": "none",
             },
             "button": Object {
@@ -196,6 +199,14 @@ exports[`Anchor icon label renders 1`] = `
               },
             },
             "calendar": Object {
+              "icons": Object {
+                "next": [Function],
+                "previous": [Function],
+                "small": Object {
+                  "next": [Function],
+                  "previous": [Function],
+                },
+              },
               "large": Object {
                 "daySize": "109.71428571428571px",
                 "fontSize": "36px",
@@ -213,6 +224,13 @@ exports[`Anchor icon label renders 1`] = `
                 "fontSize": "16px",
                 "lineHeight": 1.375,
                 "slideDuration": "0.2s",
+              },
+            },
+            "carousel": Object {
+              "icons": Object {
+                "current": [Function],
+                "next": [Function],
+                "previous": [Function],
               },
             },
             "checkBox": Object {
@@ -620,6 +638,11 @@ exports[`Anchor icon label renders 1`] = `
               },
               "overlayBackgroundColor": "rgba(0, 0, 0, 0.5)",
             },
+            "menu": Object {
+              "icons": Object {
+                "down": [Function],
+              },
+            },
             "paragraph": Object {
               "large": Object {
                 "height": 1.333,
@@ -665,6 +688,11 @@ exports[`Anchor icon label renders 1`] = `
                 ],
               },
             },
+            "select": Object {
+              "icons": Object {
+                "down": [Function],
+              },
+            },
             "text": Object {
               "large": Object {
                 "height": 1.167,
@@ -694,6 +722,15 @@ exports[`Anchor icon label renders 1`] = `
             "video": Object {
               "captions": Object {
                 "background": "rgba(0,0,0,0.7)",
+              },
+              "icons": Object {
+                "closedCaption": [Function],
+                "configure": [Function],
+                "fullScreen": [Function],
+                "pause": [Function],
+                "play": [Function],
+                "reduceVolume": [Function],
+                "volume": [Function],
               },
             },
             "worldMap": Object {
@@ -731,18 +768,6 @@ exports[`Anchor icon label renders 1`] = `
 `;
 
 exports[`Anchor primary renders 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #333333;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
 .c3 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -775,6 +800,18 @@ exports[`Anchor primary renders 1`] = `
 .c3 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
+}
+
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c1 {
@@ -822,6 +859,9 @@ exports[`Anchor primary renders 1`] = `
                 [Function],
               ],
               "fontWeight": 600,
+              "icons": Object {
+                "primary": [Function],
+              },
               "textDecoration": "none",
             },
             "button": Object {
@@ -854,6 +894,14 @@ exports[`Anchor primary renders 1`] = `
               },
             },
             "calendar": Object {
+              "icons": Object {
+                "next": [Function],
+                "previous": [Function],
+                "small": Object {
+                  "next": [Function],
+                  "previous": [Function],
+                },
+              },
               "large": Object {
                 "daySize": "109.71428571428571px",
                 "fontSize": "36px",
@@ -871,6 +919,13 @@ exports[`Anchor primary renders 1`] = `
                 "fontSize": "16px",
                 "lineHeight": 1.375,
                 "slideDuration": "0.2s",
+              },
+            },
+            "carousel": Object {
+              "icons": Object {
+                "current": [Function],
+                "next": [Function],
+                "previous": [Function],
               },
             },
             "checkBox": Object {
@@ -1278,6 +1333,11 @@ exports[`Anchor primary renders 1`] = `
               },
               "overlayBackgroundColor": "rgba(0, 0, 0, 0.5)",
             },
+            "menu": Object {
+              "icons": Object {
+                "down": [Function],
+              },
+            },
             "paragraph": Object {
               "large": Object {
                 "height": 1.333,
@@ -1323,6 +1383,11 @@ exports[`Anchor primary renders 1`] = `
                 ],
               },
             },
+            "select": Object {
+              "icons": Object {
+                "down": [Function],
+              },
+            },
             "text": Object {
               "large": Object {
                 "height": 1.167,
@@ -1352,6 +1417,15 @@ exports[`Anchor primary renders 1`] = `
             "video": Object {
               "captions": Object {
                 "background": "rgba(0,0,0,0.7)",
+              },
+              "icons": Object {
+                "closedCaption": [Function],
+                "configure": [Function],
+                "fullScreen": [Function],
+                "pause": [Function],
+                "play": [Function],
+                "reduceVolume": [Function],
+                "volume": [Function],
               },
             },
             "worldMap": Object {
@@ -1559,6 +1633,9 @@ exports[`Anchor reverse icon label renders 1`] = `
                 [Function],
               ],
               "fontWeight": 600,
+              "icons": Object {
+                "primary": [Function],
+              },
               "textDecoration": "none",
             },
             "button": Object {
@@ -1591,6 +1668,14 @@ exports[`Anchor reverse icon label renders 1`] = `
               },
             },
             "calendar": Object {
+              "icons": Object {
+                "next": [Function],
+                "previous": [Function],
+                "small": Object {
+                  "next": [Function],
+                  "previous": [Function],
+                },
+              },
               "large": Object {
                 "daySize": "109.71428571428571px",
                 "fontSize": "36px",
@@ -1608,6 +1693,13 @@ exports[`Anchor reverse icon label renders 1`] = `
                 "fontSize": "16px",
                 "lineHeight": 1.375,
                 "slideDuration": "0.2s",
+              },
+            },
+            "carousel": Object {
+              "icons": Object {
+                "current": [Function],
+                "next": [Function],
+                "previous": [Function],
               },
             },
             "checkBox": Object {
@@ -2015,6 +2107,11 @@ exports[`Anchor reverse icon label renders 1`] = `
               },
               "overlayBackgroundColor": "rgba(0, 0, 0, 0.5)",
             },
+            "menu": Object {
+              "icons": Object {
+                "down": [Function],
+              },
+            },
             "paragraph": Object {
               "large": Object {
                 "height": 1.333,
@@ -2060,6 +2157,11 @@ exports[`Anchor reverse icon label renders 1`] = `
                 ],
               },
             },
+            "select": Object {
+              "icons": Object {
+                "down": [Function],
+              },
+            },
             "text": Object {
               "large": Object {
                 "height": 1.167,
@@ -2089,6 +2191,15 @@ exports[`Anchor reverse icon label renders 1`] = `
             "video": Object {
               "captions": Object {
                 "background": "rgba(0,0,0,0.7)",
+              },
+              "icons": Object {
+                "closedCaption": [Function],
+                "configure": [Function],
+                "fullScreen": [Function],
+                "pause": [Function],
+                "play": [Function],
+                "reduceVolume": [Function],
+                "volume": [Function],
               },
             },
             "worldMap": Object {
@@ -2172,6 +2283,9 @@ exports[`Anchor warns about invalid icon render 1`] = `
                 [Function],
               ],
               "fontWeight": 600,
+              "icons": Object {
+                "primary": [Function],
+              },
               "textDecoration": "none",
             },
             "button": Object {
@@ -2204,6 +2318,14 @@ exports[`Anchor warns about invalid icon render 1`] = `
               },
             },
             "calendar": Object {
+              "icons": Object {
+                "next": [Function],
+                "previous": [Function],
+                "small": Object {
+                  "next": [Function],
+                  "previous": [Function],
+                },
+              },
               "large": Object {
                 "daySize": "109.71428571428571px",
                 "fontSize": "36px",
@@ -2221,6 +2343,13 @@ exports[`Anchor warns about invalid icon render 1`] = `
                 "fontSize": "16px",
                 "lineHeight": 1.375,
                 "slideDuration": "0.2s",
+              },
+            },
+            "carousel": Object {
+              "icons": Object {
+                "current": [Function],
+                "next": [Function],
+                "previous": [Function],
               },
             },
             "checkBox": Object {
@@ -2628,6 +2757,11 @@ exports[`Anchor warns about invalid icon render 1`] = `
               },
               "overlayBackgroundColor": "rgba(0, 0, 0, 0.5)",
             },
+            "menu": Object {
+              "icons": Object {
+                "down": [Function],
+              },
+            },
             "paragraph": Object {
               "large": Object {
                 "height": 1.333,
@@ -2673,6 +2807,11 @@ exports[`Anchor warns about invalid icon render 1`] = `
                 ],
               },
             },
+            "select": Object {
+              "icons": Object {
+                "down": [Function],
+              },
+            },
             "text": Object {
               "large": Object {
                 "height": 1.167,
@@ -2702,6 +2841,15 @@ exports[`Anchor warns about invalid icon render 1`] = `
             "video": Object {
               "captions": Object {
                 "background": "rgba(0,0,0,0.7)",
+              },
+              "icons": Object {
+                "closedCaption": [Function],
+                "configure": [Function],
+                "fullScreen": [Function],
+                "pause": [Function],
+                "play": [Function],
+                "reduceVolume": [Function],
+                "volume": [Function],
               },
             },
             "worldMap": Object {

--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
 import { compose } from 'recompose';
 
-import { FormPrevious, FormNext, Previous, Next } from 'grommet-icons';
-
 import { Box } from '../Box';
 import { Button } from '../Button';
 import { Keyboard } from '../Keyboard';
@@ -217,6 +215,18 @@ class Calendar extends Component {
       <StyledWeek key={day.getTime()} theme={theme}>{days}</StyledWeek>
     ));
 
+    const PreviousIcon = size === 'small' ? (
+      theme.calendar.icons.small.previous
+    ) : (
+      theme.calendar.icons.previous
+    );
+
+    const NextIcon = size === 'small' ? (
+      theme.calendar.icons.small.next
+    ) : (
+      theme.calendar.icons.next
+    );
+
     return (
       <StyledCalendar size={size} theme={theme} {...rest}>
         <Keyboard
@@ -239,14 +249,13 @@ class Calendar extends Component {
               <Box direction='row' align='center'>
                 <Button
                   a11yTitle={previousMonth.toLocaleDateString(locale, { month: 'long', year: 'numeric' })}
-                  icon={size === 'small' ?
-                    <FormPrevious /> : <Previous size={size} />}
+                  icon={<PreviousIcon size={size !== 'small' ? size : undefined} />}
                   onClick={(onSelect && betweenDates(previousMonth, bounds)) ?
                     () => this.setReference(previousMonth) : undefined}
                 />
                 <Button
                   a11yTitle={nextMonth.toLocaleDateString(locale, { month: 'long', year: 'numeric' })}
-                  icon={size === 'small' ? <FormNext /> : <Next size={size} />}
+                  icon={<NextIcon size={size !== 'small' ? size : undefined} />}
                   onClick={(onSelect && betweenDates(nextMonth, bounds)) ?
                     () => this.setReference(nextMonth) : undefined}
                 />

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -1,18 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Calendar date renders 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #333333;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
 .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -43,6 +31,18 @@ exports[`Calendar date renders 1`] = `
 .c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
+}
+
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c2 {
@@ -1577,18 +1577,6 @@ exports[`Calendar date renders 1`] = `
 `;
 
 exports[`Calendar dates renders 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #333333;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
 .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -1619,6 +1607,18 @@ exports[`Calendar dates renders 1`] = `
 .c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
+}
+
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c2 {
@@ -3155,18 +3155,6 @@ exports[`Calendar dates renders 1`] = `
 `;
 
 exports[`Calendar disabled renders 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #333333;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
 .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -3197,6 +3185,18 @@ exports[`Calendar disabled renders 1`] = `
 .c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
+}
+
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c2 {
@@ -4733,18 +4733,6 @@ exports[`Calendar disabled renders 1`] = `
 `;
 
 exports[`Calendar firstDayOfWeek renders 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #333333;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
 .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -4775,6 +4763,18 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
 .c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
+}
+
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c2 {
@@ -7526,18 +7526,6 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
 `;
 
 exports[`Calendar renders 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #333333;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
 .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -7568,6 +7556,18 @@ exports[`Calendar renders 1`] = `
 .c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
+}
+
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c2 {
@@ -9102,18 +9102,6 @@ exports[`Calendar renders 1`] = `
 `;
 
 exports[`Calendar size renders 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #333333;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
 .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -9178,6 +9166,18 @@ exports[`Calendar size renders 1`] = `
 .c26 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
+}
+
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c2 {
@@ -9704,7 +9704,11 @@ exports[`Calendar size renders 1`] = `
             className="c6"
             disabled={true}
             href={undefined}
-            icon={<FormPrevious />}
+            icon={
+              <FormPrevious
+                size={undefined}
+              />
+            }
             label={undefined}
             onBlur={[Function]}
             onClick={undefined}
@@ -9722,6 +9726,7 @@ exports[`Calendar size renders 1`] = `
                 className="c8"
                 height="24px"
                 role="img"
+                size={undefined}
                 version="1.1"
                 viewBox="0 0 24 24"
                 width="24px"
@@ -9741,7 +9746,11 @@ exports[`Calendar size renders 1`] = `
             className="c6"
             disabled={true}
             href={undefined}
-            icon={<FormNext />}
+            icon={
+              <FormNext
+                size={undefined}
+              />
+            }
             label={undefined}
             onBlur={[Function]}
             onClick={undefined}
@@ -9759,6 +9768,7 @@ exports[`Calendar size renders 1`] = `
                 className="c8"
                 height="24px"
                 role="img"
+                size={undefined}
                 version="1.1"
                 viewBox="0 0 24 24"
                 width="24px"

--- a/src/js/components/Carousel/Carousel.js
+++ b/src/js/components/Carousel/Carousel.js
@@ -1,8 +1,6 @@
 import React, { Children, Component } from 'react';
 import { compose } from 'recompose';
 
-import { Previous, Next, Subtract } from 'grommet-icons';
-
 import { Box } from '../Box';
 import { Button } from '../Button';
 import { Keyboard } from '../Keyboard';
@@ -67,19 +65,21 @@ class Carousel extends Component {
     };
 
   render() {
-    const { children } = this.props;
+    const { children, theme } = this.props;
     const { activeIndex, priorActiveIndex } = this.state;
 
     const lastIndex = Children.count(children) - 1;
     const onLeft = (activeIndex > 0 ? this.onLeft : undefined);
     const onRight = (activeIndex < lastIndex ? this.onRight : undefined);
 
+    const CurrentIcon = theme.carousel.icons.current;
+
     const selectors = [];
     const wrappedChildren = Children.map(children, (child, index) => {
       selectors.push((
         <Button
           key={index}
-          icon={<Subtract color={activeIndex === index ? 'brand' : undefined} />}
+          icon={<CurrentIcon color={activeIndex === index ? 'brand' : undefined} />}
           onClick={this.onSelect(index)}
         />
       ));
@@ -107,15 +107,18 @@ class Carousel extends Component {
       );
     });
 
+    const NextIcon = theme.carousel.icons.next;
+    const PreviousIcon = theme.carousel.icons.previous;
+
     return (
       <Keyboard onLeft={onLeft} onRight={onRight}>
-        <Stack guidingChild={activeIndex} tabIndex='0'>
+        <Stack guidingChild={activeIndex}>
           {wrappedChildren}
           <Box fill={true} direction='row' justify='between'>
             <Box fill='vertical'>
               <Button fill='true' onClick={onLeft} hoverIndicator={true}>
                 <Box justify='center'>
-                  <Previous />
+                  <PreviousIcon />
                 </Box>
               </Button>
             </Box>
@@ -127,7 +130,7 @@ class Carousel extends Component {
             <Box fill='vertical'>
               <Button fill='true' onClick={onRight} hoverIndicator={true}>
                 <Box justify='center'>
-                  <Next />
+                  <NextIcon />
                 </Box>
               </Button>
             </Box>

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -6,7 +6,6 @@ exports[`play renders 1`] = `
 >
   <div
     class="StyledStack-jqCQsC ewABiA"
-    tabindex="0"
   >
     <div
       class="StyledBox-bStriS hLXGcf"
@@ -185,7 +184,6 @@ exports[`play renders 2`] = `
 >
   <div
     class="StyledStack-jqCQsC ewABiA"
-    tabindex="0"
   >
     <div
       class="StyledBox-bStriS hLXGcf"
@@ -359,18 +357,6 @@ exports[`play renders 2`] = `
 `;
 
 exports[`renders 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #333333;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
 .c9 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -435,6 +421,18 @@ exports[`renders 1`] = `
 .c14 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
+}
+
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c2 {
@@ -795,7 +793,6 @@ exports[`renders 1`] = `
   <div
     className="c1"
     onKeyDown={[Function]}
-    tabIndex="0"
   >
     <div
       aria-label={undefined}

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
-
-import { FormDown } from 'grommet-icons';
+import { compose } from 'recompose';
 
 import { Box } from '../Box';
 import { Button } from '../Button';
 import { Keyboard } from '../Keyboard';
 import { DropButton } from '../DropButton';
+
+import { withTheme } from '../hocs';
 
 import doc from './doc';
 
@@ -74,17 +75,18 @@ class Menu extends Component {
   render() {
     const {
       dropAlign,
+      dropBackground,
       dropTarget,
-      icon,
       items,
       label,
       messages,
       onKeyDown,
+      theme,
       ...rest
     } = this.props;
     const { activeItemIndex, open } = this.state;
 
-    const menuIcon = icon || <FormDown />;
+    const MenuIcon = theme.menu.icons.down;
 
     const content = (
       <Box
@@ -95,7 +97,7 @@ class Menu extends Component {
         gap='small'
       >
         {label}
-        {menuIcon}
+        <MenuIcon />
       </Box>
     );
 
@@ -122,6 +124,7 @@ class Menu extends Component {
         <div>
           <DropButton
             {...rest}
+            theme={theme}
             a11yTitle={messages.openMenu || 'Open Menu'}
             dropAlign={dropAlign}
             dropTarget={dropTarget}
@@ -129,7 +132,7 @@ class Menu extends Component {
             onOpen={() => this.setState({ open: true })}
             onClose={() => this.setState({ open: false })}
             dropContent={
-              <Box>
+              <Box background={dropBackground}>
                 {dropAlign.top === 'top' ? controlMirror : undefined}
                 <Box>
                   {items.map(
@@ -172,4 +175,6 @@ if (process.env.NODE_ENV !== 'production') {
   doc(Menu);
 }
 
-export default Menu;
+export default compose(
+  withTheme,
+)(Menu);

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -125,6 +125,13 @@ exports[`Menu opens and closes on click 2`] = `
 }
 
 @media only screen and (min-width:700px) {
+  .etLvGo {
+    -webkit-transition: 0.1s ease-in-out;
+    transition: 0.1s ease-in-out;
+  }
+}
+
+@media only screen and (min-width:700px) {
   .kGZImI {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
@@ -186,17 +193,18 @@ exports[`Menu opens and closes on click 2`] = `
 exports[`Menu renders 1`] = `
 <div>
   <button
-    class="StyledButton-gXzblK kGZImI"
+    class="StyledButton-gXzblK etLvGo"
     id="test-menu"
     aria-label="Open Menu"
+    icon="[object Object]"
     type="button"
   >
-    <div
-      class="StyledBox-bStriS fpUbgn"
-      direction="row"
+    <span
+      class="StyledButton__StyledIcon-kzdZcp bhmqMt"
+      aria-hidden="true"
     >
       <svg />
-    </div>
+    </span>
   </button>
 </div>
 `;
@@ -349,6 +357,13 @@ exports[`Menu with dropAlign renders 2`] = `
 @media only screen and (max-width:699px) {
   .dUuKPc {
     padding: 4px;
+  }
+}
+
+@media only screen and (min-width:700px) {
+  .etLvGo {
+    -webkit-transition: 0.1s ease-in-out;
+    transition: 0.1s ease-in-out;
   }
 }
 

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
-
-import { FormDown } from 'grommet-icons';
+import { compose } from 'recompose';
 
 import { Box } from '../Box';
 import { DropButton } from '../DropButton';
 import { Keyboard } from '../Keyboard';
 import { TextInput } from '../TextInput';
+
+import { withTheme } from '../hocs';
 
 import SelectContainer from './SelectContainer';
 import doc from './doc';
@@ -39,6 +40,7 @@ class Select extends Component {
       onClose,
       placeholder,
       plain,
+      theme,
       value,
       ...rest
     } = this.props;
@@ -50,6 +52,8 @@ class Select extends Component {
         onChange(event, ...args);
       }
     };
+
+    const SelectIcon = theme.select.icons.down;
 
     return (
       <Keyboard onDown={this.onOpen} onUp={this.onOpen}>
@@ -88,7 +92,7 @@ class Select extends Component {
               flex={false}
               style={{ minWidth: 'auto' }}
             >
-              <FormDown />
+              <SelectIcon />
             </Box>
           </Box>
         </DropButton>
@@ -101,4 +105,6 @@ if (process.env.NODE_ENV !== 'production') {
   doc(Select);
 }
 
-export default Select;
+export default compose(
+  withTheme,
+)(Select);

--- a/src/js/components/Video/Video.js
+++ b/src/js/components/Video/Video.js
@@ -3,7 +3,6 @@ import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import { compose } from 'recompose';
 
-import { Actions, ClosedCaption, Expand, Play, Pause, Volume, VolumeLow } from 'grommet-icons';
 import { Box } from '../Box';
 import { Button } from '../Button';
 import { Menu } from '../Menu';
@@ -243,7 +242,7 @@ class Video extends Component {
   }
 
   renderControls() {
-    const { controls } = this.props;
+    const { controls, theme } = this.props;
     const {
       currentTime, duration, interacting,
       percentagePlayed, playing, scrubTime, volume,
@@ -254,6 +253,16 @@ class Video extends Component {
 
     const formattedTime = formatTime(scrubTime || currentTime || duration);
 
+    const Icons = {
+      ClosedCaption: theme.video.icons.closedCaption,
+      Configure: theme.video.icons.configure,
+      FullScreen: theme.video.icons.fullScreen,
+      Pause: theme.video.icons.pause,
+      Play: theme.video.icons.play,
+      ReduceVolume: theme.video.icons.reduceVolume,
+      Volume: theme.video.icons.volume,
+    };
+
     const captionControls = [];
     if (this.videoRef) {
       const textTracks = findDOMNode(this.videoRef).textTracks;
@@ -261,7 +270,7 @@ class Video extends Component {
         if (textTracks.length === 1) {
           const active = textTracks[0].mode === 'showing';
           captionControls.push({
-            icon: <ClosedCaption color={iconColor} />,
+            icon: <Icons.ClosedCaption color={iconColor} />,
             active,
             onClick: () => this.showCaptions(active ? -1 : 0),
           });
@@ -291,7 +300,7 @@ class Video extends Component {
           background={background}
         >
           <Button
-            icon={playing ? <Pause color={iconColor} /> : <Play color={iconColor} />}
+            icon={playing ? <Icons.Pause color={iconColor} /> : <Icons.Play color={iconColor} />}
             hoverIndicator='background'
             onClick={playing ? this.pause : this.play}
           />
@@ -322,23 +331,23 @@ class Video extends Component {
             </Box>
           </Box>
           <Menu
-            icon={<Actions color={iconColor} />}
+            icon={<Icons.Configure color={iconColor} />}
             dropAlign={{ bottom: 'top', right: 'right' }}
-            background={background || { color: 'light-2', opacity: 'weak' }}
+            dropBackground={background}
             items={[
               {
-                icon: <Volume color={iconColor} />,
+                icon: <Icons.Volume color={iconColor} />,
                 onClick: (volume <= (1 - VOLUME_STEP) ? this.louder : undefined),
                 close: false,
               },
               {
-                icon: <VolumeLow color={iconColor} />,
+                icon: <Icons.ReduceVolume color={iconColor} />,
                 onClick: (volume >= VOLUME_STEP ? this.quieter : undefined),
                 close: false,
               },
               ...captionControls,
               {
-                icon: <Expand color={iconColor} />,
+                icon: <Icons.FullScreen color={iconColor} />,
                 onClick: this.fullscreen,
               },
             ]}

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -1,18 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Video autoPlay renders 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #333333;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
 .c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -45,6 +33,18 @@ exports[`Video autoPlay renders 1`] = `
 .c7 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
+}
+
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c4 {
@@ -128,29 +128,6 @@ exports[`Video autoPlay renders 1`] = `
   padding-right: 12px;
 }
 
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  margin: 0;
-  padding: 12px;
-}
-
 .c5 {
   box-sizing: border-box;
   cursor: pointer;
@@ -191,6 +168,7 @@ exports[`Video autoPlay renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c6 {
@@ -314,18 +292,6 @@ exports[`Video autoPlay renders 1`] = `
   .c13 {
     padding-left: 4px;
     padding-right: 4px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c16 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c16 {
-    padding: 4px;
   }
 }
 
@@ -508,7 +474,11 @@ exports[`Video autoPlay renders 1`] = `
             className="c15"
             disabled={false}
             href={undefined}
-            icon={undefined}
+            icon={
+              <Actions
+                color="light-1"
+              />
+            }
             id={undefined}
             label={undefined}
             onBlur={[Function]}
@@ -518,10 +488,9 @@ exports[`Video autoPlay renders 1`] = `
             onMouseUp={[Function]}
             type="button"
           >
-            <div
-              aria-label={undefined}
-              className="c16"
-              direction="row"
+            <span
+              aria-hidden={true}
+              className="c6"
             >
               <svg
                 aria-label="Actions"
@@ -540,7 +509,7 @@ exports[`Video autoPlay renders 1`] = `
                   strokeWidth="2"
                 />
               </svg>
-            </div>
+            </span>
           </button>
         </div>
       </div>
@@ -550,18 +519,6 @@ exports[`Video autoPlay renders 1`] = `
 `;
 
 exports[`Video controls renders 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #333333;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
 .c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -596,7 +553,7 @@ exports[`Video controls renders 1`] = `
   stroke: none;
 }
 
-.c19 {
+.c18 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -605,27 +562,39 @@ exports[`Video controls renders 1`] = `
   stroke: #666666;
 }
 
-.c19 g {
+.c18 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c19 *:not([stroke])[fill="none"] {
+.c18 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c19 *[stroke*="#"],
-.c19 *[STROKE*="#"] {
+.c18 *[stroke*="#"],
+.c18 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c19 *[fill-rule],
-.c19 *[FILL-RULE],
-.c19 *[fill*="#"],
-.c19 *[FILL*="#"] {
+.c18 *[fill-rule],
+.c18 *[FILL-RULE],
+.c18 *[fill*="#"],
+.c18 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
+}
+
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c4 {
@@ -709,30 +678,7 @@ exports[`Video controls renders 1`] = `
   padding-right: 12px;
 }
 
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  margin: 0;
-  padding: 12px;
-}
-
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -795,6 +741,7 @@ exports[`Video controls renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c6 {
@@ -868,7 +815,7 @@ exports[`Video controls renders 1`] = `
   opacity: 1;
 }
 
-.c17 {
+.c16 {
   -webkit-flex: 0 0;
   -ms-flex: 0 0;
   flex: 0 0;
@@ -932,25 +879,13 @@ exports[`Video controls renders 1`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .c16 {
+  .c17 {
     margin: 0;
   }
 }
 
 @media only screen and (max-width:699px) {
-  .c16 {
-    padding: 4px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c18 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c18 {
+  .c17 {
     padding: 0;
   }
 }
@@ -1134,7 +1069,11 @@ exports[`Video controls renders 1`] = `
             className="c15"
             disabled={false}
             href={undefined}
-            icon={undefined}
+            icon={
+              <Actions
+                color="light-1"
+              />
+            }
             id={undefined}
             label={undefined}
             onBlur={[Function]}
@@ -1144,10 +1083,9 @@ exports[`Video controls renders 1`] = `
             onMouseUp={[Function]}
             type="button"
           >
-            <div
-              aria-label={undefined}
-              className="c16"
-              direction="row"
+            <span
+              aria-hidden={true}
+              className="c6"
             >
               <svg
                 aria-label="Actions"
@@ -1166,7 +1104,7 @@ exports[`Video controls renders 1`] = `
                   strokeWidth="2"
                 />
               </svg>
-            </div>
+            </span>
           </button>
         </div>
       </div>
@@ -1208,11 +1146,11 @@ exports[`Video controls renders 1`] = `
       <track />
     </video>
     <div
-      className="c17"
+      className="c16"
     >
       <div
         aria-label={undefined}
-        className="c18"
+        className="c17"
         direction="row"
       >
         <button
@@ -1239,7 +1177,7 @@ exports[`Video controls renders 1`] = `
           >
             <svg
               aria-label="Play"
-              className="c19"
+              className="c18"
               color={undefined}
               height="24px"
               role="img"
@@ -1332,7 +1270,11 @@ exports[`Video controls renders 1`] = `
             className="c15"
             disabled={false}
             href={undefined}
-            icon={undefined}
+            icon={
+              <Actions
+                color={undefined}
+              />
+            }
             id={undefined}
             label={undefined}
             onBlur={[Function]}
@@ -1342,14 +1284,13 @@ exports[`Video controls renders 1`] = `
             onMouseUp={[Function]}
             type="button"
           >
-            <div
-              aria-label={undefined}
-              className="c16"
-              direction="row"
+            <span
+              aria-hidden={true}
+              className="c6"
             >
               <svg
                 aria-label="Actions"
-                className="c19"
+                className="c18"
                 color={undefined}
                 height="24px"
                 role="img"
@@ -1364,7 +1305,7 @@ exports[`Video controls renders 1`] = `
                   strokeWidth="2"
                 />
               </svg>
-            </div>
+            </span>
           </button>
         </div>
       </div>
@@ -1374,18 +1315,6 @@ exports[`Video controls renders 1`] = `
 `;
 
 exports[`Video fit renders 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #333333;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
 .c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -1418,6 +1347,18 @@ exports[`Video fit renders 1`] = `
 .c7 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
+}
+
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c4 {
@@ -1501,29 +1442,6 @@ exports[`Video fit renders 1`] = `
   padding-right: 12px;
 }
 
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  margin: 0;
-  padding: 12px;
-}
-
 .c5 {
   box-sizing: border-box;
   cursor: pointer;
@@ -1564,6 +1482,7 @@ exports[`Video fit renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c6 {
@@ -1613,7 +1532,7 @@ exports[`Video fit renders 1`] = `
   background: rgba(0,0,0,0.7);
 }
 
-.c17 {
+.c16 {
   max-width: 100%;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
@@ -1622,7 +1541,7 @@ exports[`Video fit renders 1`] = `
   object-fit: contain;
 }
 
-.c17::cue {
+.c16::cue {
   background: rgba(0,0,0,0.7);
 }
 
@@ -1705,18 +1624,6 @@ exports[`Video fit renders 1`] = `
   .c13 {
     padding-left: 4px;
     padding-right: 4px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c16 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c16 {
-    padding: 4px;
   }
 }
 
@@ -1899,7 +1806,11 @@ exports[`Video fit renders 1`] = `
             className="c15"
             disabled={false}
             href={undefined}
-            icon={undefined}
+            icon={
+              <Actions
+                color="light-1"
+              />
+            }
             id={undefined}
             label={undefined}
             onBlur={[Function]}
@@ -1909,10 +1820,9 @@ exports[`Video fit renders 1`] = `
             onMouseUp={[Function]}
             type="button"
           >
-            <div
-              aria-label={undefined}
-              className="c16"
-              direction="row"
+            <span
+              aria-hidden={true}
+              className="c6"
             >
               <svg
                 aria-label="Actions"
@@ -1931,7 +1841,7 @@ exports[`Video fit renders 1`] = `
                   strokeWidth="2"
                 />
               </svg>
-            </div>
+            </span>
           </button>
         </div>
       </div>
@@ -1946,7 +1856,7 @@ exports[`Video fit renders 1`] = `
   >
     <video
       autoPlay={false}
-      className="c17"
+      className="c16"
       loop={false}
       onAbort={[Function]}
       onCanPlay={[Function]}
@@ -2099,7 +2009,11 @@ exports[`Video fit renders 1`] = `
             className="c15"
             disabled={false}
             href={undefined}
-            icon={undefined}
+            icon={
+              <Actions
+                color="light-1"
+              />
+            }
             id={undefined}
             label={undefined}
             onBlur={[Function]}
@@ -2109,10 +2023,9 @@ exports[`Video fit renders 1`] = `
             onMouseUp={[Function]}
             type="button"
           >
-            <div
-              aria-label={undefined}
-              className="c16"
-              direction="row"
+            <span
+              aria-hidden={true}
+              className="c6"
             >
               <svg
                 aria-label="Actions"
@@ -2131,7 +2044,7 @@ exports[`Video fit renders 1`] = `
                   strokeWidth="2"
                 />
               </svg>
-            </div>
+            </span>
           </button>
         </div>
       </div>
@@ -2141,18 +2054,6 @@ exports[`Video fit renders 1`] = `
 `;
 
 exports[`Video loop renders 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #333333;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
 .c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -2185,6 +2086,18 @@ exports[`Video loop renders 1`] = `
 .c7 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
+}
+
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c4 {
@@ -2268,29 +2181,6 @@ exports[`Video loop renders 1`] = `
   padding-right: 12px;
 }
 
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  margin: 0;
-  padding: 12px;
-}
-
 .c5 {
   box-sizing: border-box;
   cursor: pointer;
@@ -2331,6 +2221,7 @@ exports[`Video loop renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c6 {
@@ -2454,18 +2345,6 @@ exports[`Video loop renders 1`] = `
   .c13 {
     padding-left: 4px;
     padding-right: 4px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c16 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c16 {
-    padding: 4px;
   }
 }
 
@@ -2648,7 +2527,11 @@ exports[`Video loop renders 1`] = `
             className="c15"
             disabled={false}
             href={undefined}
-            icon={undefined}
+            icon={
+              <Actions
+                color="light-1"
+              />
+            }
             id={undefined}
             label={undefined}
             onBlur={[Function]}
@@ -2658,10 +2541,9 @@ exports[`Video loop renders 1`] = `
             onMouseUp={[Function]}
             type="button"
           >
-            <div
-              aria-label={undefined}
-              className="c16"
-              direction="row"
+            <span
+              aria-hidden={true}
+              className="c6"
             >
               <svg
                 aria-label="Actions"
@@ -2680,7 +2562,7 @@ exports[`Video loop renders 1`] = `
                   strokeWidth="2"
                 />
               </svg>
-            </div>
+            </span>
           </button>
         </div>
       </div>
@@ -2690,18 +2572,6 @@ exports[`Video loop renders 1`] = `
 `;
 
 exports[`Video mute renders 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #333333;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
 .c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -2734,6 +2604,18 @@ exports[`Video mute renders 1`] = `
 .c7 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
+}
+
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c4 {
@@ -2817,29 +2699,6 @@ exports[`Video mute renders 1`] = `
   padding-right: 12px;
 }
 
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  margin: 0;
-  padding: 12px;
-}
-
 .c5 {
   box-sizing: border-box;
   cursor: pointer;
@@ -2880,6 +2739,7 @@ exports[`Video mute renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c6 {
@@ -3003,18 +2863,6 @@ exports[`Video mute renders 1`] = `
   .c13 {
     padding-left: 4px;
     padding-right: 4px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c16 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c16 {
-    padding: 4px;
   }
 }
 
@@ -3197,7 +3045,11 @@ exports[`Video mute renders 1`] = `
             className="c15"
             disabled={false}
             href={undefined}
-            icon={undefined}
+            icon={
+              <Actions
+                color="light-1"
+              />
+            }
             id={undefined}
             label={undefined}
             onBlur={[Function]}
@@ -3207,10 +3059,9 @@ exports[`Video mute renders 1`] = `
             onMouseUp={[Function]}
             type="button"
           >
-            <div
-              aria-label={undefined}
-              className="c16"
-              direction="row"
+            <span
+              aria-hidden={true}
+              className="c6"
             >
               <svg
                 aria-label="Actions"
@@ -3229,7 +3080,7 @@ exports[`Video mute renders 1`] = `
                   strokeWidth="2"
                 />
               </svg>
-            </div>
+            </span>
           </button>
         </div>
       </div>
@@ -3239,18 +3090,6 @@ exports[`Video mute renders 1`] = `
 `;
 
 exports[`Video renders 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #333333;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
 .c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -3283,6 +3122,18 @@ exports[`Video renders 1`] = `
 .c7 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
+}
+
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #333333;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c4 {
@@ -3366,29 +3217,6 @@ exports[`Video renders 1`] = `
   padding-right: 12px;
 }
 
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  margin: 0;
-  padding: 12px;
-}
-
 .c5 {
   box-sizing: border-box;
   cursor: pointer;
@@ -3429,6 +3257,7 @@ exports[`Video renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c6 {
@@ -3552,18 +3381,6 @@ exports[`Video renders 1`] = `
   .c13 {
     padding-left: 4px;
     padding-right: 4px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c16 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c16 {
-    padding: 4px;
   }
 }
 
@@ -3746,7 +3563,11 @@ exports[`Video renders 1`] = `
             className="c15"
             disabled={false}
             href={undefined}
-            icon={undefined}
+            icon={
+              <Actions
+                color="light-1"
+              />
+            }
             id={undefined}
             label={undefined}
             onBlur={[Function]}
@@ -3756,10 +3577,9 @@ exports[`Video renders 1`] = `
             onMouseUp={[Function]}
             type="button"
           >
-            <div
-              aria-label={undefined}
-              className="c16"
-              direction="row"
+            <span
+              aria-hidden={true}
+              className="c6"
             >
               <svg
                 aria-label="Actions"
@@ -3778,7 +3598,7 @@ exports[`Video renders 1`] = `
                   strokeWidth="2"
                 />
               </svg>
-            </div>
+            </span>
           </button>
         </div>
       </div>

--- a/src/js/themes/vanilla.js
+++ b/src/js/themes/vanilla.js
@@ -1,6 +1,23 @@
 import { rgba } from 'polished';
 import { css } from 'styled-components';
 
+import {
+  Actions,
+  ClosedCaption,
+  Expand,
+  FormDown,
+  FormNext,
+  FormPrevious,
+  LinkNext,
+  Next,
+  Pause,
+  Play,
+  Previous,
+  Subtract,
+  Volume,
+  VolumeLow,
+} from 'grommet-icons';
+
 import { colorForName, deepFreeze } from '../utils';
 
 const brandColor = '#865CD6';
@@ -212,6 +229,9 @@ export default deepFreeze({
     textDecoration: 'none',
     fontWeight: 600,
     color: css`${props => props.theme.global.colors.brand}`,
+    icons: {
+      primary: LinkNext,
+    },
   },
   button: {
     border: {
@@ -250,6 +270,21 @@ export default deepFreeze({
       lineHeight: 1.11,
       daySize: `${(baseSpacing * 32) / 7}px`,
       slideDuration: '0.8s',
+    },
+    icons: {
+      previous: Previous,
+      next: Next,
+      small: {
+        previous: FormPrevious,
+        next: FormNext,
+      },
+    },
+  },
+  carousel: {
+    icons: {
+      current: Subtract,
+      next: Next,
+      previous: Previous,
     },
   },
   checkBox: {
@@ -368,6 +403,11 @@ export default deepFreeze({
     },
     overlayBackgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
+  menu: {
+    icons: {
+      down: FormDown,
+    },
+  },
   paragraph: {
     // maxWidth chosen to be ~50 characters wide
     // see: https://ux.stackexchange.com/a/34125
@@ -395,6 +435,11 @@ export default deepFreeze({
       color: css`${props => rgba(props.theme.global.colors.text, 0.2)}`,
     },
   },
+  select: {
+    icons: {
+      down: FormDown,
+    },
+  },
   text: {
     medium: { size: '16px', height: 1.375 },
     xsmall: { size: '12px', height: 1.5 },
@@ -406,6 +451,15 @@ export default deepFreeze({
   video: {
     captions: {
       background: rgba(0, 0, 0, 0.7),
+    },
+    icons: {
+      closedCaption: ClosedCaption,
+      configure: Actions,
+      fullScreen: Expand,
+      pause: Pause,
+      play: Play,
+      reduceVolume: VolumeLow,
+      volume: Volume,
     },
   },
   worldMap: {


### PR DESCRIPTION
#### What does this PR do?

Transfer all icons to the theme instead of embedding them inside the component

#### How should this be manually tested?

I believe it is a good idea to test the following components:

anchor, calendar, carousel, menu, select, video

#### Do the grommet docs need to be updated?

Yes

#### Should this PR be mentioned in the release notes?

Yes

#### Is this change backwards compatible or is it a breaking change?

This is a breaking change since Menu does not have the `icon` prop anymore.
