### PR TITLE
 Changed FormField to make more themable

### DIFF
--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
@@ -330,6 +330,23 @@ exports[`Anchor icon label renders 1`] = `
                 },
               },
             },
+            "formField": Object {
+              "border": Object {
+                "color": "border",
+                "error": Object {
+                  "color": "status-critical",
+                },
+                "position": "inner",
+                "side": "bottom",
+              },
+              "error": Object {
+                "color": "status-critical",
+              },
+              "help": Object {
+                "color": "dark-5",
+              },
+              "label": Object {},
+            },
             "global": Object {
               "animation": Object {
                 "duration": "1s",
@@ -1160,6 +1177,23 @@ exports[`Anchor reverse icon label renders 1`] = `
                 },
               },
             },
+            "formField": Object {
+              "border": Object {
+                "color": "border",
+                "error": Object {
+                  "color": "status-critical",
+                },
+                "position": "inner",
+                "side": "bottom",
+              },
+              "error": Object {
+                "color": "status-critical",
+              },
+              "help": Object {
+                "color": "dark-5",
+              },
+              "label": Object {},
+            },
             "global": Object {
               "animation": Object {
                 "duration": "1s",
@@ -1832,6 +1866,23 @@ exports[`Anchor warns about invalid icon render 1`] = `
                   },
                 },
               },
+            },
+            "formField": Object {
+              "border": Object {
+                "color": "border",
+                "error": Object {
+                  "color": "status-critical",
+                },
+                "position": "inner",
+                "side": "bottom",
+              },
+              "error": Object {
+                "color": "status-critical",
+              },
+              "help": Object {
+                "color": "dark-5",
+              },
+              "label": Object {},
             },
             "global": Object {
               "animation": Object {

--- a/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
+++ b/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
@@ -100,7 +100,7 @@ exports[`DropButton mounts 6`] = `
 
 exports[`DropButton mounts disabled 1`] = `
 <button
-  class="StyledButton-gXzblK cJvOXL"
+  class="StyledButton-gXzblK dUzCdF"
   aria-label="Open Drop"
   disabled=""
   label="Dropper"

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -12,15 +12,13 @@ import { withTheme } from '../hocs';
 import doc from './doc';
 
 class FormField extends Component {
-  static defaultProps = {
-    border: { color: 'border', position: 'inner', side: 'bottom' },
-  }
-
   state = {};
 
   render() {
-    const { border, children, error, help, label, style, theme,
+    const { children, error, help, htmlFor, label, style, theme,
       ...rest } = this.props;
+    const { formField } = theme;
+    const { border } = formField;
     const { focus } = this.state;
 
     let contents = children;
@@ -36,9 +34,9 @@ class FormField extends Component {
     };
     let borderColor;
     if (focus) {
-      borderColor = 'accent-1';
+      borderColor = theme.global.focus.border.color;
     } else if (error) {
-      borderColor = 'status-critical';
+      borderColor = formField.border.error.color || 'status-critical';
     } else {
       borderColor = (border ? (border.color || 'border') : 'border');
     }
@@ -101,17 +99,20 @@ class FormField extends Component {
             margin={{ vertical: 'xsmall', horizontal: 'small' }}
             gap='xsmall'
           >
-            {label ? <Text>{label}</Text> : undefined}
-            {help ? <Text color='dark-5'>{help}</Text> : undefined}
+            {label ? (
+              <Text tag='label' htmlFor={htmlFor} {...formField.label}>
+                {label}
+              </Text>
+            ) : undefined}
+            {help ? (
+              <Text {...formField.help}>{help}</Text>
+            ) : undefined}
           </Box>
         ) : undefined}
         {contents}
         {error ? (
-          <Box
-            justify='between'
-            margin={{ vertical: 'xsmall', horizontal: 'small' }}
-          >
-            <Text color='status-critical'>{error}</Text>
+          <Box margin={{ vertical: 'xsmall', horizontal: 'small' }} >
+            <Text {...formField.error}>{error}</Text>
           </Box>
         ) : undefined}
       </Box>

--- a/src/js/components/FormField/README.md
+++ b/src/js/components/FormField/README.md
@@ -11,49 +11,27 @@ import { FormField } from 'grommet';
 
 ## Properties
 
-**border**
-
-What sort of border to use. Setting this to false
-      will not show any border and will leave the focus indicator to
-      the children. Defaults to `{
-  "color": "border",
-  "position": "inner",
-  "side": "bottom"
-}`.
-
-```
-boolean
-{
-  color: string,
-  position: 
-    outer
-    inner,
-  side: 
-    top
-    left
-    bottom
-    right
-    horizontal
-    vertical
-    all,
-  size: 
-    small
-    medium
-    large
-}
-```
-
 **error**
 
 Any error text describing issues with the field
 
 ```
 string
+node
 ```
 
 **help**
 
 Any help text describing how the field works
+
+```
+string
+node
+```
+
+**htmlFor**
+
+The id of the input element contained in this field
 
 ```
 string
@@ -65,5 +43,6 @@ A short label describing the field
 
 ```
 string
+node
 ```
   

--- a/src/js/components/FormField/__tests__/FormField-test.js
+++ b/src/js/components/FormField/__tests__/FormField-test.js
@@ -47,16 +47,10 @@ test('renders error', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('renders border', () => {
+test('renders htmlFor', () => {
   const component = renderer.create(
     <Grommet>
-      {['inner', 'outer'].map(position =>
-        ['all', 'bottom', 'left', 'vertical'].map(side =>
-          ['xsmall', 'small', 'medium', 'large'].map(size => (
-            <FormField border={{ position, side, size }} />
-          ))
-        )
-      )}
+      <FormField htmlFor='test-id' />
     </Grommet>
   );
   const tree = component.toJSON();

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -165,1581 +165,6 @@ exports[`renders 1`] = `
 </div>
 `;
 
-exports[`renders border 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #444444;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin-bottom: 12px;
-  padding: 0;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border: solid 2px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border: solid 4px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border: solid 12px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-bottom: solid 2px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-bottom: solid 4px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-bottom: solid 12px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-left: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-left: solid 2px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-left: solid 4px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c13 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-left: solid 12px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-left: solid 1px rgba(0,0,0,0.33);
-  border-right: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-left: solid 2px rgba(0,0,0,0.33);
-  border-right: solid 2px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-left: solid 4px rgba(0,0,0,0.33);
-  border-right: solid 4px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-left: solid 12px rgba(0,0,0,0.33);
-  border-right: solid 12px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin-bottom: 12px;
-  padding: 0;
-}
-
-.c20 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-bottom: solid 2px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin-bottom: 12px;
-  padding: 0;
-}
-
-.c21 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-bottom: solid 4px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin-bottom: 12px;
-  padding: 0;
-}
-
-.c22 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-bottom: solid 12px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin-bottom: 12px;
-  padding: 0;
-}
-
-.c23 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-left: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin-bottom: 12px;
-  padding: 0;
-}
-
-.c24 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-left: solid 2px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin-bottom: 12px;
-  padding: 0;
-}
-
-.c25 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-left: solid 4px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin-bottom: 12px;
-  padding: 0;
-}
-
-.c26 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-left: solid 12px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin-bottom: 12px;
-  padding: 0;
-}
-
-.c27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-left: solid 1px rgba(0,0,0,0.33);
-  border-right: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin-bottom: 12px;
-  padding: 0;
-}
-
-.c28 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-left: solid 2px rgba(0,0,0,0.33);
-  border-right: solid 2px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin-bottom: 12px;
-  padding: 0;
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-left: solid 4px rgba(0,0,0,0.33);
-  border-right: solid 4px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin-bottom: 12px;
-  padding: 0;
-}
-
-.c30 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  border-left: solid 12px rgba(0,0,0,0.33);
-  border-right: solid 12px rgba(0,0,0,0.33);
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin-bottom: 12px;
-  padding: 0;
-}
-
-@media only screen and (max-width:699px) {
-  .c1 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c1 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c6 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c6 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c6 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c2 {
-    border: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c2 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c2 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c3 {
-    border: solid 2px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c3 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c3 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c4 {
-    border: solid 4px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c4 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c4 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c5 {
-    border: solid 6px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c5 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c5 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c7 {
-    border-bottom: solid 2px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c7 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c7 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c8 {
-    border-bottom: solid 4px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c8 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c8 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c9 {
-    border-bottom: solid 6px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c9 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c9 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c10 {
-    border-left: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c10 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c10 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c11 {
-    border-left: solid 2px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c11 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c11 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c12 {
-    border-left: solid 4px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c12 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c12 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c13 {
-    border-left: solid 6px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c13 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c13 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c14 {
-    border-left: solid 1px rgba(0,0,0,0.33);
-    border-right: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c14 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c14 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c15 {
-    border-left: solid 2px rgba(0,0,0,0.33);
-    border-right: solid 2px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c15 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c15 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c16 {
-    border-left: solid 4px rgba(0,0,0,0.33);
-    border-right: solid 4px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c16 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c16 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c17 {
-    border-left: solid 6px rgba(0,0,0,0.33);
-    border-right: solid 6px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c17 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c17 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c18 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c18 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c19 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c19 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c19 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c20 {
-    border-bottom: solid 2px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c20 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c20 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c21 {
-    border-bottom: solid 4px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c21 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c21 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c22 {
-    border-bottom: solid 6px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c22 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c22 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c23 {
-    border-left: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c23 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c23 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c24 {
-    border-left: solid 2px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c24 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c24 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c25 {
-    border-left: solid 4px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c25 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c25 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c26 {
-    border-left: solid 6px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c26 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c26 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c27 {
-    border-left: solid 1px rgba(0,0,0,0.33);
-    border-right: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c27 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c27 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c28 {
-    border-left: solid 2px rgba(0,0,0,0.33);
-    border-right: solid 2px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c28 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c28 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c29 {
-    border-left: solid 4px rgba(0,0,0,0.33);
-    border-right: solid 4px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c29 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c29 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c30 {
-    border-left: solid 6px rgba(0,0,0,0.33);
-    border-right: solid 6px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c30 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c30 {
-    padding: 0;
-  }
-}
-
-<div
-  className="c0"
->
-  <div
-    aria-label={undefined}
-    className="c1"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c2"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c1"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c3"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c1"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c4"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c1"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c5"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c1"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c6"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c1"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c7"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c1"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c8"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c1"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c9"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c1"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c10"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c1"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c11"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c1"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c12"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c1"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c13"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c1"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c14"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c1"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c15"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c1"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c16"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c1"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c17"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c2"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={
-      Object {
-        "marginBottom": "-1px",
-        "position": undefined,
-        "zIndex": undefined,
-      }
-    }
-  >
-    <div
-      aria-label={undefined}
-      className="c18"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c3"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={
-      Object {
-        "marginBottom": "-2px",
-        "position": undefined,
-        "zIndex": undefined,
-      }
-    }
-  >
-    <div
-      aria-label={undefined}
-      className="c18"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c4"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={
-      Object {
-        "marginBottom": "-4px",
-        "position": undefined,
-        "zIndex": undefined,
-      }
-    }
-  >
-    <div
-      aria-label={undefined}
-      className="c18"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c5"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={
-      Object {
-        "marginBottom": "-12px",
-        "position": undefined,
-        "zIndex": undefined,
-      }
-    }
-  >
-    <div
-      aria-label={undefined}
-      className="c18"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c19"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c18"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c20"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c18"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c21"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c18"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c22"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c18"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c23"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c18"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c24"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c18"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c25"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c18"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c26"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c18"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c27"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c18"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c28"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c18"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c29"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c18"
-      direction="column"
-    />
-  </div>
-  <div
-    aria-label={undefined}
-    className="c30"
-    direction="column"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    style={undefined}
-  >
-    <div
-      aria-label={undefined}
-      className="c18"
-      direction="column"
-    />
-  </div>
-</div>
-`;
-
 exports[`renders error 1`] = `
 .c0 {
   font-family: 'Work Sans',Arial,sans-serif;
@@ -1769,6 +194,25 @@ exports[`renders error 1`] = `
   padding: 0;
 }
 
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  min-width: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  padding: 0;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1783,29 +227,6 @@ exports[`renders error 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   margin: 0;
-  padding: 0;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  min-width: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 6px;
-  margin-bottom: 6px;
   padding: 0;
 }
 
@@ -1828,24 +249,6 @@ exports[`renders error 1`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .c2 {
-    border-bottom: solid 1px #E1746A;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c2 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c2 {
-    padding: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
   .c3 {
     margin-left: 6px;
     margin-right: 6px;
@@ -1861,6 +264,24 @@ exports[`renders error 1`] = `
 
 @media only screen and (max-width:699px) {
   .c3 {
+    padding: 0;
+  }
+}
+
+@media only screen and (max-width:699px) {
+  .c2 {
+    border-bottom: solid 1px #E1746A;
+  }
+}
+
+@media only screen and (max-width:699px) {
+  .c2 {
+    margin: 0;
+  }
+}
+
+@media only screen and (max-width:699px) {
+  .c2 {
     padding: 0;
   }
 }
@@ -2052,6 +473,103 @@ exports[`renders help 1`] = `
 </div>
 `;
 
+exports[`renders htmlFor 1`] = `
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #444444;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  min-width: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 12px;
+  padding: 0;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
+}
+
+@media only screen and (max-width:699px) {
+  .c1 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:699px) {
+  .c1 {
+    padding: 0;
+  }
+}
+
+@media only screen and (max-width:699px) {
+  .c2 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:699px) {
+  .c2 {
+    margin: 0;
+  }
+}
+
+@media only screen and (max-width:699px) {
+  .c2 {
+    padding: 0;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    aria-label={undefined}
+    className="c1"
+    direction="column"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    style={undefined}
+  >
+    <div
+      aria-label={undefined}
+      className="c2"
+      direction="column"
+    />
+  </div>
+</div>
+`;
+
 exports[`renders label 1`] = `
 .c0 {
   font-family: 'Work Sans',Arial,sans-serif;
@@ -2189,11 +707,12 @@ exports[`renders label 1`] = `
       className="c2"
       direction="column"
     >
-      <span
+      <label
         className="c3"
+        htmlFor={undefined}
       >
         test label
-      </span>
+      </label>
     </div>
     <div
       aria-label={undefined}

--- a/src/js/components/FormField/doc.js
+++ b/src/js/components/FormField/doc.js
@@ -12,24 +12,14 @@ export default (FormField) => {
       );
 
   DocumentedFormField.propTypes = {
-    border: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.shape({
-        color: PropTypes.string,
-        position: PropTypes.oneOf(['outer', 'inner']),
-        side: PropTypes.oneOf(['top', 'left', 'bottom', 'right',
-          'horizontal', 'vertical', 'all']),
-        size: PropTypes.oneOf(['small', 'medium', 'large']),
-      }),
-    ]).description(`What sort of border to use. Setting this to false
-      will not show any border and will leave the focus indicator to
-      the children.`)
-      .defaultValue({ color: 'border', position: 'inner', side: 'bottom' }),
-    error: PropTypes.string
+    error: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
       .description('Any error text describing issues with the field'),
-    help: PropTypes.string
+    help: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
       .description('Any help text describing how the field works'),
-    label: PropTypes.string.description('A short label describing the field'),
+    htmlFor: PropTypes.string
+      .description('The id of the input element contained in this field'),
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
+      .description('A short label describing the field'),
   };
 
   return DocumentedFormField;

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -22,7 +22,7 @@ exports[`Menu opens and closes on click 1`] = `
         direction="row"
       >
         <span
-          class="StyledText-eJMSZI ehbxjF"
+          class="StyledText-eJMSZI WtHkG"
         >
           Test
         </span>
@@ -226,7 +226,7 @@ exports[`Menu with custom message renders 1`] = `
       direction="row"
     >
       <span
-        class="StyledText-eJMSZI ehbxjF"
+        class="StyledText-eJMSZI WtHkG"
       >
         Test Menu
       </span>
@@ -278,7 +278,7 @@ exports[`Menu with dropAlign renders 1`] = `
         direction="row"
       >
         <span
-          class="StyledText-eJMSZI ehbxjF"
+          class="StyledText-eJMSZI WtHkG"
         >
           Test
         </span>

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -1774,7 +1774,7 @@ exports[`Select renders multiple 1`] = `
 
 exports[`mounts disabled 1`] = `
 <button
-  class="StyledButton-gXzblK dDrPei"
+  class="StyledButton-gXzblK gqMHaF"
   id="test-select"
   aria-label="undefined"
   disabled=""
@@ -1827,7 +1827,7 @@ exports[`mounts disabled 1`] = `
 
 exports[`mounts disabled 2`] = `
 <button
-  class="StyledButton-gXzblK dDrPei"
+  class="StyledButton-gXzblK gqMHaF"
   id="test-select"
   aria-label="undefined"
   disabled=""

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -34,7 +34,7 @@ exports[`Select closes drop on esc 1`] = `
             direction="column"
           >
             <span
-              class="StyledText-eJMSZI bUVmvh"
+              class="StyledText-eJMSZI eCycNH"
             >
               one
             </span>
@@ -50,7 +50,7 @@ exports[`Select closes drop on esc 1`] = `
             direction="column"
           >
             <span
-              class="StyledText-eJMSZI bUVmvh"
+              class="StyledText-eJMSZI eCycNH"
             >
               two
             </span>
@@ -441,7 +441,7 @@ exports[`Select mounts 3`] = `
             direction="column"
           >
             <span
-              class="StyledText-eJMSZI bUVmvh"
+              class="StyledText-eJMSZI eCycNH"
             >
               one
             </span>
@@ -457,7 +457,7 @@ exports[`Select mounts 3`] = `
             direction="column"
           >
             <span
-              class="StyledText-eJMSZI bUVmvh"
+              class="StyledText-eJMSZI eCycNH"
             >
               two
             </span>
@@ -611,7 +611,7 @@ exports[`Select mounts 5`] = `
       direction="column"
     >
       <span
-        class="StyledText-eJMSZI bUVmvh"
+        class="StyledText-eJMSZI eCycNH"
       >
         one
       </span>
@@ -627,7 +627,7 @@ exports[`Select mounts 5`] = `
       direction="column"
     >
       <span
-        class="StyledText-eJMSZI bUVmvh"
+        class="StyledText-eJMSZI eCycNH"
       >
         two
       </span>
@@ -778,7 +778,7 @@ exports[`Select mounts multiple 3`] = `
             direction="column"
           >
             <span
-              class="StyledText-eJMSZI bUVmvh"
+              class="StyledText-eJMSZI eCycNH"
             >
               one
             </span>
@@ -794,7 +794,7 @@ exports[`Select mounts multiple 3`] = `
             direction="column"
           >
             <span
-              class="StyledText-eJMSZI bUVmvh"
+              class="StyledText-eJMSZI eCycNH"
             >
               two
             </span>
@@ -979,7 +979,7 @@ exports[`Select mounts multiple 5`] = `
       direction="column"
     >
       <span
-        class="StyledText-eJMSZI bUVmvh"
+        class="StyledText-eJMSZI eCycNH"
       >
         one
       </span>
@@ -995,7 +995,7 @@ exports[`Select mounts multiple 5`] = `
       direction="column"
     >
       <span
-        class="StyledText-eJMSZI bUVmvh"
+        class="StyledText-eJMSZI eCycNH"
       >
         two
       </span>
@@ -1330,7 +1330,7 @@ exports[`Select mounts with search 1`] = `
             direction="column"
           >
             <span
-              class="StyledText-eJMSZI bUVmvh"
+              class="StyledText-eJMSZI eCycNH"
             >
               one
             </span>
@@ -1346,7 +1346,7 @@ exports[`Select mounts with search 1`] = `
             direction="column"
           >
             <span
-              class="StyledText-eJMSZI bUVmvh"
+              class="StyledText-eJMSZI eCycNH"
             >
               two
             </span>
@@ -1553,7 +1553,7 @@ exports[`Select mounts with search 4`] = `
             direction="column"
           >
             <span
-              class="StyledText-eJMSZI bUVmvh"
+              class="StyledText-eJMSZI eCycNH"
             >
               one
             </span>
@@ -1569,7 +1569,7 @@ exports[`Select mounts with search 4`] = `
             direction="column"
           >
             <span
-              class="StyledText-eJMSZI bUVmvh"
+              class="StyledText-eJMSZI eCycNH"
             >
               two
             </span>

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -20,7 +20,7 @@ exports[`Tabs changes active index 1`] = `
         direction="column"
       >
         <span
-          class="StyledText-eJMSZI ehbxjF"
+          class="StyledText-eJMSZI WtHkG"
         >
           <strong>
             Tab 1
@@ -40,7 +40,7 @@ exports[`Tabs changes active index 1`] = `
         direction="column"
       >
         <span
-          class="StyledText-eJMSZI beGKeC"
+          class="StyledText-eJMSZI cQGInD"
           color="dark-4"
         >
           Tab 2
@@ -94,7 +94,7 @@ exports[`Tabs changes to second tab 1`] = `
           direction="column"
         >
           <span
-            className="StyledText-eJMSZI beGKeC"
+            className="StyledText-eJMSZI cQGInD"
             color="dark-4"
           >
             Tab 1
@@ -126,7 +126,7 @@ exports[`Tabs changes to second tab 1`] = `
           direction="column"
         >
           <span
-            className="StyledText-eJMSZI ehbxjF"
+            className="StyledText-eJMSZI WtHkG"
           >
             <strong>
               Tab 2
@@ -263,7 +263,7 @@ exports[`Tabs renders with Tab 1`] = `
           direction="column"
         >
           <span
-            className="StyledText-eJMSZI ehbxjF"
+            className="StyledText-eJMSZI WtHkG"
           >
             <strong>
               Tab 1
@@ -296,7 +296,7 @@ exports[`Tabs renders with Tab 1`] = `
           direction="column"
         >
           <span
-            className="StyledText-eJMSZI beGKeC"
+            className="StyledText-eJMSZI cQGInD"
             color="dark-4"
           >
             Tab 2
@@ -354,7 +354,7 @@ exports[`Tabs sets on hover 1`] = `
         direction="column"
       >
         <span
-          class="StyledText-eJMSZI ehbxjF"
+          class="StyledText-eJMSZI WtHkG"
         >
           <strong>
             Tab 1
@@ -374,7 +374,7 @@ exports[`Tabs sets on hover 1`] = `
         direction="column"
       >
         <span
-          class="StyledText-eJMSZI beGKeC"
+          class="StyledText-eJMSZI cQGInD"
           color="dark-4"
         >
           Tab 2
@@ -411,7 +411,7 @@ exports[`Tabs sets on hover 2`] = `
         direction="column"
       >
         <span
-          class="StyledText-eJMSZI ehbxjF"
+          class="StyledText-eJMSZI WtHkG"
         >
           <strong>
             Tab 1
@@ -431,7 +431,7 @@ exports[`Tabs sets on hover 2`] = `
         direction="column"
       >
         <span
-          class="StyledText-eJMSZI beGKeC"
+          class="StyledText-eJMSZI cQGInD"
           color="dark-4"
         >
           Tab 2
@@ -468,7 +468,7 @@ exports[`Tabs sets on hover 3`] = `
         direction="column"
       >
         <span
-          class="StyledText-eJMSZI ehbxjF"
+          class="StyledText-eJMSZI WtHkG"
         >
           <strong>
             Tab 1
@@ -488,7 +488,7 @@ exports[`Tabs sets on hover 3`] = `
         direction="column"
       >
         <span
-          class="StyledText-eJMSZI beGKeC"
+          class="StyledText-eJMSZI cQGInD"
           color="dark-4"
         >
           Tab 2
@@ -525,7 +525,7 @@ exports[`Tabs sets on hover 4`] = `
         direction="column"
       >
         <span
-          class="StyledText-eJMSZI ehbxjF"
+          class="StyledText-eJMSZI WtHkG"
         >
           <strong>
             Tab 1
@@ -545,7 +545,7 @@ exports[`Tabs sets on hover 4`] = `
         direction="column"
       >
         <span
-          class="StyledText-eJMSZI beGKeC"
+          class="StyledText-eJMSZI cQGInD"
           color="dark-4"
         >
           Tab 2

--- a/src/js/components/Text/README.md
+++ b/src/js/components/Text/README.md
@@ -84,4 +84,14 @@ is too long to all fit.
 ```
 boolean
 ```
+
+**weight**
+
+Font weight
+
+```
+normal
+bold
+number
+```
   

--- a/src/js/components/Text/StyledText.js
+++ b/src/js/components/Text/StyledText.js
@@ -69,12 +69,17 @@ const colorStyle = css`
   color: ${props => colorForName(props.color, props.theme)}
 `;
 
+const weightStyle = css`
+  font-weight: ${props => props.weight}
+`;
+
 const StyledText = styled.span`
   ${props => sizeStyle(props)}
   ${props => props.margin && marginStyle(props)}
   ${props => props.textAlign && textAlignStyle}
   ${props => props.truncate && truncateStyle}
   ${props => props.color && colorStyle}
+  ${props => props.weight && weightStyle}
 `;
 
 export default StyledText.extend`

--- a/src/js/components/Text/__tests__/Text-test.js
+++ b/src/js/components/Text/__tests__/Text-test.js
@@ -5,7 +5,7 @@ import 'jest-styled-components';
 import { Grommet } from '../../Grommet';
 import { Text } from '../';
 
-test('Text renders', () => {
+test('renders', () => {
   const component = renderer.create(
     <Grommet>
       <Text>text</Text>
@@ -15,7 +15,7 @@ test('Text renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Text size renders', () => {
+test('renders size', () => {
   const component = renderer.create(
     <Grommet>
       <Text size='xsmall' />
@@ -30,7 +30,7 @@ test('Text size renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Text textAlign renders', () => {
+test('renders textAlign', () => {
   const component = renderer.create(
     <Grommet>
       <Text textAlign='start' />
@@ -42,7 +42,7 @@ test('Text textAlign renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Text margin renders', () => {
+test('renders margin', () => {
   const component = renderer.create(
     <Grommet>
       <Text margin='small' />
@@ -63,7 +63,7 @@ test('Text margin renders', () => {
 
 const LONG = 'a b c d e f g h i j k l m n o p q r s t u v w x y z';
 
-test('Text truncate renders', () => {
+test('renders truncate', () => {
   const component = renderer.create(
     <Grommet>
       <Text truncate={false}>{LONG}</Text>
@@ -74,7 +74,7 @@ test('Text truncate renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Text color renders', () => {
+test('renders color', () => {
   const component = renderer.create(
     <Grommet>
       <Text color='status-critical' />
@@ -84,10 +84,21 @@ test('Text color renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Text tag renders', () => {
+test('renders tag', () => {
   const component = renderer.create(
     <Grommet>
       <Text tag='div' />
+    </Grommet>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('renders weight', () => {
+  const component = renderer.create(
+    <Grommet>
+      <Text weight='normal' />
+      <Text weight='bold' />
     </Grommet>
   );
   const tree = component.toJSON();

--- a/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
+++ b/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
@@ -1,6 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Text color renders 1`] = `
+exports[`renders 1`] = `
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #444444;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  font-size: 16px;
+  line-height: 1.375;
+}
+
+<div
+  className="c0"
+>
+  <span
+    className="c1"
+  >
+    text
+  </span>
+</div>
+`;
+
+exports[`renders color 1`] = `
 .c0 {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
@@ -29,7 +58,7 @@ exports[`Text color renders 1`] = `
 </div>
 `;
 
-exports[`Text margin renders 1`] = `
+exports[`renders margin 1`] = `
 .c0 {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
@@ -152,36 +181,7 @@ exports[`Text margin renders 1`] = `
 </div>
 `;
 
-exports[`Text renders 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #444444;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  font-size: 16px;
-  line-height: 1.375;
-}
-
-<div
-  className="c0"
->
-  <span
-    className="c1"
-  >
-    text
-  </span>
-</div>
-`;
-
-exports[`Text size renders 1`] = `
+exports[`renders size 1`] = `
 .c0 {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
@@ -254,7 +254,7 @@ exports[`Text size renders 1`] = `
 </div>
 `;
 
-exports[`Text tag renders 1`] = `
+exports[`renders tag 1`] = `
 .c0 {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
@@ -281,7 +281,7 @@ exports[`Text tag renders 1`] = `
 </div>
 `;
 
-exports[`Text textAlign renders 1`] = `
+exports[`renders textAlign 1`] = `
 .c0 {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
@@ -327,7 +327,7 @@ exports[`Text textAlign renders 1`] = `
 </div>
 `;
 
-exports[`Text truncate renders 1`] = `
+exports[`renders truncate 1`] = `
 .c0 {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
@@ -366,5 +366,42 @@ exports[`Text truncate renders 1`] = `
   >
     a b c d e f g h i j k l m n o p q r s t u v w x y z
   </span>
+</div>
+`;
+
+exports[`renders weight 1`] = `
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #444444;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  font-size: 16px;
+  line-height: 1.375;
+  font-weight: normal;
+}
+
+.c2 {
+  font-size: 16px;
+  line-height: 1.375;
+  font-weight: bold;
+}
+
+<div
+  className="c0"
+>
+  <span
+    className="c1"
+  />
+  <span
+    className="c2"
+  />
 </div>
 `;

--- a/src/js/components/Text/doc.js
+++ b/src/js/components/Text/doc.js
@@ -42,6 +42,10 @@ adjustments.`
       `Restrict the text to a single line and truncate with ellipsis if it
 is too long to all fit.`
     ),
+    weight: PropTypes.oneOfType([
+      PropTypes.oneOf(['normal', 'bold']),
+      PropTypes.number,
+    ]).description('Font weight'),
   };
 
   return DocumentedText;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1347,49 +1347,27 @@ import { FormField } from 'grommet';
 
 ## Properties
 
-**border**
-
-What sort of border to use. Setting this to false
-      will not show any border and will leave the focus indicator to
-      the children. Defaults to \`{
-  \\"color\\": \\"border\\",
-  \\"position\\": \\"inner\\",
-  \\"side\\": \\"bottom\\"
-}\`.
-
-\`\`\`
-boolean
-{
-  color: string,
-  position: 
-    outer
-    inner,
-  side: 
-    top
-    left
-    bottom
-    right
-    horizontal
-    vertical
-    all,
-  size: 
-    small
-    medium
-    large
-}
-\`\`\`
-
 **error**
 
 Any error text describing issues with the field
 
 \`\`\`
 string
+node
 \`\`\`
 
 **help**
 
 Any help text describing how the field works
+
+\`\`\`
+string
+node
+\`\`\`
+
+**htmlFor**
+
+The id of the input element contained in this field
 
 \`\`\`
 string
@@ -1401,6 +1379,7 @@ A short label describing the field
 
 \`\`\`
 string
+node
 \`\`\`
   ",
   "Grid": "## Grid
@@ -2944,6 +2923,16 @@ is too long to all fit.
 
 \`\`\`
 boolean
+\`\`\`
+
+**weight**
+
+Font weight
+
+\`\`\`
+normal
+bold
+number
 \`\`\`
   ",
   "TextArea": "## TextArea

--- a/src/js/themes/vanilla.js
+++ b/src/js/themes/vanilla.js
@@ -352,6 +352,19 @@ export default deepFreeze({
       },
     },
   },
+  formField: {
+    border: {
+      color: 'border',
+      position: 'inner',
+      side: 'bottom',
+      error: {
+        color: 'status-critical',
+      },
+    },
+    error: { color: 'status-critical' },
+    help: { color: 'dark-5' },
+    label: {},
+  },
   grommet: {},
   heading: {
     font: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,8 +94,8 @@ ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
     json-schema-traverse "^0.3.0"
 
 ajv@^6.1.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.2.1.tgz#28a6abc493a2abe0fb4c8507acaedb43fa550671"
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.3.0.tgz#1650a41114ef00574cac10b8032d8f4c14812da7"
   dependencies:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
@@ -2121,8 +2121,8 @@ ejs@^2.5.6:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
 
 electron-to-chromium@^1.3.30:
-  version "1.3.38"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.38.tgz#49234b00c0592f62921f9426bccefee23de086bb"
+  version "1.3.39"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.39.tgz#d7a4696409ca0995e2750156da612c221afad84d"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -2245,11 +2245,12 @@ es-to-primitive@^1.1.1:
     is-symbol "^1.0.1"
 
 es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.40"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.40.tgz#ab3d2179b943008c5e9ef241beb25ef41424c774"
+  version "0.10.41"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.41.tgz#bab3e982d750f0112f0cb9e6abed72c59eb33eb2"
   dependencies:
     es6-iterator "~2.0.3"
     es6-symbol "~3.1.1"
+    next-tick "1"
 
 es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
   version "2.0.3"
@@ -2499,8 +2500,8 @@ eslint@^3.19.0:
     user-home "^2.0.0"
 
 eslint@^4.3.0:
-  version "4.18.2"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.18.2.tgz#0f81267ad1012e7d2051e186a9004cc2267b8d45"
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.0.tgz#9e900efb5506812ac374557034ef6f5c3642fc4c"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
@@ -2511,7 +2512,7 @@ eslint@^4.3.0:
     doctrine "^2.1.0"
     eslint-scope "^3.7.1"
     eslint-visitor-keys "^1.0.0"
-    espree "^3.5.2"
+    espree "^3.5.4"
     esquery "^1.0.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
@@ -2533,6 +2534,7 @@ eslint@^4.3.0:
     path-is-inside "^1.0.2"
     pluralize "^7.0.0"
     progress "^2.0.0"
+    regexpp "^1.0.1"
     require-uncached "^1.0.3"
     semver "^5.3.0"
     strip-ansi "^4.0.0"
@@ -2540,7 +2542,7 @@ eslint@^4.3.0:
     table "4.0.2"
     text-table "~0.2.0"
 
-espree@^3.1.6, espree@^3.4.0, espree@^3.5.2:
+espree@^3.1.6, espree@^3.4.0, espree@^3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
   dependencies:
@@ -3480,8 +3482,8 @@ iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
 ieee754@^1.1.4:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.10.tgz#719a6f7b026831e64bdb838b0de1bb0029bbf716"
 
 iferr@^0.1.5:
   version "0.1.5"
@@ -4748,8 +4750,8 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 nan@^2.3.0:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.9.2.tgz#f564d75f5f8f36a6d9456cca7a6c4fe488ab7866"
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
 nanomatch@^1.2.9:
   version "1.2.9"
@@ -4788,6 +4790,10 @@ negotiator@0.6.1:
 neo-async@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.0.tgz#76b1c823130cca26acfbaccc8fbaf0a2fa33b18f"
+
+next-tick@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
 
 node-emoji@^1.8.1:
   version "1.8.1"
@@ -4922,8 +4928,8 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
 "nwmatcher@>= 1.3.9 < 2.0.0":
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.3.tgz#64348e3b3d80f035b40ac11563d278f8b72db89c"
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.4.tgz#2285631f34a95f0d0395cd900c96ed39b58f346e"
 
 oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
@@ -5699,6 +5705,10 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+regexpp@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.0.1.tgz#d857c3a741dce075c2848dcb019a0a975b190d43"
 
 regexpu-core@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### What does this PR do?

Changed FormField to be more customizable via the theme. Removed the `border` property and use it from the theme. Added `htmlFor` property.
Changed Text to add `weight`.

#### Where should the reviewer start?

FormField/doc.js
vanilla.js

#### What testing has been done on this PR?

unit test
grommet-sandbox

#### How should this be manually tested?

grommet-sandbox

#### Any background context you want to provide?

It's most likely that callers will want to use the same FormField design throughout their app. It makes more sense to have that come through the theme.

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/1958
https://github.com/grommet/grommet/issues/1957

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

BREAKING CHANGE since `border` was removed from FormField.
