### PR TITLE
Tab: fixed title prop types and aria title too

### DIFF
--- a/src/js/components/Tab/README.md
+++ b/src/js/components/Tab/README.md
@@ -16,5 +16,6 @@ The title of the tab.
 
 ```
 string
+node
 ```
   

--- a/src/js/components/Tab/doc.js
+++ b/src/js/components/Tab/doc.js
@@ -9,8 +9,10 @@ export const doc = (Tab) => {
     );
 
   DocumentedTab.propTypes = {
-    title: PropTypes.string
-      .description('The title of the tab.'),
+    title: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.node,
+    ]).description('The title of the tab.'),
   };
 
   return DocumentedTab;

--- a/src/js/components/Tab/index.d.ts
+++ b/src/js/components/Tab/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 export interface TabProps {
-  title?: string;
+  title?: string | React.ReactNode;
 }
 
 declare const Tab: React.ComponentType<TabProps>;

--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -54,7 +54,11 @@ class Tabs extends Component {
 
       if (isTabActive) {
         activeContent = tabProps.children;
-        activeTitle = tabProps.title;
+        if (typeof tabProps.title === 'string') {
+          activeTitle = tabProps.title;
+        } else {
+          activeTitle = index + 1;
+        }
       }
 
       return cloneElement(tab, {

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -1041,7 +1041,7 @@ exports[`Tabs complex title 1`] = `
       </button>
     </div>
     <div
-      aria-label="[object Object] Tab Contents"
+      aria-label="1 Tab Contents"
       role="tabpanel"
     >
       Tab body 1

--- a/src/js/components/Tabs/tabs.stories.js
+++ b/src/js/components/Tabs/tabs.stories.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
-import { Attraction, Car, TreeOption } from 'grommet-icons';
+import { Attraction, Car, CircleInformation, Currency, TreeOption } from 'grommet-icons';
 
-import { Grommet, Box, Tab, Tabs } from '../';
+import { Box, Grommet, FormField, Tab, Tabs, Text, TextInput } from '../';
 import { grommet } from '../../themes';
 
 const UncontrolledTabs = () => (
@@ -173,8 +173,34 @@ class ResponsiveTabs extends Component {
     );
   }
 }
+const RichTabTitle = ({ icon, label }) => (
+  <Box direction='row' align='center' gap='xsmall' margin='xsmall'>
+    {icon}
+    <Text size='small'>
+      <strong>{label}</strong>
+    </Text>
+  </Box>
+);
+
+const RichTabs = () => (
+  <Grommet theme={grommet}>
+    <Tabs>
+      <Tab title={<RichTabTitle icon={<CircleInformation color='accent-1' />} label='Personal Data' />}>
+        <FormField label='Name'>
+          <TextInput placeholder='Enter your name...' />
+        </FormField>
+      </Tab>
+      <Tab title={<RichTabTitle icon={<Currency color='neutral-5' />} label='Payment' />}>
+        <FormField label='Card Number'>
+          <TextInput placeholder='Enter your card number...' />
+        </FormField>
+      </Tab>
+    </Tabs>
+  </Grommet>
+);
 
 storiesOf('Tabs', module)
   .add('Uncontrolled Tabs', () => <UncontrolledTabs />)
   .add('Controlled Tabs', () => <ControlledTabs />)
-  .add('Responsive Tabs', () => <ResponsiveTabs />);
+  .add('Responsive Tabs', () => <ResponsiveTabs />)
+  .add('Rich Tabs', () => <RichTabs />);

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -3419,6 +3419,7 @@ The title of the tab.
 
 \`\`\`
 string
+node
 \`\`\`
   ",
   "Table": "## Table

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -569,7 +569,7 @@ export { Stack };
   "Tab": "import * as React from \\"react\\";
 
 export interface TabProps {
-  title?: string;
+  title?: string | React.ReactNode;
 }
 
 declare const Tab: React.ComponentType<TabProps>;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Changed proptypes to allow more than just string.
Fixed aria label to now show `[object object]` as a string value

#### Where should the reviewer start?

Tab.js and Tabs.js

#### What testing has been done on this PR?
manual
#### How should this be manually tested?
open Rich Tab example in storybook
#### Any background context you want to provide?

#### What are the relevant issues?
Fixes https://github.com/grommet/grommet/issues/2303 and https://github.com/grommet/grommet/issues/2304

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?

backwards