### PR TITLE
Add direction prop to Collapsible to allow opening/closing animation …

### DIFF
--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -165,7 +165,6 @@ exports[`Accordion AccordionPanel 1`] = `
   flex-direction: column;
   margin: 0px;
   padding: 0px;
-  overflow: hidden;
 }
 
 .c3 {
@@ -1126,7 +1125,6 @@ exports[`Accordion change to second Panel 1`] = `
   flex-direction: column;
   margin: 0px;
   padding: 0px;
-  overflow: hidden;
 }
 
 .c3 {
@@ -1459,7 +1457,7 @@ exports[`Accordion change to second Panel 2`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 bsuXGI"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kXgRqF"
         >
           Panel body 1
         </div>
@@ -1548,7 +1546,7 @@ exports[`Accordion change to second Panel 2`] = `
       >
         <div
           aria-hidden="false"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cgDUOZ StyledBox-sc-13pk1d4-0 bsuXGI"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cgDUOZ StyledBox-sc-13pk1d4-0 kXgRqF"
           open=""
         >
           Panel body 2
@@ -2420,7 +2418,6 @@ exports[`Accordion complex title 1`] = `
   flex-direction: column;
   margin: 0px;
   padding: 0px;
-  overflow: hidden;
 }
 
 .c1 {
@@ -3909,7 +3906,6 @@ exports[`Accordion set on hover 1`] = `
   flex-direction: column;
   margin: 0px;
   padding: 0px;
-  overflow: hidden;
 }
 
 .c3 {
@@ -4242,7 +4238,7 @@ exports[`Accordion set on hover 2`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 bsuXGI"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kXgRqF"
         >
           Panel body 1
         </div>
@@ -4298,7 +4294,7 @@ exports[`Accordion set on hover 2`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 bsuXGI"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kXgRqF"
         >
           Panel body 2
         </div>
@@ -4366,7 +4362,7 @@ exports[`Accordion set on hover 3`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 bsuXGI"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kXgRqF"
         >
           Panel body 1
         </div>
@@ -4422,7 +4418,7 @@ exports[`Accordion set on hover 3`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 bsuXGI"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kXgRqF"
         >
           Panel body 2
         </div>
@@ -4490,7 +4486,7 @@ exports[`Accordion set on hover 4`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 bsuXGI"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kXgRqF"
         >
           Panel body 1
         </div>
@@ -4546,7 +4542,7 @@ exports[`Accordion set on hover 4`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 bsuXGI"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kXgRqF"
         >
           Panel body 2
         </div>
@@ -4614,7 +4610,7 @@ exports[`Accordion set on hover 5`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 bsuXGI"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kXgRqF"
         >
           Panel body 1
         </div>
@@ -4670,7 +4666,7 @@ exports[`Accordion set on hover 5`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 bsuXGI"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kXgRqF"
         >
           Panel body 2
         </div>

--- a/src/js/components/Collapsible/README.md
+++ b/src/js/components/Collapsible/README.md
@@ -17,4 +17,13 @@ Whether or not the component should be open.
 ```
 boolean
 ```
+
+**direction**
+
+Direction to animate the collapsible content. Defaults to `vertical`.
+
+```
+horizontal
+vertical
+```
   

--- a/src/js/components/Collapsible/collapsible.stories.js
+++ b/src/js/components/Collapsible/collapsible.stories.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
 
-import { FormDown, FormNext } from 'grommet-icons';
+import { FormDown, FormNext, Notification } from 'grommet-icons';
 
-import { Box, Button, Collapsible, Grommet, Text } from '../';
+import { Box, Button, Collapsible, Heading, Grommet, Text } from '../';
 import { grommet } from '../../themes';
 
 class SimpleCollapsible extends Component {
@@ -16,8 +16,14 @@ class SimpleCollapsible extends Component {
       <Grommet theme={grommet}>
         <Box align='start' gap='small'>
           <Button primary={true} onClick={() => this.setState({ open: !this.state.open })} label='Toggle' />
-          <Collapsible open={open}>
-            <Box background='light-2' round='medium' pad='medium' align='center' justify='center'>
+          <Collapsible open={open} {...this.props}>
+            <Box
+              background='light-2'
+              round='medium'
+              pad='medium'
+              align='center'
+              justify='center'
+            >
               <Text>This is a box inside a Collapsible component</Text>
             </Box>
           </Collapsible>
@@ -113,10 +119,62 @@ class NestedCollapsible extends Component {
   }
 }
 
+class HorizontalCollapsible extends Component {
+  state = {
+    openNotification: false,
+  }
+  render() {
+    const { openNotification } = this.state;
+    return (
+      <Grommet full={true} theme={grommet}>
+        <Box fill={true}>
+          <Box
+            tag='header'
+            direction='row'
+            align='center'
+            pad={{ vertical: 'small', horizontal: 'medium' }}
+            justify='between'
+            background='neutral-4'
+            elevation='large'
+            style={{ zIndex: '1000' }}
+          >
+            <Heading level={3} margin='none' color='white'>
+              <strong>My App</strong>
+            </Heading>
+            <Button
+              onClick={() => this.setState({ openNotification: !this.state.openNotification })}
+              icon={<Notification color='white' />}
+            />
+          </Box>
+          <Box flex={true} direction='row'>
+            <Box flex={true} align='center' justify='center'>
+              Dashboard content goes here
+            </Box>
+            <Collapsible direction='horizontal' open={openNotification}>
+              <Box
+                flex={true}
+                width='medium'
+                background='light-2'
+                pad='small'
+                elevation='small'
+              >
+                Sidebar
+              </Box>
+            </Collapsible>
+          </Box>
+        </Box>
+      </Grommet>
+    );
+  }
+}
+
 storiesOf('Collapsible', module)
   .add('Default', () => (
     <SimpleCollapsible />
   ))
   .add('Nested', () => (
     <NestedCollapsible />
+  ))
+  .add('Horizontal', () => (
+    <HorizontalCollapsible />
   ));

--- a/src/js/components/Collapsible/doc.js
+++ b/src/js/components/Collapsible/doc.js
@@ -13,6 +13,12 @@ export const doc = (Collapsible) => {
     open: PropTypes.bool.description(
       'Whether or not the component should be open.'
     ),
+    direction: PropTypes.oneOf([
+      'horizontal',
+      'vertical',
+    ]).description(
+      'Direction to animate the collapsible content.'
+    ).defaultValue('vertical'),
   };
 
   return DocumentedCollapsible;

--- a/src/js/components/Collapsible/index.d.ts
+++ b/src/js/components/Collapsible/index.d.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 
 export interface CollapsibleProps {
   open?: boolean;
+  direction?: "horizontal" | "vertical";
 }
 
 declare const Collapsible: React.ComponentType<CollapsibleProps>;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1306,6 +1306,15 @@ Whether or not the component should be open.
 \`\`\`
 boolean
 \`\`\`
+
+**direction**
+
+Direction to animate the collapsible content. Defaults to \`vertical\`.
+
+\`\`\`
+horizontal
+vertical
+\`\`\`
   ",
   "DataTable": "## DataTable
 A data driven table.

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -184,6 +184,7 @@ export { Clock };
 
 export interface CollapsibleProps {
   open?: boolean;
+  direction?: \\"horizontal\\" | \\"vertical\\";
 }
 
 declare const Collapsible: React.ComponentType<CollapsibleProps>;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -380,7 +380,7 @@ export const generate = (baseSpacing = 24, scale = 6) => { // 24
     },
     collapsible: {
       minSpeed: 200,
-      baseHeight: 500,
+      baseline: 500,
     },
     dataTable: {
       body: {


### PR DESCRIPTION
#### What does this PR do?
Adds a new prop to Collapsible to allow the opening/closing animation to be either horizontal or vertical.

#### Where should the reviewer start?
collapsible.stories.js Look at the HorizontalCollapsible component

#### What testing has been done on this PR?
Added a new example to stories; npm run test

#### How should this be manually tested?
Looking at the new Collapsible example from storybook

#### Do the grommet docs need to be updated?
Yes. There is a change to a theme property. One of the properties of the collapsible hash (baseHeight) has been renamed to baseline so that it can be used to calculate the animation speed for the height and the width.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Breaking change.
