### PR TITLE
Changed Drop to add center alignment. Address GitHub issue #2025.

### DIFF
--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -9,7 +9,11 @@ import StyledDrop from './StyledDrop';
 
 class DropContainer extends Component {
   static defaultProps = {
-    centered: true,
+    align: {
+      top: 'top',
+      left: 'left',
+    },
+    stretch: 'width',
   }
 
   dropRef = React.createRef();
@@ -71,7 +75,7 @@ class DropContainer extends Component {
   }
 
   place = () => {
-    const { align, dropTarget, responsive, theme } = this.props;
+    const { align, dropTarget, responsive, stretch, theme } = this.props;
     const windowWidth = window.innerWidth;
     const windowHeight = window.innerHeight;
 
@@ -90,7 +94,10 @@ class DropContainer extends Component {
 
       // determine width
       const width = Math.min(
-        Math.max(targetRect.width, containerRect.width),
+        (stretch
+          ? Math.max(targetRect.width, containerRect.width)
+          : containerRect.width
+        ),
         windowWidth
       );
 
@@ -100,7 +107,7 @@ class DropContainer extends Component {
         if (align.left === 'left') {
           left = targetRect.left;
         } else if (align.left === 'right') {
-          left = targetRect.left - width;
+          left = targetRect.left + targetRect.width;
         }
       } else if (align.right) {
         if (align.right === 'left') {
@@ -108,6 +115,8 @@ class DropContainer extends Component {
         } else if (align.right === 'right') {
           left = (targetRect.left + targetRect.width) - width;
         }
+      } else {
+        left = (targetRect.left + (targetRect.width / 2)) - (width / 2);
       }
 
       if ((left + width) > windowWidth) {
@@ -138,6 +147,8 @@ class DropContainer extends Component {
           top = targetRect.top - containerRect.height;
           maxHeight = Math.max(targetRect.top, 0);
         }
+      } else {
+        top = (targetRect.top + (targetRect.height / 2)) - (containerRect.height / 2);
       }
 
       // if we can't fit it all, see if there's more room the other direction
@@ -176,9 +187,11 @@ class DropContainer extends Component {
       }
 
       container.style.left = `${left}px`;
-      // offset width by 0.1 to avoid a bug in ie11 that
-      // unnecessarily wraps the text if width is the same
-      container.style.width = `${width + 0.1}px`;
+      if (stretch) {
+        // offset width by 0.1 to avoid a bug in ie11 that
+        // unnecessarily wraps the text if width is the same
+        container.style.width = `${width + 0.1}px`;
+      }
       // the (position:absolute + scrollTop)
       // is presenting issues with desktop scroll flickering
       container.style.top = `${top}px`;

--- a/src/js/components/Drop/README.md
+++ b/src/js/components/Drop/README.md
@@ -13,7 +13,9 @@ import { Drop } from 'grommet';
 
 **align**
 
-How to align the drop with respect to the target element. Defaults to `{
+How to align the drop with respect to the target element. Not specifying
+      a vertical or horizontal alignment will cause it to be aligned in the
+      center. Defaults to `{
   "top": "top",
   "left": "left"
 }`.
@@ -67,17 +69,19 @@ Whether the drop should control focus.
 boolean
 ```
 
+**stretch**
+
+Whether the drop element should be stretched to at least match the
+      width of the target element. The default is true because
+      that is what most uses of Drop want, like Select and Menu. Defaults to `true`.
+
+```
+boolean
+```
+
 **target**
 
 Required. Target where the drop will be aligned to. This should be a React reference.
-
-```
-object
-```
-
-**theme**
-
-Custom styles for Drop component.
 
 ```
 object

--- a/src/js/components/Drop/__tests__/Drop-test.js
+++ b/src/js/components/Drop/__tests__/Drop-test.js
@@ -98,6 +98,14 @@ describe('Drop', () => {
     expectPortal('drop-node').toMatchSnapshot();
   });
 
+  test('no stretch', () => {
+    renderIntoDocument(
+      <TestInput stretch={false} />
+    );
+
+    expectPortal('drop-node').toMatchSnapshot();
+  });
+
   test('close', () => {
     renderIntoDocument(<TestInput />);
     expectPortal('drop-node').toMatchSnapshot();

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -231,7 +231,7 @@ exports[`Drop align right random 1`] = `
 <div
   class="StyledDrop-czaYBK hDYRMY"
   id="drop-node"
-  style="width: 0.1px; max-height: 768px;"
+  style="width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   this is a test
@@ -631,7 +631,7 @@ exports[`Drop invalid align 1`] = `
 <div
   class="StyledDrop-czaYBK lgQIaN"
   id="drop-node"
-  style="width: 0.1px; max-height: 768px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   this is a test
@@ -732,6 +732,99 @@ exports[`Drop invoke onClickOutside 1`] = `
 `;
 
 exports[`Drop invoke onClickOutside 2`] = `
+"
+
+.lgQIaN {
+  font-size: 18px;
+  line-height: 24px;
+  color: #444444;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  border-radius: 0px;
+  box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
+  position: fixed;
+  z-index: 20;
+  outline: none;
+  background: #ffffff;
+  color: #444444;
+  opacity: 0;
+  -webkit-transform-origin: top left;
+  -ms-transform-origin: top left;
+  transform-origin: top left;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
+  -webkit-animation-delay: 0.01s;
+  animation-delay: 0.01s;
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .lgQIaN {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .bZfQRC {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .dGivzW {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .hDYRMY {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}"
+`;
+
+exports[`Drop no stretch 1`] = `
+<div
+  class="StyledDrop-czaYBK lgQIaN"
+  id="drop-node"
+  style="left: 0px; top: 0px; max-height: 768px;"
+  tabindex="-1"
+>
+  this is a test
+</div>
+`;
+
+exports[`Drop no stretch 2`] = `
 "
 
 .lgQIaN {

--- a/src/js/components/Drop/doc.js
+++ b/src/js/components/Drop/doc.js
@@ -13,12 +13,14 @@ export default (Drop) => {
 
   DocumentedDrop.propTypes = {
     align: PropTypes.shape({
-      top: PropTypes.oneOf(['top', 'bottom']),
-      bottom: PropTypes.oneOf(['top', 'bottom']),
-      right: PropTypes.oneOf(['left', 'right']),
-      left: PropTypes.oneOf(['left', 'right']),
+      top: PropTypes.oneOf(['top', 'bottom', undefined]),
+      bottom: PropTypes.oneOf(['top', 'bottom', undefined]),
+      right: PropTypes.oneOf(['left', 'right', undefined]),
+      left: PropTypes.oneOf(['left', 'right', undefined]),
     }).description(
-      'How to align the drop with respect to the target element.'
+      `How to align the drop with respect to the target element. Not specifying
+      a vertical or horizontal alignment will cause it to be aligned in the
+      center.`
     ).defaultValue({
       top: 'top',
       left: 'left',
@@ -35,10 +37,14 @@ export default (Drop) => {
     restrictFocus: PropTypes.bool.description(
       'Whether the drop should control focus.'
     ),
+    stretch: PropTypes.bool.description(
+      `Whether the drop element should be stretched to at least match the
+      width of the target element. The default is true because
+      that is what most uses of Drop want, like Select and Menu.`
+    ).defaultValue(true),
     target: PropTypes.object.description(
       'Target where the drop will be aligned to. This should be a React reference.'
     ).isRequired,
-    theme: PropTypes.object.description('Custom styles for Drop component.'),
   };
 
   return DocumentedDrop;

--- a/src/js/components/Drop/doc.js
+++ b/src/js/components/Drop/doc.js
@@ -13,10 +13,10 @@ export default (Drop) => {
 
   DocumentedDrop.propTypes = {
     align: PropTypes.shape({
-      top: PropTypes.oneOf(['top', 'bottom', undefined]),
-      bottom: PropTypes.oneOf(['top', 'bottom', undefined]),
-      right: PropTypes.oneOf(['left', 'right', undefined]),
-      left: PropTypes.oneOf(['left', 'right', undefined]),
+      top: PropTypes.oneOf(['top', 'bottom']),
+      bottom: PropTypes.oneOf(['top', 'bottom']),
+      right: PropTypes.oneOf(['left', 'right']),
+      left: PropTypes.oneOf(['left', 'right']),
     }).description(
       `How to align the drop with respect to the target element. Not specifying
       a vertical or horizontal alignment will cause it to be aligned in the

--- a/src/js/components/Drop/drop.stories.js
+++ b/src/js/components/Drop/drop.stories.js
@@ -1,13 +1,17 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { storiesOf } from '@storybook/react';
 
-import { Box, Drop, Grommet } from '../';
+import { Box, Drop, Grommet, Text } from '../';
 import { grommet } from '../../themes';
+import { ThemeContext } from '../../contexts';
 
 class SimpleDrop extends Component {
+  targetRef = React.createRef()
+
   componentDidMount() {
     this.forceUpdate();
   }
+
   render() {
     return (
       <Grommet theme={grommet}>
@@ -17,25 +21,187 @@ class SimpleDrop extends Component {
             pad='medium'
             align='center'
             justify='start'
-            ref={(ref) => {
-              this.targetRef = ref;
-            }}
+            ref={this.targetRef}
           >
             Target
           </Box>
-          <Drop
-            align={{ top: 'bottom', left: 'left' }}
-            target={this.targetRef}
-          >
-            <Box pad='large'>
-              Drop Contents
-            </Box>
-          </Drop>
+          {this.targetRef.current && (
+            <Drop
+              align={{ top: 'bottom', left: 'left' }}
+              target={this.targetRef.current}
+            >
+              <Box pad='large'>
+                Drop Contents
+              </Box>
+            </Drop>
+          )}
         </Box>
       </Grommet>
     );
   }
 }
 
+const OneDrop = ({ align, target }) => (
+  <Drop
+    align={align}
+    target={target}
+    stretch={false}
+  >
+    <Box pad='small' />
+  </Drop>
+);
+
+class Set extends Component {
+  targetRef = React.createRef()
+
+  componentDidMount() {
+    this.forceUpdate();
+  }
+
+  render() {
+    const { aligns, label } = this.props;
+    return (
+      <Box border={true} pad='small'>
+        <Text>{label}</Text>
+        <Box
+          margin='xlarge'
+          background='dark-4'
+          pad={{ horizontal: 'large', vertical: 'medium' }}
+          align='center'
+          justify='center'
+          ref={this.targetRef}
+        >
+          &nbsp;
+        </Box>
+        {this.targetRef.current && (
+          <Fragment>
+            {aligns.map((align, index) => (
+              <OneDrop
+                key={`${index}`}
+                align={align}
+                target={this.targetRef.current}
+              />
+            ))}
+          </Fragment>
+        )}
+      </Box>
+    );
+  }
+}
+
+class AllDrops extends Component {
+  targetRef = React.createRef()
+
+  componentDidMount() {
+    this.forceUpdate();
+  }
+
+  render() {
+    return (
+      <Grommet theme={grommet}>
+        <ThemeContext.Extend value={{ global: { drop: { background: { color: 'white', opacity: 'medium' } } } }} >
+          <Box direction='row' wrap='true' pad='medium' align='center'>
+            <Set
+              label='left: left'
+              aligns={[
+                { top: 'top', left: 'left' },
+                { top: 'bottom', left: 'left' },
+                { bottom: 'top', left: 'left' },
+                { bottom: 'bottom', left: 'left' },
+              ]}
+            />
+            <Set
+              label='left: right'
+              aligns={[
+                { top: 'top', left: 'right' },
+                { top: 'bottom', left: 'right' },
+                { bottom: 'top', left: 'right' },
+                { bottom: 'bottom', left: 'right' },
+              ]}
+            />
+            <Set
+              label='(center horizontal)'
+              aligns={[
+                { top: 'top' },
+                { top: 'bottom' },
+                { bottom: 'top' },
+                { bottom: 'bottom' },
+              ]}
+            />
+            <Set
+              label='right: left'
+              aligns={[
+                { top: 'top', right: 'left' },
+                { top: 'bottom', right: 'left' },
+                { bottom: 'top', right: 'left' },
+                { bottom: 'bottom', right: 'left' },
+              ]}
+            />
+            <Set
+              label='right: right'
+              aligns={[
+                { top: 'top', right: 'right' },
+                { top: 'bottom', right: 'right' },
+                { bottom: 'top', right: 'right' },
+                { bottom: 'bottom', right: 'right' },
+              ]}
+            />
+            <Set
+              label='top: top'
+              aligns={[
+                { left: 'left', top: 'top' },
+                { left: 'right', top: 'top' },
+                { right: 'left', top: 'top' },
+                { right: 'right', top: 'top' },
+              ]}
+            />
+            <Set
+              label='top: bottom'
+              aligns={[
+                { left: 'left', top: 'bottom' },
+                { left: 'right', top: 'bottom' },
+                { right: 'left', top: 'bottom' },
+                { right: 'right', top: 'bottom' },
+              ]}
+            />
+            <Set
+              label='(center vertical)'
+              aligns={[
+                { left: 'left' },
+                { left: 'right' },
+                { right: 'left' },
+                { right: 'right' },
+              ]}
+            />
+            <Set
+              label='bottom: top'
+              aligns={[
+                { left: 'left', bottom: 'top' },
+                { left: 'right', bottom: 'top' },
+                { right: 'left', bottom: 'top' },
+                { right: 'right', bottom: 'top' },
+              ]}
+            />
+            <Set
+              label='bottom: bottom'
+              aligns={[
+                { left: 'left', bottom: 'bottom' },
+                { left: 'right', bottom: 'bottom' },
+                { right: 'left', bottom: 'bottom' },
+                { right: 'right', bottom: 'bottom' },
+              ]}
+            />
+            <Set
+              label='(center vertical and horizontal)'
+              aligns={[{}]}
+            />
+          </Box>
+        </ThemeContext.Extend>
+      </Grommet>
+    );
+  }
+}
+
 storiesOf('Drop', module)
-  .add('Default', () => <SimpleDrop />);
+  .add('Simple', () => <SimpleDrop />)
+  .add('All not stretch', () => <AllDrops />);

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1452,7 +1452,9 @@ import { Drop } from 'grommet';
 
 **align**
 
-How to align the drop with respect to the target element. Defaults to \`{
+How to align the drop with respect to the target element. Not specifying
+      a vertical or horizontal alignment will cause it to be aligned in the
+      center. Defaults to \`{
   \\"top\\": \\"top\\",
   \\"left\\": \\"left\\"
 }\`.
@@ -1506,17 +1508,19 @@ Whether the drop should control focus.
 boolean
 \`\`\`
 
+**stretch**
+
+Whether the drop element should be stretched to at least match the
+      width of the target element. The default is true because
+      that is what most uses of Drop want, like Select and Menu. Defaults to \`true\`.
+
+\`\`\`
+boolean
+\`\`\`
+
 **target**
 
 Required. Target where the drop will be aligned to. This should be a React reference.
-
-\`\`\`
-object
-\`\`\`
-
-**theme**
-
-Custom styles for Drop component.
 
 \`\`\`
 object


### PR DESCRIPTION
#### What does this PR do?

Changed Drop to add center alignment and `stretch` property.
Address GitHub issue #2025.

#### Where should the reviewer start?

doc.js

#### What testing has been done on this PR?

storybook

#### How should this be manually tested?

storybook

#### Any background context you want to provide?

#### What are the relevant issues?

Changed Drop to add center alignment. Address GitHub issue #2025.

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
