### PR TITLE
Added babel transform plugin to convert icon imports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,5 +6,17 @@
   ],
   "plugins": [
     ["styled-components", { "useDisplayName": false }]
-  ]
+  ],
+  "env": {
+    "es6": {
+      "plugins": [
+        ["transform-imports", {
+          "grommet-icons": {
+             "transform": "grommet-icons/es6/components/icons/${member}",
+             "preventFullImport": true
+          }
+        }]
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "babel-jest": "^23.0.1",
     "babel-loader": "^7.1.1",
     "babel-plugin-styled-components": "^1.1.7",
+    "babel-plugin-transform-imports": "^1.5.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-1": "^6.24.1",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Transform icon imports from:
```
import {
  Actions,
  ClosedCaption,
  Expand,
  FormDown,
  FormNext,
  FormPrevious,
  FormUp,
  Next,
  Pause,
  Play,
  Previous,
  Subtract,
  Volume,
  VolumeLow,
} from 'grommet-icons';
```
to:
```
import Actions from 'grommet-icons/es6/components/icons/Actions';
import ClosedCaption from 'grommet-icons/es6/components/icons/ClosedCaption';
import Expand from 'grommet-icons/es6/components/icons/Expand';
import FormDown from 'grommet-icons/es6/components/icons/FormDown';
import FormNext from 'grommet-icons/es6/components/icons/FormNext';
import FormPrevious from 'grommet-icons/es6/components/icons/FormPrevious';
import FormUp from 'grommet-icons/es6/components/icons/FormUp';
import Next from 'grommet-icons/es6/components/icons/Next';
import Pause from 'grommet-icons/es6/components/icons/Pause';
import Play from 'grommet-icons/es6/components/icons/Play';
import Previous from 'grommet-icons/es6/components/icons/Previous';
import Subtract from 'grommet-icons/es6/components/icons/Subtract';
import Volume from 'grommet-icons/es6/components/icons/Volume';
import VolumeLow from 'grommet-icons/es6/components/icons/VolumeLow'; 
```

#### Where should the reviewer start?
.babelrc
#### What testing has been done on this PR?
run ```npm run dist```

#### Do the grommet docs need to be updated?
No.
#### Should this PR be mentioned in the release notes?
Yes.
#### Is this change backwards compatible or is it a breaking change?
It is backwards compatible.