### PR TITLE
Changed SelectContainer to not use fill={true} for contained Buttons. Fixes GitHub issue #2095.

### DIFF
--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -186,7 +186,6 @@ class SelectContainer extends Component {
             <InfiniteScroll items={options} step={theme.select.step}>
               {(option, index) => (
                 <Button
-                  fill={true}
                   role='menuitem'
                   ref={(ref) => { this.optionsRef[index] = ref; }}
                   active={

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -401,7 +401,7 @@ exports[`Select complex options and children 3`] = `
       tabindex="-1"
     >
       <button
-        class="StyledButton-qbvYY jYTBlN"
+        class="StyledButton-qbvYY ktbLOR"
         role="menuitem"
         type="button"
       >
@@ -410,7 +410,7 @@ exports[`Select complex options and children 3`] = `
         </span>
       </button>
       <button
-        class="StyledButton-qbvYY jYTBlN"
+        class="StyledButton-qbvYY ktbLOR"
         role="menuitem"
         type="button"
       >
@@ -511,7 +511,7 @@ exports[`Select complex options and children 4`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .jYTBlN {
+  .ktbLOR {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -1124,7 +1124,7 @@ exports[`Select multiple values 3`] = `
       tabindex="-1"
     >
       <button
-        class="StyledButton-qbvYY gfUHck"
+        class="StyledButton-qbvYY fZEyyA"
         role="menuitem"
         type="button"
       >
@@ -1139,7 +1139,7 @@ exports[`Select multiple values 3`] = `
         </div>
       </button>
       <button
-        class="StyledButton-qbvYY gfUHck"
+        class="StyledButton-qbvYY fZEyyA"
         role="menuitem"
         type="button"
       >
@@ -1270,14 +1270,14 @@ exports[`Select multiple values 4`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .jYTBlN {
+  .ktbLOR {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gfUHck {
+  .fZEyyA {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -1441,7 +1441,7 @@ exports[`Select opens 3`] = `
       tabindex="-1"
     >
       <button
-        class="StyledButton-qbvYY jYTBlN"
+        class="StyledButton-qbvYY ktbLOR"
         role="menuitem"
         type="button"
       >
@@ -1456,7 +1456,7 @@ exports[`Select opens 3`] = `
         </div>
       </button>
       <button
-        class="StyledButton-qbvYY jYTBlN"
+        class="StyledButton-qbvYY ktbLOR"
         role="menuitem"
         type="button"
       >
@@ -1563,7 +1563,7 @@ exports[`Select opens 4`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .jYTBlN {
+  .ktbLOR {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -1607,7 +1607,7 @@ exports[`Select opens 5`] = `
   tabindex="-1"
 >
   <button
-    class="StyledButton-qbvYY jYTBlN"
+    class="StyledButton-qbvYY ktbLOR"
     role="menuitem"
     type="button"
   >
@@ -1622,7 +1622,7 @@ exports[`Select opens 5`] = `
     </div>
   </button>
   <button
-    class="StyledButton-qbvYY jYTBlN"
+    class="StyledButton-qbvYY ktbLOR"
     role="menuitem"
     type="button"
   >
@@ -1725,7 +1725,7 @@ exports[`Select search 2`] = `
       tabindex="-1"
     >
       <button
-        class="StyledButton-qbvYY jYTBlN"
+        class="StyledButton-qbvYY ktbLOR"
         role="menuitem"
         type="button"
       >
@@ -1740,7 +1740,7 @@ exports[`Select search 2`] = `
         </div>
       </button>
       <button
-        class="StyledButton-qbvYY jYTBlN"
+        class="StyledButton-qbvYY ktbLOR"
         role="menuitem"
         type="button"
       >
@@ -1859,7 +1859,7 @@ exports[`Select search 3`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .jYTBlN {
+  .ktbLOR {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }

--- a/src/js/components/Select/stories/select.stories.js
+++ b/src/js/components/Select/stories/select.stories.js
@@ -16,7 +16,7 @@ import {
 import customSearchTheme from './theme';
 import SearchInputContext from './components/SearchInputContext';
 
-const DEFAULT_OPTIONS = ['one', 'two', 'three'];
+const DEFAULT_OPTIONS = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
 
 class SearchSelect extends Component {
   state = { options: DEFAULT_OPTIONS }


### PR DESCRIPTION
#### What does this PR do?

Changed SelectContainer to not use fill={true} for contained Buttons. Fixes GitHub issue #2095.

#### Where should the reviewer start?

SelectContainer.js

#### What testing has been done on this PR?

storybook on Firefox, Opera, Edge.

#### How should this be manually tested?

storybook

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/2095

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
