### PR TITLE
Updated a selector for the Box used to set flex-basis defaults when s…

### DIFF
--- a/src/scss/grommet-core/_objects.box.scss
+++ b/src/scss/grommet-core/_objects.box.scss
@@ -205,7 +205,7 @@
 .#{$grommet-namespace}box--flex-grow {
   flex: 1 0;
 
-  &:not([class^=".#{$grommet-namespace}box--basis"]) {
+  &:not([class*="#{$grommet-namespace}box--basis"]) {
     flex-basis: auto;
   }
 


### PR DESCRIPTION
…et to Grow

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR changes a selector in **objects.box.scss** which looked like this:
```
.grommetux-box--flex-grow:not([class^=".grommetux-box--basis"]) {
    flex-basis: auto;
}
```
This meant that whenever you set the Box to `flex='grow'` it set the flex-basis to auto because the selector said "not starts with .grommetux-box--basis" which, using the caret, means that the class attribute has to start with .grommetux-box--basis (including the dot) which is impossible to say since grommet could add a lot of classes to the Box element, and the user might add some him/herself. 
I changed this to:

```
  &:not([class*="#{$grommet-namespace}box--basis"]) {
```
This means that it has to contain the grommetux-box--basis (without the dot), which works.

#### Where should the reviewer start?
The only change is in _objects.box.scss on line 208.

#### What testing has been done on this PR?
I haven't added any tests. I created a create-react-app and tested a before and after scenario. I could verify the difference and see the working change afterwards.

#### How should this be manually tested?
Add the following structure to a component:
```
<Box direction='row'>
          <Box flex='grow' basis='1/4' style={{backgroundColor: 'red'}}>Red</Box>
          <Box flex='grow' basis='1/2' style={{backgroundColor: 'blue'}}>Blue</Box>
          <Box flex='grow' basis='1/4' style={{backgroundColor: 'green'}}>Green</Box>
 /Box>
```
Before the change they'll all have the same size, after the change the middle one will, correctly, be double the size of the other two (or half the combined size). You can see, using Developer Tools in your browser, that the basis set to the children is overridden and set to 'auto' on them all.

#### Any background context you want to provide?

#### What are the relevant issues?
That you can't use flex-grow and flex-basis in combination.

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
I don't know, doesn't seem all that important. It was to me, but not in general.

#### Is this change backwards compatible or is it a breaking change?
Could be breaking if anyone relies on the broken selector.
