### PR TITLE
Fixed Tabs and Accordion children types.

### DIFF
--- a/src/js/components/Accordion/README.md
+++ b/src/js/components/Accordion/README.md
@@ -38,6 +38,7 @@ boolean
 Required. Array of AccordionPanels.
 
 ```
+node
 [node]
 ```
 

--- a/src/js/components/Accordion/doc.js
+++ b/src/js/components/Accordion/doc.js
@@ -28,7 +28,10 @@ accordingly.`
     animate: PropTypes.bool.description(
       'Transition content in & out with a slide down animation.'
     ).defaultValue(true),
-    children: PropTypes.arrayOf(PropTypes.node).description(
+    children: PropTypes.oneOfType([
+      PropTypes.node,
+      PropTypes.arrayOf(PropTypes.node),
+    ]).description(
       'Array of AccordionPanels.'
     ).isRequired,
     onActive: PropTypes.func.description(

--- a/src/js/components/Accordion/index.d.ts
+++ b/src/js/components/Accordion/index.d.ts
@@ -3,7 +3,7 @@ import * as React from "react";
 export interface AccordionProps {
   activeIndex?: number | number[];
   animate?: boolean;
-  children: React.ReactNode[];
+  children: React.ReactNode | React.ReactNode[];
   onActive?: (...args: any[]) => any;
   multiple?: boolean;
   messages?: {tabContents: string};

--- a/src/js/components/Tabs/README.md
+++ b/src/js/components/Tabs/README.md
@@ -29,6 +29,7 @@ number
 Required. Array of Tab.
 
 ```
+node
 [node]
 ```
 

--- a/src/js/components/Tabs/doc.js
+++ b/src/js/components/Tabs/doc.js
@@ -20,7 +20,10 @@ export const doc = (Tabs) => {
 tab changes will not work unless you subscribe to onActive function and update activeIndex
 accordingly.`
     ),
-    children: PropTypes.arrayOf(PropTypes.node).description(
+    children: PropTypes.oneOfType([
+      PropTypes.node,
+      PropTypes.arrayOf(PropTypes.node),
+    ]).description(
       'Array of Tab.'
     ).isRequired,
     justify: PropTypes.oneOf(['start', 'center', 'end']).description(

--- a/src/js/components/Tabs/index.d.ts
+++ b/src/js/components/Tabs/index.d.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 
 export interface TabsProps {
   activeIndex?: number;
-  children: React.ReactNode[];
+  children: React.ReactNode | React.ReactNode[];
   justify?: "start" | "center" | "end";
   messages?: {tabContents: string};
   onActive?: (...args: any[]) => any;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -42,6 +42,7 @@ boolean
 Required. Array of AccordionPanels.
 
 \`\`\`
+node
 [node]
 \`\`\`
 
@@ -3527,6 +3528,7 @@ number
 Required. Array of Tab.
 
 \`\`\`
+node
 [node]
 \`\`\`
 

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -7,7 +7,7 @@ Object {
 export interface AccordionProps {
   activeIndex?: number | number[];
   animate?: boolean;
-  children: React.ReactNode[];
+  children: React.ReactNode | React.ReactNode[];
   onActive?: (...args: any[]) => any;
   multiple?: boolean;
   messages?: {tabContents: string};
@@ -643,7 +643,7 @@ export { TableRow };
 
 export interface TabsProps {
   activeIndex?: number;
-  children: React.ReactNode[];
+  children: React.ReactNode | React.ReactNode[];
   justify?: \\"start\\" | \\"center\\" | \\"end\\";
   messages?: {tabContents: string};
   onActive?: (...args: any[]) => any;


### PR DESCRIPTION
#### What does this PR do?

changes `doc` module for `Accordion` and `Tab` to enhance children with two types (a node or an array of nodes).

#### Where should the reviewer start?

doc modules for Accordion and Tab

#### What testing has been done on this PR?

storybook

#### How should this be manually tested?

storybook

#### Any background context you want to provide?


#### What are the relevant issues?

https://github.com/grommet/grommet/pull/2253

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?
backwards
