### PR TITLE
Add the possibility to style the Layer Container

### DIFF
--- a/src/js/components/Layer.js
+++ b/src/js/components/Layer.js
@@ -127,7 +127,7 @@ class LayerContents extends Component {
   }
 
   render () {
-    const { a11yTitle, children, closer, onClose } = this.props;
+    const { a11yTitle, children, closer, onClose, style } = this.props;
     const { intl } = this.context;
 
     let closerNode;
@@ -150,7 +150,7 @@ class LayerContents extends Component {
 
     return (
       <div ref={ref => this.containerRef = ref}
-        className={`${CLASS_ROOT}__container`}>
+        className={`${CLASS_ROOT}__container`} style={style}>
         <a tabIndex="-1" aria-hidden='true' style={{ outline: 'none' }}
           ref={ref => this.anchorStepRef = ref} />
         {closerNode}


### PR DESCRIPTION

#### What does this PR do?

Being able to style the Layer container is, IMO, really important. If you want a different background-color for a specific layer, it is currently not doable unless you change an scss variables (which applies the specified background color to all the layers, forbidding you from using a different background color for a specific layer)


#### Where should the reviewer start?

Layer.js

#### What testing has been done on this PR?

None 

#### How should this be manually tested?

Adding a style prop to the Layer component

#### Any background context you want to provide?

I have to maintain my own fork if I want to do that

#### What are the relevant issues?

Can't individually style a Layer

#### Screenshots (if appropriate)

None

#### Do the grommet docs need to be updated?

Yes

#### Should this PR be mentioned in the release notes?

Yes

#### Is this change backwards compatible or is it a breaking change?

It is backward compatible and won't break anything