### PR TITLE
Changed DataTable to have onSearch be a top property, not per column

### DIFF
--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -28,21 +28,15 @@ class DataTable extends Component {
   }
 
   onFilter = (property, value) => {
-    const { columns } = this.props;
+    const { onSearch } = this.props;
     const nextFilters = { ...this.state.filters };
     nextFilters[property] = value;
     this.setState({ filters: nextFilters });
 
     // Let caller know about search, if interested
-    columns.some((column) => {
-      if (column.property === property) {
-        if (column.onSearch) {
-          column.onSearch(property, value);
-        }
-        return true;
-      }
-      return false;
-    });
+    if (onSearch) {
+      onSearch(nextFilters);
+    }
   }
 
   onSort = property => () => {

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -35,7 +35,7 @@ const Header = ({
           />
         )}
 
-        {columns.map(({ property, header, align, onSearch, search }) => {
+        {columns.map(({ property, header, align, search }) => {
           let content = (typeof header === 'string' ? (
             <Text>{header}</Text>
           ) : header);
@@ -44,19 +44,19 @@ const Header = ({
             content = (
               <Sorter
                 align={align}
-                fill={!search && !onSearch}
+                fill={!search}
                 property={property}
                 onSort={onSort}
                 sort={sort}
                 theme={theme}
-                themeProps={(search || onSearch) ? innerThemeProps : theme.dataTable.header}
+                themeProps={search ? innerThemeProps : theme.dataTable.header}
               >
                 {content}
               </Sorter>
             );
           }
 
-          if ((search || onSearch) && filters) {
+          if (search && filters) {
             if (!onSort) {
               content = (
                 <Box justify='center' align={align} {...innerThemeProps}>

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -24,8 +24,7 @@ import { DataTable } from 'grommet';
       column should be aggregated. This only applies to a footer or groupBy
       context. 'footer' indicates what should be shown in the footer for
       the column. 'search' indicates whether a search filter should be
-      made available for the column. 'onSearch' will be called if the user
-      searches, allowing the data to be filtered externally.
+      made available for the column.
     
 
 ```
@@ -50,7 +49,6 @@ import { DataTable } from 'grommet';
     {
       aggregate: boolean
     },
-  onSearch: function,
   property: string,
   render: function,
   search: boolean
@@ -84,6 +82,17 @@ Use this to indicate that 'data' doesn't contain all that it could.
       to lazily fetch more from the server only when needed. This cannot
       be combined with properties that expect all data to be present in the
       browser, such as columns.search, sortable, groupBy, or columns.aggregate.
+
+```
+function
+```
+
+**onSearch**
+
+When supplied, and when at least one column has 'search' enabled,
+      this function will be called with an object with keys for property
+      names and values which are the search text strings. This is typically
+      employed so a back-end can be used to search through the data.
 
 ```
 function

--- a/src/js/components/DataTable/buildState.js
+++ b/src/js/components/DataTable/buildState.js
@@ -44,20 +44,21 @@ const findPrimary = (nextProps, prevState, nextState) => {
 };
 
 const filter = (nextProps, prevState, nextState) => {
-  const { columns } = nextProps;
+  const { columns, onSearch } = nextProps;
   const { data, filters } = nextState;
 
   let nextFilters;
   let regexps;
   columns.forEach((column) => {
-    if (column.search || column.onSearch) {
+    if (column.search) {
       if (!nextFilters) {
         nextFilters = {};
         regexps = {};
       }
       nextFilters[column.property] =
         filters ? filters[column.property] || '' : '';
-      if (nextFilters[column.property] && column.search) {
+      // don't do filtering if the caller has supplied onSearch
+      if (nextFilters[column.property] && column.search && !onSearch) {
         regexps[column.property] =
           new RegExp(nextFilters[column.property], 'i');
       }

--- a/src/js/components/DataTable/datatable.stories.js
+++ b/src/js/components/DataTable/datatable.stories.js
@@ -132,11 +132,14 @@ class GroupedDataTable extends Component {
 class ServedDataTable extends Component {
   state = { data: DATA }
 
-  onSearch = (property, search) => {
+  onSearch = (search) => {
     let nextData;
     if (search) {
-      const exp = new RegExp(search, 'i');
-      nextData = DATA.filter(d => exp.test(d[property]));
+      const expressions = Object.keys(search).map(property => ({
+        property,
+        exp: new RegExp(search[property], 'i'),
+      }));
+      nextData = DATA.filter(d => !expressions.some(e => !e.exp.test(d[e.property])));
     } else {
       nextData = DATA;
     }
@@ -150,10 +153,10 @@ class ServedDataTable extends Component {
         <DataTable
           columns={columns.map(column => ({
             ...column,
-            onSearch: (column.property === 'name' || column.property === 'location')
-              && this.onSearch,
+            search: column.property === 'name' || column.property === 'location',
           }))}
           data={servedData}
+          onSearch={this.onSearch}
         />
       </Grommet>
     );

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -28,7 +28,6 @@ export default (DataTable) => {
           aggregate: PropTypes.bool,
         }),
       ]),
-      onSearch: PropTypes.func,
       property: PropTypes.string.isRequired,
       render: PropTypes.func,
       search: PropTypes.bool,
@@ -44,8 +43,7 @@ export default (DataTable) => {
       column should be aggregated. This only applies to a footer or groupBy
       context. 'footer' indicates what should be shown in the footer for
       the column. 'search' indicates whether a search filter should be
-      made available for the column. 'onSearch' will be called if the user
-      searches, allowing the data to be filtered externally.
+      made available for the column.
     `),
     data: PropTypes.arrayOf(PropTypes.shape({}))
       .description('Array of data objects.'),
@@ -59,6 +57,12 @@ export default (DataTable) => {
       to lazily fetch more from the server only when needed. This cannot
       be combined with properties that expect all data to be present in the
       browser, such as columns.search, sortable, groupBy, or columns.aggregate.`
+    ),
+    onSearch: PropTypes.func.description(
+      `When supplied, and when at least one column has 'search' enabled,
+      this function will be called with an object with keys for property
+      names and values which are the search text strings. This is typically
+      employed so a back-end can be used to search through the data.`
     ),
     resizeable: PropTypes.string
       .description('Whether to allow the user to resize column widths.'),

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1227,8 +1227,7 @@ import { DataTable } from 'grommet';
       column should be aggregated. This only applies to a footer or groupBy
       context. 'footer' indicates what should be shown in the footer for
       the column. 'search' indicates whether a search filter should be
-      made available for the column. 'onSearch' will be called if the user
-      searches, allowing the data to be filtered externally.
+      made available for the column.
     
 
 \`\`\`
@@ -1253,7 +1252,6 @@ import { DataTable } from 'grommet';
     {
       aggregate: boolean
     },
-  onSearch: function,
   property: string,
   render: function,
   search: boolean
@@ -1287,6 +1285,17 @@ Use this to indicate that 'data' doesn't contain all that it could.
       to lazily fetch more from the server only when needed. This cannot
       be combined with properties that expect all data to be present in the
       browser, such as columns.search, sortable, groupBy, or columns.aggregate.
+
+\`\`\`
+function
+\`\`\`
+
+**onSearch**
+
+When supplied, and when at least one column has 'search' enabled,
+      this function will be called with an object with keys for property
+      names and values which are the search text strings. This is typically
+      employed so a back-end can be used to search through the data.
 
 \`\`\`
 function


### PR DESCRIPTION
#### What does this PR do?

Changed DataTable to have onSearch be a top property, not per column

#### Where should the reviewer start?

doc.js

#### What testing has been done on this PR?

storybook

#### How should this be manually tested?

storybook

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

well, strictly this is breaking compared to the prior version, which only existed for about 15 minutes.
So, effectively this is backwards compatible.
