### PR TITLE
Collapsible: fixed bug in ie11 when resetting styles.

### DIFF
--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -1550,7 +1550,6 @@ exports[`Accordion change to second Panel 2`] = `
           aria-hidden="false"
           class="Collapsible__AnimatedBox-sc-15kniua-0 cgDUOZ StyledBox-sc-13pk1d4-0 bsuXGI"
           open=""
-          style=""
         >
           Panel body 2
         </div>

--- a/src/js/components/Collapsible/Collapsible.js
+++ b/src/js/components/Collapsible/Collapsible.js
@@ -73,7 +73,7 @@ class Collapsible extends Component {
           container.style['max-height'] = open ? `${height}px` : '0px';
 
           this.animationTimeout = setTimeout(() => {
-            container.style = '';
+            container.removeAttribute('style');
             this.setState(
               {
                 animate: false,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes IE11 bug that would prevent collpasible to work when resetting styles

#### Where should the reviewer start?

Collapsible.js

#### What testing has been done on this PR?

manual

#### How should this be manually tested?

open Collpasible and Accordion storybook examples

#### Any background context you want to provide?

#### What are the relevant issues?

Fixes https://github.com/grommet/grommet/issues/2309

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes 

#### Is this change backwards compatible or is it a breaking change?

backwards compatible