### PR TITLE
Changed Grommet to set dark context from global background

### DIFF
--- a/src/js/components/Grommet/Grommet.js
+++ b/src/js/components/Grommet/Grommet.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import baseTheme from '../../themes/vanilla';
-import { deepMerge } from '../../utils';
+import { colorIsDark, deepMerge } from '../../utils';
 
 import StyledGrommet from './StyledGrommet';
 import doc from './doc';
@@ -28,11 +28,16 @@ class Grommet extends Component {
   getChildContext() {
     const { theme } = this.props;
 
+    const mergedTheme = deepMerge(baseTheme, theme);
+    const color = mergedTheme.global.colors.background;
+    const dark = color ? colorIsDark(color) : false;
+
     return {
       grommet: {
         announce: this.announce,
+        dark,
       },
-      theme: deepMerge(baseTheme, theme),
+      theme: mergedTheme,
     };
   }
 


### PR DESCRIPTION
#### What does this PR do?

Changed Grommet to set the initial dark context from the global background.

#### Where should the reviewer start?

Grommet.js

#### What testing has been done on this PR?

grommet-sandbox

#### How should this be manually tested?

grommet-sandbox

#### Any background context you want to provide?

This change adds background context. :)

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/1987

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
