### PR TITLE
Layer bugfix

### DIFF
--- a/src/js/components/Layer.js
+++ b/src/js/components/Layer.js
@@ -69,6 +69,10 @@ class LayerContents extends Component {
       KeyboardAccelerators.stopListeningToKeyboard(
         this, this._keyboardHandlers
       );
+    } else {
+      KeyboardAccelerators.startListeningToKeyboard(
+        this, this._keyboardHandlers
+      );
     };
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Returns the listener for a button click for the Layer

#### What testing has been done on this PR?
npm test / manual

#### What are the relevant issues?
When the layer is used in a component that is "observer", and after receiving the new properties (componentDidUpdate), the exit event (keyboard) does not work
