### PR TITLE
Box: fix to avoid width and height bleeding to the DOM

### DIFF
--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -65,7 +65,9 @@ class Box extends Component {
       responsive,
       tag,
       theme: propsTheme,
-      wrap, // munged to avoid styled-components putting it in the DOM
+      wrap, // munged to avoid styled-components putting it in the DOM,
+      width, // munged to avoid styled-components putting it in the DOM
+      height, // munged to avoid styled-components putting it in the DOM
       ...rest
     } = this.props;
     const { theme: stateTheme } = this.state;
@@ -110,6 +112,8 @@ class Box extends Component {
         fillProp={fill}
         overflowProp={overflow}
         wrapProp={wrap}
+        widthProp={width}
+        heightProp={height}
         responsive={responsive}
         theme={theme}
         {...rest}

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -334,10 +334,10 @@ export const StyledBox = styled.div`
   outline: none;
   ${props => !props.basis && 'max-width: 100%;'};
 
-  ${props => props.height &&
-    `height: ${props.theme.global.size[props.height]};`}
-  ${props => props.width &&
-    `width: ${props.theme.global.size[props.width]};`}
+  ${props => props.heightProp &&
+    `height: ${props.theme.global.size[props.heightProp]};`}
+  ${props => props.widthProp &&
+    `width: ${props.theme.global.size[props.widthProp]};`}
   ${props => props.align && alignStyle}
   ${props => props.alignContent && alignContentStyle}
   ${props => props.alignSelf && alignSelfStyle}

--- a/src/js/components/Box/box.stories.js
+++ b/src/js/components/Box/box.stories.js
@@ -77,6 +77,48 @@ class CustomColorBox extends Component {
   }
 }
 
+class FixedSizesBox extends Component {
+  render() {
+    return (
+      <Grommet theme={grommet}>
+        <Box pad='small' gap='small'>
+          <Box
+            width='small'
+            height='small'
+            round='small'
+            align='center'
+            justify='center'
+            background='brand'
+          >
+            Small
+          </Box>
+          <Box
+            width='medium'
+            height='medium'
+            round='small'
+            align='center'
+            justify='center'
+            background='brand'
+          >
+            Medium
+          </Box>
+          <Box
+            width='large'
+            height='large'
+            round='small'
+            align='center'
+            justify='center'
+            background='brand'
+          >
+            Large
+          </Box>
+        </Box>
+      </Grommet>
+    );
+  }
+}
+
 storiesOf('Box', module)
   .add('Simple Box', () => <SimpleBox />)
-  .add('Custom color', () => <CustomColorBox />);
+  .add('Custom color', () => <CustomColorBox />)
+  .add('Fixed sizes', () => <FixedSizesBox />);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Changes Box to avoid width and height props to be in the DOM

#### Where should the reviewer start?

Box.js and StyledBox.js

#### What testing has been done on this PR?

manual

#### How should this be manually tested?

Open Fixed Sizes storybook example inside Box stories

#### Any background context you want to provide?

#### What are the relevant issues?

Fixes https://github.com/grommet/grommet/issues/2312

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
