### PR TITLE
Drop, Layer: changed onclick to mousedown to handle click outside.

### DIFF
--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -53,7 +53,7 @@ export class DropContainer extends Component {
     const { restrictFocus } = this.props;
     this.addScrollListener();
     window.addEventListener('resize', this.onResize);
-    document.addEventListener('click', this.onClickDocument);
+    document.addEventListener('mousedown', this.onClickDocument);
 
     this.place();
 
@@ -69,7 +69,7 @@ export class DropContainer extends Component {
   componentWillUnmount() {
     this.removeScrollListener();
     window.removeEventListener('resize', this.onResize);
-    document.removeEventListener('click', this.onClickDocument);
+    document.removeEventListener('mousedown', this.onClickDocument);
   }
 
   addScrollListener = () => {

--- a/src/js/components/Drop/__tests__/Drop-test.js
+++ b/src/js/components/Drop/__tests__/Drop-test.js
@@ -119,7 +119,7 @@ describe('Drop', () => {
     renderIntoDocument(<TestInput onClickOutside={onClickOutside} />);
     expectPortal('drop-node').toMatchSnapshot();
 
-    fireEvent(document, new MouseEvent('click', { bubbles: true, cancelable: true }));
+    fireEvent(document, new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
     expect(onClickOutside).toBeCalled();
   });
 

--- a/src/js/components/Drop/drop.stories.js
+++ b/src/js/components/Drop/drop.stories.js
@@ -1,12 +1,12 @@
-import React, { Component, Fragment } from 'react';
+import React, { createRef, Component, Fragment } from 'react';
 import { storiesOf } from '@storybook/react';
 
-import { Box, Drop, Grommet, Text } from 'grommet';
+import { Box, Button, Drop, Grommet, Text } from 'grommet';
 import { grommet } from 'grommet/themes';
 import { ThemeContext } from 'grommet/contexts';
 
 class SimpleDrop extends Component {
-  targetRef = React.createRef()
+  targetRef = createRef()
 
   componentDidMount() {
     this.forceUpdate();
@@ -52,7 +52,7 @@ const OneDrop = ({ align, target }) => (
 );
 
 class Set extends Component {
-  targetRef = React.createRef()
+  targetRef = createRef()
 
   componentDidMount() {
     this.forceUpdate();
@@ -90,7 +90,7 @@ class Set extends Component {
 }
 
 class AllDrops extends Component {
-  targetRef = React.createRef()
+  targetRef = createRef()
 
   componentDidMount() {
     this.forceUpdate();
@@ -202,6 +202,55 @@ class AllDrops extends Component {
   }
 }
 
+class ProgressiveDrop extends Component {
+  boxRef = createRef()
+  state = {
+    openDrop: false,
+    openInnerDrop: false,
+  }
+  onCloseDrop = () => this.setState({ openDrop: false, openInnerDrop: false })
+  onOpenDrop = () => this.setState({ openDrop: true, openInnerDrop: false })
+  render() {
+    const { openDrop, openInnerDrop } = this.state;
+    return (
+      <Grommet theme={grommet}>
+        <Box align='start'>
+          <Button
+            ref={this.boxRef}
+            primary={true}
+            label='Click me'
+            onClick={this.onOpenDrop}
+          />
+          {openDrop && (
+            <Drop
+              target={this.boxRef.current}
+              align={{ top: 'bottom' }}
+              onClickOutside={this.onCloseDrop}
+              onEsc={this.onCloseDrop}
+            >
+              {!openInnerDrop && (
+                <Box pad='large'>
+                  <Button
+                    primary={true}
+                    label='Click me again'
+                    onClick={() => this.setState({ openInnerDrop: true })}
+                  />
+                </Box>
+              )}
+              {openInnerDrop && (
+                <Box pad='large'>
+                  You can click outside now
+                </Box>
+              )}
+            </Drop>
+          )}
+        </Box>
+      </Grommet>
+    );
+  }
+}
+
 storiesOf('Drop', module)
   .add('Simple', () => <SimpleDrop />)
-  .add('All not stretch', () => <AllDrops />);
+  .add('All not stretch', () => <AllDrops />)
+  .add('Progressive', () => <ProgressiveDrop />);

--- a/src/js/components/DropButton/__tests__/DropButton-test.js
+++ b/src/js/components/DropButton/__tests__/DropButton-test.js
@@ -65,7 +65,7 @@ describe('DropButton', () => {
     Simulate.click(getByText('Dropper'));
     expectPortal('drop-contents').toMatchSnapshot();
 
-    fireEvent(document, new MouseEvent('click', { bubbles: true, cancelable: true }));
+    fireEvent(document, new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
 
     setTimeout(() => {
       expect(document.getElementById('drop-contents')).toBeNull();

--- a/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
+++ b/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
@@ -612,13 +612,6 @@ exports[`DropButton opened ref 3`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .ighkQC {
-    -webkit-transition: 0.1s ease-in-out;
-    transition: 0.1s ease-in-out;
-  }
-}
-
-@media only screen and (min-width:700px) {
   .bYlrVG {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;

--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -108,7 +108,7 @@ class LayerContainer extends Component {
           tabIndex='-1'
           ref={this.layerRef}
         >
-          <StyledOverlay onClick={onClickOutside} responsive={responsive} theme={theme} />
+          <StyledOverlay onMouseDown={onClickOutside} responsive={responsive} theme={theme} />
           {content}
         </StyledLayer>
       );

--- a/src/js/components/Menu/__tests__/Menu-test.js
+++ b/src/js/components/Menu/__tests__/Menu-test.js
@@ -92,7 +92,7 @@ describe('Menu', () => {
     Simulate.click(getByText('Test'));
     expectPortal('test-menu__drop').toMatchSnapshot();
 
-    fireEvent(document, new MouseEvent('click', { bubbles: true, cancelable: true }));
+    fireEvent(document, new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
     setTimeout(() => {
       expect(document.getElementById('test-menu__drop')).toBeNull();
       done();

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -3185,13 +3185,6 @@ exports[`Menu with dropAlign renders 3`] = `
 }
 
 @media only screen and (min-width:700px) {
-  .huvvip {
-    -webkit-transition: 0.1s ease-in-out;
-    transition: 0.1s ease-in-out;
-  }
-}
-
-@media only screen and (min-width:700px) {
   .jUYLaA {
     -webkit-transition: 0.1s ease-in-out;
     transition: 0.1s ease-in-out;

--- a/src/js/components/TextInput/__tests__/TextInput-test.js
+++ b/src/js/components/TextInput/__tests__/TextInput-test.js
@@ -42,7 +42,7 @@ describe('TextInput', () => {
       expect(onInput).toBeCalled();
       expect(onFocus).toBeCalled();
 
-      fireEvent(document, new MouseEvent('click', { bubbles: true, cancelable: true }));
+      fireEvent(document, new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
       expect(document.getElementById('text-input-drop__item')).toBeNull();
       done();
     }, 50);
@@ -69,7 +69,7 @@ describe('TextInput', () => {
     setTimeout(() => {
       expectPortal('text-input-drop__item').toMatchSnapshot();
 
-      fireEvent(document, new MouseEvent('click', { bubbles: true, cancelable: true }));
+      fireEvent(document, new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
       expect(document.getElementById('text-input-drop__item')).toBeNull();
       done();
     }, 50);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
 Changes click outside event listener in layer and drop to use `mousedown` instead of `click`. this avoids the drop closing for progressive drops.

#### Where should the reviewer start?

DropContainer and LayerContainer

#### What testing has been done on this PR?

manual
#### How should this be manually tested?
open progressive drop example in storybook

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards