### PR TITLE
Remove old IE11 style fix

### DIFF
--- a/src/js/components/WorldMap/StyledWorldMap.js
+++ b/src/js/components/WorldMap/StyledWorldMap.js
@@ -2,13 +2,6 @@ import styled from 'styled-components';
 
 const StyledWorldMap = styled.svg`
   width: 100%;
-
-  // IE11 fix world map height
-  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-    // The padding value below comes from svg height / width
-    padding-bottom: 49%; // 460 / 940 = .489361702 rounding off to 49
-    height: 1px;
-  }
 `;
 
 export default StyledWorldMap.extend`

--- a/src/js/components/WorldMap/__tests__/__snapshots__/WorldMap-test.js.snap
+++ b/src/js/components/WorldMap/__tests__/__snapshots__/WorldMap-test.js.snap
@@ -17,13 +17,6 @@ exports[`WorldMap color renders 1`] = `
   width: 100%;
 }
 
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c1 {
-    padding-bottom: 49%;
-    height: 1px;
-  }
-}
-
 <div
   className="c0"
 >
@@ -143,13 +136,6 @@ exports[`WorldMap continents renders 1`] = `
 
 .c1 {
   width: 100%;
-}
-
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c1 {
-    padding-bottom: 49%;
-    height: 1px;
-  }
 }
 
 <div
@@ -282,13 +268,6 @@ exports[`WorldMap onSelectPlace renders 1`] = `
   width: 100%;
 }
 
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c1 {
-    padding-bottom: 49%;
-    height: 1px;
-  }
-}
-
 <div
   className="c0"
 >
@@ -410,13 +389,6 @@ exports[`WorldMap places renders 1`] = `
 
 .c1 {
   width: 100%;
-}
-
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c1 {
-    padding-bottom: 49%;
-    height: 1px;
-  }
 }
 
 <div
@@ -552,13 +524,6 @@ exports[`WorldMap renders 1`] = `
 
 .c1 {
   width: 100%;
-}
-
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c1 {
-    padding-bottom: 49%;
-    height: 1px;
-  }
 }
 
 <div


### PR DESCRIPTION
Signed-off-by: Sean Kim <nogever@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes the WorldMap not shown in IE11. Please see https://github.com/grommet/grommet/issues/2052

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
