### PR TITLE
Changed Button to set disabled opacity from theme

### DIFF
--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
@@ -188,6 +188,9 @@ exports[`Anchor icon label renders 1`] = `
                   [Function],
                 ],
               },
+              "disabled": Object {
+                "opacity": 0.3,
+              },
               "maxWidth": "384px",
               "minWidth": "96px",
               "padding": Object {
@@ -1018,6 +1021,9 @@ exports[`Anchor reverse icon label renders 1`] = `
                   [Function],
                 ],
               },
+              "disabled": Object {
+                "opacity": 0.3,
+              },
               "maxWidth": "384px",
               "minWidth": "96px",
               "padding": Object {
@@ -1690,6 +1696,9 @@ exports[`Anchor warns about invalid icon render 1`] = `
                 "text": Array [
                   [Function],
                 ],
+              },
+              "disabled": Object {
+                "opacity": 0.3,
               },
               "maxWidth": "384px",
               "minWidth": "96px",

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -24,8 +24,8 @@ const primaryStyle = props => css`
   }
 `;
 
-const disabledStyle = `
-  opacity: 0.3;
+const disabledStyle = css`
+  opacity: ${props => props.theme.button.disabled.opacity};
   cursor: default;
 `;
 

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -50,7 +50,7 @@ exports[`play renders 1`] = `
         direction="column"
       >
         <button
-          class="StyledButton-gXzblK jZsiZy"
+          class="StyledButton-gXzblK erxOgR"
           disabled=""
           type="button"
         >
@@ -326,7 +326,7 @@ exports[`play renders 2`] = `
         direction="column"
       >
         <button
-          class="StyledButton-gXzblK jZsiZy"
+          class="StyledButton-gXzblK erxOgR"
           type="button"
           disabled=""
         >

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -54,7 +54,7 @@ exports[`Menu opens and closes on click 1`] = `
       direction="column"
     >
       <button
-        class="StyledButton-gXzblK dDrPei"
+        class="StyledButton-gXzblK gqMHaF"
         disabled=""
         type="button"
       >
@@ -151,7 +151,7 @@ exports[`Menu opens and closes on click 2`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .dDrPei {
+  .gqMHaF {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -310,7 +310,7 @@ exports[`Menu with dropAlign renders 1`] = `
       direction="column"
     >
       <button
-        class="StyledButton-gXzblK dDrPei"
+        class="StyledButton-gXzblK gqMHaF"
         disabled=""
         type="button"
       >
@@ -322,7 +322,7 @@ exports[`Menu with dropAlign renders 1`] = `
         </div>
       </button>
       <button
-        class="StyledButton-gXzblK dDrPei"
+        class="StyledButton-gXzblK gqMHaF"
         disabled=""
         type="button"
       >
@@ -397,7 +397,7 @@ exports[`Menu with dropAlign renders 2`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .dDrPei {
+  .gqMHaF {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }

--- a/src/js/themes/vanilla.js
+++ b/src/js/themes/vanilla.js
@@ -242,6 +242,9 @@ export default deepFreeze({
       secondary: css`${props => colorForName('neutral-2', props.theme)}`,
       text: css`${props => props.theme.global.colors.text}`,
     },
+    disabled: {
+      opacity: 0.3,
+    },
     minWidth: `${baseSpacing * 4}px`,
     maxWidth: `${baseSpacing * 16}px`,
     padding: {


### PR DESCRIPTION
#### What does this PR do?

Changed Button to set disabled opacity from theme.

#### Where should the reviewer start?

vanilla.js

#### What testing has been done on this PR?

grommet-sandbox

#### How should this be manually tested?

grommet-sandbox

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/1913

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible with v2
