### PR TITLE
TextInput: fixed opening suggestions after an async response

### DIFF
--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -85,13 +85,21 @@ class TextInput extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { onSuggestionsOpen, onSuggestionsClose } = this.props;
+    const { onSuggestionsOpen, onSuggestionsClose, suggestions } = this.props;
     if (this.state.showDrop !== prevState.showDrop) {
       if (this.state.showDrop && onSuggestionsOpen) {
         onSuggestionsOpen();
       } else if (onSuggestionsClose) {
         onSuggestionsClose();
       }
+    }
+
+    if (
+      !this.state.showDrop &&
+      suggestions &&
+      (!prevProps.suggestions || !prevProps.suggestions.length)
+    ) {
+      this.resetSuggestions();
     }
   }
 

--- a/src/js/components/TextInput/textinput.stories.js
+++ b/src/js/components/TextInput/textinput.stories.js
@@ -12,7 +12,7 @@ class SimpleTextInput extends Component {
 
   ref = React.createRef()
 
-  onChange = event => this.setState({ value: event.target.value })
+  onChange = event => setTimeout(() => this.setState({ value: event.target.value }), 500)
 
   render() {
     const { value } = this.state;
@@ -109,11 +109,20 @@ const folks = [
 ];
 
 class CustomSuggestionsTextInput extends Component {
-  state = { value: '', suggestionOpen: false }
+  state = { value: '', suggestionOpen: false, suggestedFolks: [] }
 
   boxRef= createRef()
 
-  onChange = event => this.setState({ value: event.target.value })
+  onChange = event => this.setState({ value: event.target.value },
+    () => {
+      if (!this.state.value.trim()) {
+        this.setState({ suggestedFolks: [] });
+      } else {
+        // simulate an async call to the backend
+        setTimeout(() => this.setState({ suggestedFolks: folks }), 300);
+      }
+    }
+  )
 
   onSelect = event => this.setState({ value: event.suggestion.value })
 
@@ -122,10 +131,10 @@ class CustomSuggestionsTextInput extends Component {
   }
 
   renderSuggestions = () => {
-    const { value } = this.state;
+    const { value, suggestedFolks } = this.state;
 
     return (
-      folks
+      suggestedFolks
         .filter(
           ({ name }) => name.toLowerCase().indexOf(value.toLowerCase()) >= 0
         )

--- a/src/js/components/TextInput/textinput.stories.js
+++ b/src/js/components/TextInput/textinput.stories.js
@@ -12,7 +12,7 @@ class SimpleTextInput extends Component {
 
   ref = React.createRef()
 
-  onChange = event => setTimeout(() => this.setState({ value: event.target.value }), 500)
+  onChange = event => () => this.setState({ value: event.target.value })
 
   render() {
     const { value } = this.state;

--- a/src/js/components/TextInput/textinput.stories.js
+++ b/src/js/components/TextInput/textinput.stories.js
@@ -12,7 +12,7 @@ class SimpleTextInput extends Component {
 
   ref = React.createRef()
 
-  onChange = event => () => this.setState({ value: event.target.value })
+  onChange = event => this.setState({ value: event.target.value })
 
   render() {
     const { value } = this.state;


### PR DESCRIPTION
TextInput suggestions were not being rendered if the suggestions were fetched from a server asynchronously in some cases, such as when the user pastes the text into the input field.

#### What does this PR do?
Suggestions will properly show up when the state changes asynchronously.

#### Where should the reviewer start?
TextInput.

#### What testing has been done on this PR?
Npm run test and stories.

#### How should this be manually tested?
Look at the CustomSuggestionsTextInput story inside of TextInput stories.

#### Do the grommet docs need to be updated?
NO

#### Should this PR be mentioned in the release notes?
YES

#### Is this change backwards compatible or is it a breaking change?
backwards compatible
