### PR TITLE
Fixed an issue with Button styling when primary + icon

### DIFF
--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -1,7 +1,10 @@
 import styled, { css } from 'styled-components';
 import { rgba } from 'polished';
 
-import { activeStyle, backgroundStyle, colorForName, colorIsDark, focusStyle, fontSize, lapAndUp } from '../../utils';
+import {
+  activeStyle, backgroundStyle, colorForName, colorIsDark, focusStyle,
+  fontSize, lapAndUp,
+} from '../../utils';
 
 const basicStyle = props => css`
   border: ${props.theme.button.border.width} solid ${props.color ? colorForName(props.color, props.theme) : props.theme.button.border.color};
@@ -129,12 +132,12 @@ const StyledButton = styled.button`
   outline: none;
   font: inherit;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
   text-transform: none;
 
+  ${props => props.plain && plainStyle}
   ${props => !props.plain && css`
     text-align: center;
     display: inline-block;
@@ -143,7 +146,7 @@ const StyledButton = styled.button`
     font-weight: ${props.theme.global.control.font.weight};
   `}
   ${props => !props.plain && !props.primary && basicStyle(props)}
-  ${props => !props.plain && props.primary && primaryStyle(props)}
+  ${props => props.primary && primaryStyle(props)}
 
   ${props => (
     !props.disabled && !props.focus && hoverStyle
@@ -166,7 +169,6 @@ const StyledButton = styled.button`
   ${lapAndUp(`
     transition: 0.1s ease-in-out;
   `)}
-  ${props => props.plain && plainStyle}
   ${props => props.fillContainer && fillStyle}
   ${props => props.icon && !props.label && `
     padding: ${props.theme.global.edgeSize.small};

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -20,7 +20,6 @@ exports[`Button color renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -56,7 +55,6 @@ exports[`Button color renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -172,7 +170,6 @@ exports[`Button disabled renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -239,7 +236,6 @@ exports[`Button focus renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -326,7 +322,6 @@ exports[`Button hoverIndicator as object renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -391,7 +386,6 @@ exports[`Button hoverIndicator as object with color renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -456,7 +450,6 @@ exports[`Button hoverIndicator as object with colorIndex renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -521,7 +514,6 @@ exports[`Button hoverIndicator as object with invalid color renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -586,7 +578,6 @@ exports[`Button hoverIndicator as object with invalid color renders 2`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -651,7 +642,6 @@ exports[`Button hoverIndicator as object with invalid colorIndex renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -716,7 +706,6 @@ exports[`Button hoverIndicator renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -781,7 +770,6 @@ exports[`Button href renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -857,7 +845,6 @@ exports[`Button icon label renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -961,7 +948,6 @@ exports[`Button primary renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -1048,7 +1034,6 @@ exports[`Button renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -1134,7 +1119,6 @@ exports[`Button reverse icon label renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -1238,7 +1222,6 @@ exports[`Button warns about invalid icon render 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -1316,7 +1299,6 @@ exports[`Button warns about invalid label render 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;

--- a/src/js/components/Button/__tests__/__snapshots__/RoutedButton-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/RoutedButton-test.js.snap
@@ -20,7 +20,6 @@ exports[`RoutedButton renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -112,17 +112,16 @@ exports[`Calendar date renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
   text-transform: none;
-  opacity: 0.3;
-  cursor: default;
   color: inherit;
   border: none;
   padding: 0;
   text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
   padding: 12px;
 }
 
@@ -133,7 +132,6 @@ exports[`Calendar date renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -156,17 +154,16 @@ exports[`Calendar date renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
   text-transform: none;
-  background-color: rgba(221,221,221,0.5);
-  color: #000000;
   color: inherit;
   border: none;
   padding: 0;
   text-align: inherit;
+  background-color: rgba(221,221,221,0.5);
+  color: #000000;
 }
 
 .c16:hover {
@@ -1692,17 +1689,16 @@ exports[`Calendar dates renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
   text-transform: none;
-  opacity: 0.3;
-  cursor: default;
   color: inherit;
   border: none;
   padding: 0;
   text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
   padding: 12px;
 }
 
@@ -1713,7 +1709,6 @@ exports[`Calendar dates renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -1736,17 +1731,16 @@ exports[`Calendar dates renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
   text-transform: none;
-  background-color: rgba(221,221,221,0.5);
-  color: #000000;
   color: inherit;
   border: none;
   padding: 0;
   text-align: inherit;
+  background-color: rgba(221,221,221,0.5);
+  color: #000000;
 }
 
 .c17:hover {
@@ -3274,17 +3268,16 @@ exports[`Calendar disabled renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
   text-transform: none;
-  opacity: 0.3;
-  cursor: default;
   color: inherit;
   border: none;
   padding: 0;
   text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
   padding: 12px;
 }
 
@@ -3295,7 +3288,6 @@ exports[`Calendar disabled renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -3318,17 +3310,16 @@ exports[`Calendar disabled renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
   text-transform: none;
-  background-color: rgba(221,221,221,0.5);
-  color: #000000;
   color: inherit;
   border: none;
   padding: 0;
   text-align: inherit;
+  background-color: rgba(221,221,221,0.5);
+  color: #000000;
 }
 
 .c17:hover {
@@ -4856,17 +4847,16 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
   text-transform: none;
-  opacity: 0.3;
-  cursor: default;
   color: inherit;
   border: none;
   padding: 0;
   text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
   padding: 12px;
 }
 
@@ -4877,7 +4867,6 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -4900,17 +4889,16 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
   text-transform: none;
-  background-color: rgba(221,221,221,0.5);
-  color: #000000;
   color: inherit;
   border: none;
   padding: 0;
   text-align: inherit;
+  background-color: rgba(221,221,221,0.5);
+  color: #000000;
 }
 
 .c16:hover {
@@ -7653,17 +7641,16 @@ exports[`Calendar renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
   text-transform: none;
-  opacity: 0.3;
-  cursor: default;
   color: inherit;
   border: none;
   padding: 0;
   text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
   padding: 12px;
 }
 
@@ -7674,7 +7661,6 @@ exports[`Calendar renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -7697,17 +7683,16 @@ exports[`Calendar renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
   text-transform: none;
-  background-color: rgba(221,221,221,0.5);
-  color: #000000;
   color: inherit;
   border: none;
   padding: 0;
   text-align: inherit;
+  background-color: rgba(221,221,221,0.5);
+  color: #000000;
 }
 
 .c16:hover {
@@ -9267,17 +9252,16 @@ exports[`Calendar size renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
   text-transform: none;
-  opacity: 0.3;
-  cursor: default;
   color: inherit;
   border: none;
   padding: 0;
   text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
   padding: 12px;
 }
 
@@ -9288,7 +9272,6 @@ exports[`Calendar size renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -9311,17 +9294,16 @@ exports[`Calendar size renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
   text-transform: none;
-  background-color: rgba(221,221,221,0.5);
-  color: #000000;
   color: inherit;
   border: none;
   padding: 0;
   text-align: inherit;
+  background-color: rgba(221,221,221,0.5);
+  color: #000000;
 }
 
 .c16:hover {

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -50,7 +50,7 @@ exports[`play renders 1`] = `
         direction="column"
       >
         <button
-          class="StyledButton-gXzblK erxOgR"
+          class="StyledButton-gXzblK gpCJao"
           disabled=""
           type="button"
         >
@@ -87,7 +87,7 @@ exports[`play renders 1`] = `
           direction="row"
         >
           <button
-            class="StyledButton-gXzblK etLvGo"
+            class="StyledButton-gXzblK kANibo"
             icon="[object Object]"
             type="button"
           >
@@ -115,7 +115,7 @@ exports[`play renders 1`] = `
             </span>
           </button>
           <button
-            class="StyledButton-gXzblK etLvGo"
+            class="StyledButton-gXzblK kANibo"
             icon="[object Object]"
             type="button"
           >
@@ -148,7 +148,7 @@ exports[`play renders 1`] = `
         direction="column"
       >
         <button
-          class="StyledButton-gXzblK djbfBD"
+          class="StyledButton-gXzblK fdbYpb"
           type="button"
         >
           <div
@@ -229,7 +229,7 @@ exports[`play renders 2`] = `
         direction="column"
       >
         <button
-          class="StyledButton-gXzblK djbfBD"
+          class="StyledButton-gXzblK fdbYpb"
           type="button"
         >
           <div
@@ -265,7 +265,7 @@ exports[`play renders 2`] = `
           direction="row"
         >
           <button
-            class="StyledButton-gXzblK etLvGo"
+            class="StyledButton-gXzblK kANibo"
             icon="[object Object]"
             type="button"
           >
@@ -292,7 +292,7 @@ exports[`play renders 2`] = `
             </span>
           </button>
           <button
-            class="StyledButton-gXzblK etLvGo"
+            class="StyledButton-gXzblK kANibo"
             icon="[object Object]"
             type="button"
           >
@@ -326,7 +326,7 @@ exports[`play renders 2`] = `
         direction="column"
       >
         <button
-          class="StyledButton-gXzblK erxOgR"
+          class="StyledButton-gXzblK gpCJao"
           disabled=""
           type="button"
         >
@@ -595,17 +595,16 @@ exports[`renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
   text-transform: none;
-  opacity: 0.3;
-  cursor: default;
   color: inherit;
   border: none;
   padding: 0;
   text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
   width: 100%;
   height: 100%;
   max-width: none;
@@ -622,7 +621,6 @@ exports[`renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -641,7 +639,6 @@ exports[`renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;

--- a/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
+++ b/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
@@ -3,7 +3,7 @@
 exports[`DropButton closes 1`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-gXzblK dZIZPB"
+  class="StyledButton-gXzblK gTFGea"
   label="Dropper"
   type="button"
 >
@@ -25,7 +25,7 @@ exports[`DropButton closes 2`] = `
 
 exports[`DropButton closes 3`] = `
 "@media only screen and (min-width:700px) {
-  .dZIZPB {
+  .gTFGea {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -35,7 +35,7 @@ exports[`DropButton closes 3`] = `
 exports[`DropButton mounts 1`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-gXzblK dZIZPB"
+  class="StyledButton-gXzblK gTFGea"
   label="Dropper"
   type="button"
 >
@@ -57,7 +57,7 @@ exports[`DropButton mounts 2`] = `
 
 exports[`DropButton mounts 3`] = `
 "@media only screen and (min-width:700px) {
-  .dZIZPB {
+  .gTFGea {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -67,7 +67,7 @@ exports[`DropButton mounts 3`] = `
 exports[`DropButton mounts 4`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-gXzblK dZIZPB"
+  class="StyledButton-gXzblK gTFGea"
   id="test"
   label="Dropper"
   tabindex="-1"
@@ -91,7 +91,7 @@ exports[`DropButton mounts 5`] = `
 
 exports[`DropButton mounts 6`] = `
 "@media only screen and (min-width:700px) {
-  .dZIZPB {
+  .gTFGea {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -101,7 +101,7 @@ exports[`DropButton mounts 6`] = `
 exports[`DropButton mounts disabled 1`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-gXzblK dUzCdF"
+  class="StyledButton-gXzblK gXena"
   disabled=""
   label="Dropper"
   type="button"

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -14,7 +14,7 @@ exports[`Menu opens and closes on click 1`] = `
   >
     <button
       aria-label="Close Menu"
-      class="StyledButton-gXzblK eCeZBH"
+      class="StyledButton-gXzblK cfZmJV"
       type="button"
     >
       <div
@@ -54,7 +54,7 @@ exports[`Menu opens and closes on click 1`] = `
       direction="column"
     >
       <button
-        class="StyledButton-gXzblK gqMHaF"
+        class="StyledButton-gXzblK cDmTYk"
         disabled=""
         type="button"
       >
@@ -66,7 +66,7 @@ exports[`Menu opens and closes on click 1`] = `
         </div>
       </button>
       <button
-        class="StyledButton-gXzblK faBScD"
+        class="StyledButton-gXzblK fWHUwZ"
         type="button"
       >
         <div
@@ -77,7 +77,7 @@ exports[`Menu opens and closes on click 1`] = `
         </div>
       </button>
       <a
-        class="StyledButton-gXzblK faBScD"
+        class="StyledButton-gXzblK fWHUwZ"
         href="/test"
       >
         <div
@@ -130,28 +130,28 @@ exports[`Menu opens and closes on click 2`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .kGZImI {
+  .fYUIhN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .eCeZBH {
+  .cfZmJV {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gqMHaF {
+  .cDmTYk {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .faBScD {
+  .fWHUwZ {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -192,7 +192,7 @@ exports[`Menu renders 1`] = `
 <div>
   <button
     aria-label="Open Menu"
-    class="StyledButton-gXzblK kGZImI"
+    class="StyledButton-gXzblK fYUIhN"
     id="test-menu"
     type="button"
   >
@@ -219,7 +219,7 @@ exports[`Menu with custom message renders 1`] = `
 <div>
   <button
     aria-label="Abrir Menu"
-    class="StyledButton-gXzblK kGZImI"
+    class="StyledButton-gXzblK fYUIhN"
     type="button"
   >
     <div
@@ -271,7 +271,7 @@ exports[`Menu with dropAlign renders 1`] = `
   >
     <button
       aria-label="Close Menu"
-      class="StyledButton-gXzblK eCeZBH"
+      class="StyledButton-gXzblK cfZmJV"
       type="button"
     >
       <div
@@ -311,7 +311,7 @@ exports[`Menu with dropAlign renders 1`] = `
       direction="column"
     >
       <button
-        class="StyledButton-gXzblK gqMHaF"
+        class="StyledButton-gXzblK cDmTYk"
         disabled=""
         type="button"
       >
@@ -323,7 +323,7 @@ exports[`Menu with dropAlign renders 1`] = `
         </div>
       </button>
       <button
-        class="StyledButton-gXzblK gqMHaF"
+        class="StyledButton-gXzblK cDmTYk"
         disabled=""
         type="button"
       >
@@ -377,35 +377,35 @@ exports[`Menu with dropAlign renders 2`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .kGZImI {
+  .fYUIhN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .eCeZBH {
+  .cfZmJV {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gqMHaF {
+  .cDmTYk {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .faBScD {
+  .fWHUwZ {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .kZkhbU {
+  .dQbnPv {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -20,7 +20,7 @@ exports[`Select closes drop on esc 1`] = `
       tabindex="-1"
     >
       <button
-        class="StyledButton-gXzblK faBScD"
+        class="StyledButton-gXzblK fWHUwZ"
         role="menuitem"
         type="button"
       >
@@ -36,7 +36,7 @@ exports[`Select closes drop on esc 1`] = `
         </div>
       </button>
       <button
-        class="StyledButton-gXzblK faBScD"
+        class="StyledButton-gXzblK fWHUwZ"
         role="menuitem"
         type="button"
       >
@@ -137,14 +137,14 @@ exports[`Select closes drop on esc 2`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .kGZImI {
+  .fYUIhN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .faBScD {
+  .fWHUwZ {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -184,7 +184,7 @@ exports[`Select closes drop on esc 2`] = `
 exports[`Select closes drop on esc 3`] = `
 <button
   aria-label="undefined"
-  class="StyledButton-gXzblK kGZImI"
+  class="StyledButton-gXzblK fYUIhN"
   id="test-select"
   type="button"
 >
@@ -236,7 +236,7 @@ exports[`Select closes drop on esc 3`] = `
 exports[`Select closes drop on esc 4`] = `
 <button
   aria-label="undefined"
-  class="StyledButton-gXzblK kGZImI"
+  class="StyledButton-gXzblK fYUIhN"
   id="test-select"
   type="button"
 >
@@ -288,7 +288,7 @@ exports[`Select closes drop on esc 4`] = `
 exports[`Select mounts 1`] = `
 <button
   aria-label="undefined"
-  class="StyledButton-gXzblK kGZImI"
+  class="StyledButton-gXzblK fYUIhN"
   id="test-select"
   type="button"
 >
@@ -340,7 +340,7 @@ exports[`Select mounts 1`] = `
 exports[`Select mounts 2`] = `
 <button
   aria-label="undefined"
-  class="StyledButton-gXzblK kGZImI"
+  class="StyledButton-gXzblK fYUIhN"
   id="test-select"
   type="button"
 >
@@ -409,7 +409,7 @@ exports[`Select mounts 3`] = `
       tabindex="-1"
     >
       <button
-        class="StyledButton-gXzblK faBScD"
+        class="StyledButton-gXzblK fWHUwZ"
         role="menuitem"
         type="button"
       >
@@ -425,7 +425,7 @@ exports[`Select mounts 3`] = `
         </div>
       </button>
       <button
-        class="StyledButton-gXzblK faBScD"
+        class="StyledButton-gXzblK fWHUwZ"
         role="menuitem"
         type="button"
       >
@@ -514,14 +514,14 @@ exports[`Select mounts 4`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .kGZImI {
+  .fYUIhN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .faBScD {
+  .fWHUwZ {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -566,7 +566,7 @@ exports[`Select mounts 5`] = `
   tabindex="-1"
 >
   <button
-    class="StyledButton-gXzblK faBScD"
+    class="StyledButton-gXzblK fWHUwZ"
     role="menuitem"
     type="button"
   >
@@ -582,7 +582,7 @@ exports[`Select mounts 5`] = `
     </div>
   </button>
   <button
-    class="StyledButton-gXzblK faBScD"
+    class="StyledButton-gXzblK fWHUwZ"
     role="menuitem"
     type="button"
   >
@@ -603,7 +603,7 @@ exports[`Select mounts 5`] = `
 exports[`Select mounts disabled 1`] = `
 <button
   aria-label="undefined"
-  class="StyledButton-gXzblK gqMHaF"
+  class="StyledButton-gXzblK cDmTYk"
   disabled=""
   id="test-select"
   type="button"
@@ -656,7 +656,7 @@ exports[`Select mounts disabled 1`] = `
 exports[`Select mounts disabled 2`] = `
 <button
   aria-label="undefined"
-  class="StyledButton-gXzblK gqMHaF"
+  class="StyledButton-gXzblK cDmTYk"
   disabled=""
   id="test-select"
   type="button"
@@ -709,7 +709,7 @@ exports[`Select mounts disabled 2`] = `
 exports[`Select mounts multiple 1`] = `
 <button
   aria-label="undefined"
-  class="StyledButton-gXzblK kGZImI"
+  class="StyledButton-gXzblK fYUIhN"
   id="test-select"
   type="button"
 >
@@ -763,7 +763,7 @@ exports[`Select mounts multiple 1`] = `
 exports[`Select mounts multiple 2`] = `
 <button
   aria-label="undefined"
-  class="StyledButton-gXzblK kGZImI"
+  class="StyledButton-gXzblK fYUIhN"
   id="test-select"
   type="button"
 >
@@ -834,7 +834,7 @@ exports[`Select mounts multiple 3`] = `
       tabindex="-1"
     >
       <button
-        class="StyledButton-gXzblK kZkhbU"
+        class="StyledButton-gXzblK dQbnPv"
         role="menuitem"
         type="button"
       >
@@ -850,7 +850,7 @@ exports[`Select mounts multiple 3`] = `
         </div>
       </button>
       <button
-        class="StyledButton-gXzblK kZkhbU"
+        class="StyledButton-gXzblK dQbnPv"
         role="menuitem"
         type="button"
       >
@@ -963,21 +963,21 @@ exports[`Select mounts multiple 4`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .kGZImI {
+  .fYUIhN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .faBScD {
+  .fWHUwZ {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .kZkhbU {
+  .dQbnPv {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -1022,7 +1022,7 @@ exports[`Select mounts multiple 5`] = `
   tabindex="-1"
 >
   <button
-    class="StyledButton-gXzblK kZkhbU"
+    class="StyledButton-gXzblK dQbnPv"
     role="menuitem"
     type="button"
   >
@@ -1038,7 +1038,7 @@ exports[`Select mounts multiple 5`] = `
     </div>
   </button>
   <button
-    class="StyledButton-gXzblK kZkhbU"
+    class="StyledButton-gXzblK dQbnPv"
     role="menuitem"
     type="button"
   >
@@ -1059,7 +1059,7 @@ exports[`Select mounts multiple 5`] = `
 exports[`Select mounts with complex options and children 1`] = `
 <button
   aria-label="undefined"
-  class="StyledButton-gXzblK kGZImI"
+  class="StyledButton-gXzblK fYUIhN"
   id="test-select"
   type="button"
 >
@@ -1111,7 +1111,7 @@ exports[`Select mounts with complex options and children 1`] = `
 exports[`Select mounts with complex options and children 2`] = `
 <button
   aria-label="undefined"
-  class="StyledButton-gXzblK kGZImI"
+  class="StyledButton-gXzblK fYUIhN"
   id="test-select"
   type="button"
 >
@@ -1180,7 +1180,7 @@ exports[`Select mounts with complex options and children 3`] = `
       tabindex="-1"
     >
       <button
-        class="StyledButton-gXzblK faBScD"
+        class="StyledButton-gXzblK fWHUwZ"
         role="menuitem"
         type="button"
       >
@@ -1189,7 +1189,7 @@ exports[`Select mounts with complex options and children 3`] = `
         </span>
       </button>
       <button
-        class="StyledButton-gXzblK faBScD"
+        class="StyledButton-gXzblK fWHUwZ"
         role="menuitem"
         type="button"
       >
@@ -1271,14 +1271,14 @@ exports[`Select mounts with complex options and children 4`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .kGZImI {
+  .fYUIhN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .faBScD {
+  .fWHUwZ {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -1350,7 +1350,7 @@ exports[`Select mounts with search 1`] = `
       tabindex="-1"
     >
       <button
-        class="StyledButton-gXzblK faBScD"
+        class="StyledButton-gXzblK fWHUwZ"
         role="menuitem"
         type="button"
       >
@@ -1366,7 +1366,7 @@ exports[`Select mounts with search 1`] = `
         </div>
       </button>
       <button
-        class="StyledButton-gXzblK faBScD"
+        class="StyledButton-gXzblK fWHUwZ"
         role="menuitem"
         type="button"
       >
@@ -1467,14 +1467,14 @@ exports[`Select mounts with search 2`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .kGZImI {
+  .fYUIhN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .faBScD {
+  .fWHUwZ {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -1555,7 +1555,7 @@ exports[`Select mounts with search 4`] = `
       tabindex="-1"
     >
       <button
-        class="StyledButton-gXzblK faBScD"
+        class="StyledButton-gXzblK fWHUwZ"
         role="menuitem"
         type="button"
       >
@@ -1571,7 +1571,7 @@ exports[`Select mounts with search 4`] = `
         </div>
       </button>
       <button
-        class="StyledButton-gXzblK faBScD"
+        class="StyledButton-gXzblK fWHUwZ"
         role="menuitem"
         type="button"
       >
@@ -1672,14 +1672,14 @@ exports[`Select mounts with search 5`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .kGZImI {
+  .fYUIhN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .faBScD {
+  .fWHUwZ {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -1719,7 +1719,7 @@ exports[`Select mounts with search 5`] = `
 exports[`Select renders multiple 1`] = `
 <button
   aria-label="undefined"
-  class="StyledButton-gXzblK kGZImI"
+  class="StyledButton-gXzblK fYUIhN"
   id="test-select"
   type="button"
 >
@@ -1773,7 +1773,7 @@ exports[`Select renders multiple 1`] = `
 exports[`Select renders size 1`] = `
 <button
   aria-label="undefined"
-  class="StyledButton-gXzblK kGZImI"
+  class="StyledButton-gXzblK fYUIhN"
   id="test-select"
   type="button"
 >

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -11,7 +11,7 @@ exports[`Tabs changes active index 1`] = `
     <button
       aria-expanded="true"
       aria-selected="true"
-      class="StyledButton-gXzblK kGZImI"
+      class="StyledButton-gXzblK fYUIhN"
       role="tab"
       type="button"
     >
@@ -31,7 +31,7 @@ exports[`Tabs changes active index 1`] = `
     <button
       aria-expanded="false"
       aria-selected="false"
-      class="StyledButton-gXzblK kGZImI"
+      class="StyledButton-gXzblK fYUIhN"
       role="tab"
       type="button"
     >
@@ -73,7 +73,7 @@ exports[`Tabs changes to second tab 1`] = `
         aria-expanded={false}
         aria-label={undefined}
         aria-selected={false}
-        className="StyledButton-gXzblK kGZImI"
+        className="StyledButton-gXzblK fYUIhN"
         disabled={false}
         href={undefined}
         icon={undefined}
@@ -105,7 +105,7 @@ exports[`Tabs changes to second tab 1`] = `
         aria-expanded={true}
         aria-label={undefined}
         aria-selected={true}
-        className="StyledButton-gXzblK kGZImI"
+        className="StyledButton-gXzblK fYUIhN"
         disabled={false}
         href={undefined}
         icon={undefined}
@@ -161,7 +161,7 @@ exports[`Tabs renders complex Tab title 1`] = `
         aria-expanded={true}
         aria-label={undefined}
         aria-selected={true}
-        className="StyledButton-gXzblK kGZImI"
+        className="StyledButton-gXzblK fYUIhN"
         disabled={false}
         href={undefined}
         icon={undefined}
@@ -190,7 +190,7 @@ exports[`Tabs renders complex Tab title 1`] = `
         aria-expanded={false}
         aria-label={undefined}
         aria-selected={false}
-        className="StyledButton-gXzblK kGZImI"
+        className="StyledButton-gXzblK fYUIhN"
         disabled={false}
         href={undefined}
         icon={undefined}
@@ -242,7 +242,7 @@ exports[`Tabs renders with Tab 1`] = `
         aria-expanded={true}
         aria-label={undefined}
         aria-selected={true}
-        className="StyledButton-gXzblK kGZImI"
+        className="StyledButton-gXzblK fYUIhN"
         disabled={false}
         href={undefined}
         icon={undefined}
@@ -275,7 +275,7 @@ exports[`Tabs renders with Tab 1`] = `
         aria-expanded={false}
         aria-label={undefined}
         aria-selected={false}
-        className="StyledButton-gXzblK kGZImI"
+        className="StyledButton-gXzblK fYUIhN"
         disabled={false}
         href={undefined}
         icon={undefined}
@@ -345,7 +345,7 @@ exports[`Tabs sets on hover 1`] = `
     <button
       aria-expanded="true"
       aria-selected="true"
-      class="StyledButton-gXzblK kGZImI"
+      class="StyledButton-gXzblK fYUIhN"
       role="tab"
       type="button"
     >
@@ -365,7 +365,7 @@ exports[`Tabs sets on hover 1`] = `
     <button
       aria-expanded="false"
       aria-selected="false"
-      class="StyledButton-gXzblK kGZImI"
+      class="StyledButton-gXzblK fYUIhN"
       role="tab"
       type="button"
     >
@@ -402,7 +402,7 @@ exports[`Tabs sets on hover 2`] = `
     <button
       aria-expanded="true"
       aria-selected="true"
-      class="StyledButton-gXzblK kGZImI"
+      class="StyledButton-gXzblK fYUIhN"
       role="tab"
       type="button"
     >
@@ -422,7 +422,7 @@ exports[`Tabs sets on hover 2`] = `
     <button
       aria-expanded="false"
       aria-selected="false"
-      class="StyledButton-gXzblK kGZImI"
+      class="StyledButton-gXzblK fYUIhN"
       role="tab"
       type="button"
     >
@@ -459,7 +459,7 @@ exports[`Tabs sets on hover 3`] = `
     <button
       aria-expanded="true"
       aria-selected="true"
-      class="StyledButton-gXzblK kGZImI"
+      class="StyledButton-gXzblK fYUIhN"
       role="tab"
       type="button"
     >
@@ -479,7 +479,7 @@ exports[`Tabs sets on hover 3`] = `
     <button
       aria-expanded="false"
       aria-selected="false"
-      class="StyledButton-gXzblK kGZImI"
+      class="StyledButton-gXzblK fYUIhN"
       role="tab"
       type="button"
     >
@@ -516,7 +516,7 @@ exports[`Tabs sets on hover 4`] = `
     <button
       aria-expanded="true"
       aria-selected="true"
-      class="StyledButton-gXzblK kGZImI"
+      class="StyledButton-gXzblK fYUIhN"
       role="tab"
       type="button"
     >
@@ -536,7 +536,7 @@ exports[`Tabs sets on hover 4`] = `
     <button
       aria-expanded="false"
       aria-selected="false"
-      class="StyledButton-gXzblK kGZImI"
+      class="StyledButton-gXzblK fYUIhN"
       role="tab"
       type="button"
     >

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -13,7 +13,7 @@ exports[`TextInput closes suggestion drop 1`] = `
   >
     <li>
       <button
-        class="StyledButton-gXzblK djbfBD"
+        class="StyledButton-gXzblK fdbYpb"
         type="button"
       >
         <div
@@ -26,7 +26,7 @@ exports[`TextInput closes suggestion drop 1`] = `
     </li>
     <li>
       <button
-        class="StyledButton-gXzblK djbfBD"
+        class="StyledButton-gXzblK fdbYpb"
         type="button"
       >
         <div
@@ -55,7 +55,7 @@ exports[`TextInput closes suggestion drop 2`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .djbfBD {
+  .fdbYpb {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -151,7 +151,7 @@ exports[`TextInput mounts with complex suggestions 1`] = `
   >
     <li>
       <button
-        class="StyledButton-gXzblK djbfBD"
+        class="StyledButton-gXzblK fdbYpb"
         type="button"
       >
         <div
@@ -164,7 +164,7 @@ exports[`TextInput mounts with complex suggestions 1`] = `
     </li>
     <li>
       <button
-        class="StyledButton-gXzblK djbfBD"
+        class="StyledButton-gXzblK fdbYpb"
         type="button"
       >
         <div
@@ -193,7 +193,7 @@ exports[`TextInput mounts with complex suggestions 2`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .djbfBD {
+  .fdbYpb {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -243,7 +243,7 @@ exports[`TextInput mounts with suggestions 1`] = `
   >
     <li>
       <button
-        class="StyledButton-gXzblK djbfBD"
+        class="StyledButton-gXzblK fdbYpb"
         type="button"
       >
         <div
@@ -256,7 +256,7 @@ exports[`TextInput mounts with suggestions 1`] = `
     </li>
     <li>
       <button
-        class="StyledButton-gXzblK djbfBD"
+        class="StyledButton-gXzblK fdbYpb"
         type="button"
       >
         <div
@@ -285,7 +285,7 @@ exports[`TextInput mounts with suggestions 2`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .djbfBD {
+  .fdbYpb {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -335,7 +335,7 @@ exports[`TextInput selects suggestion 1`] = `
   >
     <li>
       <button
-        class="StyledButton-gXzblK djbfBD"
+        class="StyledButton-gXzblK fdbYpb"
         type="button"
       >
         <div
@@ -348,7 +348,7 @@ exports[`TextInput selects suggestion 1`] = `
     </li>
     <li>
       <button
-        class="StyledButton-gXzblK djbfBD"
+        class="StyledButton-gXzblK fdbYpb"
         type="button"
       >
         <div
@@ -377,7 +377,7 @@ exports[`TextInput selects suggestion 2`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .djbfBD {
+  .fdbYpb {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -163,7 +163,6 @@ exports[`Video autoPlay renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -187,7 +186,6 @@ exports[`Video autoPlay renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -782,7 +780,6 @@ exports[`Video controls renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -806,7 +803,6 @@ exports[`Video controls renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -1569,7 +1565,6 @@ exports[`Video fit renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -1593,7 +1588,6 @@ exports[`Video fit renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -2354,7 +2348,6 @@ exports[`Video loop renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -2378,7 +2371,6 @@ exports[`Video loop renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -2917,7 +2909,6 @@ exports[`Video mute renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -2941,7 +2932,6 @@ exports[`Video mute renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -3480,7 +3470,6 @@ exports[`Video renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;
@@ -3504,7 +3493,6 @@ exports[`Video renders 1`] = `
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font: inherit;
   margin: 0;
   background-color: transparent;
   overflow: visible;


### PR DESCRIPTION
#### What does this PR do?

Fixed an issue with Button styling when primary + icon.
Now, when using `<Button primary icon={...} />`, the button background and rounding is styled. Before, this was treated the same as if there were only children and no label or icon.

#### Where should the reviewer start?

StyledButton.js

#### What testing has been done on this PR?

grommet-sandbox
grommet-site

#### How should this be manually tested?

grommet-sandbox

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
