### PR TITLE
Fix to close a drop element without having the focus on the drop

### DIFF
--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -274,7 +274,7 @@ export class DropContainer extends Component {
 
     return (
       <FocusedContainer>
-        <Keyboard onEsc={onEsc} onKeyDown={onKeyDown}>
+        <Keyboard onEsc={onEsc} onKeyDown={onKeyDown} target='document'>
           {content}
         </Keyboard>
       </FocusedContainer>


### PR DESCRIPTION
#### What does this PR do?
Allows Drop components to be close with the ESC key even if the Drop element has no focus. This is useful in cases such as when you have a text input and a drop with suggestions but the focus is on the text input. 

#### Where should the reviewer start?
DropContainer

#### What testing has been done on this PR?
npm run test

#### How should this be manually tested?
By opening a Drop component with a correct onEsc handler, removing the focus from it and pressing esc.

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
