### PR TITLE
Added support for class properties in v1.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,7 @@
     "add-module-exports",
     "transform-object-rest-spread",
     "transform-react-es6-displayname",
-    "transform-object-assign"
+    "transform-object-assign",
+    "transform-class-properties"
   ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -84,5 +84,6 @@ rules:
   react/no-unknown-property: 1
   react/react-in-jsx-scope: 1
   react/self-closing-comp: 1
-  react/sort-comp: 1
+  react/sort-comp: 0
   react/jsx-wrap-multilines: 1
+

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel-core": "^6.21.0",
     "babel-eslint": "^8.0.1",
     "babel-plugin-add-module-exports": "^0.2.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
     "babel-plugin-transform-react-es6-displayname": "^1.0.0-beta1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -667,6 +667,10 @@ babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
@@ -694,6 +698,15 @@ babel-plugin-transform-async-to-generator@^6.22.0:
     babel-helper-remap-async-to-generator "^6.24.1"
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-class-properties@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"


### PR DESCRIPTION
#### What does this PR do?

Changes babel config to add support for class properties

#### Where should the reviewer start?

.babelrc

#### What testing has been done on this PR?

manual

#### How should this be manually tested?

run `gulp test` and `gulp jslint`

#### Any background context you want to provide?

In v2 we use class properties and in https://github.com/grommet/grommet/pull/2111 @RobertGary1 wants to add the event listeners to the class level. it would be nice to follow the same pattern as in v2.

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible