### PR TITLE
Show suggestions on focus in text input

### DIFF
--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -48,11 +48,15 @@ class DropContainer extends Component {
   }
 
   onClickDocument = (event) => {
-    const { onClickOutside } = this.props;
-    if (!findDOMNode(this.dropRef).contains(event.target)) {
-      if (onClickOutside) {
-        onClickOutside(event);
-      }
+    const { dropTarget, onClickOutside } = this.props;
+    const dropTargetNode = findDOMNode(dropTarget);
+    const dropNode = findDOMNode(this.dropRef);
+    if (
+      onClickOutside &&
+      !dropTargetNode.contains(event.target) &&
+      !dropNode.contains(event.target)
+    ) {
+      onClickOutside();
     }
   }
 

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -51,7 +51,7 @@ class DropContainer extends Component {
     const { onClickOutside } = this.props;
     if (!findDOMNode(this.dropRef).contains(event.target)) {
       if (onClickOutside) {
-        onClickOutside();
+        onClickOutside(event);
       }
     }
   }

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { findDOMNode } from 'react-dom';
 import { compose } from 'recompose';
 
 import { Box } from '../Box';
@@ -228,7 +229,13 @@ class TextInput extends Component {
           align={dropAlign}
           responsive={false}
           target={dropTarget || inputRef.current}
-          onClickOutside={() => this.setState({ showDrop: false })}
+          onClickOutside={(event) => {
+            if (findDOMNode(inputRef.current).contains(event.target)) {
+              // The input was clicked. Do not hide the drop.
+              return;
+            }
+            this.setState({ showDrop: false });
+          }}
           onEsc={() => this.setState({ showDrop: false })}
         >
           {this.renderSuggestions()}
@@ -260,6 +267,7 @@ class TextInput extends Component {
             value={renderLabel(value)}
             onFocus={(event) => {
               this.announceSuggestionsExist();
+              this.resetSuggestions();
               if (onFocus) {
                 onFocus(event);
               }

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { findDOMNode } from 'react-dom';
 import { compose } from 'recompose';
 
 import { Box } from '../Box';
@@ -229,13 +228,7 @@ class TextInput extends Component {
           align={dropAlign}
           responsive={false}
           target={dropTarget || inputRef.current}
-          onClickOutside={(event) => {
-            if (findDOMNode(inputRef.current).contains(event.target)) {
-              // The input was clicked. Do not hide the drop.
-              return;
-            }
-            this.setState({ showDrop: false });
-          }}
+          onClickOutside={() => this.setState({ showDrop: false })}
           onEsc={() => this.setState({ showDrop: false })}
         >
           {this.renderSuggestions()}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Shows text input suggestions when focusing on input.

#### Where should the reviewer start?
TextInput

#### What testing has been done on this PR?
TextInput stories.  The suggestions will show when focusing on the text field and will not hide when clicking on the input.  Selecting a suggestion should still hide the suggestions drop.

#### How should this be manually tested?
This needs to be tested in other scenarios.  I could use some help linking grommet to the OneSphere app so that we can test it more thoroughly.

#### Any background context you want to provide?
See issue below

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/2091

#### Screenshots (if appropriate)
N/A

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Should be backwards compatible