### PR TITLE
Changed Grid to enhance rows and columns and added fill

### DIFF
--- a/src/js/components/Grid/Grid.js
+++ b/src/js/components/Grid/Grid.js
@@ -17,6 +17,8 @@ class Grid extends Component {
 
   render() {
     const {
+      fill, // munged to avoid styled-components putting it in the DOM
+      rows, // munged to avoid styled-components putting it in the DOM
       tag,
       ...rest
     } = this.props;
@@ -28,7 +30,11 @@ class Grid extends Component {
     }
 
     return (
-      <StyledComponent {...rest} />
+      <StyledComponent
+        fillContainer={fill}
+        rowsProp={rows}
+        {...rest}
+      />
     );
   }
 }

--- a/src/js/components/Grid/StyledGrid.js
+++ b/src/js/components/Grid/StyledGrid.js
@@ -1,5 +1,21 @@
 import styled, { css } from 'styled-components';
 
+const fillStyle = (fill) => {
+  if (fill === 'horizontal') {
+    return 'width: 100%;';
+  }
+  if (fill === 'vertical') {
+    return 'height: 100%;';
+  }
+  if (fill) {
+    return `
+      width: 100%;
+      height: 100%;
+    `;
+  }
+  return undefined;
+};
+
 const ALIGN_MAP = {
   center: 'center',
   end: 'flex-end',
@@ -53,6 +69,23 @@ const gapStyle = (props) => {
     const gapSize = props.theme.global.edgeSize[props.gap];
     return `grid-gap: ${gapSize} ${gapSize};`;
   }
+  if (props.gap.row && props.gap.column) {
+    return `
+      grid-row-gap: ${props.theme.global.edgeSize[props.gap.row]};
+      grid-column-gap: ${props.theme.global.edgeSize[props.gap.column]};
+    `;
+  }
+  if (props.gap.row) {
+    return `
+      grid-row-gap: ${props.theme.global.edgeSize[props.gap.row]};
+    `;
+  }
+  if (props.gap.column) {
+    return `
+      grid-column-gap: ${props.theme.global.edgeSize[props.gap.column]};
+    `;
+  }
+  // horizontal and vertical are deprecated, remove before 2.0.0
   if (props.gap.horizontal && props.gap.vertical) {
     return `
       grid-row-gap: ${props.theme.global.edgeSize[props.gap.horizontal]};
@@ -82,21 +115,52 @@ const SIZE_MAP = {
   '2/3': '66.66%',
 };
 
-const columnsStyle = css`
-  grid-template-columns: ${props => props.columns.map(s => (
-    SIZE_MAP[s] || props.theme.global.size[s])
-  ).join(' ')};
-`;
+const sizeFor = (size, props) =>
+  SIZE_MAP[size] || props.theme.global.size[size];
 
-const rowsStyle = css`
-  grid-template-rows: ${props => props.rows.map(s => (
-    SIZE_MAP[s] || props.theme.global.size[s])
-  ).join(' ')};
-`;
+const columnsStyle = (props) => {
+  if (Array.isArray(props.columns)) {
+    return css`
+      grid-template-columns: ${props.columns.map((s) => {
+        if (Array.isArray(s)) {
+          return `minmax(${sizeFor(s[0], props)}, ${sizeFor(s[1], props)})`;
+        }
+        return sizeFor(s, props);
+      }).join(' ')};
+    `;
+  }
+  if (typeof props.columns === 'object') {
+    return css`
+      grid-template-columns:
+        repeat(auto-${props.columns.count},
+          minmax(${props.theme.global.size[props.columns.size]}, 1fr));
+    `;
+  }
+  return css`
+    grid-template-columns:
+      repeat(auto-fill, minmax(${props.theme.global.size[props.columns]}, 1fr));
+  `;
+};
+
+const rowsStyle = (props) => {
+  if (Array.isArray(props.rowsProp)) {
+    return css`
+      grid-template-rows: ${props.rowsProp.map((s) => {
+        if (Array.isArray(s)) {
+          return `minmax(${sizeFor(s[0], props)}, ${sizeFor(s[1], props)})`;
+        }
+        return sizeFor(s, props);
+      }).join(' ')};
+    `;
+  }
+  return css`
+    grid-auto-rows: ${props.theme.global.size[props.rowsProp]};
+  `;
+};
 
 const areasStyle = (props) => {
   // translate areas objects into grid-template-areas syntax
-  const cells = props.rows.map(() => props.columns.map(() => '.'));
+  const cells = props.rowsProp.map(() => props.columns.map(() => '.'));
   props.areas.forEach((area) => {
     for (let row = area.start[1]; row <= area.end[1]; row += 1) {
       for (let column = area.start[0]; column <= area.end[0]; column += 1) {
@@ -110,16 +174,16 @@ const areasStyle = (props) => {
 const StyledGrid = styled.div`
   display: grid;
   box-sizing: border-box;
-  height: 100%;
 
+  ${props => props.fillContainer && fillStyle(props.fillContainer)}
   ${props => props.align && alignStyle}
   ${props => props.alignContent && alignContentStyle}
   ${props => props.areas && areasStyle(props)}
-  ${props => props.columns && columnsStyle}
+  ${props => props.columns && columnsStyle(props)}
   ${props => props.gap && gapStyle(props)}
   ${props => props.justify && justifyStyle}
   ${props => props.justifyContent && justifyContentStyle}
-  ${props => props.rows && rowsStyle}
+  ${props => props.rowsProp && rowsStyle(props)}
 `;
 
 export default StyledGrid.extend`

--- a/src/js/components/Grid/__tests__/Grid-test.js
+++ b/src/js/components/Grid/__tests__/Grid-test.js
@@ -19,6 +19,7 @@ test('Grid rows renders', () => {
   const component = renderer.create(
     <Grommet>
       <Grid rows={['small', 'large', 'medium']} />
+      <Grid rows='small' />
     </Grommet>
   );
   const tree = component.toJSON();
@@ -29,6 +30,8 @@ test('Grid columns renders', () => {
   const component = renderer.create(
     <Grommet>
       <Grid columns={['1/2', '1/4', '1/4']} />
+      <Grid columns='small' />
+      <Grid columns={{ count: 'fit', size: 'small' }} />
     </Grommet>
   );
   const tree = component.toJSON();
@@ -123,6 +126,19 @@ test('Grid gap renders', () => {
       <Grid gap={{ vertical: 'medium' }} />
       <Grid gap={{ vertical: 'large' }} />
       <Grid gap={{ horizontal: 'small', vertical: 'medium' }} />
+    </Grommet>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Grid fill renders', () => {
+  const component = renderer.create(
+    <Grommet>
+      <Grid fill={true} />
+      <Grid fill={false} />
+      <Grid fill='horizontal' />
+      <Grid fill='vertical' />
     </Grommet>
   );
   const tree = component.toJSON();

--- a/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
+++ b/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
@@ -16,7 +16,6 @@ exports[`Grid align renders 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -26,7 +25,6 @@ exports[`Grid align renders 1`] = `
 .c2 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -36,7 +34,6 @@ exports[`Grid align renders 1`] = `
 .c3 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
@@ -46,7 +43,6 @@ exports[`Grid align renders 1`] = `
 .c4 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -87,7 +83,6 @@ exports[`Grid alignContent renders 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-align-content: flex-start;
   -ms-flex-line-pack: start;
   align-content: flex-start;
@@ -96,7 +91,6 @@ exports[`Grid alignContent renders 1`] = `
 .c2 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
@@ -105,7 +99,6 @@ exports[`Grid alignContent renders 1`] = `
 .c3 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-align-content: space-between;
   -ms-flex-line-pack: space-between;
   align-content: space-between;
@@ -114,7 +107,6 @@ exports[`Grid alignContent renders 1`] = `
 .c4 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-align-content: space-around;
   -ms-flex-line-pack: space-around;
   align-content: space-around;
@@ -123,7 +115,6 @@ exports[`Grid alignContent renders 1`] = `
 .c5 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-align-content: flex-end;
   -ms-flex-line-pack: end;
   align-content: flex-end;
@@ -132,7 +123,6 @@ exports[`Grid alignContent renders 1`] = `
 .c6 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
   align-content: stretch;
@@ -178,7 +168,6 @@ exports[`Grid areas renders 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   grid-template-areas: "header main footer" "header sidebar footer" ". .";
   grid-template-columns: 75% 25%;
   grid-template-rows: 48px 384px 96px;
@@ -189,13 +178,6 @@ exports[`Grid areas renders 1`] = `
 >
   <div
     className="c1"
-    rows={
-      Array [
-        "xxsmall",
-        "medium",
-        "xsmall",
-      ]
-    }
   />
 </div>
 `;
@@ -216,8 +198,19 @@ exports[`Grid columns renders 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   grid-template-columns: 50% 25% 25%;
+}
+
+.c2 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-columns: repeat(auto-fill,minmax(192px,1fr));
+}
+
+.c3 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-columns: repeat(auto-fit,minmax(192px,1fr));
 }
 
 <div
@@ -225,6 +218,67 @@ exports[`Grid columns renders 1`] = `
 >
   <div
     className="c1"
+  />
+  <div
+    className="c2"
+  />
+  <div
+    className="c3"
+  />
+</div>
+`;
+
+exports[`Grid fill renders 1`] = `
+.c0 {
+  font-family: 'Work Sans',Arial,sans-serif;
+  font-size: 1em;
+  line-height: 1.5;
+  color: #444444;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: grid;
+  box-sizing: border-box;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+}
+
+.c3 {
+  display: grid;
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.c4 {
+  display: grid;
+  box-sizing: border-box;
+  height: 100%;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  />
+  <div
+    className="c2"
+  />
+  <div
+    className="c3"
+  />
+  <div
+    className="c4"
   />
 </div>
 `;
@@ -245,70 +299,60 @@ exports[`Grid gap renders 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   grid-gap: 12px 12px;
 }
 
 .c2 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   grid-gap: 24px 24px;
 }
 
 .c3 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   grid-gap: 48px 48px;
 }
 
 .c4 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   grid-row-gap: 12px;
 }
 
 .c5 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   grid-row-gap: 24px;
 }
 
 .c6 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   grid-row-gap: 48px;
 }
 
 .c7 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   grid-column-gap: 12px;
 }
 
 .c8 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   grid-column-gap: 24px;
 }
 
 .c9 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   grid-column-gap: 48px;
 }
 
 .c10 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   grid-row-gap: 12px;
   grid-column-gap: 24px;
 }
@@ -365,7 +409,6 @@ exports[`Grid justify renders 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -375,7 +418,6 @@ exports[`Grid justify renders 1`] = `
 .c2 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -385,7 +427,6 @@ exports[`Grid justify renders 1`] = `
 .c3 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-box-pack: end;
   -webkit-justify-content: flex-end;
   -ms-flex-pack: end;
@@ -395,7 +436,6 @@ exports[`Grid justify renders 1`] = `
 .c4 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-box-pack: stretch;
   -webkit-justify-content: stretch;
   -ms-flex-pack: stretch;
@@ -436,7 +476,6 @@ exports[`Grid justifyContent renders 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -446,7 +485,6 @@ exports[`Grid justifyContent renders 1`] = `
 .c2 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -456,7 +494,6 @@ exports[`Grid justifyContent renders 1`] = `
 .c3 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
@@ -466,7 +503,6 @@ exports[`Grid justifyContent renders 1`] = `
 .c4 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-box-pack: space-around;
   -webkit-justify-content: space-around;
   -ms-flex-pack: space-around;
@@ -476,7 +512,6 @@ exports[`Grid justifyContent renders 1`] = `
 .c5 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-box-pack: end;
   -webkit-justify-content: flex-end;
   -ms-flex-pack: end;
@@ -486,7 +521,6 @@ exports[`Grid justifyContent renders 1`] = `
 .c6 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   -webkit-box-pack: stretch;
   -webkit-justify-content: stretch;
   -ms-flex-pack: stretch;
@@ -533,7 +567,6 @@ exports[`Grid renders 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
 }
 
 <div
@@ -561,8 +594,13 @@ exports[`Grid rows renders 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
   grid-template-rows: 192px 768px 384px;
+}
+
+.c2 {
+  display: grid;
+  box-sizing: border-box;
+  grid-auto-rows: 192px;
 }
 
 <div
@@ -570,13 +608,9 @@ exports[`Grid rows renders 1`] = `
 >
   <div
     className="c1"
-    rows={
-      Array [
-        "small",
-        "large",
-        "medium",
-      ]
-    }
+  />
+  <div
+    className="c2"
   />
 </div>
 `;
@@ -597,7 +631,6 @@ exports[`Grid tag renders 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
-  height: 100%;
 }
 
 <div

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -2,6 +2,7 @@ import { describe, PropTypes } from 'react-desc';
 
 import { getAvailableAtBadge } from '../../utils';
 
+const fixedSizes = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
 const sizes = ['xsmall', 'small', 'medium', 'large', 'xlarge',
   'full', '1/2', '1/3', '2/3', '1/4', '3/4', 'flex'];
 const edgeSizes = ['small', 'medium', 'large', 'none'];
@@ -34,12 +35,35 @@ space in the column axis.`
         end: PropTypes.arrayOf(PropTypes.number),
       }),
     ).description('Area names and column,row coordinates.'),
-    columns: PropTypes.arrayOf(PropTypes.oneOf(sizes)).description('Column sizes.'),
+    columns: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.oneOfType([
+        PropTypes.oneOf(sizes),
+        PropTypes.arrayOf(PropTypes.oneOf(sizes)),
+      ])),
+      PropTypes.oneOf(fixedSizes),
+      PropTypes.shape({
+        count: PropTypes.oneOf(['fit', 'fill']),
+        size: PropTypes.oneOfType([
+          PropTypes.oneOf(fixedSizes),
+          PropTypes.arrayOf(PropTypes.oneOf(sizes)),
+        ]),
+      }),
+    ]).description(
+      `Column sizes.
+      If an array value is an array, the inner array indicates the
+      minimum and maximum sizes for the column.
+      Specifying a single string will repeat multiple columns
+      of that size, as long as there is room for more.
+      Specifying an object allows indicating how the columns
+      stretch to fit the available space.`
+    ),
+    fill: PropTypes.oneOf(['horizontal', 'vertical', true, false])
+      .description('Whether the width and/or height should fill the container.'),
     gap: PropTypes.oneOfType([
       PropTypes.oneOf(edgeSizes),
       PropTypes.shape({
-        horizontal: PropTypes.oneOf(edgeSizes),
-        vertical: PropTypes.oneOf(edgeSizes),
+        row: PropTypes.oneOf(edgeSizes),
+        column: PropTypes.oneOf(edgeSizes),
       }),
     ]).description(
       'Gap sizes between rows and/or columns.'
@@ -51,7 +75,19 @@ space in the row axis.`
     justifyContent: PropTypes.oneOf(
       ['start', 'center', 'end', 'between', 'around', 'stretch']
     ).description('How to align the contents along the row axis.'),
-    rows: PropTypes.arrayOf(PropTypes.oneOf(sizes)).description('Row sizes.'),
+    rows: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.oneOfType([
+        PropTypes.oneOf(sizes),
+        PropTypes.arrayOf(PropTypes.oneOf(sizes)),
+      ])),
+      PropTypes.oneOf(fixedSizes),
+    ]).description(
+      `Row sizes.
+      If an array value is an array, the inner array indicates the
+      minimum and maximum sizes for the row.
+      Specifying a single string will cause automatically added rows to be
+      the specified size.`
+    ),
     tag: PropTypes.string.description(
       'The DOM tag to use for the element.'
     ).defaultValue('div'),


### PR DESCRIPTION
#### What does this PR do?

Changed Grid to enhance `rows` and `columns` and added `fill`.

#### Where should the reviewer start?

Grid/doc.js

#### What testing has been done on this PR?

grommet-site
grommet-sandbox

#### How should this be manually tested?

grommet-sandbox

#### Any background context you want to provide?

These changes take advantage of the `repeat()` and `minmax()` parts of the CSS grid spec to allow callers to use grids with variable numbers of rows or columns. Typically, this is better approach than `<Box wrap={true} />`.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
BUT, callers should check the updated Grid `gap` property to use `row` and `column` instead of `horizontal` and `vertical`. The old behavior will be preserved for a short while to allow upgrading.