### PR TITLE
Improved performance of deepMerge and withTheme

### DIFF
--- a/src/js/components/hocs.js
+++ b/src/js/components/hocs.js
@@ -75,12 +75,31 @@ export const withTheme = (WrappedComponent) => {
     static contextTypes = {
       theme: PropTypes.object,
     }
-    render() {
-      const { theme, ...rest } = this.props;
-      const { theme: contextTheme } = this.context;
+
+    constructor(props, context) {
+      super(props, context);
+      this.buildTheme(props, context);
+    }
+
+    componentWillReceiveProps(nextProps) {
+      // only merge on existence changes
+      if ((nextProps.theme && !this.props.theme) ||
+        (!nextProps.theme && this.props.theme)) {
+        this.buildTheme(nextProps, this.context);
+      }
+    }
+
+    buildTheme = (props, context) => {
+      const { theme } = props;
+      const { theme: contextTheme } = context;
       const localTheme = deepMerge(baseTheme, contextTheme, theme);
+      this.state = { theme: localTheme };
+    }
+
+    render() {
+      const { theme } = this.state;
       return (
-        <WrappedComponent theme={localTheme} {...rest} />
+        <WrappedComponent {...this.props} theme={theme} />
       );
     }
   }

--- a/src/js/utils/object.js
+++ b/src/js/utils/object.js
@@ -15,21 +15,22 @@ export function deepMerge(target, ...sources) {
   }
   // making sure to not change target (immutable)
   const output = { ...target };
-  const source = sources.shift();
-  if (isObject(output) && isObject(source)) {
-    Object.keys(source).forEach((key) => {
-      if (isObject(source[key])) {
-        if (!output[key]) {
-          output[key] = { ...source[key] };
+  sources.forEach((source) => {
+    if (isObject(source)) {
+      Object.keys(source).forEach((key) => {
+        if (isObject(source[key])) {
+          if (!output[key]) {
+            output[key] = { ...source[key] };
+          } else {
+            output[key] = deepMerge(output[key], source[key]);
+          }
         } else {
-          output[key] = deepMerge({}, output[key], source[key]);
+          output[key] = source[key];
         }
-      } else {
-        output[key] = source[key];
-      }
-    });
-  }
-  return deepMerge(output, ...sources);
+      });
+    }
+  });
+  return output;
 }
 
 export function removeUndefined(obj) {


### PR DESCRIPTION
#### What does this PR do?

Avoids `deepMerge` on every render via `withTheme`.
Instead, `withTheme` only merges themes in the constructor or when props change.
Also reduced extra object creation and function calls in `deepMerge`.

#### Where should the reviewer start?

hocs.js

#### What testing has been done on this PR?

grommet-sandbox InfiniteScroll with theme per item.

#### How should this be manually tested?

same as above

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/1985

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
