### PR TITLE
Added defaultMessage as an argument in getMessage function to avoid maintaining a separate translation file for default locale language

### DIFF
--- a/src/js/utils/Intl.js
+++ b/src/js/utils/Intl.js
@@ -1,10 +1,10 @@
 // (C) Copyright 2014 Hewlett Packard Enterprise Development LP
 export default {
-  getMessage (intl, key, values) {
+  getMessage (intl, key, values, defaultMessage) {
     if (intl) {
       return intl.formatMessage({
         id: key,
-        defaultMessage: key
+        defaultMessage: defaultMessage || key
       }, values);
     } else {
       return key;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Helps give developers freedom to show defaultMessage without maintaining a seperate translation file for default locale language. They can just pass defaultMessage value as an argument to the getMessage function and there is no need to keep the key argument value same as the defaultMessage value
#### Where should the reviewer start?
default message function
#### What testing has been done on this PR?
Testing has been done checking backward compatibility. Also tested on google chrome and mozilla firefox.
#### How should this be manually tested?
Suppose i want to show a error on home screen - "Error retreiving data from api". So, I pass the value of key argument as unique - "HOME_API_ERROR" in the getMessage function of grommet util for internationalization  and do not keep this key in any of the translation file in the project. The default message in this case will be shown on the user interface as same as the key value - HOME.ERROR which is not intended. We want default message to be shown as different as mentioned above.
#### Any background context you want to provide?
Adding "defaultMessage" argument to the getMessage function so that the defaultMessage value is not always same as the key argument value which is passed to the getMessage function. 
Due to the absence of "defaultMessage" argument in getMessage function,  developers are forced to keep the value of key argument as what they want the defaultMessage to be shown.
 Devs want to name their keys in a unique manner and sometimes component specific however the current code restricts it as only key argument is present in the getMessage function which assigns the same value to the defaultMessage key in the object passed to formatMessage function. Due to this, if they name thier keys uniquely, the default message will be same as the key which we do not want to be shown as default message. Then, the developer has to have a separate translation file for default language fallback which should not be mandatory but currently being forced to do so. In this way, the defaultMessage key (or the defaultMessage feature) of formatMessage function used in the getMessage function of Intl of Grommet is not being used by any developer. They don't have any other option than maintaining a separate translation file for default language.
#### What are the relevant issues?
https://github.com/grommet/grommet/issues/2156
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
This code can be updated through a patch version release
#### Should this PR be mentioned in the release notes?
Yes it should be as we are now using defaultMessage feature properly and devs will not have to maitain a separate translation file for default language.
#### Is this change backwards compatible or is it a breaking change?
It is backward compatible and will not a breaking change
