### PR TITLE
Removed justifySelf from Box documentation. It isn't implemented and not enough browsers support it.

### DIFF
--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -291,17 +291,6 @@ between
 end
 ```
 
-**justifySelf**
-
-How to align along the row axis when contained in a Grid.
-
-```
-start
-center
-end
-stretch
-```
-
 **margin**
 
 The amount of margin around the box. An object can

--- a/src/js/components/Box/__tests__/Box-test.js
+++ b/src/js/components/Box/__tests__/Box-test.js
@@ -104,19 +104,6 @@ test('Box alignSelf renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Box justifySelf renders', () => {
-  const component = renderer.create(
-    <Grommet>
-      <Box justifySelf='start' />
-      <Box justifySelf='center' />
-      <Box justifySelf='stretch' />
-      <Box justifySelf='end' />
-    </Grommet>
-  );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-});
-
 test('Box background renders', () => {
   const component = renderer.create(
     <Grommet>

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -3438,66 +3438,6 @@ exports[`Box justify renders 1`] = `
 </div>
 `;
 
-exports[`Box justifySelf renders 1`] = `
-.c0 {
-  font-family: 'Work Sans',Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.5;
-  color: #444444;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-}
-
-@media only screen and (max-width:699px) {
-  .c1 {
-    margin: 0;
-  }
-}
-
-@media only screen and (max-width:699px) {
-  .c1 {
-    padding: 0;
-  }
-}
-
-<div
-  className="c0"
->
-  <div
-    className="c1"
-  />
-  <div
-    className="c1"
-  />
-  <div
-    className="c1"
-  />
-  <div
-    className="c1"
-  />
-</div>
-`;
-
 exports[`Box margin renders 1`] = `
 .c0 {
   font-family: 'Work Sans',Arial,sans-serif;

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -104,10 +104,6 @@ export default (Box) => {
       .description('A fixed height.'),
     justify: PropTypes.oneOf(['start', 'center', 'between', 'end'])
       .description('How to align the contents along the main axis.'),
-    justifySelf: PropTypes.oneOf(['start', 'center', 'end', 'stretch'])
-      .description(
-        'How to align along the row axis when contained in a Grid.'
-      ),
     margin: PropTypes.oneOfType([
       PropTypes.oneOf(['none', ...PAD_SIZES]),
       PropTypes.shape({

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -439,17 +439,6 @@ between
 end
 \`\`\`
 
-**justifySelf**
-
-How to align along the row axis when contained in a Grid.
-
-\`\`\`
-start
-center
-end
-stretch
-\`\`\`
-
 **margin**
 
 The amount of margin around the box. An object can


### PR DESCRIPTION
#### What does this PR do?

Removed justifySelf from Box documentation. It isn't implemented and not enough browsers support it.

#### Where should the reviewer start?

Box/doc.js

#### What testing has been done on this PR?

storybook

#### How should this be manually tested?

storybook

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/2045

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
