### PR TITLE
Button: fixed padding and height when icon is present

### DIFF
--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -862,7 +862,7 @@ exports[`Accordion change active index 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -911,7 +911,7 @@ exports[`Accordion change active index 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -1415,7 +1415,7 @@ exports[`Accordion change to second Panel 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -1471,7 +1471,7 @@ exports[`Accordion change to second Panel 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -1965,7 +1965,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -2014,7 +2014,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -3127,7 +3127,7 @@ exports[`Accordion multiple panels 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -3176,7 +3176,7 @@ exports[`Accordion multiple panels 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -3272,7 +3272,7 @@ exports[`Accordion multiple panels 3`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -3356,7 +3356,7 @@ exports[`Accordion multiple panels 3`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -3420,7 +3420,7 @@ exports[`Accordion multiple panels 4`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -3472,7 +3472,7 @@ exports[`Accordion multiple panels 4`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -3565,7 +3565,7 @@ exports[`Accordion multiple panels 5`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -3646,7 +3646,7 @@ exports[`Accordion multiple panels 5`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -4199,7 +4199,7 @@ exports[`Accordion set on hover 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -4255,7 +4255,7 @@ exports[`Accordion set on hover 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -4323,7 +4323,7 @@ exports[`Accordion set on hover 3`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -4379,7 +4379,7 @@ exports[`Accordion set on hover 3`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -4447,7 +4447,7 @@ exports[`Accordion set on hover 4`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -4503,7 +4503,7 @@ exports[`Accordion set on hover 4`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -4571,7 +4571,7 @@ exports[`Accordion set on hover 5`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -4627,7 +4627,7 @@ exports[`Accordion set on hover 5`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -4,7 +4,6 @@ import {
   activeStyle,
   backgroundStyle,
   colorForName,
-  colorIsDark,
   focusStyle,
   lapAndUp,
   normalizeColor,
@@ -19,6 +18,8 @@ const basicStyle = props => css`
   border-radius: ${props.theme.button.border.radius};
   color: ${(props.theme.button.color ||
     props.theme.global.text.color)[props.theme.dark ? 'dark' : 'light']};
+  padding: ${props.theme.button.padding.vertical} ${props.theme.button.padding.horizontal};
+  font-size: ${props.theme.text.medium.size};
 `;
 
 const primaryStyle = props => css`
@@ -33,15 +34,6 @@ const primaryStyle = props => css`
     )
   }
   border-radius: ${props.theme.button.border.radius};
-
-  // TODO: revisit this
-  svg {
-    fill: ${props.theme.global.text.color[
-      colorIsDark(colorForName('brand', props.theme)) ? 'dark' : 'light']};
-    stroke: ${props.theme.global.text.color[
-      colorIsDark(colorForName('brand', props.theme)) ? 'dark' : 'light']};
-    transition: none;
-  }
 `;
 
 const disabledStyle = css`
@@ -79,18 +71,6 @@ const hoverStyle = css`
     ${props => !props.plain && (
       css`box-shadow: 0px 0px 0px 2px ${getHoverColor(props)};`
     )}
-
-    ${props => !props.plain && !props.primary && (
-      css`
-        // TODO: revisit this
-        svg {
-          fill: ${props.theme.global.hover.textColor};
-          stroke: ${props.theme.global.hover.textColor};
-          transition: none;
-        }
-      `
-    )}
-
   }
 `;
 
@@ -130,18 +110,12 @@ export const StyledButton = styled.button`
 
   ${props => !props.disabled && props.active && activeStyle}
   ${props => props.disabled && disabledStyle}
-
-  ${props => (
-    !props.plain && (
-      `padding: ${props.theme.button.padding.vertical} ${props.theme.button.padding.horizontal};`
-    )
-  )}
   ${props => props.focus && (!props.plain || props.focusIndicator) && focusStyle}
   ${lapAndUp(`
     transition: 0.1s ease-in-out;
   `)}
   ${props => props.fillContainer && fillStyle}
-  ${props => props.hasIcon && !props.hasLabel && !props.plain && `
+  ${props => props.hasIcon && !props.hasLabel && `
     padding: ${props.theme.global.edgeSize.small};
   `}
   ${props => props.theme.button.extend}

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -20,6 +20,7 @@ const basicStyle = props => css`
     props.theme.global.text.color)[props.theme.dark ? 'dark' : 'light']};
   padding: ${props.theme.button.padding.vertical} ${props.theme.button.padding.horizontal};
   font-size: ${props.theme.text.medium.size};
+  line-height: ${props.theme.text.medium.height};
 `;
 
 const primaryStyle = props => css`

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -26,11 +26,6 @@ exports[`Button color renders 1`] = `
   padding: 0px;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -47,18 +42,14 @@ exports[`Button color renders 1`] = `
   border-radius: 18px;
   color: #444444;
   padding: 4px 22px;
+  font-size: 18px;
 }
 
 .c1:hover {
   box-shadow: 0px 0px 0px 2px #FD6FFF;
 }
 
-.c1:hover svg {
-  -webkit-transition: none;
-  transition: none;
-}
-
-.c4 {
+.c3 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -73,20 +64,14 @@ exports[`Button color renders 1`] = `
   border: 2px solid #FD6FFF;
   border-radius: 18px;
   color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
   background: #FD6FFF;
   color: #444444;
   border-radius: 18px;
-  padding: 4px 22px;
 }
 
-.c4 svg {
-  fill: #f8f8f8;
-  stroke: #f8f8f8;
-  -webkit-transition: none;
-  transition: none;
-}
-
-.c4:hover {
+.c3:hover {
   box-shadow: 0px 0px 0px 2px #FD6FFF;
 }
 
@@ -121,7 +106,7 @@ exports[`Button color renders 1`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .c4 {
+  .c3 {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -141,17 +126,11 @@ exports[`Button color renders 1`] = `
     <div
       className="c2"
     >
-      <span
-        className="c3"
-      >
-        <strong>
-          Test
-        </strong>
-      </span>
+      Test
     </div>
   </button>
   <button
-    className="c4"
+    className="c3"
     disabled={false}
     onBlur={[Function]}
     onClick={[Function]}
@@ -161,13 +140,7 @@ exports[`Button color renders 1`] = `
     <div
       className="c2"
     >
-      <span
-        className="c3"
-      >
-        <strong>
-          Test
-        </strong>
-      </span>
+      Test
     </div>
   </button>
 </div>
@@ -189,9 +162,10 @@ exports[`Button disabled renders 1`] = `
   border: 2px solid #7D4CDB;
   border-radius: 18px;
   color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
   opacity: 0.3;
   cursor: default;
-  padding: 4px 22px;
 }
 
 .c0 {
@@ -251,11 +225,6 @@ exports[`Button focus renders 1`] = `
   padding: 0px;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -272,6 +241,7 @@ exports[`Button focus renders 1`] = `
   border-radius: 18px;
   color: #444444;
   padding: 4px 22px;
+  font-size: 18px;
   border-color: #FD6FFF;
   box-shadow: 0 0 2px 2px #FD6FFF;
 }
@@ -330,13 +300,7 @@ exports[`Button focus renders 1`] = `
     <div
       className="c2"
     >
-      <span
-        className="c3"
-      >
-        <strong>
-          Test
-        </strong>
-      </span>
+      Test
     </div>
   </button>
 </div>
@@ -760,15 +724,11 @@ exports[`Button href renders 1`] = `
   border-radius: 18px;
   color: #444444;
   padding: 4px 22px;
+  font-size: 18px;
 }
 
 .c1:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c1:hover svg {
-  -webkit-transition: none;
-  transition: none;
 }
 
 .c0 {
@@ -793,7 +753,7 @@ exports[`Button href renders 1`] = `
   className="c0"
 >
   <a
-    className="-a c1"
+    className="c1"
     disabled={false}
     href="test"
     onBlur={[Function]}
@@ -825,7 +785,7 @@ exports[`Button icon label renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c3 {
@@ -833,11 +793,6 @@ exports[`Button icon label renders 1`] = `
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   width: 12px;
-}
-
-.c4 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c1 {
@@ -856,15 +811,11 @@ exports[`Button icon label renders 1`] = `
   border-radius: 18px;
   color: #444444;
   padding: 4px 22px;
+  font-size: 18px;
 }
 
 .c1:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c1:hover svg {
-  -webkit-transition: none;
-  transition: none;
 }
 
 .c0 {
@@ -886,7 +837,7 @@ exports[`Button icon label renders 1`] = `
 
 @media only screen and (max-width:699px) {
   .c2 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -915,13 +866,7 @@ exports[`Button icon label renders 1`] = `
       <div
         className="c3"
       />
-      <span
-        className="c4"
-      >
-        <strong>
-          Test
-        </strong>
-      </span>
+      Test
     </div>
   </button>
 </div>
@@ -953,11 +898,6 @@ exports[`Button primary renders 1`] = `
   padding: 0px;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -973,17 +913,11 @@ exports[`Button primary renders 1`] = `
   border: 2px solid #7D4CDB;
   border-radius: 18px;
   color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
   background: #7D4CDB;
   color: #f8f8f8;
   border-radius: 18px;
-  padding: 4px 22px;
-}
-
-.c1 svg {
-  fill: #f8f8f8;
-  stroke: #f8f8f8;
-  -webkit-transition: none;
-  transition: none;
 }
 
 .c1:hover {
@@ -1034,13 +968,7 @@ exports[`Button primary renders 1`] = `
     <div
       className="c2"
     >
-      <span
-        className="c3"
-      >
-        <strong>
-          Test
-        </strong>
-      </span>
+      Test
     </div>
   </button>
 </div>
@@ -1072,11 +1000,6 @@ exports[`Button renders 1`] = `
   padding: 0px;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -1093,15 +1016,11 @@ exports[`Button renders 1`] = `
   border-radius: 18px;
   color: #444444;
   padding: 4px 22px;
+  font-size: 18px;
 }
 
 .c1:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c1:hover svg {
-  -webkit-transition: none;
-  transition: none;
 }
 
 .c0 {
@@ -1148,13 +1067,7 @@ exports[`Button renders 1`] = `
     <div
       className="c2"
     >
-      <span
-        className="c3"
-      >
-        <strong>
-          Test
-        </strong>
-      </span>
+      Test
     </div>
   </button>
 </div>
@@ -1183,19 +1096,14 @@ exports[`Button reverse icon label renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
-.c4 {
+.c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   width: 12px;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
 }
 
 .c1 {
@@ -1214,15 +1122,11 @@ exports[`Button reverse icon label renders 1`] = `
   border-radius: 18px;
   color: #444444;
   padding: 4px 22px;
+  font-size: 18px;
 }
 
 .c1:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c1:hover svg {
-  -webkit-transition: none;
-  transition: none;
 }
 
 .c0 {
@@ -1244,7 +1148,7 @@ exports[`Button reverse icon label renders 1`] = `
 
 @media only screen and (max-width:699px) {
   .c2 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -1269,15 +1173,9 @@ exports[`Button reverse icon label renders 1`] = `
     <div
       className="c2"
     >
-      <span
-        className="c3"
-      >
-        <strong>
-          Test
-        </strong>
-      </span>
+      Test
       <div
-        className="c4"
+        className="c3"
       />
       <svg />
     </div>
@@ -1308,7 +1206,7 @@ exports[`Button warns about invalid icon render 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c1 {
@@ -1327,6 +1225,7 @@ exports[`Button warns about invalid icon render 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c0 {
@@ -1348,7 +1247,7 @@ exports[`Button warns about invalid icon render 1`] = `
 
 @media only screen and (max-width:699px) {
   .c2 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -1405,11 +1304,6 @@ exports[`Button warns about invalid label render 1`] = `
   padding: 0px;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -1472,13 +1366,7 @@ exports[`Button warns about invalid label render 1`] = `
     <div
       className="c2"
     >
-      <span
-        className="c3"
-      >
-        <strong>
-          Test
-        </strong>
-      </span>
+      Test
     </div>
   </button>
 </div>

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -43,6 +43,7 @@ exports[`Button color renders 1`] = `
   color: #444444;
   padding: 4px 22px;
   font-size: 18px;
+  line-height: 24px;
 }
 
 .c1:hover {
@@ -66,6 +67,7 @@ exports[`Button color renders 1`] = `
   color: #444444;
   padding: 4px 22px;
   font-size: 18px;
+  line-height: 24px;
   background: #FD6FFF;
   color: #444444;
   border-radius: 18px;
@@ -164,6 +166,7 @@ exports[`Button disabled renders 1`] = `
   color: #444444;
   padding: 4px 22px;
   font-size: 18px;
+  line-height: 24px;
   opacity: 0.3;
   cursor: default;
 }
@@ -242,6 +245,7 @@ exports[`Button focus renders 1`] = `
   color: #444444;
   padding: 4px 22px;
   font-size: 18px;
+  line-height: 24px;
   border-color: #FD6FFF;
   box-shadow: 0 0 2px 2px #FD6FFF;
 }
@@ -725,6 +729,7 @@ exports[`Button href renders 1`] = `
   color: #444444;
   padding: 4px 22px;
   font-size: 18px;
+  line-height: 24px;
 }
 
 .c1:hover {
@@ -812,6 +817,7 @@ exports[`Button icon label renders 1`] = `
   color: #444444;
   padding: 4px 22px;
   font-size: 18px;
+  line-height: 24px;
 }
 
 .c1:hover {
@@ -915,6 +921,7 @@ exports[`Button primary renders 1`] = `
   color: #444444;
   padding: 4px 22px;
   font-size: 18px;
+  line-height: 24px;
   background: #7D4CDB;
   color: #f8f8f8;
   border-radius: 18px;
@@ -1017,6 +1024,7 @@ exports[`Button renders 1`] = `
   color: #444444;
   padding: 4px 22px;
   font-size: 18px;
+  line-height: 24px;
 }
 
 .c1:hover {
@@ -1123,6 +1131,7 @@ exports[`Button reverse icon label renders 1`] = `
   color: #444444;
   padding: 4px 22px;
   font-size: 18px;
+  line-height: 24px;
 }
 
 .c1:hover {

--- a/src/js/components/Button/button.stories.js
+++ b/src/js/components/Button/button.stories.js
@@ -7,13 +7,24 @@ import { grommet } from '../../themes';
 
 const SimpleButton = props => (
   <Grommet theme={grommet}>
-    <Button fill={true} label='Submit' onClick={() => {}} {...props} />
+    <Box align='start'>
+      <Button label='Submit' onClick={() => {}} {...props} />
+    </Box>
   </Grommet>
 );
 
 const IconButton = () => (
   <Grommet theme={grommet}>
     <Button icon={<Add />} hoverIndicator={true} onClick={() => {}} />
+  </Grommet>
+);
+
+const IconLabelButton = () => (
+  <Grommet theme={grommet}>
+    <Box align='start' gap='small'>
+      <Button icon={<Add />} label='Add' onClick={() => {}} primary={true} />
+      <Button icon={<Add />} label='Add' onClick={() => {}} />
+    </Box>
   </Grommet>
 );
 
@@ -67,10 +78,8 @@ const customTheme = {
       }
       return `
         color: white;
-
-        span {
-          font-size: 12px;
-        }
+        font-size: 12px;
+        font-weight: bold;
 
         ${extraStyles}
       `;
@@ -84,12 +93,58 @@ const CustomThemeButton = () => (
   </Grommet>
 );
 
+const MultipleButton = () => (
+  <Grommet theme={grommet}>
+    <Box direction='row' align='center' gap='small' pad='xsmall'>
+      <Button label='Cancel' onClick={() => {}} />
+      <Button
+        color='dark-1'
+        primary={true}
+        icon={<Add color='accent-1' />}
+        label='Add'
+        onClick={() => {}}
+      />
+    </Box>
+    <Box direction='row' align='center' gap='small' pad='xsmall'>
+      <Button label='Cancel' onClick={() => {}} />
+      <Button
+        color='dark-1'
+        primary={true}
+        icon={<Add />}
+        label='Add'
+        onClick={() => {}}
+      />
+    </Box>
+    <Box direction='row' align='center' gap='small' pad='xsmall'>
+      <Button label='Cancel' onClick={() => {}} />
+      <Button
+        primary={true}
+        icon={<Add />}
+        label='Add'
+        onClick={() => {}}
+      />
+    </Box>
+    <Box direction='row' align='center' gap='small' pad='xsmall'>
+      <Button label='Cancel' onClick={() => {}} />
+      <Button
+        color='light-2'
+        primary={true}
+        icon={<Add />}
+        label='Add'
+        onClick={() => {}}
+      />
+    </Box>
+  </Grommet>
+);
+
 storiesOf('Button', module)
   .add('Default', () => <SimpleButton />)
   .add('Primary', () => <SimpleButton primary={true} />)
   .add('Icon', () => <IconButton />)
+  .add('Icon Label', () => <IconLabelButton />)
   .add('Plain', () => <PlainButton />)
   .add('Anchor', () => <AnchorButton />)
   .add('RoutedButton', () => <RouteButton />)
   .add('Active', () => <PlainButton active={true} />)
-  .add('Custom theme', () => <CustomThemeButton />);
+  .add('Custom theme', () => <CustomThemeButton />)
+  .add('Multiple Same Line', () => <MultipleButton />);

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -136,7 +136,7 @@ exports[`Calendar date renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c7 {
@@ -157,6 +157,7 @@ exports[`Calendar date renders 1`] = `
   text-align: inherit;
   opacity: 0.3;
   cursor: default;
+  padding: 12px;
 }
 
 .c14 {
@@ -376,7 +377,7 @@ exports[`Calendar date renders 1`] = `
 
 @media only screen and (max-width:699px) {
   .c8 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -1543,7 +1544,7 @@ exports[`Calendar dates renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c7 {
@@ -1564,6 +1565,7 @@ exports[`Calendar dates renders 1`] = `
   text-align: inherit;
   opacity: 0.3;
   cursor: default;
+  padding: 12px;
 }
 
 .c14 {
@@ -1783,7 +1785,7 @@ exports[`Calendar dates renders 1`] = `
 
 @media only screen and (max-width:699px) {
   .c8 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -2950,7 +2952,7 @@ exports[`Calendar disabled renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c7 {
@@ -2971,6 +2973,7 @@ exports[`Calendar disabled renders 1`] = `
   text-align: inherit;
   opacity: 0.3;
   cursor: default;
+  padding: 12px;
 }
 
 .c14 {
@@ -3190,7 +3193,7 @@ exports[`Calendar disabled renders 1`] = `
 
 @media only screen and (max-width:699px) {
   .c8 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -4357,7 +4360,7 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c7 {
@@ -4378,6 +4381,7 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
   text-align: inherit;
   opacity: 0.3;
   cursor: default;
+  padding: 12px;
 }
 
 .c14 {
@@ -4597,7 +4601,7 @@ exports[`Calendar firstDayOfWeek renders 1`] = `
 
 @media only screen and (max-width:699px) {
   .c8 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -6748,7 +6752,7 @@ exports[`Calendar renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c7 {
@@ -6769,6 +6773,7 @@ exports[`Calendar renders 1`] = `
   text-align: inherit;
   opacity: 0.3;
   cursor: default;
+  padding: 12px;
 }
 
 .c14 {
@@ -6988,7 +6993,7 @@ exports[`Calendar renders 1`] = `
 
 @media only screen and (max-width:699px) {
   .c8 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -8189,7 +8194,7 @@ exports[`Calendar size renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c7 {
@@ -8210,6 +8215,7 @@ exports[`Calendar size renders 1`] = `
   text-align: inherit;
   opacity: 0.3;
   cursor: default;
+  padding: 12px;
 }
 
 .c14 {
@@ -8570,7 +8576,7 @@ exports[`Calendar size renders 1`] = `
 
 @media only screen and (max-width:699px) {
   .c8 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -257,7 +257,7 @@ exports[`Carousel basic 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c9 {
@@ -302,6 +302,7 @@ exports[`Carousel basic 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c17 {
@@ -455,7 +456,7 @@ exports[`Carousel basic 1`] = `
 
 @media only screen and (max-width:699px) {
   .c15 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -924,7 +925,7 @@ exports[`Carousel navigate 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c9 {
@@ -969,6 +970,7 @@ exports[`Carousel navigate 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c17 {
@@ -1122,7 +1124,7 @@ exports[`Carousel navigate 1`] = `
 
 @media only screen and (max-width:699px) {
   .c15 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -1369,7 +1371,7 @@ exports[`Carousel navigate 2`] = `
           class="StyledBox-sc-13pk1d4-0 hoZmmL"
         >
           <button
-            class="StyledButton-sc-323bzc-0 hVXlHQ"
+            class="StyledButton-sc-323bzc-0 eUdNKh"
             type="button"
           >
             <div
@@ -1402,11 +1404,11 @@ exports[`Carousel navigate 2`] = `
             class="StyledBox-sc-13pk1d4-0 kijwgq"
           >
             <button
-              class="StyledButton-sc-323bzc-0 eFkyjH"
+              class="StyledButton-sc-323bzc-0 cGpETu"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 eQOfmN"
+                class="StyledBox-sc-13pk1d4-0 ksxcgD"
               >
                 <svg
                   aria-label="Subtract"
@@ -1427,11 +1429,11 @@ exports[`Carousel navigate 2`] = `
               </div>
             </button>
             <button
-              class="StyledButton-sc-323bzc-0 eFkyjH"
+              class="StyledButton-sc-323bzc-0 cGpETu"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 eQOfmN"
+                class="StyledBox-sc-13pk1d4-0 ksxcgD"
               >
                 <svg
                   aria-label="Subtract"
@@ -1458,7 +1460,7 @@ exports[`Carousel navigate 2`] = `
           class="StyledBox-sc-13pk1d4-0 hoZmmL"
         >
           <button
-            class="StyledButton-sc-323bzc-0 bpXwFO"
+            class="StyledButton-sc-323bzc-0 hvgqUe"
             disabled=""
             type="button"
           >
@@ -1541,7 +1543,7 @@ exports[`Carousel navigate 3`] = `
           class="StyledBox-sc-13pk1d4-0 hoZmmL"
         >
           <button
-            class="StyledButton-sc-323bzc-0 bpXwFO"
+            class="StyledButton-sc-323bzc-0 hvgqUe"
             disabled=""
             type="button"
           >
@@ -1575,11 +1577,11 @@ exports[`Carousel navigate 3`] = `
             class="StyledBox-sc-13pk1d4-0 kijwgq"
           >
             <button
-              class="StyledButton-sc-323bzc-0 eFkyjH"
+              class="StyledButton-sc-323bzc-0 cGpETu"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 eQOfmN"
+                class="StyledBox-sc-13pk1d4-0 ksxcgD"
               >
                 <svg
                   aria-label="Subtract"
@@ -1601,11 +1603,11 @@ exports[`Carousel navigate 3`] = `
               </div>
             </button>
             <button
-              class="StyledButton-sc-323bzc-0 eFkyjH"
+              class="StyledButton-sc-323bzc-0 cGpETu"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 eQOfmN"
+                class="StyledBox-sc-13pk1d4-0 ksxcgD"
               >
                 <svg
                   aria-label="Subtract"
@@ -1631,7 +1633,7 @@ exports[`Carousel navigate 3`] = `
           class="StyledBox-sc-13pk1d4-0 hoZmmL"
         >
           <button
-            class="StyledButton-sc-323bzc-0 hVXlHQ"
+            class="StyledButton-sc-323bzc-0 eUdNKh"
             type="button"
           >
             <div
@@ -1919,7 +1921,7 @@ exports[`Carousel play 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c9 {
@@ -1964,6 +1966,7 @@ exports[`Carousel play 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c17 {
@@ -2117,7 +2120,7 @@ exports[`Carousel play 1`] = `
 
 @media only screen and (max-width:699px) {
   .c15 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -2362,7 +2365,7 @@ exports[`Carousel play 2`] = `
           class="StyledBox-sc-13pk1d4-0 hoZmmL"
         >
           <button
-            class="StyledButton-sc-323bzc-0 hVXlHQ"
+            class="StyledButton-sc-323bzc-0 eUdNKh"
             type="button"
           >
             <div
@@ -2395,11 +2398,11 @@ exports[`Carousel play 2`] = `
             class="StyledBox-sc-13pk1d4-0 kijwgq"
           >
             <button
-              class="StyledButton-sc-323bzc-0 eFkyjH"
+              class="StyledButton-sc-323bzc-0 cGpETu"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 eQOfmN"
+                class="StyledBox-sc-13pk1d4-0 ksxcgD"
               >
                 <svg
                   aria-label="Subtract"
@@ -2420,11 +2423,11 @@ exports[`Carousel play 2`] = `
               </div>
             </button>
             <button
-              class="StyledButton-sc-323bzc-0 eFkyjH"
+              class="StyledButton-sc-323bzc-0 cGpETu"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 eQOfmN"
+                class="StyledBox-sc-13pk1d4-0 ksxcgD"
               >
                 <svg
                   aria-label="Subtract"
@@ -2451,7 +2454,7 @@ exports[`Carousel play 2`] = `
           class="StyledBox-sc-13pk1d4-0 hoZmmL"
         >
           <button
-            class="StyledButton-sc-323bzc-0 bpXwFO"
+            class="StyledButton-sc-323bzc-0 hvgqUe"
             disabled=""
             type="button"
           >

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -1436,7 +1436,7 @@ exports[`DataTable groupBy 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 hVXlHQ"
+            class="StyledButton-sc-323bzc-0 eUdNKh"
             type="button"
           >
             <div
@@ -1503,7 +1503,7 @@ exports[`DataTable groupBy 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 hVXlHQ"
+            class="StyledButton-sc-323bzc-0 eUdNKh"
             type="button"
           >
             <div
@@ -1559,7 +1559,7 @@ exports[`DataTable groupBy 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 hVXlHQ"
+            class="StyledButton-sc-323bzc-0 eUdNKh"
             type="button"
           >
             <div

--- a/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
+++ b/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
@@ -26,11 +26,6 @@ exports[`DropButton close by clicking outside 1`] = `
   padding: 0px;
 }
 
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c0 {
   display: inline-block;
   box-sizing: border-box;
@@ -47,15 +42,11 @@ exports[`DropButton close by clicking outside 1`] = `
   border-radius: 18px;
   color: #444444;
   padding: 4px 22px;
+  font-size: 18px;
 }
 
 .c0:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c0:hover svg {
-  -webkit-transition: none;
-  transition: none;
 }
 
 @media only screen and (max-width:699px) {
@@ -85,13 +76,7 @@ exports[`DropButton close by clicking outside 1`] = `
   <div
     class="c1"
   >
-    <span
-      class="c2"
-    >
-      <strong>
-        Dropper
-      </strong>
-    </span>
+    Dropper
   </div>
 </button>
 `;
@@ -118,7 +103,7 @@ exports[`DropButton close by clicking outside 3`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .dtcgqD {
+  .gKHIXA {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -164,11 +149,6 @@ exports[`DropButton closed 1`] = `
   padding: 0px;
 }
 
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c0 {
   display: inline-block;
   box-sizing: border-box;
@@ -185,15 +165,11 @@ exports[`DropButton closed 1`] = `
   border-radius: 18px;
   color: #444444;
   padding: 4px 22px;
+  font-size: 18px;
 }
 
 .c0:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c0:hover svg {
-  -webkit-transition: none;
-  transition: none;
 }
 
 @media only screen and (max-width:699px) {
@@ -227,13 +203,7 @@ exports[`DropButton closed 1`] = `
   <div
     className="c1"
   >
-    <span
-      className="c2"
-    >
-      <strong>
-        Dropper
-      </strong>
-    </span>
+    Dropper
   </div>
 </button>
 `;
@@ -264,11 +234,6 @@ exports[`DropButton disabled 1`] = `
   padding: 0px;
 }
 
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c0 {
   display: inline-block;
   box-sizing: border-box;
@@ -284,9 +249,10 @@ exports[`DropButton disabled 1`] = `
   border: 2px solid #7D4CDB;
   border-radius: 18px;
   color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
   opacity: 0.3;
   cursor: default;
-  padding: 4px 22px;
 }
 
 @media only screen and (max-width:699px) {
@@ -317,13 +283,7 @@ exports[`DropButton disabled 1`] = `
   <div
     class="c1"
   >
-    <span
-      class="c2"
-    >
-      <strong>
-        Dropper
-      </strong>
-    </span>
+    Dropper
   </div>
 </button>
 `;
@@ -354,11 +314,6 @@ exports[`DropButton open and close 1`] = `
   padding: 0px;
 }
 
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c0 {
   display: inline-block;
   box-sizing: border-box;
@@ -375,15 +330,11 @@ exports[`DropButton open and close 1`] = `
   border-radius: 18px;
   color: #444444;
   padding: 4px 22px;
+  font-size: 18px;
 }
 
 .c0:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c0:hover svg {
-  -webkit-transition: none;
-  transition: none;
 }
 
 @media only screen and (max-width:699px) {
@@ -413,13 +364,7 @@ exports[`DropButton open and close 1`] = `
   <div
     class="c1"
   >
-    <span
-      class="c2"
-    >
-      <strong>
-        Dropper
-      </strong>
-    </span>
+    Dropper
   </div>
 </button>
 `;
@@ -446,7 +391,7 @@ exports[`DropButton open and close 3`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .dtcgqD {
+  .gKHIXA {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -492,11 +437,6 @@ exports[`DropButton opened 1`] = `
   padding: 0px;
 }
 
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c0 {
   display: inline-block;
   box-sizing: border-box;
@@ -513,15 +453,11 @@ exports[`DropButton opened 1`] = `
   border-radius: 18px;
   color: #444444;
   padding: 4px 22px;
+  font-size: 18px;
 }
 
 .c0:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c0:hover svg {
-  -webkit-transition: none;
-  transition: none;
 }
 
 @media only screen and (max-width:699px) {
@@ -555,13 +491,7 @@ exports[`DropButton opened 1`] = `
   <div
     className="c1"
   >
-    <span
-      className="c2"
-    >
-      <strong>
-        Dropper
-      </strong>
-    </span>
+    Dropper
   </div>
 </button>
 `;
@@ -592,11 +522,6 @@ exports[`DropButton opened ref 1`] = `
   padding: 0px;
 }
 
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c0 {
   display: inline-block;
   box-sizing: border-box;
@@ -613,15 +538,11 @@ exports[`DropButton opened ref 1`] = `
   border-radius: 18px;
   color: #444444;
   padding: 4px 22px;
+  font-size: 18px;
 }
 
 .c0:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c0:hover svg {
-  -webkit-transition: none;
-  transition: none;
 }
 
 @media only screen and (max-width:699px) {
@@ -651,13 +572,7 @@ exports[`DropButton opened ref 1`] = `
   <div
     class="c1"
   >
-    <span
-      class="c2"
-    >
-      <strong>
-        Dropper
-      </strong>
-    </span>
+    Dropper
   </div>
 </button>
 `;
@@ -684,21 +599,21 @@ exports[`DropButton opened ref 3`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .dtcgqD {
+  .gKHIXA {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .fiHkqW {
+  .iKaXUd {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iFLiwK {
+  .gnSkEU {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }

--- a/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
+++ b/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
@@ -43,6 +43,7 @@ exports[`DropButton close by clicking outside 1`] = `
   color: #444444;
   padding: 4px 22px;
   font-size: 18px;
+  line-height: 24px;
 }
 
 .c0:hover {
@@ -103,7 +104,7 @@ exports[`DropButton close by clicking outside 3`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .gKHIXA {
+  .kXrZjK {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -166,6 +167,7 @@ exports[`DropButton closed 1`] = `
   color: #444444;
   padding: 4px 22px;
   font-size: 18px;
+  line-height: 24px;
 }
 
 .c0:hover {
@@ -251,6 +253,7 @@ exports[`DropButton disabled 1`] = `
   color: #444444;
   padding: 4px 22px;
   font-size: 18px;
+  line-height: 24px;
   opacity: 0.3;
   cursor: default;
 }
@@ -331,6 +334,7 @@ exports[`DropButton open and close 1`] = `
   color: #444444;
   padding: 4px 22px;
   font-size: 18px;
+  line-height: 24px;
 }
 
 .c0:hover {
@@ -391,7 +395,7 @@ exports[`DropButton open and close 3`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .gKHIXA {
+  .kXrZjK {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -454,6 +458,7 @@ exports[`DropButton opened 1`] = `
   color: #444444;
   padding: 4px 22px;
   font-size: 18px;
+  line-height: 24px;
 }
 
 .c0:hover {
@@ -539,6 +544,7 @@ exports[`DropButton opened ref 1`] = `
   color: #444444;
   padding: 4px 22px;
   font-size: 18px;
+  line-height: 24px;
 }
 
 .c0:hover {
@@ -599,21 +605,21 @@ exports[`DropButton opened ref 3`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .gKHIXA {
+  .kXrZjK {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .iKaXUd {
+  .ighkQC {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .gnSkEU {
+  .bYlrVG {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -33,11 +33,6 @@ exports[`Menu basic 1`] = `
   width: 12px;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -54,6 +49,11 @@ exports[`Menu basic 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c0 {
@@ -185,11 +185,6 @@ exports[`Menu close by clicking outside 1`] = `
   width: 12px;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -206,6 +201,11 @@ exports[`Menu close by clicking outside 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c0 {
@@ -423,11 +423,6 @@ exports[`Menu close by clicking outside 2`] = `
   width: 12px;
 }
 
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c4 {
   display: inline-block;
   box-sizing: border-box;
@@ -464,6 +459,11 @@ exports[`Menu close by clicking outside 2`] = `
   text-align: inherit;
   opacity: 0.3;
   cursor: default;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c0 {
@@ -737,28 +737,21 @@ exports[`Menu close by clicking outside 3`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .eFkyjH {
+  .jeDfzo {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .glXJnP {
+  .GOlmK {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .kixBti {
-    -webkit-transition: 0.1s ease-in-out;
-    transition: 0.1s ease-in-out;
-  }
-}
-
-@media only screen and (min-width:700px) {
-  .iqiGzx {
+  .gavjLN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -871,11 +864,6 @@ exports[`Menu close on esc 1`] = `
   width: 12px;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -892,6 +880,11 @@ exports[`Menu close on esc 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c0 {
@@ -1033,11 +1026,6 @@ exports[`Menu close on tab 1`] = `
   width: 12px;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -1054,6 +1042,11 @@ exports[`Menu close on tab 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c0 {
@@ -1195,11 +1188,6 @@ exports[`Menu custom message 1`] = `
   width: 12px;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -1216,6 +1204,11 @@ exports[`Menu custom message 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c0 {
@@ -1362,11 +1355,6 @@ exports[`Menu disabled 1`] = `
   width: 12px;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -1385,6 +1373,11 @@ exports[`Menu disabled 1`] = `
   text-align: inherit;
   opacity: 0.3;
   cursor: default;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c0 {
@@ -1527,11 +1520,6 @@ exports[`Menu navigate through suggestions and select 1`] = `
   width: 12px;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -1548,6 +1536,11 @@ exports[`Menu navigate through suggestions and select 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c0 {
@@ -1689,11 +1682,6 @@ exports[`Menu open and close on click 1`] = `
   width: 12px;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -1710,6 +1698,11 @@ exports[`Menu open and close on click 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c0 {
@@ -1793,7 +1786,7 @@ exports[`Menu open and close on click 2`] = `
   <div>
     <button
       aria-label="Open Menu"
-      class="StyledButton-sc-323bzc-0 eFkyjH"
+      class="StyledButton-sc-323bzc-0 jeDfzo"
       id="test-menu"
       type="button"
     >
@@ -1972,11 +1965,6 @@ exports[`Menu open and close on click 3`] = `
   width: 12px;
 }
 
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c4 {
   display: inline-block;
   box-sizing: border-box;
@@ -2039,28 +2027,9 @@ exports[`Menu open and close on click 3`] = `
   color: black;
 }
 
-.c13 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  outline: none;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c13:hover {
-  background: rgba(221,221,221,0.4);
-  color: #444444;
-  color: black;
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c0 {
@@ -2174,13 +2143,6 @@ exports[`Menu open and close on click 3`] = `
   }
 }
 
-@media only screen and (min-width:700px) {
-  .c13 {
-    -webkit-transition: 0.1s ease-in-out;
-    transition: 0.1s ease-in-out;
-  }
-}
-
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
   .c0 {
     display: -webkit-box;
@@ -2284,7 +2246,7 @@ exports[`Menu open and close on click 3`] = `
         class="c3"
       >
         <a
-          class="-a c13"
+          class="c12"
           href="/test"
         >
           <div
@@ -2361,28 +2323,21 @@ exports[`Menu open and close on click 4`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .eFkyjH {
+  .jeDfzo {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .glXJnP {
+  .GOlmK {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .kixBti {
-    -webkit-transition: 0.1s ease-in-out;
-    transition: 0.1s ease-in-out;
-  }
-}
-
-@media only screen and (min-width:700px) {
-  .iqiGzx {
+  .gavjLN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -2495,11 +2450,6 @@ exports[`Menu select an item 1`] = `
   width: 12px;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -2516,6 +2466,11 @@ exports[`Menu select an item 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c0 {
@@ -2657,11 +2612,6 @@ exports[`Menu with dropAlign renders 1`] = `
   width: 12px;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -2678,6 +2628,11 @@ exports[`Menu with dropAlign renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c0 {
@@ -2895,11 +2850,6 @@ exports[`Menu with dropAlign renders 2`] = `
   width: 12px;
 }
 
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c4 {
   display: inline-block;
   box-sizing: border-box;
@@ -2936,6 +2886,11 @@ exports[`Menu with dropAlign renders 2`] = `
   text-align: inherit;
   opacity: 0.3;
   cursor: default;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c0 {
@@ -3209,42 +3164,35 @@ exports[`Menu with dropAlign renders 3`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .eFkyjH {
+  .jeDfzo {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .glXJnP {
+  .GOlmK {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .kixBti {
+  .gavjLN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .hjlAVQ {
+  .huvvip {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .bxwYdc {
-    -webkit-transition: 0.1s ease-in-out;
-    transition: 0.1s ease-in-out;
-  }
-}
-
-@media only screen and (min-width:700px) {
-  .iqiGzx {
+  .fuBvtX {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }

--- a/src/js/components/RoutedButton/__tests__/__snapshots__/RoutedButton-test.js.snap
+++ b/src/js/components/RoutedButton/__tests__/__snapshots__/RoutedButton-test.js.snap
@@ -26,11 +26,6 @@ exports[`RoutedButton renders 1`] = `
   padding: 0px;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -47,15 +42,11 @@ exports[`RoutedButton renders 1`] = `
   border-radius: 18px;
   color: #444444;
   padding: 4px 22px;
+  font-size: 18px;
 }
 
 .c1:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c1:hover svg {
-  -webkit-transition: none;
-  transition: none;
 }
 
 .c0 {
@@ -93,7 +84,7 @@ exports[`RoutedButton renders 1`] = `
 >
   <div>
     <a
-      className="-a c1"
+      className="c1"
       disabled={false}
       href="/"
       onBlur={[Function]}
@@ -103,13 +94,7 @@ exports[`RoutedButton renders 1`] = `
       <div
         className="c2"
       >
-        <span
-          className="c3"
-        >
-          <strong>
-            Test
-          </strong>
-        </span>
+        Test
       </div>
     </a>
   </div>

--- a/src/js/components/RoutedButton/__tests__/__snapshots__/RoutedButton-test.js.snap
+++ b/src/js/components/RoutedButton/__tests__/__snapshots__/RoutedButton-test.js.snap
@@ -43,6 +43,7 @@ exports[`RoutedButton renders 1`] = `
   color: #444444;
   padding: 4px 22px;
   font-size: 18px;
+  line-height: 24px;
 }
 
 .c1:hover {

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -551,7 +551,7 @@ exports[`Select complex options and children 1`] = `
 exports[`Select complex options and children 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 eFkyjH"
+  class="StyledButton-sc-323bzc-0 jeDfzo"
   id="test-select"
   type="button"
 >
@@ -917,14 +917,14 @@ exports[`Select complex options and children 4`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .eFkyjH {
+  .jeDfzo {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .kixBti {
+  .gavjLN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -1521,7 +1521,7 @@ exports[`Select disabled 1`] = `
 exports[`Select disabled 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 glXJnP"
+  class="StyledButton-sc-323bzc-0 GOlmK"
   disabled=""
   id="test-select"
   type="button"
@@ -2128,7 +2128,7 @@ exports[`Select multiple values 1`] = `
 exports[`Select multiple values 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 eFkyjH"
+  class="StyledButton-sc-323bzc-0 jeDfzo"
   id="test-select"
   type="button"
 >
@@ -2260,15 +2260,6 @@ exports[`Select multiple values 3`] = `
   padding: 12px;
 }
 
-.c8 {
-  font-size: 18px;
-  line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
-}
-
 .c6 {
   display: inline-block;
   box-sizing: border-box;
@@ -2320,6 +2311,15 @@ exports[`Select multiple values 3`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
+}
+
+.c8 {
+  font-size: 18px;
+  line-height: 24px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
 }
 
 .c1 {
@@ -2564,21 +2564,21 @@ exports[`Select multiple values 4`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .eFkyjH {
+  .jeDfzo {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .kixBti {
+  .gavjLN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .bxwYdc {
+  .fuBvtX {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -2903,7 +2903,7 @@ exports[`Select opens 1`] = `
 exports[`Select opens 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 eFkyjH"
+  class="StyledButton-sc-323bzc-0 jeDfzo"
   id="test-select"
   type="button"
 >
@@ -3034,15 +3034,6 @@ exports[`Select opens 3`] = `
   padding: 12px;
 }
 
-.c8 {
-  font-size: 18px;
-  line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
-}
-
 .c6 {
   display: inline-block;
   box-sizing: border-box;
@@ -3091,6 +3082,15 @@ exports[`Select opens 3`] = `
   animation: jNdvGQ 0.1s forwards;
   -webkit-animation-delay: 0.01s;
   animation-delay: 0.01s;
+}
+
+.c8 {
+  font-size: 18px;
+  line-height: 24px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
 }
 
 .c1 {
@@ -3323,14 +3323,14 @@ exports[`Select opens 4`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .eFkyjH {
+  .jeDfzo {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .kixBti {
+  .gavjLN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -3394,7 +3394,7 @@ exports[`Select opens 5`] = `
     class="StyledBox-sc-13pk1d4-0 hvNmzo"
   >
     <button
-      class="StyledButton-sc-323bzc-0 kixBti"
+      class="StyledButton-sc-323bzc-0 gavjLN"
       role="menuitem"
       type="button"
     >
@@ -3413,7 +3413,7 @@ exports[`Select opens 5`] = `
     class="StyledBox-sc-13pk1d4-0 hvNmzo"
   >
     <button
-      class="StyledButton-sc-323bzc-0 kixBti"
+      class="StyledButton-sc-323bzc-0 gavjLN"
       role="menuitem"
       type="button"
     >
@@ -3799,15 +3799,6 @@ exports[`Select search 2`] = `
   padding: 6px;
 }
 
-.c11 {
-  font-size: 18px;
-  line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
-}
-
 .c9 {
   display: inline-block;
   box-sizing: border-box;
@@ -3900,6 +3891,15 @@ exports[`Select search 2`] = `
 .c4 {
   position: relative;
   width: 100%;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
 }
 
 .c1 {
@@ -4170,14 +4170,14 @@ exports[`Select search 3`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .eFkyjH {
+  .jeDfzo {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
 }
 
 @media only screen and (min-width:700px) {
-  .kixBti {
+  .gavjLN {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -60,18 +60,6 @@ exports[`Tabs Tab 1`] = `
   padding-bottom: 6px;
 }
 
-.c4 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-  color: #444444;
-}
-
 .c2 {
   display: inline-block;
   box-sizing: border-box;
@@ -88,6 +76,18 @@ exports[`Tabs Tab 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  color: #444444;
 }
 
 .c0 {
@@ -284,18 +284,6 @@ exports[`Tabs change active index 1`] = `
   padding-bottom: 6px;
 }
 
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c4 {
-  font-size: 18px;
-  line-height: 24px;
-  color: #444444;
-}
-
 .c2 {
   display: inline-block;
   box-sizing: border-box;
@@ -312,6 +300,18 @@ exports[`Tabs change active index 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+  color: #444444;
 }
 
 .c0 {
@@ -449,7 +449,7 @@ exports[`Tabs change active index 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -466,7 +466,7 @@ exports[`Tabs change active index 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -551,18 +551,6 @@ exports[`Tabs change to second tab 1`] = `
   padding-bottom: 6px;
 }
 
-.c4 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-  color: #444444;
-}
-
 .c2 {
   display: inline-block;
   box-sizing: border-box;
@@ -579,6 +567,18 @@ exports[`Tabs change to second tab 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  color: #444444;
 }
 
 .c0 {
@@ -716,7 +716,7 @@ exports[`Tabs change to second tab 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -733,7 +733,7 @@ exports[`Tabs change to second tab 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -1088,18 +1088,6 @@ exports[`Tabs set on hover 1`] = `
   padding-bottom: 6px;
 }
 
-.c4 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-  color: #444444;
-}
-
 .c2 {
   display: inline-block;
   box-sizing: border-box;
@@ -1116,6 +1104,18 @@ exports[`Tabs set on hover 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  color: #444444;
 }
 
 .c0 {
@@ -1253,7 +1253,7 @@ exports[`Tabs set on hover 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -1270,7 +1270,7 @@ exports[`Tabs set on hover 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -1308,7 +1308,7 @@ exports[`Tabs set on hover 3`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -1325,7 +1325,7 @@ exports[`Tabs set on hover 3`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -1363,7 +1363,7 @@ exports[`Tabs set on hover 4`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -1380,7 +1380,7 @@ exports[`Tabs set on hover 4`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -1418,7 +1418,7 @@ exports[`Tabs set on hover 5`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >
@@ -1435,7 +1435,7 @@ exports[`Tabs set on hover 5`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eFkyjH"
+        class="StyledButton-sc-323bzc-0 jeDfzo"
         role="tab"
         type="button"
       >

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -352,7 +352,7 @@ exports[`TextInput close suggestion drop 3`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .hVXlHQ {
+  .eUdNKh {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -681,7 +681,7 @@ exports[`TextInput complex suggestions 3`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .hVXlHQ {
+  .eUdNKh {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -1270,7 +1270,7 @@ exports[`TextInput select suggestion 3`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .hVXlHQ {
+  .eUdNKh {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }
@@ -1625,7 +1625,7 @@ exports[`TextInput suggestions 3`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .hVXlHQ {
+  .eUdNKh {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;
   }

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -82,7 +82,7 @@ exports[`Video autoPlay renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c8 {
@@ -172,20 +172,6 @@ exports[`Video autoPlay renders 1`] = `
   padding: 12px;
 }
 
-.c16 {
-  font-size: 18px;
-  line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
-}
-
-.c19 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -202,6 +188,7 @@ exports[`Video autoPlay renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c5:hover {
@@ -226,6 +213,20 @@ exports[`Video autoPlay renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c16 {
+  font-size: 18px;
+  line-height: 24px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.c19 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c10 {
@@ -327,7 +328,7 @@ exports[`Video autoPlay renders 1`] = `
 
 @media only screen and (max-width:699px) {
   .c6 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -681,7 +682,7 @@ exports[`Video controls renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c8 {
@@ -796,20 +797,6 @@ exports[`Video controls renders 1`] = `
   padding: 0px;
 }
 
-.c16 {
-  font-size: 18px;
-  line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
-}
-
-.c19 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -826,6 +813,7 @@ exports[`Video controls renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c5:hover {
@@ -868,12 +856,27 @@ exports[`Video controls renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c22:hover {
   background: rgba(221,221,221,0.4);
   color: #444444;
   color: black;
+}
+
+.c16 {
+  font-size: 18px;
+  line-height: 24px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.c19 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c10 {
@@ -985,7 +988,7 @@ exports[`Video controls renders 1`] = `
 
 @media only screen and (max-width:699px) {
   .c6 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -1489,7 +1492,7 @@ exports[`Video fit renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c8 {
@@ -1579,20 +1582,6 @@ exports[`Video fit renders 1`] = `
   padding: 12px;
 }
 
-.c16 {
-  font-size: 18px;
-  line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
-}
-
-.c19 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -1609,6 +1598,7 @@ exports[`Video fit renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c5:hover {
@@ -1633,6 +1623,20 @@ exports[`Video fit renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c16 {
+  font-size: 18px;
+  line-height: 24px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.c19 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c10 {
@@ -1752,7 +1756,7 @@ exports[`Video fit renders 1`] = `
 
 @media only screen and (max-width:699px) {
   .c6 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -2241,7 +2245,7 @@ exports[`Video loop renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c8 {
@@ -2331,20 +2335,6 @@ exports[`Video loop renders 1`] = `
   padding: 12px;
 }
 
-.c16 {
-  font-size: 18px;
-  line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
-}
-
-.c19 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -2361,6 +2351,7 @@ exports[`Video loop renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c5:hover {
@@ -2385,6 +2376,20 @@ exports[`Video loop renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c16 {
+  font-size: 18px;
+  line-height: 24px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.c19 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c10 {
@@ -2486,7 +2491,7 @@ exports[`Video loop renders 1`] = `
 
 @media only screen and (max-width:699px) {
   .c6 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -2808,7 +2813,7 @@ exports[`Video mute renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c8 {
@@ -2898,20 +2903,6 @@ exports[`Video mute renders 1`] = `
   padding: 12px;
 }
 
-.c16 {
-  font-size: 18px;
-  line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
-}
-
-.c19 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -2928,6 +2919,7 @@ exports[`Video mute renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c5:hover {
@@ -2952,6 +2944,20 @@ exports[`Video mute renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c16 {
+  font-size: 18px;
+  line-height: 24px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.c19 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c10 {
@@ -3053,7 +3059,7 @@ exports[`Video mute renders 1`] = `
 
 @media only screen and (max-width:699px) {
   .c6 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -3375,7 +3381,7 @@ exports[`Video renders 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   margin: 0px;
-  padding: 12px;
+  padding: 0px;
 }
 
 .c8 {
@@ -3465,20 +3471,6 @@ exports[`Video renders 1`] = `
   padding: 12px;
 }
 
-.c16 {
-  font-size: 18px;
-  line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
-}
-
-.c19 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -3495,6 +3487,7 @@ exports[`Video renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  padding: 12px;
 }
 
 .c5:hover {
@@ -3519,6 +3512,20 @@ exports[`Video renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c16 {
+  font-size: 18px;
+  line-height: 24px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.c19 {
+  font-size: 18px;
+  line-height: 24px;
 }
 
 .c10 {
@@ -3620,7 +3627,7 @@ exports[`Video renders 1`] = `
 
 @media only screen and (max-width:699px) {
   .c6 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 

--- a/src/js/themes/grommet.js
+++ b/src/js/themes/grommet.js
@@ -1,3 +1,5 @@
+import { css } from 'styled-components';
+
 import { deepFreeze } from '../utils';
 
 const workSansPath = 'https://fonts.gstatic.com/s/worksans/v2';
@@ -56,6 +58,11 @@ export const grommet = deepFreeze({
       dark: '#9060EB',
       light: '#9060EB',
     },
+  },
+  button: {
+    extend: css`
+      ${props => !props.plain && 'font-weight: bold;'}
+    `,
   },
   checkBox: {
     check: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

1) Updated Button to use `as` from styled-components v4
2) Removes `strong` to be used inside Button and add it to the `grommet` theme
3) Fixes padding logic for icon and label instance
4) Improved logic to change icon color based on the background 
5) Removed Text component usage to avoid issues with customizations

#### Where should the reviewer start?

Button and StyledButton

#### What testing has been done on this PR?

manual

#### How should this be manually tested?

Open storybook examples for buttons

#### Any background context you want to provide?

#### What are the relevant issues?

Fixes https://github.com/grommet/grommet/issues/2215 and https://github.com/grommet/grommet/issues/2313

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

This is a backwards compatible change. Although, previously you had to specify `span` to customize the text color of the button. Now the span is not there anymore, since we removed Text. So now to customize the text inside the button, you should not pass `span` anymore.