### PR TITLE
Changed Layer and Drop to not control overflow in containers.

### DIFF
--- a/src/js/components/Drop/StyledDrop.js
+++ b/src/js/components/Drop/StyledDrop.js
@@ -33,8 +33,6 @@ const StyledDrop = styled.div`
     props.theme.global.drop.shadow[props.theme.dark ? 'dark' : 'light']};
   position: fixed;
   z-index: 20;
-
-  overflow: auto;
   outline: none;
 
   ${props => backgroundStyle(

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Drop align left random 1`] = `
 <div
-  class="StyledDrop-czaYBK jxdrKb"
+  class="StyledDrop-czaYBK bQLOYY"
   id="drop-node"
   style="width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -14,7 +14,7 @@ exports[`Drop align left random 1`] = `
 exports[`Drop align left random 2`] = `
 "
 
-.jxdrKb {
+.bQLOYY {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -28,7 +28,6 @@ exports[`Drop align left random 2`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -45,7 +44,7 @@ exports[`Drop align left random 2`] = `
 
 exports[`Drop align left right top bottom 1`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -57,7 +56,7 @@ exports[`Drop align left right top bottom 1`] = `
 exports[`Drop align left right top bottom 2`] = `
 "
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -71,7 +70,6 @@ exports[`Drop align left right top bottom 2`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -88,7 +86,7 @@ exports[`Drop align left right top bottom 2`] = `
 
 exports[`Drop align right left top top 1`] = `
 <div
-  class="StyledDrop-czaYBK gdDJrs"
+  class="StyledDrop-czaYBK cGZHRZ"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -100,7 +98,7 @@ exports[`Drop align right left top top 1`] = `
 exports[`Drop align right left top top 2`] = `
 "
 
-.gdDJrs {
+.cGZHRZ {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -114,7 +112,6 @@ exports[`Drop align right left top top 2`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -131,7 +128,7 @@ exports[`Drop align right left top top 2`] = `
 
 exports[`Drop align right random 1`] = `
 <div
-  class="StyledDrop-czaYBK gdDJrs"
+  class="StyledDrop-czaYBK cGZHRZ"
   id="drop-node"
   style="width: 0.1px; max-height: 768px;"
   tabindex="-1"
@@ -143,7 +140,7 @@ exports[`Drop align right random 1`] = `
 exports[`Drop align right random 2`] = `
 "
 
-.gdDJrs {
+.cGZHRZ {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -157,7 +154,6 @@ exports[`Drop align right random 2`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -174,7 +170,7 @@ exports[`Drop align right random 2`] = `
 
 exports[`Drop align right right bottom top 1`] = `
 <div
-  class="StyledDrop-czaYBK hThgnU"
+  class="StyledDrop-czaYBK gAVfkz"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -186,7 +182,7 @@ exports[`Drop align right right bottom top 1`] = `
 exports[`Drop align right right bottom top 2`] = `
 "
 
-.hThgnU {
+.gAVfkz {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -200,7 +196,6 @@ exports[`Drop align right right bottom top 2`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -217,7 +212,7 @@ exports[`Drop align right right bottom top 2`] = `
 
 exports[`Drop align right right bottom top 3`] = `
 <div
-  class="StyledDrop-czaYBK hThgnU"
+  class="StyledDrop-czaYBK gAVfkz"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -229,7 +224,7 @@ exports[`Drop align right right bottom top 3`] = `
 exports[`Drop align right right bottom top 4`] = `
 "
 
-.hThgnU {
+.gAVfkz {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -243,7 +238,6 @@ exports[`Drop align right right bottom top 4`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -260,7 +254,7 @@ exports[`Drop align right right bottom top 4`] = `
 
 exports[`Drop basic 1`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -272,7 +266,7 @@ exports[`Drop basic 1`] = `
 exports[`Drop basic 2`] = `
 "
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -286,7 +280,6 @@ exports[`Drop basic 2`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -303,7 +296,7 @@ exports[`Drop basic 2`] = `
 
 exports[`Drop close 1`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -315,7 +308,7 @@ exports[`Drop close 1`] = `
 exports[`Drop close 2`] = `
 "
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -329,7 +322,6 @@ exports[`Drop close 2`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -346,7 +338,7 @@ exports[`Drop close 2`] = `
 
 exports[`Drop invalid align 1`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="drop-node"
   style="width: 0.1px; max-height: 768px;"
   tabindex="-1"
@@ -358,7 +350,7 @@ exports[`Drop invalid align 1`] = `
 exports[`Drop invalid align 2`] = `
 "
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -372,7 +364,6 @@ exports[`Drop invalid align 2`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -389,7 +380,7 @@ exports[`Drop invalid align 2`] = `
 
 exports[`Drop invoke onClickOutside 1`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -401,7 +392,7 @@ exports[`Drop invoke onClickOutside 1`] = `
 exports[`Drop invoke onClickOutside 2`] = `
 "
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -415,7 +406,6 @@ exports[`Drop invoke onClickOutside 2`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -432,7 +422,7 @@ exports[`Drop invoke onClickOutside 2`] = `
 
 exports[`Drop resize 1`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
   tabindex="-1"
@@ -444,7 +434,7 @@ exports[`Drop resize 1`] = `
 exports[`Drop resize 2`] = `
 "
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -458,7 +448,6 @@ exports[`Drop resize 2`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -475,7 +464,7 @@ exports[`Drop resize 2`] = `
 
 exports[`Drop restrict focus 1`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
   tabindex="-1"
@@ -486,7 +475,7 @@ exports[`Drop restrict focus 1`] = `
 
 exports[`Drop restrict focus 2`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
   tabindex="-1"
@@ -498,7 +487,7 @@ exports[`Drop restrict focus 2`] = `
 exports[`Drop restrict focus 3`] = `
 "
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -512,7 +501,6 @@ exports[`Drop restrict focus 3`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -22,10 +22,8 @@ const desktopLayerStyle = `
 const StyledLayer = styled.div`
   ${baseStyle}
   background-color: unset;
-
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 
@@ -33,7 +31,8 @@ const StyledLayer = styled.div`
     position: absolute;
     height: 100%;
     width: 100%;
-  `)}
+    overflow: auto;
+    `)}
 
   ${(props) => {
     if (props.position === 'hidden') {
@@ -324,13 +323,12 @@ const POSITIONS = {
 };
 
 const desktopContainerStyle = css`
-position: ${props => (props.modal ? 'absolute' : 'fixed')};
-max-height: 100%;
-max-width: 100%;
-overflow: auto;
-border-radius: ${props => (props.plain ? 'none' : props.theme.layer.border.radius)};
-${props => (props.position !== 'hidden' &&
-  POSITIONS[props.position][props.full](props.margin, props.theme)) || ''}
+  position: ${props => (props.modal ? 'absolute' : 'fixed')};
+  max-height: 100%;
+  max-width: 100%;
+  border-radius: ${props => (props.plain ? 'none' : props.theme.layer.border.radius)};
+  ${props => (props.position !== 'hidden' &&
+    POSITIONS[props.position][props.full](props.margin, props.theme)) || ''}
 `;
 
 export const StyledContainer = styled.div`

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Layer full false 1`] = `
 <div
-  class="StyledLayer-EylWz jFhlSf"
+  class="StyledLayer-EylWz hklOtd"
   id="full-test"
   tabindex="-1"
 >
@@ -10,7 +10,7 @@ exports[`Layer full false 1`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv dfKPwT"
+    class="StyledLayer__StyledContainer-iKmEpv olEXI"
     id="full-test"
   >
     This is a layer
@@ -26,18 +26,17 @@ exports[`Layer full false 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -50,18 +49,17 @@ exports[`Layer full false 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -74,18 +72,17 @@ exports[`Layer full false 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .iXeeHa {
+  .louyLk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iXeeHa {
+  .louyLk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     top: 50%;
@@ -98,18 +95,17 @@ exports[`Layer full false 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .ipcyXx {
+  .dHETQk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .ipcyXx {
+  .dHETQk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     right: 0;
     top: 50%;
@@ -122,18 +118,17 @@ exports[`Layer full false 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dfKPwT {
+  .olEXI {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dfKPwT {
+  .olEXI {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -147,18 +142,17 @@ exports[`Layer full false 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .GUFQp {
+  .kTJNQT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .GUFQp {
+  .kTJNQT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -171,7 +165,7 @@ exports[`Layer full false 2`] = `
 
 
 
-.jFhlSf {
+.hklOtd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -184,21 +178,21 @@ exports[`Layer full false 2`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -212,7 +206,7 @@ exports[`Layer full false 2`] = `
 
 exports[`Layer full horizontal 1`] = `
 <div
-  class="StyledLayer-EylWz jFhlSf"
+  class="StyledLayer-EylWz hklOtd"
   id="full-test"
   tabindex="-1"
 >
@@ -220,7 +214,7 @@ exports[`Layer full horizontal 1`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv gqXeUQ"
+    class="StyledLayer__StyledContainer-iKmEpv cixDNB"
     id="full-test"
   >
     This is a layer
@@ -236,18 +230,17 @@ exports[`Layer full horizontal 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -260,18 +253,17 @@ exports[`Layer full horizontal 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -284,18 +276,17 @@ exports[`Layer full horizontal 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .iXeeHa {
+  .louyLk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iXeeHa {
+  .louyLk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     top: 50%;
@@ -308,18 +299,17 @@ exports[`Layer full horizontal 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .ipcyXx {
+  .dHETQk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .ipcyXx {
+  .dHETQk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     right: 0;
     top: 50%;
@@ -332,18 +322,17 @@ exports[`Layer full horizontal 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dfKPwT {
+  .olEXI {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dfKPwT {
+  .olEXI {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -357,18 +346,17 @@ exports[`Layer full horizontal 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .GUFQp {
+  .kTJNQT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .GUFQp {
+  .kTJNQT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -380,18 +368,17 @@ exports[`Layer full horizontal 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .gqXeUQ {
+  .cixDNB {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gqXeUQ {
+  .cixDNB {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     right: 0;
@@ -406,7 +393,7 @@ exports[`Layer full horizontal 2`] = `
 
 
 
-.jFhlSf {
+.hklOtd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -419,21 +406,21 @@ exports[`Layer full horizontal 2`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -447,7 +434,7 @@ exports[`Layer full horizontal 2`] = `
 
 exports[`Layer full true 1`] = `
 <div
-  class="StyledLayer-EylWz jFhlSf"
+  class="StyledLayer-EylWz hklOtd"
   id="full-test"
   tabindex="-1"
 >
@@ -455,7 +442,7 @@ exports[`Layer full true 1`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv GUFQp"
+    class="StyledLayer__StyledContainer-iKmEpv kTJNQT"
     id="full-test"
   >
     This is a layer
@@ -471,18 +458,17 @@ exports[`Layer full true 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -495,18 +481,17 @@ exports[`Layer full true 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -519,18 +504,17 @@ exports[`Layer full true 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .iXeeHa {
+  .louyLk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iXeeHa {
+  .louyLk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     top: 50%;
@@ -543,18 +527,17 @@ exports[`Layer full true 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .ipcyXx {
+  .dHETQk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .ipcyXx {
+  .dHETQk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     right: 0;
     top: 50%;
@@ -567,18 +550,17 @@ exports[`Layer full true 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dfKPwT {
+  .olEXI {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dfKPwT {
+  .olEXI {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -592,18 +574,17 @@ exports[`Layer full true 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .GUFQp {
+  .kTJNQT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .GUFQp {
+  .kTJNQT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -616,7 +597,7 @@ exports[`Layer full true 2`] = `
 
 
 
-.jFhlSf {
+.hklOtd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -629,21 +610,21 @@ exports[`Layer full true 2`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -657,7 +638,7 @@ exports[`Layer full true 2`] = `
 
 exports[`Layer full vertical 1`] = `
 <div
-  class="StyledLayer-EylWz jFhlSf"
+  class="StyledLayer-EylWz hklOtd"
   id="full-test"
   tabindex="-1"
 >
@@ -665,7 +646,7 @@ exports[`Layer full vertical 1`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv daWuPp"
+    class="StyledLayer__StyledContainer-iKmEpv dNTzs"
     id="full-test"
   >
     This is a layer
@@ -681,18 +662,17 @@ exports[`Layer full vertical 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -705,18 +685,17 @@ exports[`Layer full vertical 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -729,18 +708,17 @@ exports[`Layer full vertical 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .iXeeHa {
+  .louyLk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iXeeHa {
+  .louyLk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     top: 50%;
@@ -753,18 +731,17 @@ exports[`Layer full vertical 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .ipcyXx {
+  .dHETQk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .ipcyXx {
+  .dHETQk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     right: 0;
     top: 50%;
@@ -777,18 +754,17 @@ exports[`Layer full vertical 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dfKPwT {
+  .olEXI {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dfKPwT {
+  .olEXI {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -802,18 +778,17 @@ exports[`Layer full vertical 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .GUFQp {
+  .kTJNQT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .GUFQp {
+  .kTJNQT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -825,18 +800,17 @@ exports[`Layer full vertical 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .gqXeUQ {
+  .cixDNB {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gqXeUQ {
+  .cixDNB {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     right: 0;
@@ -850,18 +824,17 @@ exports[`Layer full vertical 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .daWuPp {
+  .dNTzs {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .daWuPp {
+  .dNTzs {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -876,7 +849,7 @@ exports[`Layer full vertical 2`] = `
 
 
 
-.jFhlSf {
+.hklOtd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -889,21 +862,21 @@ exports[`Layer full vertical 2`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -917,7 +890,7 @@ exports[`Layer full vertical 2`] = `
 
 exports[`Layer hidden 1`] = `
 <div
-  class="StyledLayer-EylWz hoUxsi"
+  class="StyledLayer-EylWz gMMmVO"
   id="hidden-test"
   tabindex="-1"
 >
@@ -925,7 +898,7 @@ exports[`Layer hidden 1`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv eFAfvP"
+    class="StyledLayer__StyledContainer-iKmEpv geFqau"
     id="hidden-test"
   >
     This is a layer
@@ -941,18 +914,17 @@ exports[`Layer hidden 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -965,18 +937,17 @@ exports[`Layer hidden 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -989,18 +960,17 @@ exports[`Layer hidden 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .iXeeHa {
+  .louyLk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iXeeHa {
+  .louyLk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     top: 50%;
@@ -1013,18 +983,17 @@ exports[`Layer hidden 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .ipcyXx {
+  .dHETQk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .ipcyXx {
+  .dHETQk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     right: 0;
     top: 50%;
@@ -1037,18 +1006,17 @@ exports[`Layer hidden 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dfKPwT {
+  .olEXI {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dfKPwT {
+  .olEXI {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -1062,18 +1030,17 @@ exports[`Layer hidden 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .GUFQp {
+  .kTJNQT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .GUFQp {
+  .kTJNQT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -1085,18 +1052,17 @@ exports[`Layer hidden 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .gqXeUQ {
+  .cixDNB {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gqXeUQ {
+  .cixDNB {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     right: 0;
@@ -1110,18 +1076,17 @@ exports[`Layer hidden 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .daWuPp {
+  .dNTzs {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .daWuPp {
+  .dNTzs {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -1135,18 +1100,17 @@ exports[`Layer hidden 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .egXFGk {
+  .gAqdZk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .egXFGk {
+  .gAqdZk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -1160,18 +1124,17 @@ exports[`Layer hidden 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dagEci {
+  .cATdPp {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dagEci {
+  .cATdPp {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -1185,18 +1148,17 @@ exports[`Layer hidden 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .hyecKU {
+  .kEWQBd {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .hyecKU {
+  .kEWQBd {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -1210,18 +1172,17 @@ exports[`Layer hidden 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .gRmmPN {
+  .juMqwC {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gRmmPN {
+  .juMqwC {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -1235,18 +1196,17 @@ exports[`Layer hidden 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .eFAfvP {
+  .geFqau {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .eFAfvP {
+  .geFqau {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
   }
 }
@@ -1254,15 +1214,16 @@ exports[`Layer hidden 2`] = `
 
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -1273,7 +1234,7 @@ exports[`Layer hidden 2`] = `
   }
 }
 
-.hoUxsi {
+.gMMmVO {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -1286,7 +1247,6 @@ exports[`Layer hidden 2`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
   left: -100%;
@@ -1296,17 +1256,18 @@ exports[`Layer hidden 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .hoUxsi {
+  .gMMmVO {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }"
 `;
 
 exports[`Layer hidden 3`] = `
 <div
-  class="StyledLayer-EylWz jFhlSf"
+  class="StyledLayer-EylWz hklOtd"
   id="hidden-test"
   tabindex="-1"
 >
@@ -1314,7 +1275,7 @@ exports[`Layer hidden 3`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv dfKPwT"
+    class="StyledLayer__StyledContainer-iKmEpv olEXI"
     id="hidden-test"
   >
     This is a layer
@@ -1330,18 +1291,17 @@ exports[`Layer hidden 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -1354,18 +1314,17 @@ exports[`Layer hidden 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -1378,18 +1337,17 @@ exports[`Layer hidden 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .iXeeHa {
+  .louyLk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iXeeHa {
+  .louyLk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     top: 50%;
@@ -1402,18 +1360,17 @@ exports[`Layer hidden 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .ipcyXx {
+  .dHETQk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .ipcyXx {
+  .dHETQk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     right: 0;
     top: 50%;
@@ -1426,18 +1383,17 @@ exports[`Layer hidden 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dfKPwT {
+  .olEXI {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dfKPwT {
+  .olEXI {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -1451,18 +1407,17 @@ exports[`Layer hidden 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .GUFQp {
+  .kTJNQT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .GUFQp {
+  .kTJNQT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -1474,18 +1429,17 @@ exports[`Layer hidden 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .gqXeUQ {
+  .cixDNB {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gqXeUQ {
+  .cixDNB {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     right: 0;
@@ -1499,18 +1453,17 @@ exports[`Layer hidden 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .daWuPp {
+  .dNTzs {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .daWuPp {
+  .dNTzs {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -1524,18 +1477,17 @@ exports[`Layer hidden 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .egXFGk {
+  .gAqdZk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .egXFGk {
+  .gAqdZk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -1549,18 +1501,17 @@ exports[`Layer hidden 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dagEci {
+  .cATdPp {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dagEci {
+  .cATdPp {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -1574,18 +1525,17 @@ exports[`Layer hidden 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .hyecKU {
+  .kEWQBd {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .hyecKU {
+  .kEWQBd {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -1599,18 +1549,17 @@ exports[`Layer hidden 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .gRmmPN {
+  .juMqwC {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gRmmPN {
+  .juMqwC {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -1624,25 +1573,24 @@ exports[`Layer hidden 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .eFAfvP {
+  .geFqau {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .eFAfvP {
+  .geFqau {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
   }
 }
 
 
 
-.jFhlSf {
+.hklOtd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -1655,21 +1603,21 @@ exports[`Layer hidden 4`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -1681,10 +1629,11 @@ exports[`Layer hidden 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .hoUxsi {
+  .gMMmVO {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }"
 `;
@@ -1722,7 +1671,7 @@ exports[`Layer is accessible 3`] = `
 
 exports[`Layer margin large 1`] = `
 <div
-  class="StyledLayer-EylWz jFhlSf"
+  class="StyledLayer-EylWz hklOtd"
   id="margin-test"
   tabindex="-1"
 >
@@ -1730,7 +1679,7 @@ exports[`Layer margin large 1`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv gRmmPN"
+    class="StyledLayer__StyledContainer-iKmEpv juMqwC"
     id="margin-test"
   >
     This is a layer
@@ -1746,18 +1695,17 @@ exports[`Layer margin large 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -1770,18 +1718,17 @@ exports[`Layer margin large 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -1794,18 +1741,17 @@ exports[`Layer margin large 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .iXeeHa {
+  .louyLk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iXeeHa {
+  .louyLk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     top: 50%;
@@ -1818,18 +1764,17 @@ exports[`Layer margin large 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .ipcyXx {
+  .dHETQk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .ipcyXx {
+  .dHETQk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     right: 0;
     top: 50%;
@@ -1842,18 +1787,17 @@ exports[`Layer margin large 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dfKPwT {
+  .olEXI {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dfKPwT {
+  .olEXI {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -1867,18 +1811,17 @@ exports[`Layer margin large 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .GUFQp {
+  .kTJNQT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .GUFQp {
+  .kTJNQT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -1890,18 +1833,17 @@ exports[`Layer margin large 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .gqXeUQ {
+  .cixDNB {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gqXeUQ {
+  .cixDNB {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     right: 0;
@@ -1915,18 +1857,17 @@ exports[`Layer margin large 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .daWuPp {
+  .dNTzs {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .daWuPp {
+  .dNTzs {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -1940,18 +1881,17 @@ exports[`Layer margin large 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .egXFGk {
+  .gAqdZk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .egXFGk {
+  .gAqdZk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -1965,18 +1905,17 @@ exports[`Layer margin large 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dagEci {
+  .cATdPp {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dagEci {
+  .cATdPp {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -1990,18 +1929,17 @@ exports[`Layer margin large 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .hyecKU {
+  .kEWQBd {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .hyecKU {
+  .kEWQBd {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -2015,18 +1953,17 @@ exports[`Layer margin large 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .gRmmPN {
+  .juMqwC {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gRmmPN {
+  .juMqwC {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -2041,7 +1978,7 @@ exports[`Layer margin large 2`] = `
 
 
 
-.jFhlSf {
+.hklOtd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -2054,21 +1991,21 @@ exports[`Layer margin large 2`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -2082,7 +2019,7 @@ exports[`Layer margin large 2`] = `
 
 exports[`Layer margin medium 1`] = `
 <div
-  class="StyledLayer-EylWz jFhlSf"
+  class="StyledLayer-EylWz hklOtd"
   id="margin-test"
   tabindex="-1"
 >
@@ -2090,7 +2027,7 @@ exports[`Layer margin medium 1`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv hyecKU"
+    class="StyledLayer__StyledContainer-iKmEpv kEWQBd"
     id="margin-test"
   >
     This is a layer
@@ -2106,18 +2043,17 @@ exports[`Layer margin medium 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -2130,18 +2066,17 @@ exports[`Layer margin medium 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -2154,18 +2089,17 @@ exports[`Layer margin medium 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .iXeeHa {
+  .louyLk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iXeeHa {
+  .louyLk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     top: 50%;
@@ -2178,18 +2112,17 @@ exports[`Layer margin medium 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .ipcyXx {
+  .dHETQk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .ipcyXx {
+  .dHETQk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     right: 0;
     top: 50%;
@@ -2202,18 +2135,17 @@ exports[`Layer margin medium 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dfKPwT {
+  .olEXI {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dfKPwT {
+  .olEXI {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -2227,18 +2159,17 @@ exports[`Layer margin medium 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .GUFQp {
+  .kTJNQT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .GUFQp {
+  .kTJNQT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -2250,18 +2181,17 @@ exports[`Layer margin medium 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .gqXeUQ {
+  .cixDNB {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gqXeUQ {
+  .cixDNB {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     right: 0;
@@ -2275,18 +2205,17 @@ exports[`Layer margin medium 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .daWuPp {
+  .dNTzs {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .daWuPp {
+  .dNTzs {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -2300,18 +2229,17 @@ exports[`Layer margin medium 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .egXFGk {
+  .gAqdZk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .egXFGk {
+  .gAqdZk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -2325,18 +2253,17 @@ exports[`Layer margin medium 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dagEci {
+  .cATdPp {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dagEci {
+  .cATdPp {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -2350,18 +2277,17 @@ exports[`Layer margin medium 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .hyecKU {
+  .kEWQBd {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .hyecKU {
+  .kEWQBd {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -2376,7 +2302,7 @@ exports[`Layer margin medium 2`] = `
 
 
 
-.jFhlSf {
+.hklOtd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -2389,21 +2315,21 @@ exports[`Layer margin medium 2`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -2417,7 +2343,7 @@ exports[`Layer margin medium 2`] = `
 
 exports[`Layer margin none 1`] = `
 <div
-  class="StyledLayer-EylWz jFhlSf"
+  class="StyledLayer-EylWz hklOtd"
   id="margin-test"
   tabindex="-1"
 >
@@ -2425,7 +2351,7 @@ exports[`Layer margin none 1`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv dfKPwT"
+    class="StyledLayer__StyledContainer-iKmEpv olEXI"
     id="margin-test"
   >
     This is a layer
@@ -2441,18 +2367,17 @@ exports[`Layer margin none 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -2465,18 +2390,17 @@ exports[`Layer margin none 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -2489,18 +2413,17 @@ exports[`Layer margin none 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .iXeeHa {
+  .louyLk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iXeeHa {
+  .louyLk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     top: 50%;
@@ -2513,18 +2436,17 @@ exports[`Layer margin none 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .ipcyXx {
+  .dHETQk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .ipcyXx {
+  .dHETQk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     right: 0;
     top: 50%;
@@ -2537,18 +2459,17 @@ exports[`Layer margin none 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dfKPwT {
+  .olEXI {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dfKPwT {
+  .olEXI {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -2562,18 +2483,17 @@ exports[`Layer margin none 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .GUFQp {
+  .kTJNQT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .GUFQp {
+  .kTJNQT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -2585,18 +2505,17 @@ exports[`Layer margin none 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .gqXeUQ {
+  .cixDNB {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gqXeUQ {
+  .cixDNB {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     right: 0;
@@ -2610,18 +2529,17 @@ exports[`Layer margin none 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .daWuPp {
+  .dNTzs {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .daWuPp {
+  .dNTzs {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -2636,7 +2554,7 @@ exports[`Layer margin none 2`] = `
 
 
 
-.jFhlSf {
+.hklOtd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -2649,21 +2567,21 @@ exports[`Layer margin none 2`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -2677,7 +2595,7 @@ exports[`Layer margin none 2`] = `
 
 exports[`Layer margin small 1`] = `
 <div
-  class="StyledLayer-EylWz jFhlSf"
+  class="StyledLayer-EylWz hklOtd"
   id="margin-test"
   tabindex="-1"
 >
@@ -2685,7 +2603,7 @@ exports[`Layer margin small 1`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv dagEci"
+    class="StyledLayer__StyledContainer-iKmEpv cATdPp"
     id="margin-test"
   >
     This is a layer
@@ -2701,18 +2619,17 @@ exports[`Layer margin small 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -2725,18 +2642,17 @@ exports[`Layer margin small 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -2749,18 +2665,17 @@ exports[`Layer margin small 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .iXeeHa {
+  .louyLk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iXeeHa {
+  .louyLk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     top: 50%;
@@ -2773,18 +2688,17 @@ exports[`Layer margin small 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .ipcyXx {
+  .dHETQk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .ipcyXx {
+  .dHETQk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     right: 0;
     top: 50%;
@@ -2797,18 +2711,17 @@ exports[`Layer margin small 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dfKPwT {
+  .olEXI {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dfKPwT {
+  .olEXI {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -2822,18 +2735,17 @@ exports[`Layer margin small 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .GUFQp {
+  .kTJNQT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .GUFQp {
+  .kTJNQT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -2845,18 +2757,17 @@ exports[`Layer margin small 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .gqXeUQ {
+  .cixDNB {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gqXeUQ {
+  .cixDNB {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     right: 0;
@@ -2870,18 +2781,17 @@ exports[`Layer margin small 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .daWuPp {
+  .dNTzs {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .daWuPp {
+  .dNTzs {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -2895,18 +2805,17 @@ exports[`Layer margin small 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .egXFGk {
+  .gAqdZk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .egXFGk {
+  .gAqdZk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -2920,18 +2829,17 @@ exports[`Layer margin small 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dagEci {
+  .cATdPp {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dagEci {
+  .cATdPp {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -2946,7 +2854,7 @@ exports[`Layer margin small 2`] = `
 
 
 
-.jFhlSf {
+.hklOtd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -2959,21 +2867,21 @@ exports[`Layer margin small 2`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -2987,7 +2895,7 @@ exports[`Layer margin small 2`] = `
 
 exports[`Layer margin xsmall 1`] = `
 <div
-  class="StyledLayer-EylWz jFhlSf"
+  class="StyledLayer-EylWz hklOtd"
   id="margin-test"
   tabindex="-1"
 >
@@ -2995,7 +2903,7 @@ exports[`Layer margin xsmall 1`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv egXFGk"
+    class="StyledLayer__StyledContainer-iKmEpv gAqdZk"
     id="margin-test"
   >
     This is a layer
@@ -3011,18 +2919,17 @@ exports[`Layer margin xsmall 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -3035,18 +2942,17 @@ exports[`Layer margin xsmall 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -3059,18 +2965,17 @@ exports[`Layer margin xsmall 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .iXeeHa {
+  .louyLk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iXeeHa {
+  .louyLk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     top: 50%;
@@ -3083,18 +2988,17 @@ exports[`Layer margin xsmall 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .ipcyXx {
+  .dHETQk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .ipcyXx {
+  .dHETQk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     right: 0;
     top: 50%;
@@ -3107,18 +3011,17 @@ exports[`Layer margin xsmall 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dfKPwT {
+  .olEXI {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dfKPwT {
+  .olEXI {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -3132,18 +3035,17 @@ exports[`Layer margin xsmall 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .GUFQp {
+  .kTJNQT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .GUFQp {
+  .kTJNQT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -3155,18 +3057,17 @@ exports[`Layer margin xsmall 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .gqXeUQ {
+  .cixDNB {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gqXeUQ {
+  .cixDNB {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     right: 0;
@@ -3180,18 +3081,17 @@ exports[`Layer margin xsmall 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .daWuPp {
+  .dNTzs {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .daWuPp {
+  .dNTzs {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -3205,18 +3105,17 @@ exports[`Layer margin xsmall 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .egXFGk {
+  .gAqdZk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .egXFGk {
+  .gAqdZk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -3231,7 +3130,7 @@ exports[`Layer margin xsmall 2`] = `
 
 
 
-.jFhlSf {
+.hklOtd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -3244,21 +3143,21 @@ exports[`Layer margin xsmall 2`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -3272,7 +3171,7 @@ exports[`Layer margin xsmall 2`] = `
 
 exports[`Layer non-modal renders 1`] = `
 <div
-  class="StyledLayer__StyledContainer-iKmEpv dfKPwT"
+  class="StyledLayer__StyledContainer-iKmEpv olEXI"
   id="non-modal-test"
 >
   This is a non-modal layer
@@ -3289,18 +3188,17 @@ exports[`Layer non-modal renders 2`] = `
 
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -3313,18 +3211,17 @@ exports[`Layer non-modal renders 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -3337,18 +3234,17 @@ exports[`Layer non-modal renders 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .iXeeHa {
+  .louyLk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iXeeHa {
+  .louyLk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     top: 50%;
@@ -3361,18 +3257,17 @@ exports[`Layer non-modal renders 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .ipcyXx {
+  .dHETQk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .ipcyXx {
+  .dHETQk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     right: 0;
     top: 50%;
@@ -3384,7 +3279,7 @@ exports[`Layer non-modal renders 2`] = `
   }
 }
 
-.dfKPwT {
+.olEXI {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -3409,18 +3304,17 @@ exports[`Layer non-modal renders 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dfKPwT {
+  .olEXI {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dfKPwT {
+  .olEXI {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -3434,18 +3328,17 @@ exports[`Layer non-modal renders 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .GUFQp {
+  .kTJNQT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .GUFQp {
+  .kTJNQT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -3457,18 +3350,17 @@ exports[`Layer non-modal renders 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .gqXeUQ {
+  .cixDNB {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gqXeUQ {
+  .cixDNB {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     right: 0;
@@ -3482,18 +3374,17 @@ exports[`Layer non-modal renders 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .daWuPp {
+  .dNTzs {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .daWuPp {
+  .dNTzs {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -3507,18 +3398,17 @@ exports[`Layer non-modal renders 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .egXFGk {
+  .gAqdZk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .egXFGk {
+  .gAqdZk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -3532,18 +3422,17 @@ exports[`Layer non-modal renders 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dagEci {
+  .cATdPp {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dagEci {
+  .cATdPp {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -3557,18 +3446,17 @@ exports[`Layer non-modal renders 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .hyecKU {
+  .kEWQBd {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .hyecKU {
+  .kEWQBd {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -3582,18 +3470,17 @@ exports[`Layer non-modal renders 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .gRmmPN {
+  .juMqwC {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gRmmPN {
+  .juMqwC {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -3607,35 +3494,33 @@ exports[`Layer non-modal renders 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .eFAfvP {
+  .geFqau {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .eFAfvP {
+  .geFqau {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
   }
 }
 
 @media only screen and (max-width:699px) {
-  .kPHQvR {
+  .coDRaV {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .kPHQvR {
+  .coDRaV {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: none;
     top: 50%;
     left: 50%;
@@ -3649,15 +3534,16 @@ exports[`Layer non-modal renders 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -3669,17 +3555,18 @@ exports[`Layer non-modal renders 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .hoUxsi {
+  .gMMmVO {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }"
 `;
 
 exports[`Layer plain 1`] = `
 <div
-  class="StyledLayer-EylWz jFhlSf"
+  class="StyledLayer-EylWz hklOtd"
   id="plain-test"
   tabindex="-1"
 >
@@ -3687,7 +3574,7 @@ exports[`Layer plain 1`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv kPHQvR"
+    class="StyledLayer__StyledContainer-iKmEpv coDRaV"
     id="plain-test"
   >
     This is a plain layer
@@ -3703,18 +3590,17 @@ exports[`Layer plain 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -3727,18 +3613,17 @@ exports[`Layer plain 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -3751,18 +3636,17 @@ exports[`Layer plain 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .iXeeHa {
+  .louyLk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iXeeHa {
+  .louyLk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     top: 50%;
@@ -3775,18 +3659,17 @@ exports[`Layer plain 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .ipcyXx {
+  .dHETQk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .ipcyXx {
+  .dHETQk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     right: 0;
     top: 50%;
@@ -3799,18 +3682,17 @@ exports[`Layer plain 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dfKPwT {
+  .olEXI {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dfKPwT {
+  .olEXI {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -3824,18 +3706,17 @@ exports[`Layer plain 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .GUFQp {
+  .kTJNQT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .GUFQp {
+  .kTJNQT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -3847,18 +3728,17 @@ exports[`Layer plain 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .gqXeUQ {
+  .cixDNB {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gqXeUQ {
+  .cixDNB {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     right: 0;
@@ -3872,18 +3752,17 @@ exports[`Layer plain 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .daWuPp {
+  .dNTzs {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .daWuPp {
+  .dNTzs {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     bottom: 0;
@@ -3897,18 +3776,17 @@ exports[`Layer plain 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .egXFGk {
+  .gAqdZk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .egXFGk {
+  .gAqdZk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -3922,18 +3800,17 @@ exports[`Layer plain 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dagEci {
+  .cATdPp {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dagEci {
+  .cATdPp {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -3947,18 +3824,17 @@ exports[`Layer plain 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .hyecKU {
+  .kEWQBd {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .hyecKU {
+  .kEWQBd {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -3972,18 +3848,17 @@ exports[`Layer plain 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .gRmmPN {
+  .juMqwC {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gRmmPN {
+  .juMqwC {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -3997,35 +3872,33 @@ exports[`Layer plain 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .eFAfvP {
+  .geFqau {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .eFAfvP {
+  .geFqau {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
   }
 }
 
 @media only screen and (max-width:699px) {
-  .kPHQvR {
+  .coDRaV {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .kPHQvR {
+  .coDRaV {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: none;
     top: 50%;
     left: 50%;
@@ -4040,7 +3913,7 @@ exports[`Layer plain 2`] = `
 
 
 
-.jFhlSf {
+.hklOtd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -4053,21 +3926,21 @@ exports[`Layer plain 2`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -4079,17 +3952,18 @@ exports[`Layer plain 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .hoUxsi {
+  .gMMmVO {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }"
 `;
 
 exports[`Layer position bottom 1`] = `
 <div
-  class="StyledLayer-EylWz jFhlSf"
+  class="StyledLayer-EylWz hklOtd"
   id="position-test"
   tabindex="-1"
 >
@@ -4097,7 +3971,7 @@ exports[`Layer position bottom 1`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv fjaUWp"
+    class="StyledLayer__StyledContainer-iKmEpv iiIQzz"
     id="position-test"
   >
     This is a layer
@@ -4113,18 +3987,17 @@ exports[`Layer position bottom 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -4137,18 +4010,17 @@ exports[`Layer position bottom 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -4162,7 +4034,7 @@ exports[`Layer position bottom 2`] = `
 
 
 
-.jFhlSf {
+.hklOtd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -4175,21 +4047,21 @@ exports[`Layer position bottom 2`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -4203,7 +4075,7 @@ exports[`Layer position bottom 2`] = `
 
 exports[`Layer position center 1`] = `
 <div
-  class="StyledLayer-EylWz jFhlSf"
+  class="StyledLayer-EylWz hklOtd"
   id="position-test"
   tabindex="-1"
 >
@@ -4211,7 +4083,7 @@ exports[`Layer position center 1`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv dfKPwT"
+    class="StyledLayer__StyledContainer-iKmEpv olEXI"
     id="position-test"
   >
     This is a layer
@@ -4227,18 +4099,17 @@ exports[`Layer position center 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -4251,18 +4122,17 @@ exports[`Layer position center 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -4275,18 +4145,17 @@ exports[`Layer position center 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .iXeeHa {
+  .louyLk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iXeeHa {
+  .louyLk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     top: 50%;
@@ -4299,18 +4168,17 @@ exports[`Layer position center 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .ipcyXx {
+  .dHETQk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .ipcyXx {
+  .dHETQk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     right: 0;
     top: 50%;
@@ -4323,18 +4191,17 @@ exports[`Layer position center 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .dfKPwT {
+  .olEXI {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .dfKPwT {
+  .olEXI {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 50%;
     left: 50%;
@@ -4349,7 +4216,7 @@ exports[`Layer position center 2`] = `
 
 
 
-.jFhlSf {
+.hklOtd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -4362,21 +4229,21 @@ exports[`Layer position center 2`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -4390,7 +4257,7 @@ exports[`Layer position center 2`] = `
 
 exports[`Layer position left 1`] = `
 <div
-  class="StyledLayer-EylWz jFhlSf"
+  class="StyledLayer-EylWz hklOtd"
   id="position-test"
   tabindex="-1"
 >
@@ -4398,7 +4265,7 @@ exports[`Layer position left 1`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv iXeeHa"
+    class="StyledLayer__StyledContainer-iKmEpv louyLk"
     id="position-test"
   >
     This is a layer
@@ -4414,18 +4281,17 @@ exports[`Layer position left 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -4438,18 +4304,17 @@ exports[`Layer position left 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -4462,18 +4327,17 @@ exports[`Layer position left 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .iXeeHa {
+  .louyLk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iXeeHa {
+  .louyLk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     top: 50%;
@@ -4487,7 +4351,7 @@ exports[`Layer position left 2`] = `
 
 
 
-.jFhlSf {
+.hklOtd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -4500,21 +4364,21 @@ exports[`Layer position left 2`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -4528,7 +4392,7 @@ exports[`Layer position left 2`] = `
 
 exports[`Layer position right 1`] = `
 <div
-  class="StyledLayer-EylWz jFhlSf"
+  class="StyledLayer-EylWz hklOtd"
   id="position-test"
   tabindex="-1"
 >
@@ -4536,7 +4400,7 @@ exports[`Layer position right 1`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv ipcyXx"
+    class="StyledLayer__StyledContainer-iKmEpv dHETQk"
     id="position-test"
   >
     This is a layer
@@ -4552,18 +4416,17 @@ exports[`Layer position right 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -4576,18 +4439,17 @@ exports[`Layer position right 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fjaUWp {
+  .iiIQzz {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fjaUWp {
+  .iiIQzz {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     bottom: 0;
     left: 50%;
@@ -4600,18 +4462,17 @@ exports[`Layer position right 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .iXeeHa {
+  .louyLk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iXeeHa {
+  .louyLk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     left: 0;
     top: 50%;
@@ -4624,18 +4485,17 @@ exports[`Layer position right 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .ipcyXx {
+  .dHETQk {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .ipcyXx {
+  .dHETQk {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     right: 0;
     top: 50%;
@@ -4649,7 +4509,7 @@ exports[`Layer position right 2`] = `
 
 
 
-.jFhlSf {
+.hklOtd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -4662,21 +4522,21 @@ exports[`Layer position right 2`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -4690,7 +4550,7 @@ exports[`Layer position right 2`] = `
 
 exports[`Layer position top 1`] = `
 <div
-  class="StyledLayer-EylWz jFhlSf"
+  class="StyledLayer-EylWz hklOtd"
   id="position-test"
   tabindex="-1"
 >
@@ -4698,7 +4558,7 @@ exports[`Layer position top 1`] = `
     class="StyledLayer__StyledOverlay-fQvaYh fBhMMM"
   />
   <div
-    class="StyledLayer__StyledContainer-iKmEpv fhpaBb"
+    class="StyledLayer__StyledContainer-iKmEpv hsaGuT"
     id="position-test"
   >
     This is a layer
@@ -4714,18 +4574,17 @@ exports[`Layer position top 2`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .fhpaBb {
+  .hsaGuT {
     min-height: 100%;
     min-width: 100%;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fhpaBb {
+  .hsaGuT {
     position: fixed;
     max-height: 100%;
     max-width: 100%;
-    overflow: auto;
     border-radius: 4px;
     top: 0;
     left: 50%;
@@ -4739,7 +4598,7 @@ exports[`Layer position top 2`] = `
 
 
 
-.jFhlSf {
+.hklOtd {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -4752,21 +4611,21 @@ exports[`Layer position top 2`] = `
   background-color: unset;
   position: relative;
   z-index: 10;
-  overflow: auto;
   pointer-events: none;
   outline: none;
 }
 
 @media only screen and (max-width:699px) {
-  .jFhlSf {
+  .hklOtd {
     position: absolute;
     height: 100%;
     width: 100%;
+    overflow: auto;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .jFhlSf {
+  .hklOtd {
     position: fixed;
     top: 0px;
     left: 0px;

--- a/src/js/components/Layer/layer.stories.js
+++ b/src/js/components/Layer/layer.stories.js
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 
 import {
   Add,
+  Close,
   FormClose,
   StatusGood,
   Trash,
@@ -11,10 +12,12 @@ import {
 import {
   Box,
   Button,
+  FormField,
   Grommet,
   Heading,
   Layer,
   Text,
+  TextInput,
 } from '../';
 
 class CenterLayer extends Component {
@@ -106,6 +109,72 @@ class CenterLayer extends Component {
   }
 }
 
+class FormLayer extends Component {
+  state = {}
+
+  onOpen = () => this.setState({ open: true })
+
+  onClose = () => this.setState({ open: undefined })
+
+  render() {
+    const { open } = this.state;
+    return (
+      <Grommet>
+        <Button
+          icon={<Add />}
+          label='Add'
+          onClick={this.onOpen}
+        />
+        {open && (
+          <Layer
+            position='right'
+            full='vertical'
+            modal={true}
+            onClickOutside={this.onClose}
+            onEsc={this.onClose}
+          >
+            <Box
+              tag='form'
+              fill='vertical'
+              overflow='auto'
+              width='medium'
+              pad='medium'
+              onSubmit={this.onClose}
+            >
+              <Box flex={false} direction='row' justify='between'>
+                <Heading level={2} margin='none'>Add</Heading>
+                <Button icon={<Close />} onClick={this.onClose} />
+              </Box>
+              <Box flex='grow' overflow={true} pad={{ vertical: 'medium' }}>
+                <FormField label='First'>
+                  <TextInput />
+                </FormField>
+                <FormField label='Second'>
+                  <TextInput />
+                </FormField>
+                <FormField label='Third'>
+                  <TextInput />
+                </FormField>
+                <FormField label='Fourth'>
+                  <TextInput />
+                </FormField>
+              </Box>
+              <Box flex={false} tag='footer' align='start'>
+                <Button
+                  type='submit'
+                  label='Submit'
+                  onClick={this.onClose}
+                  primary={true}
+                />
+              </Box>
+            </Box>
+          </Layer>
+        )}
+      </Grommet>
+    );
+  }
+}
+
 class NotificationLayer extends Component {
   state = {}
 
@@ -158,4 +227,5 @@ class NotificationLayer extends Component {
 
 storiesOf('Layer', module)
   .add('Center', () => <CenterLayer />)
+  .add('Form', () => <FormLayer />)
   .add('Notification', () => <NotificationLayer />);

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -147,7 +147,7 @@ exports[`Menu close by clicking outside 1`] = `
 
 exports[`Menu close by clicking outside 2`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="test-menu__drop"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -294,7 +294,7 @@ exports[`Menu close by clicking outside 3`] = `
 
 
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -308,7 +308,6 @@ exports[`Menu close by clicking outside 3`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -723,7 +722,7 @@ exports[`Menu open and close on click 2`] = `
 
 exports[`Menu open and close on click 3`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="test-menu__drop"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -879,7 +878,7 @@ exports[`Menu open and close on click 4`] = `
 
 
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -893,7 +892,6 @@ exports[`Menu open and close on click 4`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -992,7 +990,7 @@ exports[`Menu with dropAlign renders 1`] = `
 
 exports[`Menu with dropAlign renders 2`] = `
 <div
-  class="StyledDrop-czaYBK gdDJrs"
+  class="StyledDrop-czaYBK cGZHRZ"
   id="test-menu__drop"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -1146,7 +1144,7 @@ exports[`Menu with dropAlign renders 3`] = `
 
 
 
-.gdDJrs {
+.cGZHRZ {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -1160,7 +1158,6 @@ exports[`Menu with dropAlign renders 3`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -18,8 +18,12 @@ import { Keyboard } from '../Keyboard';
 import { Text } from '../Text';
 import { TextInput } from '../TextInput';
 
-const SelectContainerBox = styled(Box)`
-  max-height: ${props => props.theme.select.drop.maxHeight};
+const ContainerBox = styled(Box)`
+  height: ${props => props.theme.select.drop.maxHeight};
+  max-height: inherit;
+`;
+
+const OptionsBox = styled(Box)`
   scroll-behavior: smooth;
 `;
 
@@ -159,8 +163,9 @@ class SelectContainer extends Component {
         onDown={this.onNextOption}
         onKeyDown={onKeyDown}
       >
-        <Box
+        <ContainerBox
           id={id ? `${id}__select-drop` : undefined}
+          theme={theme}
         >
           {onSearch && (
             <Box pad={!customSearchInput ? 'xsmall' : undefined} flex={false}>
@@ -175,7 +180,7 @@ class SelectContainer extends Component {
               />
             </Box>
           )}
-          <SelectContainerBox
+          <OptionsBox
             flex={true}
             role='menubar'
             tabIndex='-1'
@@ -185,33 +190,34 @@ class SelectContainer extends Component {
           >
             <InfiniteScroll items={options} step={theme.select.step}>
               {(option, index) => (
-                <Button
-                  role='menuitem'
-                  ref={(ref) => { this.optionsRef[index] = ref; }}
-                  active={
-                    selected === index ||
-                    (Array.isArray(selected) && selected.indexOf(index) !== -1) ||
-                    activeIndex === index ||
-                    (option && option === value) ||
-                    (option && Array.isArray(value) && value.indexOf(option) !== -1)
-                  }
-                  key={`option_${name || ''}_${index}`}
-                  onClick={() => this.selectOption(option, index)}
-                  hoverIndicator='background'
-                >
-                  {children ? children(option, index, options) : (
-                    <Box align='start' pad='small'>
-                      <Text margin='none'>
-                        {(option !== null && option !== undefined) ?
-                          option.toString() : undefined}
-                      </Text>
-                    </Box>
-                  )}
-                </Button>
+                <Box key={`option_${name || ''}_${index}`} flex={false}>
+                  <Button
+                    role='menuitem'
+                    ref={(ref) => { this.optionsRef[index] = ref; }}
+                    active={
+                      selected === index ||
+                      (Array.isArray(selected) && selected.indexOf(index) !== -1) ||
+                      activeIndex === index ||
+                      (option && option === value) ||
+                      (option && Array.isArray(value) && value.indexOf(option) !== -1)
+                    }
+                    onClick={() => this.selectOption(option, index)}
+                    hoverIndicator='background'
+                  >
+                    {children ? children(option, index, options) : (
+                      <Box align='start' pad='small'>
+                        <Text margin='none'>
+                          {(option !== null && option !== undefined) ?
+                            option.toString() : undefined}
+                        </Text>
+                      </Box>
+                    )}
+                  </Button>
+                </Box>
               )}
             </InfiniteScroll>
-          </SelectContainerBox>
-        </Box>
+          </OptionsBox>
+        </ContainerBox>
       </Keyboard>
     );
   }

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -386,38 +386,46 @@ exports[`Select complex options and children 2`] = `
 
 exports[`Select complex options and children 3`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="test-select__drop"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
-    class="StyledBox-YaZNy hQeqTY"
+    class="SelectContainer__ContainerBox-cmlGXd cMIoSE StyledBox-YaZNy hQeqTY"
     id="test-select__select-drop"
   >
     <div
-      class="SelectContainer__SelectContainerBox-dqwAiO bNTcOA StyledBox-YaZNy fvEbPE"
+      class="SelectContainer__OptionsBox-ivZYuf dsVoEJ StyledBox-YaZNy fvEbPE"
       role="menubar"
       tabindex="-1"
     >
-      <button
-        class="StyledButton-qbvYY ktbLOR"
-        role="menuitem"
-        type="button"
+      <div
+        class="StyledBox-YaZNy ckMYwJ"
       >
-        <span>
-          one
-        </span>
-      </button>
-      <button
-        class="StyledButton-qbvYY ktbLOR"
-        role="menuitem"
-        type="button"
+        <button
+          class="StyledButton-qbvYY ktbLOR"
+          role="menuitem"
+          type="button"
+        >
+          <span>
+            one
+          </span>
+        </button>
+      </div>
+      <div
+        class="StyledBox-YaZNy ckMYwJ"
       >
-        <span>
-          two
-        </span>
-      </button>
+        <button
+          class="StyledButton-qbvYY ktbLOR"
+          role="menuitem"
+          type="button"
+        >
+          <span>
+            two
+          </span>
+        </button>
+      </div>
     </div>
   </div>
 </div>
@@ -492,6 +500,18 @@ exports[`Select complex options and children 4`] = `
 }
 
 @media only screen and (max-width:699px) {
+  .ckMYwJ {
+    margin: 0;
+  }
+}
+
+@media only screen and (max-width:699px) {
+  .ckMYwJ {
+    padding: 0;
+  }
+}
+
+@media only screen and (max-width:699px) {
   .hZNqBU {
     margin: 0;
   }
@@ -519,7 +539,7 @@ exports[`Select complex options and children 4`] = `
 
 
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -533,7 +553,6 @@ exports[`Select complex options and children 4`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -1109,50 +1128,58 @@ exports[`Select multiple values 2`] = `
 
 exports[`Select multiple values 3`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="test-select__drop"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
-    class="StyledBox-YaZNy hQeqTY"
+    class="SelectContainer__ContainerBox-cmlGXd cMIoSE StyledBox-YaZNy hQeqTY"
     id="test-select__select-drop"
   >
     <div
-      class="SelectContainer__SelectContainerBox-dqwAiO bNTcOA StyledBox-YaZNy fvEbPE"
+      class="SelectContainer__OptionsBox-ivZYuf dsVoEJ StyledBox-YaZNy fvEbPE"
       role="menubar"
       tabindex="-1"
     >
-      <button
-        class="StyledButton-qbvYY fZEyyA"
-        role="menuitem"
-        type="button"
+      <div
+        class="StyledBox-YaZNy ckMYwJ"
       >
-        <div
-          class="StyledBox-YaZNy hZNqBU"
+        <button
+          class="StyledButton-qbvYY fZEyyA"
+          role="menuitem"
+          type="button"
         >
-          <span
-            class="StyledText-dmaDlZ iRQiFb"
+          <div
+            class="StyledBox-YaZNy hZNqBU"
           >
-            one
-          </span>
-        </div>
-      </button>
-      <button
-        class="StyledButton-qbvYY fZEyyA"
-        role="menuitem"
-        type="button"
+            <span
+              class="StyledText-dmaDlZ iRQiFb"
+            >
+              one
+            </span>
+          </div>
+        </button>
+      </div>
+      <div
+        class="StyledBox-YaZNy ckMYwJ"
       >
-        <div
-          class="StyledBox-YaZNy hZNqBU"
+        <button
+          class="StyledButton-qbvYY fZEyyA"
+          role="menuitem"
+          type="button"
         >
-          <span
-            class="StyledText-dmaDlZ iRQiFb"
+          <div
+            class="StyledBox-YaZNy hZNqBU"
           >
-            two
-          </span>
-        </div>
-      </button>
+            <span
+              class="StyledText-dmaDlZ iRQiFb"
+            >
+              two
+            </span>
+          </div>
+        </button>
+      </div>
     </div>
   </div>
 </div>
@@ -1227,6 +1254,18 @@ exports[`Select multiple values 4`] = `
 }
 
 @media only screen and (max-width:699px) {
+  .ckMYwJ {
+    margin: 0;
+  }
+}
+
+@media only screen and (max-width:699px) {
+  .ckMYwJ {
+    padding: 0;
+  }
+}
+
+@media only screen and (max-width:699px) {
   .hZNqBU {
     margin: 0;
   }
@@ -1285,7 +1324,7 @@ exports[`Select multiple values 4`] = `
 
 
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -1299,7 +1338,6 @@ exports[`Select multiple values 4`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -1426,50 +1464,58 @@ exports[`Select opens 2`] = `
 
 exports[`Select opens 3`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="test-select__drop"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
-    class="StyledBox-YaZNy hQeqTY"
+    class="SelectContainer__ContainerBox-cmlGXd cMIoSE StyledBox-YaZNy hQeqTY"
     id="test-select__select-drop"
   >
     <div
-      class="SelectContainer__SelectContainerBox-dqwAiO bNTcOA StyledBox-YaZNy fvEbPE"
+      class="SelectContainer__OptionsBox-ivZYuf dsVoEJ StyledBox-YaZNy fvEbPE"
       role="menubar"
       tabindex="-1"
     >
-      <button
-        class="StyledButton-qbvYY ktbLOR"
-        role="menuitem"
-        type="button"
+      <div
+        class="StyledBox-YaZNy ckMYwJ"
       >
-        <div
-          class="StyledBox-YaZNy hZNqBU"
+        <button
+          class="StyledButton-qbvYY ktbLOR"
+          role="menuitem"
+          type="button"
         >
-          <span
-            class="StyledText-dmaDlZ iRQiFb"
+          <div
+            class="StyledBox-YaZNy hZNqBU"
           >
-            one
-          </span>
-        </div>
-      </button>
-      <button
-        class="StyledButton-qbvYY ktbLOR"
-        role="menuitem"
-        type="button"
+            <span
+              class="StyledText-dmaDlZ iRQiFb"
+            >
+              one
+            </span>
+          </div>
+        </button>
+      </div>
+      <div
+        class="StyledBox-YaZNy ckMYwJ"
       >
-        <div
-          class="StyledBox-YaZNy hZNqBU"
+        <button
+          class="StyledButton-qbvYY ktbLOR"
+          role="menuitem"
+          type="button"
         >
-          <span
-            class="StyledText-dmaDlZ iRQiFb"
+          <div
+            class="StyledBox-YaZNy hZNqBU"
           >
-            two
-          </span>
-        </div>
-      </button>
+            <span
+              class="StyledText-dmaDlZ iRQiFb"
+            >
+              two
+            </span>
+          </div>
+        </button>
+      </div>
     </div>
   </div>
 </div>
@@ -1544,6 +1590,18 @@ exports[`Select opens 4`] = `
 }
 
 @media only screen and (max-width:699px) {
+  .ckMYwJ {
+    margin: 0;
+  }
+}
+
+@media only screen and (max-width:699px) {
+  .ckMYwJ {
+    padding: 0;
+  }
+}
+
+@media only screen and (max-width:699px) {
   .hZNqBU {
     margin: 0;
   }
@@ -1571,7 +1629,7 @@ exports[`Select opens 4`] = `
 
 
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -1585,7 +1643,6 @@ exports[`Select opens 4`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -1602,40 +1659,48 @@ exports[`Select opens 4`] = `
 
 exports[`Select opens 5`] = `
 <div
-  class="SelectContainer__SelectContainerBox-dqwAiO bNTcOA StyledBox-YaZNy fvEbPE"
+  class="SelectContainer__OptionsBox-ivZYuf dsVoEJ StyledBox-YaZNy fvEbPE"
   role="menubar"
   tabindex="-1"
 >
-  <button
-    class="StyledButton-qbvYY ktbLOR"
-    role="menuitem"
-    type="button"
+  <div
+    class="StyledBox-YaZNy ckMYwJ"
   >
-    <div
-      class="StyledBox-YaZNy hZNqBU"
+    <button
+      class="StyledButton-qbvYY ktbLOR"
+      role="menuitem"
+      type="button"
     >
-      <span
-        class="StyledText-dmaDlZ iRQiFb"
+      <div
+        class="StyledBox-YaZNy hZNqBU"
       >
-        one
-      </span>
-    </div>
-  </button>
-  <button
-    class="StyledButton-qbvYY ktbLOR"
-    role="menuitem"
-    type="button"
+        <span
+          class="StyledText-dmaDlZ iRQiFb"
+        >
+          one
+        </span>
+      </div>
+    </button>
+  </div>
+  <div
+    class="StyledBox-YaZNy ckMYwJ"
   >
-    <div
-      class="StyledBox-YaZNy hZNqBU"
+    <button
+      class="StyledButton-qbvYY ktbLOR"
+      role="menuitem"
+      type="button"
     >
-      <span
-        class="StyledText-dmaDlZ iRQiFb"
+      <div
+        class="StyledBox-YaZNy hZNqBU"
       >
-        two
-      </span>
-    </div>
-  </button>
+        <span
+          class="StyledText-dmaDlZ iRQiFb"
+        >
+          two
+        </span>
+      </div>
+    </button>
+  </div>
 </div>
 `;
 
@@ -1696,13 +1761,13 @@ exports[`Select search 1`] = `
 
 exports[`Select search 2`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="test-select__drop"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
-    class="StyledBox-YaZNy hQeqTY"
+    class="SelectContainer__ContainerBox-cmlGXd cMIoSE StyledBox-YaZNy hQeqTY"
     id="test-select__select-drop"
   >
     <div
@@ -1720,40 +1785,48 @@ exports[`Select search 2`] = `
       </div>
     </div>
     <div
-      class="SelectContainer__SelectContainerBox-dqwAiO bNTcOA StyledBox-YaZNy fvEbPE"
+      class="SelectContainer__OptionsBox-ivZYuf dsVoEJ StyledBox-YaZNy fvEbPE"
       role="menubar"
       tabindex="-1"
     >
-      <button
-        class="StyledButton-qbvYY ktbLOR"
-        role="menuitem"
-        type="button"
+      <div
+        class="StyledBox-YaZNy ckMYwJ"
       >
-        <div
-          class="StyledBox-YaZNy hZNqBU"
+        <button
+          class="StyledButton-qbvYY ktbLOR"
+          role="menuitem"
+          type="button"
         >
-          <span
-            class="StyledText-dmaDlZ iRQiFb"
+          <div
+            class="StyledBox-YaZNy hZNqBU"
           >
-            one
-          </span>
-        </div>
-      </button>
-      <button
-        class="StyledButton-qbvYY ktbLOR"
-        role="menuitem"
-        type="button"
+            <span
+              class="StyledText-dmaDlZ iRQiFb"
+            >
+              one
+            </span>
+          </div>
+        </button>
+      </div>
+      <div
+        class="StyledBox-YaZNy ckMYwJ"
       >
-        <div
-          class="StyledBox-YaZNy hZNqBU"
+        <button
+          class="StyledButton-qbvYY ktbLOR"
+          role="menuitem"
+          type="button"
         >
-          <span
-            class="StyledText-dmaDlZ iRQiFb"
+          <div
+            class="StyledBox-YaZNy hZNqBU"
           >
-            two
-          </span>
-        </div>
-      </button>
+            <span
+              class="StyledText-dmaDlZ iRQiFb"
+            >
+              two
+            </span>
+          </div>
+        </button>
+      </div>
     </div>
   </div>
 </div>
@@ -1828,6 +1901,18 @@ exports[`Select search 3`] = `
 }
 
 @media only screen and (max-width:699px) {
+  .ckMYwJ {
+    margin: 0;
+  }
+}
+
+@media only screen and (max-width:699px) {
+  .ckMYwJ {
+    padding: 0;
+  }
+}
+
+@media only screen and (max-width:699px) {
   .hZNqBU {
     margin: 0;
   }
@@ -1867,7 +1952,7 @@ exports[`Select search 3`] = `
 
 
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -1881,7 +1966,6 @@ exports[`Select search 3`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -34,7 +34,7 @@ exports[`TextInput close suggestion drop 1`] = `
 
 exports[`TextInput close suggestion drop 2`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -92,7 +92,7 @@ exports[`TextInput close suggestion drop 3`] = `
 
 
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -106,7 +106,6 @@ exports[`TextInput close suggestion drop 3`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -161,7 +160,7 @@ exports[`TextInput complex suggestions 1`] = `
 
 exports[`TextInput complex suggestions 2`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -219,7 +218,7 @@ exports[`TextInput complex suggestions 3`] = `
 
 
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -233,7 +232,6 @@ exports[`TextInput complex suggestions 3`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -345,7 +343,7 @@ exports[`TextInput select suggestion 1`] = `
 
 exports[`TextInput select suggestion 2`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -403,7 +401,7 @@ exports[`TextInput select suggestion 3`] = `
 
 
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -417,7 +415,6 @@ exports[`TextInput select suggestion 3`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;
@@ -468,7 +465,7 @@ exports[`TextInput suggestions 1`] = `
 
 exports[`TextInput suggestions 2`] = `
 <div
-  class="StyledDrop-czaYBK igFhFE"
+  class="StyledDrop-czaYBK iNJpQg"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -526,7 +523,7 @@ exports[`TextInput suggestions 3`] = `
 
 
 
-.igFhFE {
+.iNJpQg {
   font-family: 'Work Sans',Arial,sans-serif;
   font-size: 1em;
   line-height: 1.5;
@@ -540,7 +537,6 @@ exports[`TextInput suggestions 3`] = `
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
   position: fixed;
   z-index: 20;
-  overflow: auto;
   outline: none;
   background-color: #f8f8f8;
   color: #444444;


### PR DESCRIPTION
#### What does this PR do?

Changed Layer and Drop to not control overflow in containers.

#### Where should the reviewer start?

StyledDrop.js
StyledLayer.js

#### What testing has been done on this PR?

storybook

#### How should this be manually tested?

storybook Opera, Firefox, Edge, IE11

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/2103
https://github.com/grommet/grommet/issues/2107

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

Usage of Layer or Drop expecting the container to control overflow should be updated to control the overflow in a containing Box.

