### PR TITLE
Issue 2160 - Enhancement to specify the DOM element to create the Men…

### DIFF
--- a/__tests__/components/Menu-test.js
+++ b/__tests__/components/Menu-test.js
@@ -27,4 +27,25 @@ describe('Menu', () => {
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+  it('Generate the menu within the DOM of the parent div', () => {
+    let divRef;
+    const component = renderer.create(
+      <div ref={ref=> divRef = ref}>
+        <Menu dropContainer={divRef}>
+          <a href="#" className="active">
+            First
+          </a>
+          <a href="#">
+            Second
+          </a>
+          <a href="#">
+            Third
+          </a>
+        </Menu>
+      </div>
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
 });

--- a/__tests__/components/__snapshots__/Menu-test.js.snap
+++ b/__tests__/components/__snapshots__/Menu-test.js.snap
@@ -1,8 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Menu Generate the menu within the DOM of the parent div 1`] = `
+<div>
+  <nav
+    className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-none grommetux-menu grommetux-menu--column grommetux-menu--inline"
+    dropContainer={undefined}
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}
+  >
+    <a
+      className="active"
+      href="#"
+    >
+      First
+    </a>
+    <a
+      href="#"
+    >
+      Second
+    </a>
+    <a
+      href="#"
+    >
+      Third
+    </a>
+  </nav>
+</div>
+`;
+
 exports[`Menu has correct default options 1`] = `
 <nav
   className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-none grommetux-menu grommetux-menu--column grommetux-menu--inline"
+  dropContainer={undefined}
   id={undefined}
   onClick={undefined}
   role={undefined}

--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -275,6 +275,8 @@ export default class Menu extends Component {
   }
 
   componentDidUpdate (prevProps, prevState) {
+    const { dropContainer } = this.props;
+
     if (this.state.state !== prevState.state) {
       let activeKeyboardHandlers = {
         esc: this._onClose
@@ -332,7 +334,8 @@ export default class Menu extends Component {
                 colorIndex: this.props.dropColorIndex,
                 className: this.props.className &&
                 `${this.props.className}__drop--container`,
-                focusControl: true
+                focusControl: true,
+                dropContainer: dropContainer
               });
           }
           break;
@@ -524,6 +527,7 @@ Menu.propTypes = {
   closeOnClick: PropTypes.bool,
   dropAlign: dropAlignPropType,
   dropColorIndex: PropTypes.string,
+  dropContainer: PropTypes.object,
   icon: PropTypes.node,
   id: PropTypes.string,
   inline: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['expand'])]),
@@ -544,5 +548,6 @@ Menu.defaultProps = {
   closeOnClick: true,
   direction: 'column',
   dropAlign: {top: 'top', left: 'left'},
-  pad: 'none'
+  pad: 'none',
+  dropContainer: undefined
 };

--- a/src/js/utils/Drop.js
+++ b/src/js/utils/Drop.js
@@ -181,8 +181,15 @@ export default class Drop {
       [`${BACKGROUND_COLOR_INDEX}-${options.colorIndex}`]: options.colorIndex
     });
 
-    // prepend in body to avoid browser scroll issues
-    document.body.insertBefore(container, document.body.firstChild);
+    if ( opts.dropContainer ) {
+      opts.dropContainer.appendChild(container);
+      this.parentContainer = opts.dropContainer;
+
+    } else {
+      // prepend in body to avoid browser scroll issues
+      document.body.insertBefore(container, document.body.firstChild);
+      this.parentContainer = document.body;
+    }
 
     const scrollParents = findScrollParents(control);
 
@@ -385,7 +392,7 @@ export default class Drop {
     window.removeEventListener('resize', this._onResize);
 
     unmountComponentAtNode(container);
-    document.body.removeChild(container);
+    this.parentContainer.removeChild(container);
     // weird bug in Chrome does not remove child if
     // document.body.insertBefore is called in another new drop.
     // the code below will go over remaining drop that was not removed


### PR DESCRIPTION
…u drop down in

If a developer wants to place a Menu within a floating panel (tooltip,etc) its very helpful to constrain the Menu's floating drop down to be rendered in the DOM of the floating parent. This makes life cycle much easier (Menu won't hang around after floating parent is dismissed) and it makes it easier to cause the menu to render within the parent.

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
