### PR TITLE
Added dynamic responsive breakpoints.

### DIFF
--- a/src/js/components/Grommet/Grommet.js
+++ b/src/js/components/Grommet/Grommet.js
@@ -4,7 +4,7 @@ import { compose } from 'recompose';
 
 import { ResponsiveContext, ThemeContext } from '../../contexts';
 import { base as baseTheme } from '../../themes/base';
-import { colorIsDark, deepMerge } from '../../utils';
+import { colorIsDark, deepMerge, getBreakpoint } from '../../utils';
 import { withIconTheme } from '../hocs';
 
 import { StyledGrommet } from './StyledGrommet';
@@ -58,12 +58,11 @@ class Grommet extends Component {
 
   onResize = () => {
     const { theme, responsive } = this.state;
-    if (window.innerWidth > theme.global.breakpoints.narrow) {
-      if (responsive !== 'wide') {
-        this.setState({ responsive: 'wide' });
-      }
-    } else if (responsive !== 'narrow') {
-      this.setState({ responsive: 'narrow' });
+
+    const breakpoint = getBreakpoint(window.innerWidth, theme);
+
+    if (breakpoint !== responsive) {
+      this.setState({ responsive: breakpoint });
     }
   }
 

--- a/src/js/contexts/ResponsiveContext/doc.js
+++ b/src/js/contexts/ResponsiveContext/doc.js
@@ -13,7 +13,9 @@ export const doc = (ResponsiveContext) => {
   DocumentedResponsiveContext.propTypes = {
     children: PropTypes.func.description(
       `Render function that will be called with the current screen resolution
-      size, either 'wide' or 'narrow'.`),
+      size (e.g 'wide', 'narrow'). The size value will be derived from global.breakpoints entry
+      in the theme object.`
+    ),
   };
 
   return DocumentedResponsiveContext;

--- a/src/js/contexts/ResponsiveContext/responsive-context.stories.js
+++ b/src/js/contexts/ResponsiveContext/responsive-context.stories.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { deepMerge } from '../../utils';
+import { grommet } from '../../themes';
+
+import { Box, Grommet, Heading, ResponsiveContext } from '../../';
+
+const customBreakpoints = deepMerge(grommet, {
+  global: {
+    breakpoints: {
+      medium: 800,
+    },
+  },
+});
+
+storiesOf('ResponsiveContext', module)
+  .add('Custom Breakpoints', () => (
+    <Grommet theme={customBreakpoints} full={true}>
+      <ResponsiveContext.Consumer>
+        {size => (
+          <Box fill={true} background='brand'>
+            <Heading>Hi, I&#39;m {size}, resize me!</Heading>
+          </Box>
+        )}
+      </ResponsiveContext.Consumer>
+    </Grommet>
+  ));

--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -7,5 +7,6 @@ export * from './prop-types';
 export * from './styles';
 export * from './mixins';
 export * from './object';
+export * from './responsive';
 export * from './router';
 export * from './throttle';

--- a/src/js/utils/responsive.js
+++ b/src/js/utils/responsive.js
@@ -1,0 +1,13 @@
+export const getBreakpoint = (windowWidth, theme) => Object.keys(theme.global.breakpoints)
+  .map(
+    size => ({ size, value: theme.global.breakpoints[size] })
+  )
+  .sort(
+    (a, b) => b.value > a.value
+  )
+  .reduce(
+    (size, breakpoint) => (
+      (windowWidth <= breakpoint.value) ? breakpoint.size : size
+    ),
+    'wide'
+  );

--- a/storybook/config.js
+++ b/storybook/config.js
@@ -1,6 +1,6 @@
 import { configure } from '@storybook/react';
 
-const req = require.context('../src/js/components', true, /\.stories\.js$/);
+const req = require.context('../src/js', true, /\.stories\.js$/);
 
 function loadStories() {
   req.keys().forEach(filename => req(filename));


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changes our theme to allow any breakpoint value to be passed in addition to `narrow`.

#### Where should the reviewer start?

responsive-context.stories.js

#### What testing has been done on this PR?
manual
#### How should this be manually tested?
open and test resizing the window for responsive-context.stories.js

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/2251

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible