### PR TITLE
Changed Select to fix an issue with duplicate DOM ids and names

### DIFF
--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -53,6 +53,7 @@ class Select extends Component {
       dropAlign,
       dropTarget,
       forwardRef,
+      id,
       messages,
       onChange,
       onClose,
@@ -109,14 +110,13 @@ class Select extends Component {
       <Keyboard onDown={this.onOpen} onUp={this.onOpen}>
         <DropButton
           ref={forwardRef}
+          id={id}
           disabled={disabled}
           dropAlign={dropAlign}
           dropTarget={dropTarget}
-          {...rest}
           open={open}
           onOpen={this.onOpen}
           onClose={this.onClose}
-          a11yTitle={`${a11yTitle}${typeof value === 'string' ? `, ${value}` : ''}`}
           dropContent={<SelectContainer {...this.props} onChange={onSelectChange} />}
         >
           <StyledSelectBox
@@ -130,7 +130,8 @@ class Select extends Component {
             <Box direction='row' flex={true} basis='auto'>
               {selectValue || (
                 <SelectTextInput
-                  ref={(ref) => { this.inputRef = ref; }}
+                  a11yTitle={a11yTitle && `${a11yTitle}${typeof value === 'string' ? `, ${value}` : ''}`}
+                  id={id ? `${id}__input` : undefined}
                   {...rest}
                   tabIndex='-1'
                   type='text'
@@ -139,6 +140,7 @@ class Select extends Component {
                   readOnly={true}
                   value={textValue}
                   size={size}
+                  onClick={disabled ? undefined : this.onOpen}
                 />
               )}
             </Box>

--- a/src/js/components/Select/__tests__/Select-test.js
+++ b/src/js/components/Select/__tests__/Select-test.js
@@ -21,13 +21,13 @@ describe('Select', () => {
 
   test('opens', (done) => {
     window.scrollTo = jest.fn();
-    const { getByTestId, container } = renderIntoDocument(
-      <Select data-testid='test-select' id='test-select' options={['one', 'two']} />
+    const { getByPlaceholderText, container } = renderIntoDocument(
+      <Select placeholder='test select' id='test-select' options={['one', 'two']} />
     );
     expect(container.firstChild).toMatchSnapshot();
     expect(document.getElementById('test-select__drop')).toBeNull();
 
-    Simulate.click(getByTestId('test-select'));
+    Simulate.click(getByPlaceholderText('test select'));
 
     expect(container.firstChild).toMatchSnapshot();
     expectPortal('test-select__drop').toMatchSnapshot();
@@ -39,10 +39,10 @@ describe('Select', () => {
   });
 
   test('complex options and children', () => {
-    const { getByTestId, container } = renderIntoDocument(
+    const { getByPlaceholderText, container } = renderIntoDocument(
       <Select
-        data-testid='test-select'
         id='test-select'
+        placeholder='test select'
         options={[{ test: 'one' }, { test: 'two' }]}
       >
         {option => <span>{option.test}</span>}
@@ -51,7 +51,7 @@ describe('Select', () => {
     expect(container.firstChild).toMatchSnapshot();
     expect(document.getElementById('test-select__drop')).toBeNull();
 
-    Simulate.click(getByTestId('test-select'));
+    Simulate.click(getByPlaceholderText('test select'));
 
     expect(container.firstChild).toMatchSnapshot();
     expectPortal('test-select__drop').toMatchSnapshot();
@@ -60,17 +60,17 @@ describe('Select', () => {
   test('search', () => {
     jest.useFakeTimers();
     const onSearch = jest.fn();
-    const { getByTestId, container } = renderIntoDocument(
+    const { getByPlaceholderText, container } = renderIntoDocument(
       <Select
-        data-testid='test-select'
         id='test-select'
+        placeholder='test select'
         options={['one', 'two']}
         onSearch={onSearch}
       />
     );
     expect(container.firstChild).toMatchSnapshot();
 
-    Simulate.click(getByTestId('test-select'));
+    Simulate.click(getByPlaceholderText('test select'));
 
     expectPortal('test-select__drop').toMatchSnapshot();
 
@@ -114,17 +114,17 @@ describe('Select', () => {
   test('select an option', () => {
     window.scrollTo = jest.fn();
     const onChange = jest.fn();
-    const { getByTestId, container } = renderIntoDocument(
+    const { getByPlaceholderText, container } = renderIntoDocument(
       <Select
-        data-testid='test-select'
         id='test-select'
+        placeholder='test select'
         options={['one', 'two']}
         onChange={onChange}
       />
     );
     expect(container.firstChild).toMatchSnapshot();
 
-    Simulate.click(getByTestId('test-select'));
+    Simulate.click(getByPlaceholderText('test select'));
 
     // pressing enter here nothing will happen
     Simulate.click(
@@ -137,9 +137,8 @@ describe('Select', () => {
   test('select an option with complex options', () => {
     window.scrollTo = jest.fn();
     const onChange = jest.fn();
-    const { getByTestId, container } = renderIntoDocument(
+    const { getByText, container } = renderIntoDocument(
       <Select
-        data-testid='test-select'
         id='test-select'
         plain={true}
         value={<span>one</span>}
@@ -151,7 +150,7 @@ describe('Select', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
 
-    Simulate.click(getByTestId('test-select'));
+    Simulate.click(getByText('one'));
 
     // pressing enter here nothing will happen
     Simulate.click(
@@ -164,17 +163,17 @@ describe('Select', () => {
   test('select an option with enter', () => {
     window.scrollTo = jest.fn();
     const onChange = jest.fn();
-    const { getByTestId, container } = renderIntoDocument(
+    const { getByPlaceholderText, container } = renderIntoDocument(
       <Select
-        data-testid='test-select'
         id='test-select'
+        placeholder='test select'
         options={['one', 'two']}
         onChange={onChange}
       />
     );
     expect(container.firstChild).toMatchSnapshot();
 
-    Simulate.click(getByTestId('test-select'));
+    Simulate.click(getByPlaceholderText('test select'));
 
     const preventDefault = jest.fn();
     Simulate.keyDown(
@@ -223,10 +222,10 @@ describe('Select', () => {
   });
 
   test('multiple values', () => {
-    const { getByTestId, container } = render(
+    const { getByPlaceholderText, container } = render(
       <Select
-        data-testid='test-select'
         id='test-select'
+        placeholder='test select'
         multiple={true}
         options={['one', 'two']}
         selected={[0, 1]}
@@ -235,7 +234,7 @@ describe('Select', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
 
-    Simulate.click(getByTestId('test-select'));
+    Simulate.click(getByPlaceholderText('test select'));
 
     expect(container.firstChild).toMatchSnapshot();
     expectPortal('test-select__drop').toMatchSnapshot();
@@ -243,10 +242,10 @@ describe('Select', () => {
 
   test('select another option', () => {
     const onChange = jest.fn();
-    const { getByTestId, container } = renderIntoDocument(
+    const { getByPlaceholderText, container } = renderIntoDocument(
       <Select
-        data-testid='test-select'
         id='test-select'
+        placeholder='test select'
         multiple={true}
         options={['one', 'two']}
         onChange={onChange}
@@ -256,7 +255,7 @@ describe('Select', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
 
-    Simulate.click(getByTestId('test-select'));
+    Simulate.click(getByPlaceholderText('test select'));
 
     Simulate.click(
       document.getElementById('test-select__drop').querySelector('button')
@@ -266,10 +265,10 @@ describe('Select', () => {
 
   test('deselect an option', () => {
     const onChange = jest.fn();
-    const { getByTestId, container } = renderIntoDocument(
+    const { getByPlaceholderText, container } = renderIntoDocument(
       <Select
-        data-testid='test-select'
         id='test-select'
+        placeholder='test select'
         multiple={true}
         options={['one', 'two']}
         onChange={onChange}
@@ -279,7 +278,7 @@ describe('Select', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
 
-    Simulate.click(getByTestId('test-select'));
+    Simulate.click(getByPlaceholderText('test select'));
 
     Simulate.click(
       document.getElementById('test-select__drop').querySelector('button')
@@ -288,10 +287,10 @@ describe('Select', () => {
   });
 
   test('disabled', () => {
-    const { getByTestId, container } = renderIntoDocument(
+    const { getByPlaceholderText, container } = renderIntoDocument(
       <Select
-        data-testid='test-select'
         id='test-select'
+        placeholder='test select'
         disabled={true}
         options={['one', 'two']}
       />
@@ -299,7 +298,7 @@ describe('Select', () => {
     expect(container.firstChild).toMatchSnapshot();
     expect(document.getElementById('test-select__drop')).toBeNull();
 
-    Simulate.click(getByTestId('test-select'));
+    Simulate.click(getByPlaceholderText('test select'));
 
     expect(container.firstChild).toMatchSnapshot();
     expect(document.getElementById('test-select__drop')).toBeNull();

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -212,7 +212,7 @@ exports[`Select basic 1`] = `
 }
 
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   className="c0"
   disabled={false}
   id="test-select"
@@ -234,8 +234,9 @@ exports[`Select basic 1`] = `
         <input
           autoComplete="off"
           className="c5 c6"
-          id="test-select"
+          id="test-select__input"
           onBlur={[Function]}
+          onClick={[Function]}
           onFocus={[Function]}
           onInput={[Function]}
           onKeyDown={[Function]}
@@ -277,9 +278,8 @@ exports[`Select basic 1`] = `
 
 exports[`Select complex options and children 1`] = `
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   class="StyledButton-qbvYY jZaTeL"
-  data-testid="test-select"
   id="test-select"
   type="button"
 >
@@ -295,8 +295,8 @@ exports[`Select complex options and children 1`] = `
         <input
           autocomplete="off"
           class="Select__SelectTextInput-eJgcSa nKUgh StyledTextInput-bqUxsy hSAYeR"
-          data-testid="test-select"
-          id="test-select"
+          id="test-select__input"
+          placeholder="test select"
           readonly=""
           tabindex="-1"
           type="text"
@@ -332,9 +332,8 @@ exports[`Select complex options and children 1`] = `
 
 exports[`Select complex options and children 2`] = `
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   class="StyledButton-qbvYY jZaTeL"
-  data-testid="test-select"
   id="test-select"
   type="button"
 >
@@ -350,8 +349,8 @@ exports[`Select complex options and children 2`] = `
         <input
           autocomplete="off"
           class="Select__SelectTextInput-eJgcSa nKUgh StyledTextInput-bqUxsy hSAYeR"
-          data-testid="test-select"
-          id="test-select"
+          id="test-select__input"
+          placeholder="test select"
           readonly=""
           tabindex="-1"
           type="text"
@@ -582,9 +581,8 @@ exports[`Select complex options and children 4`] = `
 
 exports[`Select deselect an option 1`] = `
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   class="StyledButton-qbvYY jZaTeL"
-  data-testid="test-select"
   id="test-select"
   type="button"
 >
@@ -600,9 +598,9 @@ exports[`Select deselect an option 1`] = `
         <input
           autocomplete="off"
           class="Select__SelectTextInput-eJgcSa nKUgh StyledTextInput-bqUxsy hSAYeR"
-          data-testid="test-select"
-          id="test-select"
+          id="test-select__input"
           multiple=""
+          placeholder="test select"
           readonly=""
           tabindex="-1"
           type="text"
@@ -638,9 +636,8 @@ exports[`Select deselect an option 1`] = `
 
 exports[`Select disabled 1`] = `
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   class="StyledButton-qbvYY fILeAh"
-  data-testid="test-select"
   disabled=""
   id="test-select"
   type="button"
@@ -657,8 +654,8 @@ exports[`Select disabled 1`] = `
         <input
           autocomplete="off"
           class="Select__SelectTextInput-eJgcSa nKUgh StyledTextInput-bqUxsy hSAYeR"
-          data-testid="test-select"
-          id="test-select"
+          id="test-select__input"
+          placeholder="test select"
           readonly=""
           tabindex="-1"
           type="text"
@@ -694,9 +691,8 @@ exports[`Select disabled 1`] = `
 
 exports[`Select disabled 2`] = `
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   class="StyledButton-qbvYY fILeAh"
-  data-testid="test-select"
   disabled=""
   id="test-select"
   type="button"
@@ -713,8 +709,8 @@ exports[`Select disabled 2`] = `
         <input
           autocomplete="off"
           class="Select__SelectTextInput-eJgcSa nKUgh StyledTextInput-bqUxsy hSAYeR"
-          data-testid="test-select"
-          id="test-select"
+          id="test-select__input"
+          placeholder="test select"
           readonly=""
           tabindex="-1"
           type="text"
@@ -960,16 +956,14 @@ exports[`Select multiple 1`] = `
 }
 
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   className="c0"
   disabled={false}
   id="test-select"
-  multiple={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
   onKeyDown={[Function]}
-  selected={Array []}
   type="button"
 >
   <div
@@ -984,9 +978,10 @@ exports[`Select multiple 1`] = `
         <input
           autoComplete="off"
           className="c5 c6"
-          id="test-select"
+          id="test-select__input"
           multiple={true}
           onBlur={[Function]}
+          onClick={[Function]}
           onFocus={[Function]}
           onInput={[Function]}
           onKeyDown={[Function]}
@@ -1030,9 +1025,8 @@ exports[`Select multiple 1`] = `
 
 exports[`Select multiple values 1`] = `
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   class="StyledButton-qbvYY jZaTeL"
-  data-testid="test-select"
   id="test-select"
   type="button"
 >
@@ -1048,9 +1042,9 @@ exports[`Select multiple values 1`] = `
         <input
           autocomplete="off"
           class="Select__SelectTextInput-eJgcSa nKUgh StyledTextInput-bqUxsy hSAYeR"
-          data-testid="test-select"
-          id="test-select"
+          id="test-select__input"
           multiple=""
+          placeholder="test select"
           readonly=""
           tabindex="-1"
           type="text"
@@ -1086,9 +1080,8 @@ exports[`Select multiple values 1`] = `
 
 exports[`Select multiple values 2`] = `
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   class="StyledButton-qbvYY jZaTeL"
-  data-testid="test-select"
   id="test-select"
   type="button"
 >
@@ -1104,9 +1097,9 @@ exports[`Select multiple values 2`] = `
         <input
           autocomplete="off"
           class="Select__SelectTextInput-eJgcSa nKUgh StyledTextInput-bqUxsy hSAYeR"
-          data-testid="test-select"
-          id="test-select"
+          id="test-select__input"
           multiple=""
+          placeholder="test select"
           readonly=""
           tabindex="-1"
           type="text"
@@ -1368,9 +1361,8 @@ exports[`Select multiple values 4`] = `
 
 exports[`Select opens 1`] = `
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   class="StyledButton-qbvYY jZaTeL"
-  data-testid="test-select"
   id="test-select"
   type="button"
 >
@@ -1386,8 +1378,8 @@ exports[`Select opens 1`] = `
         <input
           autocomplete="off"
           class="Select__SelectTextInput-eJgcSa nKUgh StyledTextInput-bqUxsy hSAYeR"
-          data-testid="test-select"
-          id="test-select"
+          id="test-select__input"
+          placeholder="test select"
           readonly=""
           tabindex="-1"
           type="text"
@@ -1423,9 +1415,8 @@ exports[`Select opens 1`] = `
 
 exports[`Select opens 2`] = `
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   class="StyledButton-qbvYY jZaTeL"
-  data-testid="test-select"
   id="test-select"
   type="button"
 >
@@ -1441,8 +1432,8 @@ exports[`Select opens 2`] = `
         <input
           autocomplete="off"
           class="Select__SelectTextInput-eJgcSa nKUgh StyledTextInput-bqUxsy hSAYeR"
-          data-testid="test-select"
-          id="test-select"
+          id="test-select__input"
+          placeholder="test select"
           readonly=""
           tabindex="-1"
           type="text"
@@ -1732,9 +1723,8 @@ exports[`Select opens 5`] = `
 
 exports[`Select search 1`] = `
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   class="StyledButton-qbvYY jZaTeL"
-  data-testid="test-select"
   id="test-select"
   type="button"
 >
@@ -1750,8 +1740,8 @@ exports[`Select search 1`] = `
         <input
           autocomplete="off"
           class="Select__SelectTextInput-eJgcSa nKUgh StyledTextInput-bqUxsy hSAYeR"
-          data-testid="test-select"
-          id="test-select"
+          id="test-select__input"
+          placeholder="test select"
           readonly=""
           tabindex="-1"
           type="text"
@@ -2020,9 +2010,8 @@ exports[`Select search 3`] = `
 
 exports[`Select select an option 1`] = `
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   class="StyledButton-qbvYY jZaTeL"
-  data-testid="test-select"
   id="test-select"
   type="button"
 >
@@ -2038,8 +2027,8 @@ exports[`Select select an option 1`] = `
         <input
           autocomplete="off"
           class="Select__SelectTextInput-eJgcSa nKUgh StyledTextInput-bqUxsy hSAYeR"
-          data-testid="test-select"
-          id="test-select"
+          id="test-select__input"
+          placeholder="test select"
           readonly=""
           tabindex="-1"
           type="text"
@@ -2075,9 +2064,8 @@ exports[`Select select an option 1`] = `
 
 exports[`Select select an option with complex options 1`] = `
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   class="StyledButton-qbvYY jZaTeL"
-  data-testid="test-select"
   id="test-select"
   type="button"
 >
@@ -2119,9 +2107,8 @@ exports[`Select select an option with complex options 1`] = `
 
 exports[`Select select an option with enter 1`] = `
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   class="StyledButton-qbvYY jZaTeL"
-  data-testid="test-select"
   id="test-select"
   type="button"
 >
@@ -2137,8 +2124,8 @@ exports[`Select select an option with enter 1`] = `
         <input
           autocomplete="off"
           class="Select__SelectTextInput-eJgcSa nKUgh StyledTextInput-bqUxsy hSAYeR"
-          data-testid="test-select"
-          id="test-select"
+          id="test-select__input"
+          placeholder="test select"
           readonly=""
           tabindex="-1"
           type="text"
@@ -2174,9 +2161,8 @@ exports[`Select select an option with enter 1`] = `
 
 exports[`Select select another option 1`] = `
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   class="StyledButton-qbvYY jZaTeL"
-  data-testid="test-select"
   id="test-select"
   type="button"
 >
@@ -2192,9 +2178,9 @@ exports[`Select select another option 1`] = `
         <input
           autocomplete="off"
           class="Select__SelectTextInput-eJgcSa nKUgh StyledTextInput-bqUxsy hSAYeR"
-          data-testid="test-select"
-          id="test-select"
+          id="test-select__input"
           multiple=""
+          placeholder="test select"
           readonly=""
           tabindex="-1"
           type="text"
@@ -2444,7 +2430,7 @@ exports[`Select size 1`] = `
 }
 
 <button
-  aria-label="undefined"
+  aria-label="Open Drop"
   className="c0"
   disabled={false}
   id="test-select"
@@ -2452,7 +2438,6 @@ exports[`Select size 1`] = `
   onClick={[Function]}
   onFocus={[Function]}
   onKeyDown={[Function]}
-  selected={Array []}
   type="button"
 >
   <div
@@ -2467,8 +2452,9 @@ exports[`Select size 1`] = `
         <input
           autoComplete="off"
           className="c5 c6"
-          id="test-select"
+          id="test-select__input"
           onBlur={[Function]}
+          onClick={[Function]}
           onFocus={[Function]}
           onInput={[Function]}
           onKeyDown={[Function]}

--- a/src/js/components/Select/stories/select.stories.js
+++ b/src/js/components/Select/stories/select.stories.js
@@ -60,6 +60,8 @@ class SimpleSelect extends Component {
     return (
       <Grommet theme={theme || grommet}>
         <Select
+          id='select'
+          name='select'
           placeholder='Select'
           value={value}
           options={options}


### PR DESCRIPTION
#### What does this PR do?

Changed Select to fix an issue with duplicate DOM ids and names

#### Where should the reviewer start?

Select.js

#### What testing has been done on this PR?

storybook, unit tests

#### How should this be manually tested?

storybook

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/2214
https://github.com/grommet/grommet/issues/2204

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible for usage

However, the way `id` and `name` properties are passed to the underlying elements within `Select` has changed. For instance, if you have automated tests that were relying on the `name` being associated with the `<button>` element, that will not match anymore. Similarly, if you were relying on `id` being associated with the `<input>` element, that will not match anymore. Instead, `<id>__input` will be the id of the input element now.
