### PR TITLE
Changed Select to add size

### DIFF
--- a/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
+++ b/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
@@ -100,7 +100,7 @@ exports[`DropButton mounts 6`] = `
 
 exports[`DropButton mounts disabled 1`] = `
 <button
-  class="StyledButton-gXzblK cJvOXL"
+  class="StyledButton-gXzblK dUzCdF"
   aria-label="Open Drop"
   disabled=""
   label="Dropper"

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -15,6 +15,7 @@ import doc from './doc';
 class Menu extends Component {
   static defaultProps = {
     dropAlign: { top: 'top', left: 'left' },
+    items: [],
     messages: { openMenu: 'Open Menu', closeMenu: 'Close Menu' },
   };
 

--- a/src/js/components/Menu/README.md
+++ b/src/js/components/Menu/README.md
@@ -116,5 +116,6 @@ The size of the menu.
 small
 medium
 large
+xlarge
 ```
   

--- a/src/js/components/Menu/doc.js
+++ b/src/js/components/Menu/doc.js
@@ -59,7 +59,7 @@ The object values can be any Button prop, for example: label and onClick.`
     }).description(
       'Custom messages. Used for accessibility by screen readers.'
     ),
-    size: PropTypes.oneOf(['small', 'medium', 'large']).description(
+    size: PropTypes.oneOf(['small', 'medium', 'large', 'xlarge']).description(
       'The size of the menu.'
     ),
   };

--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -191,6 +191,17 @@ number
 [number]
 ```
 
+**size**
+
+The size of the select.
+
+```
+small
+medium
+large
+xlarge
+```
+
 **value**
 
 Currently selected value. This will be an array

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -43,6 +43,7 @@ class Select extends Component {
       onClose,
       placeholder,
       plain,
+      size,
       theme,
       value,
       ...rest
@@ -108,6 +109,7 @@ class Select extends Component {
                 type='text'
                 placeholder={placeholder}
                 plain={true}
+                size={size}
                 readOnly={true}
                 value={textValue}
               />
@@ -117,7 +119,7 @@ class Select extends Component {
               flex={false}
               style={{ minWidth: 'auto' }}
             >
-              <SelectIcon color='brand' />
+              <SelectIcon color='brand' size={size} />
             </Box>
           </Box>
         </DropButton>

--- a/src/js/components/Select/__tests__/Select-test.js
+++ b/src/js/components/Select/__tests__/Select-test.js
@@ -164,6 +164,22 @@ describe('Select', () => {
     expect(onChange).toBeCalled();
   });
 
+  test('renders size', () => {
+    const component = mount(
+      <Select
+        id='test-select'
+        size='large'
+        options={['one', 'two']}
+        selected={[]}
+        value={[]}
+      />, {
+        attachTo: document.body.firstChild,
+      }
+    );
+    expect(component.getDOMNode()).toMatchSnapshot();
+    expect(document.getElementById('test-menu__drop')).toBeNull();
+  });
+
   test('renders multiple', () => {
     const component = mount(
       <Select
@@ -247,17 +263,17 @@ describe('Select', () => {
     );
     expect(onChange).toBeCalled();
   });
-});
 
-test('mounts disabled', () => {
-  const component = mount(
-    <Select id='test-select' disabled={true} options={['one', 'two']} />
-  );
-  expect(component.getDOMNode()).toMatchSnapshot();
-  expect(document.getElementById('test-select__drop')).toBeNull();
+  test('mounts disabled', () => {
+    const component = mount(
+      <Select id='test-select' disabled={true} options={['one', 'two']} />
+    );
+    expect(component.getDOMNode()).toMatchSnapshot();
+    expect(document.getElementById('test-select__drop')).toBeNull();
 
-  component.simulate('click');
+    component.simulate('click');
 
-  expect(component.getDOMNode()).toMatchSnapshot();
-  expect(document.getElementById('test-select__drop')).toBeNull();
+    expect(component.getDOMNode()).toMatchSnapshot();
+    expect(document.getElementById('test-select__drop')).toBeNull();
+  });
 });

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -636,6 +636,112 @@ exports[`Select mounts 5`] = `
 </div>
 `;
 
+exports[`Select mounts disabled 1`] = `
+<button
+  class="StyledButton-gXzblK gqMHaF"
+  id="test-select"
+  aria-label="undefined"
+  disabled=""
+  type="button"
+>
+  <div
+    class="StyledBox-bStriS iiEOir"
+    direction="row"
+    aria-hidden="true"
+  >
+    <div
+      class="StyledTextInput__StyledTextInputContainer-bPTWQl hasTun"
+    >
+      <input
+        type="text"
+        class="StyledTextInput-bzOzsW bhNKQj"
+        id="test-select"
+        autocomplete="off"
+        style="cursor: pointer;"
+        tabindex="-1"
+        readonly=""
+      />
+    </div>
+    <div
+      class="StyledBox-bStriS kzhXNn"
+      direction="column"
+      style="min-width: auto;"
+    >
+      <svg
+        class="StyledIcon-gTfjEw htxeRg"
+        width="24px"
+        height="24px"
+        viewBox="0 0 24 24"
+        version="1.1"
+        role="img"
+        aria-label="FormDown"
+        color="brand"
+      >
+        <polyline
+          fill="none"
+          stroke="#000"
+          stroke-width="2"
+          points="18 9 12 15 6 9"
+        />
+      </svg>
+    </div>
+  </div>
+</button>
+`;
+
+exports[`Select mounts disabled 2`] = `
+<button
+  class="StyledButton-gXzblK gqMHaF"
+  id="test-select"
+  aria-label="undefined"
+  disabled=""
+  type="button"
+>
+  <div
+    class="StyledBox-bStriS iiEOir"
+    direction="row"
+    aria-hidden="true"
+  >
+    <div
+      class="StyledTextInput__StyledTextInputContainer-bPTWQl hasTun"
+    >
+      <input
+        type="text"
+        class="StyledTextInput-bzOzsW bhNKQj"
+        id="test-select"
+        autocomplete="off"
+        style="cursor: pointer;"
+        tabindex="-1"
+        readonly=""
+      />
+    </div>
+    <div
+      class="StyledBox-bStriS kzhXNn"
+      direction="column"
+      style="min-width: auto;"
+    >
+      <svg
+        class="StyledIcon-gTfjEw htxeRg"
+        width="24px"
+        height="24px"
+        viewBox="0 0 24 24"
+        version="1.1"
+        role="img"
+        aria-label="FormDown"
+        color="brand"
+      >
+        <polyline
+          fill="none"
+          stroke="#000"
+          stroke-width="2"
+          points="18 9 12 15 6 9"
+        />
+      </svg>
+    </div>
+  </div>
+</button>
+`;
+
 exports[`Select mounts multiple 1`] = `
 <button
   class="StyledButton-gXzblK kGZImI"
@@ -1772,12 +1878,11 @@ exports[`Select renders multiple 1`] = `
 </button>
 `;
 
-exports[`mounts disabled 1`] = `
+exports[`Select renders size 1`] = `
 <button
-  class="StyledButton-gXzblK dDrPei"
+  class="StyledButton-gXzblK kGZImI"
   id="test-select"
   aria-label="undefined"
-  disabled=""
   type="button"
 >
   <div
@@ -1790,12 +1895,13 @@ exports[`mounts disabled 1`] = `
     >
       <input
         type="text"
-        class="StyledTextInput-bzOzsW bhNKQj"
+        class="StyledTextInput-bzOzsW hjHbnR"
         id="test-select"
         autocomplete="off"
         style="cursor: pointer;"
         tabindex="-1"
         readonly=""
+        value=""
       />
     </div>
     <div
@@ -1804,60 +1910,7 @@ exports[`mounts disabled 1`] = `
       style="min-width: auto;"
     >
       <svg
-        class="StyledIcon-gTfjEw htxeRg"
-        width="24px"
-        height="24px"
-        viewBox="0 0 24 24"
-        version="1.1"
-        role="img"
-        aria-label="FormDown"
-        color="brand"
-      >
-        <polyline
-          fill="none"
-          stroke="#000"
-          stroke-width="2"
-          points="18 9 12 15 6 9"
-        />
-      </svg>
-    </div>
-  </div>
-</button>
-`;
-
-exports[`mounts disabled 2`] = `
-<button
-  class="StyledButton-gXzblK dDrPei"
-  id="test-select"
-  aria-label="undefined"
-  disabled=""
-  type="button"
->
-  <div
-    class="StyledBox-bStriS iiEOir"
-    direction="row"
-    aria-hidden="true"
-  >
-    <div
-      class="StyledTextInput__StyledTextInputContainer-bPTWQl hasTun"
-    >
-      <input
-        type="text"
-        class="StyledTextInput-bzOzsW bhNKQj"
-        id="test-select"
-        autocomplete="off"
-        style="cursor: pointer;"
-        tabindex="-1"
-        readonly=""
-      />
-    </div>
-    <div
-      class="StyledBox-bStriS kzhXNn"
-      direction="column"
-      style="min-width: auto;"
-    >
-      <svg
-        class="StyledIcon-gTfjEw htxeRg"
+        class="StyledIcon-gTfjEw cKOunL"
         width="24px"
         height="24px"
         viewBox="0 0 24 24"

--- a/src/js/components/Select/doc.js
+++ b/src/js/components/Select/doc.js
@@ -77,6 +77,9 @@ export default (Select) => {
       `Index of the currently selected option. When multiple, the set of
       options selected. This property is required when multiple.`
     ),
+    size: PropTypes.oneOf(['small', 'medium', 'large', 'xlarge']).description(
+      'The size of the select.'
+    ),
     value: PropTypes.oneOfType([
       PropTypes.string, PropTypes.element, PropTypes.object,
       PropTypes.arrayOf(PropTypes.oneOfType([

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -2069,6 +2069,7 @@ The size of the menu.
 small
 medium
 large
+xlarge
 \`\`\`
   ",
   "Meter": "## Meter
@@ -2696,6 +2697,17 @@ Index of the currently selected option. When multiple, the set of
 \`\`\`
 number
 [number]
+\`\`\`
+
+**size**
+
+The size of the select.
+
+\`\`\`
+small
+medium
+large
+xlarge
 \`\`\`
 
 **value**


### PR DESCRIPTION
#### What does this PR do?

Changed Select to add the `size` property.

#### Where should the reviewer start?

Select/doc.js

#### What testing has been done on this PR?

grommet-sandbox

#### How should this be manually tested?

grommet-sandbox

#### Any background context you want to provide?

This allows TextInput, Menu, and Select to all be kept at a consistent size in forms.

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/1954

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible with v2
