### PR TITLE
Fixed select in dark mode. Fixes #2101

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,4 @@
 {
-  "plugins": [
-    ["grommet"]
-  ],
   "presets": [
     "./tools/grommet-babel-preset-es2015",
     "stage-1",

--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -131,7 +131,7 @@ class Box extends Component {
     );
 
     if (stateTheme) {
-      if (stateTheme.dark !== propsTheme.dark) {
+      if (stateTheme.dark !== propsTheme.dark && stateTheme.icon) {
         content = (
           <IconThemeContext.Provider value={stateTheme.icon}>
             {content}

--- a/src/js/components/Drop/StyledDrop.js
+++ b/src/js/components/Drop/StyledDrop.js
@@ -36,7 +36,7 @@ const StyledDrop = styled.div`
   outline: none;
 
   ${props => backgroundStyle(
-    props.theme.global.drop.backgroundColor[props.theme.dark ? 'dark' : 'light'],
+    props.theme.global.drop.backgroundColor,
     props.theme
   )}
 

--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -67,22 +67,6 @@ How to align the drop. Defaults to `{
 }
 ```
 
-**dropBackground**
-
-Background color
-
-```
-string
-{
-  color: string,
-  opacity: 
-    weak
-    medium
-    strong
-    boolean
-}
-```
-
 **dropTarget**
 
 Target where the options drop will be aligned to. This should be

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -117,6 +117,7 @@ class Select extends Component {
             border={!plain ? 'all' : undefined}
             direction='row'
             justify='between'
+            background={theme.select.backgroundColor}
           >
             <Box direction='row' flex={true} basis='auto'>
               {selectValue || (

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -45,6 +45,8 @@ exports[`Select basic 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  background-color: #ffffff;
+  color: #444444;
   border: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
@@ -285,7 +287,7 @@ exports[`Select complex options and children 1`] = `
   type="button"
 >
   <div
-    class="StyledBox-YaZNy filaRb"
+    class="StyledBox-YaZNy eVmkkr"
   >
     <div
       class="StyledBox-YaZNy eMTjTC"
@@ -340,7 +342,7 @@ exports[`Select complex options and children 2`] = `
   type="button"
 >
   <div
-    class="StyledBox-YaZNy filaRb"
+    class="StyledBox-YaZNy eVmkkr"
   >
     <div
       class="StyledBox-YaZNy eMTjTC"
@@ -435,19 +437,19 @@ exports[`Select complex options and children 3`] = `
 
 exports[`Select complex options and children 4`] = `
 "@media only screen and (max-width:699px) {
-  .filaRb {
+  .eVmkkr {
     border: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:699px) {
-  .filaRb {
+  .eVmkkr {
     margin: 0;
   }
 }
 
 @media only screen and (max-width:699px) {
-  .filaRb {
+  .eVmkkr {
     padding: 0;
   }
 }
@@ -597,7 +599,7 @@ exports[`Select deselect an option 1`] = `
   type="button"
 >
   <div
-    class="StyledBox-YaZNy filaRb"
+    class="StyledBox-YaZNy eVmkkr"
   >
     <div
       class="StyledBox-YaZNy eMTjTC"
@@ -654,7 +656,7 @@ exports[`Select disabled 1`] = `
   type="button"
 >
   <div
-    class="StyledBox-YaZNy filaRb"
+    class="StyledBox-YaZNy eVmkkr"
   >
     <div
       class="StyledBox-YaZNy eMTjTC"
@@ -710,7 +712,7 @@ exports[`Select disabled 2`] = `
   type="button"
 >
   <div
-    class="StyledBox-YaZNy filaRb"
+    class="StyledBox-YaZNy eVmkkr"
   >
     <div
       class="StyledBox-YaZNy eMTjTC"
@@ -801,6 +803,8 @@ exports[`Select multiple 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  background-color: #ffffff;
+  color: #444444;
   border: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
@@ -1046,7 +1050,7 @@ exports[`Select multiple values 1`] = `
   type="button"
 >
   <div
-    class="StyledBox-YaZNy filaRb"
+    class="StyledBox-YaZNy eVmkkr"
   >
     <div
       class="StyledBox-YaZNy eMTjTC"
@@ -1102,7 +1106,7 @@ exports[`Select multiple values 2`] = `
   type="button"
 >
   <div
-    class="StyledBox-YaZNy filaRb"
+    class="StyledBox-YaZNy eVmkkr"
   >
     <div
       class="StyledBox-YaZNy eMTjTC"
@@ -1210,19 +1214,19 @@ exports[`Select multiple values 3`] = `
 
 exports[`Select multiple values 4`] = `
 "@media only screen and (max-width:699px) {
-  .filaRb {
+  .eVmkkr {
     border: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:699px) {
-  .filaRb {
+  .eVmkkr {
     margin: 0;
   }
 }
 
 @media only screen and (max-width:699px) {
-  .filaRb {
+  .eVmkkr {
     padding: 0;
   }
 }
@@ -1313,13 +1317,13 @@ exports[`Select multiple values 4`] = `
 }
 
 @media only screen and (max-width:699px) {
-  .flHrpn {
+  .dfWhFv {
     margin: 0;
   }
 }
 
 @media only screen and (max-width:699px) {
-  .flHrpn {
+  .dfWhFv {
     padding: 0;
   }
 }
@@ -1410,7 +1414,7 @@ exports[`Select opens 1`] = `
   type="button"
 >
   <div
-    class="StyledBox-YaZNy filaRb"
+    class="StyledBox-YaZNy eVmkkr"
   >
     <div
       class="StyledBox-YaZNy eMTjTC"
@@ -1465,7 +1469,7 @@ exports[`Select opens 2`] = `
   type="button"
 >
   <div
-    class="StyledBox-YaZNy filaRb"
+    class="StyledBox-YaZNy eVmkkr"
   >
     <div
       class="StyledBox-YaZNy eMTjTC"
@@ -1572,19 +1576,19 @@ exports[`Select opens 3`] = `
 
 exports[`Select opens 4`] = `
 "@media only screen and (max-width:699px) {
-  .filaRb {
+  .eVmkkr {
     border: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:699px) {
-  .filaRb {
+  .eVmkkr {
     margin: 0;
   }
 }
 
 @media only screen and (max-width:699px) {
-  .filaRb {
+  .eVmkkr {
     padding: 0;
   }
 }
@@ -1781,7 +1785,7 @@ exports[`Select search 1`] = `
   type="button"
 >
   <div
-    class="StyledBox-YaZNy filaRb"
+    class="StyledBox-YaZNy eVmkkr"
   >
     <div
       class="StyledBox-YaZNy eMTjTC"
@@ -1902,19 +1906,19 @@ exports[`Select search 2`] = `
 
 exports[`Select search 3`] = `
 "@media only screen and (max-width:699px) {
-  .filaRb {
+  .eVmkkr {
     border: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:699px) {
-  .filaRb {
+  .eVmkkr {
     margin: 0;
   }
 }
 
 @media only screen and (max-width:699px) {
-  .filaRb {
+  .eVmkkr {
     padding: 0;
   }
 }
@@ -2076,7 +2080,7 @@ exports[`Select select an option 1`] = `
   type="button"
 >
   <div
-    class="StyledBox-YaZNy filaRb"
+    class="StyledBox-YaZNy eVmkkr"
   >
     <div
       class="StyledBox-YaZNy eMTjTC"
@@ -2131,7 +2135,7 @@ exports[`Select select an option with complex options 1`] = `
   type="button"
 >
   <div
-    class="StyledBox-YaZNy flHrpn"
+    class="StyledBox-YaZNy dfWhFv"
   >
     <div
       class="StyledBox-YaZNy eMTjTC"
@@ -2175,7 +2179,7 @@ exports[`Select select an option with enter 1`] = `
   type="button"
 >
   <div
-    class="StyledBox-YaZNy filaRb"
+    class="StyledBox-YaZNy eVmkkr"
   >
     <div
       class="StyledBox-YaZNy eMTjTC"
@@ -2230,7 +2234,7 @@ exports[`Select select another option 1`] = `
   type="button"
 >
   <div
-    class="StyledBox-YaZNy filaRb"
+    class="StyledBox-YaZNy eVmkkr"
   >
     <div
       class="StyledBox-YaZNy eMTjTC"
@@ -2324,6 +2328,8 @@ exports[`Select size 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  background-color: #ffffff;
+  color: #444444;
   border: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;

--- a/src/js/components/Select/doc.js
+++ b/src/js/components/Select/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { a11yTitlePropType, backgroundPropType, getAvailableAtBadge } from '../../utils';
+import { a11yTitlePropType, getAvailableAtBadge } from '../../utils';
 
 export default (Select) => {
   const DocumentedSelect = describe(Select)
@@ -31,7 +31,6 @@ export default (Select) => {
       top: 'top',
       left: 'left',
     }),
-    dropBackground: backgroundPropType,
     dropTarget: PropTypes.object.description(
       `Target where the options drop will be aligned to. This should be
       a React reference. Typically, this is not required as the drop will be

--- a/src/js/components/Select/stories/select.stories.js
+++ b/src/js/components/Select/stories/select.stories.js
@@ -365,8 +365,32 @@ class CustomSearchSelect extends Component {
   }
 }
 
+class DarkSelect extends Component {
+  state = {
+    options: ['one', 'two'],
+    value: '',
+  }
+
+  render() {
+    const { options, value } = this.state;
+    return (
+      <Grommet full={true}>
+        <Box fill={true} background='dark-1' align='center' justify='center'>
+          <Select
+            placeholder='Select'
+            value={value}
+            options={options}
+            onChange={({ option }) => this.setState({ value: option })}
+          />
+        </Box>
+      </Grommet>
+    );
+  }
+}
+
 storiesOf('Select', module)
   .add('Simple Select', () => <SimpleSelect />)
   .add('Search Select', () => <SearchSelect />)
   .add('Seasons Select', () => <SeasonsSelect />)
-  .add('Custom Search', () => <CustomSearchSelect />);
+  .add('Custom Search', () => <CustomSearchSelect />)
+  .add('Dark', () => <DarkSelect />);

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -2992,22 +2992,6 @@ How to align the drop. Defaults to \`{
 }
 \`\`\`
 
-**dropBackground**
-
-Background color
-
-\`\`\`
-string
-{
-  color: string,
-  opacity: 
-    weak
-    medium
-    strong
-    boolean
-}
-\`\`\`
-
 **dropTarget**
 
 Target where the options drop will be aligned to. This should be

--- a/src/js/themes/vanilla.js
+++ b/src/js/themes/vanilla.js
@@ -113,10 +113,7 @@ export default deepFreeze({
       },
     },
     drop: {
-      backgroundColor: {
-        light: '#f8f8f8',
-        dark: '#222222',
-      },
+      backgroundColor: '#f8f8f8',
       border: {
         width: '0px',
         radius: '0px',
@@ -524,6 +521,7 @@ export default deepFreeze({
     },
   },
   select: {
+    backgroundColor: '#ffffff',
     icons: {
       down: FormDown,
     },


### PR DESCRIPTION
#### What does this PR do?

Added backgroundColor to Select in the theme (defaults to white).
Changed Drop to not switch automatically to dark mode (this should be done through the theme).

#### Where should the reviewer start?

select.stories.js (see the Dark mode example)

#### What testing has been done on this PR?

storybook

#### How should this be manually tested?

storybook

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/2101

#### Screenshots (if appropriate)

https://codesandbox.io/s/myll4rzkz9

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

breaking change since I've changed the structure of the theme file for drop.

See [here](https://github.com/grommet/grommet/compare/NEXT...fix/dark-select?expand=1#diff-160b5717fa2a8150be7705c30b0ca040L117)