### PR TITLE
Add minified dxc CSS file

### DIFF
--- a/gulpfile-grommet-dist.js
+++ b/gulpfile-grommet-dist.js
@@ -136,6 +136,14 @@ module.exports = function(gulp) {
       .pipe(minifyCss())
       .pipe(gulp.dest('dist/'));
 
+    gulp.src('src/scss/dxc/*.scss')
+      .pipe(sass({
+        includePaths: [path.resolve(__dirname, './node_modules')]
+      }))
+      .pipe(rename('grommet-dxc.min.css'))
+      .pipe(minifyCss())
+      .pipe(gulp.dest('dist/'));
+
     return gulp.src('src/scss/vanilla/*.scss')
       .pipe(sass({
         includePaths: [path.resolve(__dirname, './node_modules')]
@@ -180,6 +188,8 @@ module.exports = function(gulp) {
     distCss('src/scss/hpinc/*.scss', 'grommet-hpinc.min.css', true);
     distCss('src/scss/aruba/*.scss', 'grommet-aruba.css');
     distCss('src/scss/aruba/*.scss', 'grommet-aruba.min.css', true);
+    distCss('src/scss/dxc/*.scss', 'grommet-dxc.css');
+    distCss('src/scss/dxc/*.scss', 'grommet-dxc.min.css', true);
 
     runSequence(['dist-bower:exploded', 'dist-bower:minified'], done);
   });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

There are minified CSS theme file for all the other themes (aruba, hpe...), but not for dxc theme. This PR adds a minified dxc CSS file.

#### Where should the reviewer start?

Only one file has been changed.

#### What testing has been done on this PR?

I tested it by importing in my personal project, the CSS works well.

#### How should this be manually tested?

See above.

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #2062.

#### Screenshots (if appropriate)

There should be a dxc them minified css file.

![screen shot 2018-06-02 at 13 03 36](https://user-images.githubusercontent.com/1293565/40880579-04a181ce-66b4-11e8-9790-343a1d30cb76.png)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.