### PR TITLE
Added generic styling to most components: a11yTitle, alignSelf, gridArea, margin

### DIFF
--- a/src/js/components/Accordion/README.md
+++ b/src/js/components/Accordion/README.md
@@ -14,6 +14,102 @@ import { Accordion, AccordionPanel } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **activeIndex**
 
 Active panel index. If specified, Accordion will be a controlled component. This means that future

--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -41,12 +41,12 @@ exports[`Accordion AccordionPanel 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -59,6 +59,7 @@ exports[`Accordion AccordionPanel 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -67,7 +68,6 @@ exports[`Accordion AccordionPanel 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -79,6 +79,7 @@ exports[`Accordion AccordionPanel 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -92,7 +93,6 @@ exports[`Accordion AccordionPanel 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -104,12 +104,12 @@ exports[`Accordion AccordionPanel 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 6px;
   padding-right: 6px;
 }
@@ -122,12 +122,12 @@ exports[`Accordion AccordionPanel 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -140,13 +140,13 @@ exports[`Accordion AccordionPanel 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -158,12 +158,12 @@ exports[`Accordion AccordionPanel 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -271,13 +271,13 @@ exports[`Accordion AccordionPanel 1`] = `
 
 @media only screen and (max-width:768px) {
   .c9 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c9 {
-    margin: 0px;
+    border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
@@ -481,12 +481,12 @@ exports[`Accordion change active index 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -499,6 +499,7 @@ exports[`Accordion change active index 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -507,7 +508,6 @@ exports[`Accordion change active index 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -519,6 +519,7 @@ exports[`Accordion change active index 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -532,7 +533,6 @@ exports[`Accordion change active index 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -544,12 +544,12 @@ exports[`Accordion change active index 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 6px;
   padding-right: 6px;
 }
@@ -562,12 +562,12 @@ exports[`Accordion change active index 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -580,13 +580,13 @@ exports[`Accordion change active index 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -689,13 +689,13 @@ exports[`Accordion change active index 1`] = `
 
 @media only screen and (max-width:768px) {
   .c9 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c9 {
-    margin: 0px;
+    border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
@@ -828,33 +828,33 @@ exports[`Accordion change active index 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 blARAh"
+    class="StyledBox-sc-13pk1d4-0 gFbzfm"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             <svg
               aria-label="FormDown"
@@ -876,33 +876,33 @@ exports[`Accordion change active index 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       />
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             <svg
               aria-label="FormUp"
@@ -925,7 +925,7 @@ exports[`Accordion change active index 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       >
         Panel body 2
       </div>
@@ -975,12 +975,12 @@ exports[`Accordion change to second Panel 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -993,6 +993,7 @@ exports[`Accordion change to second Panel 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1001,7 +1002,6 @@ exports[`Accordion change to second Panel 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1013,6 +1013,7 @@ exports[`Accordion change to second Panel 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1026,7 +1027,6 @@ exports[`Accordion change to second Panel 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1038,12 +1038,12 @@ exports[`Accordion change to second Panel 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 6px;
   padding-right: 6px;
 }
@@ -1056,12 +1056,12 @@ exports[`Accordion change to second Panel 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -1074,13 +1074,13 @@ exports[`Accordion change to second Panel 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1092,12 +1092,12 @@ exports[`Accordion change to second Panel 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1205,13 +1205,13 @@ exports[`Accordion change to second Panel 1`] = `
 
 @media only screen and (max-width:768px) {
   .c9 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c9 {
-    margin: 0px;
+    border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
@@ -1367,33 +1367,33 @@ exports[`Accordion change to second Panel 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 blARAh"
+    class="StyledBox-sc-13pk1d4-0 gFbzfm"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             <svg
               aria-label="FormDown"
@@ -1415,40 +1415,40 @@ exports[`Accordion change to second Panel 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kWLcGV"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 cJEczh"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             .c0 {
   display: inline-block;
@@ -1503,11 +1503,11 @@ exports[`Accordion change to second Panel 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       >
         <div
           aria-hidden="false"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cgDUOZ StyledBox-sc-13pk1d4-0 kWLcGV"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cgDUOZ StyledBox-sc-13pk1d4-0 cJEczh"
           open=""
         >
           Panel body 2
@@ -1559,12 +1559,12 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -1577,6 +1577,7 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1585,7 +1586,6 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1597,6 +1597,7 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1610,7 +1611,6 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1622,12 +1622,12 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 6px;
   padding-right: 6px;
 }
@@ -1640,12 +1640,12 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -1658,13 +1658,13 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1767,13 +1767,13 @@ exports[`Accordion change to second Panel without onActive 1`] = `
 
 @media only screen and (max-width:768px) {
   .c9 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c9 {
-    margin: 0px;
+    border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
@@ -1903,33 +1903,33 @@ exports[`Accordion change to second Panel without onActive 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 blARAh"
+    class="StyledBox-sc-13pk1d4-0 gFbzfm"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             <svg
               aria-label="FormDown"
@@ -1951,33 +1951,33 @@ exports[`Accordion change to second Panel without onActive 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       />
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             .c0 {
   display: inline-block;
@@ -2032,7 +2032,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       >
         Panel body 2
       </div>
@@ -2050,12 +2050,12 @@ exports[`Accordion complex header 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -2068,6 +2068,7 @@ exports[`Accordion complex header 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -2076,7 +2077,6 @@ exports[`Accordion complex header 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2088,13 +2088,13 @@ exports[`Accordion complex header 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2152,13 +2152,13 @@ exports[`Accordion complex header 1`] = `
 
 @media only screen and (max-width:768px) {
   .c4 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c4 {
-    margin: 0px;
+    border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
@@ -2268,12 +2268,12 @@ exports[`Accordion complex title 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -2286,6 +2286,7 @@ exports[`Accordion complex title 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -2294,7 +2295,6 @@ exports[`Accordion complex title 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2306,6 +2306,7 @@ exports[`Accordion complex title 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2319,7 +2320,6 @@ exports[`Accordion complex title 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2331,12 +2331,12 @@ exports[`Accordion complex title 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -2349,12 +2349,12 @@ exports[`Accordion complex title 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2366,6 +2366,7 @@ exports[`Accordion complex title 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #333333;
   color: #f8f8f8;
   min-width: 0;
@@ -2373,7 +2374,6 @@ exports[`Accordion complex title 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2385,13 +2385,13 @@ exports[`Accordion complex title 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-bottom: solid 1px rgba(255,255,255,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2503,13 +2503,13 @@ exports[`Accordion complex title 1`] = `
 
 @media only screen and (max-width:768px) {
   .c8 {
-    border-bottom: solid 1px rgba(255,255,255,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c8 {
-    margin: 0px;
+    border-bottom: solid 1px rgba(255,255,255,0.33);
   }
 }
 
@@ -2685,12 +2685,12 @@ exports[`Accordion multiple panels 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -2703,6 +2703,7 @@ exports[`Accordion multiple panels 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -2711,7 +2712,6 @@ exports[`Accordion multiple panels 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2723,6 +2723,7 @@ exports[`Accordion multiple panels 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2736,7 +2737,6 @@ exports[`Accordion multiple panels 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2748,12 +2748,12 @@ exports[`Accordion multiple panels 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 6px;
   padding-right: 6px;
 }
@@ -2766,12 +2766,12 @@ exports[`Accordion multiple panels 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -2784,13 +2784,13 @@ exports[`Accordion multiple panels 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2893,13 +2893,13 @@ exports[`Accordion multiple panels 1`] = `
 
 @media only screen and (max-width:768px) {
   .c9 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c9 {
-    margin: 0px;
+    border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
@@ -3029,33 +3029,33 @@ exports[`Accordion multiple panels 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 blARAh"
+    class="StyledBox-sc-13pk1d4-0 gFbzfm"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             <svg
               aria-label="FormDown"
@@ -3077,33 +3077,33 @@ exports[`Accordion multiple panels 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       />
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             .c0 {
   display: inline-block;
@@ -3158,7 +3158,7 @@ exports[`Accordion multiple panels 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       >
         Panel body 2
       </div>
@@ -3172,33 +3172,33 @@ exports[`Accordion multiple panels 3`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 blARAh"
+    class="StyledBox-sc-13pk1d4-0 gFbzfm"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             .c0 {
   display: inline-block;
@@ -3253,35 +3253,35 @@ exports[`Accordion multiple panels 3`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       >
         Panel body 1
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             <svg
               aria-label="FormUp"
@@ -3304,7 +3304,7 @@ exports[`Accordion multiple panels 3`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       >
         Panel body 2
       </div>
@@ -3318,33 +3318,33 @@ exports[`Accordion multiple panels 4`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 blARAh"
+    class="StyledBox-sc-13pk1d4-0 gFbzfm"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             <svg
               aria-label="FormUp"
@@ -3367,35 +3367,35 @@ exports[`Accordion multiple panels 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       >
         Panel body 1
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             .c0 {
   display: inline-block;
@@ -3449,7 +3449,7 @@ exports[`Accordion multiple panels 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       />
     </div>
   </div>
@@ -3461,33 +3461,33 @@ exports[`Accordion multiple panels 5`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 blARAh"
+    class="StyledBox-sc-13pk1d4-0 gFbzfm"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             .c0 {
   display: inline-block;
@@ -3541,33 +3541,33 @@ exports[`Accordion multiple panels 5`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       />
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             <svg
               aria-label="FormDown"
@@ -3589,7 +3589,7 @@ exports[`Accordion multiple panels 5`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       />
     </div>
   </div>
@@ -3605,12 +3605,12 @@ exports[`Accordion no AccordionPanel 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -3688,12 +3688,12 @@ exports[`Accordion set on hover 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -3706,6 +3706,7 @@ exports[`Accordion set on hover 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3714,7 +3715,6 @@ exports[`Accordion set on hover 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3726,6 +3726,7 @@ exports[`Accordion set on hover 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3739,7 +3740,6 @@ exports[`Accordion set on hover 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3751,12 +3751,12 @@ exports[`Accordion set on hover 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 6px;
   padding-right: 6px;
 }
@@ -3769,12 +3769,12 @@ exports[`Accordion set on hover 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -3787,13 +3787,13 @@ exports[`Accordion set on hover 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3805,12 +3805,12 @@ exports[`Accordion set on hover 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3918,13 +3918,13 @@ exports[`Accordion set on hover 1`] = `
 
 @media only screen and (max-width:768px) {
   .c9 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c9 {
-    margin: 0px;
+    border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
@@ -4080,33 +4080,33 @@ exports[`Accordion set on hover 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 blARAh"
+    class="StyledBox-sc-13pk1d4-0 gFbzfm"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 frFkXz"
+              class="StyledHeading-sc-1rdh4aw-0-h4 jmxbQM"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             <svg
               aria-label="FormDown"
@@ -4128,40 +4128,40 @@ exports[`Accordion set on hover 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kWLcGV"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 cJEczh"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             <svg
               aria-label="FormDown"
@@ -4183,11 +4183,11 @@ exports[`Accordion set on hover 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kWLcGV"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 cJEczh"
         >
           Panel body 2
         </div>
@@ -4202,33 +4202,33 @@ exports[`Accordion set on hover 3`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 blARAh"
+    class="StyledBox-sc-13pk1d4-0 gFbzfm"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 frFkXz"
+              class="StyledHeading-sc-1rdh4aw-0-h4 jmxbQM"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             <svg
               aria-label="FormDown"
@@ -4250,40 +4250,40 @@ exports[`Accordion set on hover 3`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kWLcGV"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 cJEczh"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 frFkXz"
+              class="StyledHeading-sc-1rdh4aw-0-h4 jmxbQM"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             <svg
               aria-label="FormDown"
@@ -4305,11 +4305,11 @@ exports[`Accordion set on hover 3`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kWLcGV"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 cJEczh"
         >
           Panel body 2
         </div>
@@ -4324,33 +4324,33 @@ exports[`Accordion set on hover 4`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 blARAh"
+    class="StyledBox-sc-13pk1d4-0 gFbzfm"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             <svg
               aria-label="FormDown"
@@ -4372,40 +4372,40 @@ exports[`Accordion set on hover 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kWLcGV"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 cJEczh"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 frFkXz"
+              class="StyledHeading-sc-1rdh4aw-0-h4 jmxbQM"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             <svg
               aria-label="FormDown"
@@ -4427,11 +4427,11 @@ exports[`Accordion set on hover 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kWLcGV"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 cJEczh"
         >
           Panel body 2
         </div>
@@ -4446,33 +4446,33 @@ exports[`Accordion set on hover 5`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 blARAh"
+    class="StyledBox-sc-13pk1d4-0 gFbzfm"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             <svg
               aria-label="FormDown"
@@ -4494,40 +4494,40 @@ exports[`Accordion set on hover 5`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kWLcGV"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 cJEczh"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hOiaYa"
+      class="StyledBox-sc-13pk1d4-0 dUQcVP"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 RiBtR"
+          class="StyledBox-sc-13pk1d4-0 dzfHcI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fdEGrh"
+            class="StyledBox-sc-13pk1d4-0 cntfAr"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 YTktk"
+              class="StyledHeading-sc-1rdh4aw-0-h4 eAJLwr"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ikdhHS"
+            class="StyledBox-sc-13pk1d4-0 eYwGvp"
           >
             <svg
               aria-label="FormDown"
@@ -4549,11 +4549,11 @@ exports[`Accordion set on hover 5`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 iVquIr"
+        class="StyledBox-sc-13pk1d4-0 hZpqjT"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 kWLcGV"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 gJklyv StyledBox-sc-13pk1d4-0 cJEczh"
         >
           Panel body 2
         </div>

--- a/src/js/components/Accordion/doc.js
+++ b/src/js/components/Accordion/doc.js
@@ -1,8 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import {
-  getAvailableAtBadge,
-} from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Accordion) => {
   const DocumentedAccordion = describe(Accordion)
@@ -17,6 +15,7 @@ export const doc = (Accordion) => {
     );
 
   DocumentedAccordion.propTypes = {
+    ...genericProps,
     activeIndex: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.arrayOf(PropTypes.number),

--- a/src/js/components/Accordion/index.d.ts
+++ b/src/js/components/Accordion/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
 export interface AccordionProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   activeIndex?: number | number[];
   animate?: boolean;
   children: React.ReactNode;

--- a/src/js/components/Anchor/README.md
+++ b/src/js/components/Anchor/README.md
@@ -21,6 +21,94 @@ Custom title to be used by screen readers.
 string
 ```
 
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **href**
 
 Hyperlink reference to place in the anchor.

--- a/src/js/components/Anchor/StyledAnchor.js
+++ b/src/js/components/Anchor/StyledAnchor.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { focusStyle, normalizeColor } from '../../utils';
+import { focusStyle, genericStyles, normalizeColor } from '../../utils';
 
 const disabledStyle = `
   opacity: 0.3;
@@ -16,6 +16,7 @@ export const StyledAnchor = styled.a`
   text-decoration: ${props => (props.hasIcon ? 'none' : props.theme.anchor.textDecoration)};
   cursor: pointer;
   outline: none;
+  ${genericStyles}
 
   ${props => !props.disabled && `
     &:hover {

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
@@ -90,6 +90,7 @@ exports[`Anchor focus renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -99,7 +100,6 @@ exports[`Anchor focus renders 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -192,6 +192,7 @@ exports[`Anchor icon label renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -201,7 +202,6 @@ exports[`Anchor icon label renders 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -290,6 +290,7 @@ exports[`Anchor primary renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -299,7 +300,6 @@ exports[`Anchor primary renders 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -471,6 +471,7 @@ exports[`Anchor reverse icon label renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -480,7 +481,6 @@ exports[`Anchor reverse icon label renders 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -565,6 +565,7 @@ exports[`Anchor warns about invalid icon render 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -574,7 +575,6 @@ exports[`Anchor warns about invalid icon render 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -653,6 +653,7 @@ exports[`Anchor warns about invalid label render 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -662,7 +663,6 @@ exports[`Anchor warns about invalid label render 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 

--- a/src/js/components/Anchor/doc.js
+++ b/src/js/components/Anchor/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Anchor) => {
   const DocumentedAnchor = describe(Anchor)
@@ -15,6 +15,7 @@ or just use children.`
     );
 
   DocumentedAnchor.propTypes = {
+    ...genericProps,
     a11yTitle: PropTypes.string.description('Custom title to be used by screen readers.'),
     href: PropTypes.string.description('Hyperlink reference to place in the anchor.'),
     icon: PropTypes.element.description('Icon element to place in the anchor.'),

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -2,6 +2,9 @@ import * as React from "react";
 
 export interface AnchorProps {
   a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   href?: string;
   icon?: JSX.Element;
   label?: React.ReactNode;

--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -19,6 +19,94 @@ Custom title to be used by screen readers.
 string
 ```
 
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **align**
 
 How to align the contents along the cross axis.
@@ -42,18 +130,6 @@ center
 end
 between
 around
-stretch
-```
-
-**alignSelf**
-
-How to align along the cross axis when contained in
-        a Box or along the column axis when contained in a Grid.
-
-```
-start
-center
-end
 stretch
 ```
 
@@ -276,15 +352,6 @@ xlarge
 string
 ```
 
-**gridArea**
-
-The name of the area to place
-      this Box in inside a parent Grid.
-
-```
-string
-```
-
 **height**
 
 A fixed height.
@@ -307,73 +374,6 @@ start
 center
 between
 end
-```
-
-**margin**
-
-The amount of margin around the box. An object can
-        be specified to distinguish horizontal margin, vertical margin, and
-        margin on a particular side of the box
-
-```
-none
-xxsmall
-xsmall
-small
-medium
-large
-xlarge
-{
-  bottom: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge
-    string,
-  horizontal: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge
-    string,
-  left: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge
-    string,
-  right: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge
-    string,
-  top: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge
-    string,
-  vertical: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge
-    string
-}
-string
 ```
 
 **overflow**

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -2,7 +2,7 @@ import styled, { css, keyframes } from 'styled-components';
 
 import {
   backgroundStyle, breakpointStyle, edgeStyle, focusStyle,
-  normalizeColor, overflowStyle,
+  genericStyles, normalizeColor, overflowStyle,
 } from '../../utils';
 
 const ALIGN_MAP = {
@@ -28,17 +28,6 @@ const ALIGN_CONTENT_MAP = {
 
 const alignContentStyle = css`
   align-content: ${props => ALIGN_CONTENT_MAP[props.alignContent]};
-`;
-
-const ALIGN_SELF_MAP = {
-  center: 'center',
-  end: 'flex-end',
-  start: 'flex-start',
-  stretch: 'stretch',
-};
-
-const alignSelfStyle = css`
-  align-self: ${props => ALIGN_SELF_MAP[props.alignSelf]};
 `;
 
 const BASIS_MAP = {
@@ -114,10 +103,6 @@ const fillStyle = (fillProp) => {
   }
   return undefined;
 };
-
-const gridAreaStyle = css`
-  grid-area: ${props => props.gridArea};
-`;
 
 const JUSTIFY_MAP = {
   between: 'space-between',
@@ -432,13 +417,13 @@ export const StyledBox = styled.div`
   outline: none;
   ${props => !props.basis && 'max-width: 100%;'};
 
+  ${genericStyles}
   ${props => props.heightProp
     && `height: ${props.theme.global.size[props.heightProp] || props.heightProp};`}
   ${props => props.widthProp
     && `width: ${props.theme.global.size[props.widthProp] || props.widthProp};`}
   ${props => props.align && alignStyle}
   ${props => props.alignContent && alignContentStyle}
-  ${props => props.alignSelf && alignSelfStyle}
   ${props => props.background && backgroundStyle(props.background, props.theme)}
   ${props => props.border
     && borderStyle(props.border, props.responsive, props.theme)}
@@ -447,11 +432,7 @@ export const StyledBox = styled.div`
   ${props => props.flex !== undefined && flexStyle}
   ${props => props.basis && basisStyle}
   ${props => props.fillProp && fillStyle(props.fillProp)}
-  ${props => props.gridArea && gridAreaStyle}
   ${props => props.justify && justifyStyle}
-  ${props => (props.margin
-    && edgeStyle('margin', props.margin, props.responsive,
-      props.theme.box.responsiveBreakpoint, props.theme))}
   ${props => (props.pad
     && edgeStyle('padding', props.pad, props.responsive,
       props.theme.box.responsiveBreakpoint, props.theme))}

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -19,6 +19,7 @@ exports[`Box align 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -28,7 +29,6 @@ exports[`Box align 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -40,6 +40,7 @@ exports[`Box align 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -49,7 +50,6 @@ exports[`Box align 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -61,6 +61,7 @@ exports[`Box align 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -70,7 +71,6 @@ exports[`Box align 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -82,6 +82,7 @@ exports[`Box align 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -91,7 +92,6 @@ exports[`Box align 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -103,6 +103,7 @@ exports[`Box align 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
@@ -112,7 +113,6 @@ exports[`Box align 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -216,6 +216,7 @@ exports[`Box alignContent 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-content: flex-start;
   -ms-flex-line-pack: start;
   align-content: flex-start;
@@ -224,7 +225,6 @@ exports[`Box alignContent 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -236,6 +236,7 @@ exports[`Box alignContent 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
@@ -244,7 +245,6 @@ exports[`Box alignContent 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -256,6 +256,7 @@ exports[`Box alignContent 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-content: between;
   -ms-flex-line-pack: between;
   align-content: between;
@@ -264,7 +265,6 @@ exports[`Box alignContent 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -276,6 +276,7 @@ exports[`Box alignContent 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-content: around;
   -ms-flex-line-pack: around;
   align-content: around;
@@ -284,7 +285,6 @@ exports[`Box alignContent 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -296,6 +296,7 @@ exports[`Box alignContent 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
   align-content: stretch;
@@ -304,7 +305,6 @@ exports[`Box alignContent 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -316,6 +316,7 @@ exports[`Box alignContent 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-content: flex-end;
   -ms-flex-line-pack: end;
   align-content: flex-end;
@@ -324,7 +325,6 @@ exports[`Box alignContent 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -446,12 +446,12 @@ exports[`Box alignSelf 1`] = `
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -466,12 +466,12 @@ exports[`Box alignSelf 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -486,12 +486,12 @@ exports[`Box alignSelf 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -506,12 +506,12 @@ exports[`Box alignSelf 1`] = `
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
   align-self: flex-end;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -600,12 +600,12 @@ exports[`Box animation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   opacity: 0;
   -webkit-animation: dHUfhi 1s 0s forwards;
@@ -620,12 +620,12 @@ exports[`Box animation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   opacity: 1;
   -webkit-animation: gmgyXe 1s 0s forwards;
@@ -640,12 +640,12 @@ exports[`Box animation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   -webkit-transform: rotate(-5deg);
   -ms-transform: rotate(-5deg);
@@ -662,12 +662,12 @@ exports[`Box animation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
@@ -684,12 +684,12 @@ exports[`Box animation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   -webkit-transform: translateY(10%);
   -ms-transform: translateY(10%);
@@ -706,12 +706,12 @@ exports[`Box animation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   -webkit-transform: translateY(-10%);
   -ms-transform: translateY(-10%);
@@ -728,12 +728,12 @@ exports[`Box animation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   -webkit-transform: translateX(10%);
   -ms-transform: translateX(10%);
@@ -750,12 +750,12 @@ exports[`Box animation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   -webkit-transform: translateX(-10%);
   -ms-transform: translateX(-10%);
@@ -772,12 +772,12 @@ exports[`Box animation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   -webkit-transform: scale(0.95);
   -ms-transform: scale(0.95);
@@ -794,12 +794,12 @@ exports[`Box animation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   -webkit-transform: scale(1.05);
   -ms-transform: scale(1.05);
@@ -816,12 +816,12 @@ exports[`Box animation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   opacity: 0;
   -webkit-transform: translateY(10%);
@@ -839,12 +839,12 @@ exports[`Box animation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   opacity: 0;
   -webkit-animation: dHUfhi 1s 0.5s forwards;
@@ -859,12 +859,12 @@ exports[`Box animation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   opacity: 0;
   -webkit-transform: translateY(10%);
@@ -1094,6 +1094,7 @@ exports[`Box background 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
@@ -1101,7 +1102,6 @@ exports[`Box background 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1113,6 +1113,7 @@ exports[`Box background 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #FD6FFF;
   color: #444444;
   min-width: 0;
@@ -1120,7 +1121,6 @@ exports[`Box background 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1132,6 +1132,7 @@ exports[`Box background 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #3D138D;
   color: #f8f8f8;
   min-width: 0;
@@ -1139,7 +1140,6 @@ exports[`Box background 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1151,6 +1151,7 @@ exports[`Box background 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #F6F6F6;
   color: #444444;
   min-width: 0;
@@ -1158,7 +1159,6 @@ exports[`Box background 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1170,6 +1170,7 @@ exports[`Box background 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #333333;
   color: #f8f8f8;
   min-width: 0;
@@ -1177,7 +1178,6 @@ exports[`Box background 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1189,6 +1189,7 @@ exports[`Box background 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #EB6060;
   color: #444444;
   min-width: 0;
@@ -1196,7 +1197,6 @@ exports[`Box background 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1208,6 +1208,7 @@ exports[`Box background 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==) no-repeat center center;
   background-size: cover;
   min-width: 0;
@@ -1215,7 +1216,6 @@ exports[`Box background 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1227,6 +1227,7 @@ exports[`Box background 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==);
   background-repeat: no-repeat;
   background-position: center center;
@@ -1238,7 +1239,6 @@ exports[`Box background 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1250,6 +1250,7 @@ exports[`Box background 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==);
   background-repeat: no-repeat;
   background-position: center center;
@@ -1261,7 +1262,6 @@ exports[`Box background 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1273,6 +1273,7 @@ exports[`Box background 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==);
   background-repeat: no-repeat;
   background-position: top center;
@@ -1283,7 +1284,6 @@ exports[`Box background 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1295,6 +1295,7 @@ exports[`Box background 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==);
   background-repeat: no-repeat;
   background-position: center center;
@@ -1307,7 +1308,6 @@ exports[`Box background 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1501,12 +1501,12 @@ exports[`Box basis 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1518,12 +1518,12 @@ exports[`Box basis 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1534,6 +1534,7 @@ exports[`Box basis 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1542,7 +1543,6 @@ exports[`Box basis 1`] = `
   -webkit-flex-basis: 96px;
   -ms-flex-preferred-size: 96px;
   flex-basis: 96px;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1553,6 +1553,7 @@ exports[`Box basis 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1561,7 +1562,6 @@ exports[`Box basis 1`] = `
   -webkit-flex-basis: 192px;
   -ms-flex-preferred-size: 192px;
   flex-basis: 192px;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1572,6 +1572,7 @@ exports[`Box basis 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1580,7 +1581,6 @@ exports[`Box basis 1`] = `
   -webkit-flex-basis: 384px;
   -ms-flex-preferred-size: 384px;
   flex-basis: 384px;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1591,6 +1591,7 @@ exports[`Box basis 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1599,7 +1600,6 @@ exports[`Box basis 1`] = `
   -webkit-flex-basis: 768px;
   -ms-flex-preferred-size: 768px;
   flex-basis: 768px;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1610,6 +1610,7 @@ exports[`Box basis 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1618,7 +1619,6 @@ exports[`Box basis 1`] = `
   -webkit-flex-basis: 1152px;
   -ms-flex-preferred-size: 1152px;
   flex-basis: 1152px;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1629,6 +1629,7 @@ exports[`Box basis 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1637,7 +1638,6 @@ exports[`Box basis 1`] = `
   -webkit-flex-basis: 100%;
   -ms-flex-preferred-size: 100%;
   flex-basis: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1648,6 +1648,7 @@ exports[`Box basis 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1656,7 +1657,6 @@ exports[`Box basis 1`] = `
   -webkit-flex-basis: 50%;
   -ms-flex-preferred-size: 50%;
   flex-basis: 50%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1667,6 +1667,7 @@ exports[`Box basis 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1675,7 +1676,6 @@ exports[`Box basis 1`] = `
   -webkit-flex-basis: 33.33%;
   -ms-flex-preferred-size: 33.33%;
   flex-basis: 33.33%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1686,6 +1686,7 @@ exports[`Box basis 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1694,7 +1695,6 @@ exports[`Box basis 1`] = `
   -webkit-flex-basis: 66.66%;
   -ms-flex-preferred-size: 66.66%;
   flex-basis: 66.66%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1705,6 +1705,7 @@ exports[`Box basis 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1713,7 +1714,6 @@ exports[`Box basis 1`] = `
   -webkit-flex-basis: 25%;
   -ms-flex-preferred-size: 25%;
   flex-basis: 25%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1724,6 +1724,7 @@ exports[`Box basis 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1732,7 +1733,6 @@ exports[`Box basis 1`] = `
   -webkit-flex-basis: 75%;
   -ms-flex-preferred-size: 75%;
   flex-basis: 75%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1973,13 +1973,13 @@ exports[`Box border 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1991,6 +1991,7 @@ exports[`Box border 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-top: solid 1px rgba(0,0,0,0.33);
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1998,7 +1999,6 @@ exports[`Box border 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2010,6 +2010,7 @@ exports[`Box border 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-left: solid 1px rgba(0,0,0,0.33);
   border-right: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -2017,7 +2018,6 @@ exports[`Box border 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2029,13 +2029,13 @@ exports[`Box border 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-top: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2047,13 +2047,13 @@ exports[`Box border 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-left: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2065,13 +2065,13 @@ exports[`Box border 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2083,13 +2083,13 @@ exports[`Box border 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-right: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2101,13 +2101,13 @@ exports[`Box border 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border: solid 1px #FD6FFF;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2119,13 +2119,13 @@ exports[`Box border 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border: solid 2px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2137,13 +2137,13 @@ exports[`Box border 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border: solid 4px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2155,13 +2155,13 @@ exports[`Box border 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border: solid 12px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2173,14 +2173,20 @@ exports[`Box border 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border: solid 24px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
 }
 
 @media only screen and (max-width:768px) {
@@ -2191,13 +2197,13 @@ exports[`Box border 1`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
-    margin: 0px;
+    padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
-    padding: 0px;
+  .c2 {
+    margin: 0px;
   }
 }
 
@@ -2210,13 +2216,13 @@ exports[`Box border 1`] = `
 
 @media only screen and (max-width:768px) {
   .c2 {
-    margin: 0px;
+    padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
-    padding: 0px;
+  .c3 {
+    margin: 0px;
   }
 }
 
@@ -2229,13 +2235,13 @@ exports[`Box border 1`] = `
 
 @media only screen and (max-width:768px) {
   .c3 {
-    margin: 0px;
+    padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
-    padding: 0px;
+  .c4 {
+    margin: 0px;
   }
 }
 
@@ -2247,13 +2253,13 @@ exports[`Box border 1`] = `
 
 @media only screen and (max-width:768px) {
   .c4 {
-    margin: 0px;
+    padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
-    padding: 0px;
+  .c5 {
+    margin: 0px;
   }
 }
 
@@ -2265,13 +2271,13 @@ exports[`Box border 1`] = `
 
 @media only screen and (max-width:768px) {
   .c5 {
-    margin: 0px;
+    padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
-    padding: 0px;
+  .c6 {
+    margin: 0px;
   }
 }
 
@@ -2283,13 +2289,13 @@ exports[`Box border 1`] = `
 
 @media only screen and (max-width:768px) {
   .c6 {
-    margin: 0px;
+    padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
-    padding: 0px;
+  .c7 {
+    margin: 0px;
   }
 }
 
@@ -2301,13 +2307,13 @@ exports[`Box border 1`] = `
 
 @media only screen and (max-width:768px) {
   .c7 {
-    margin: 0px;
+    padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
-    padding: 0px;
+  .c8 {
+    margin: 0px;
   }
 }
 
@@ -2319,13 +2325,13 @@ exports[`Box border 1`] = `
 
 @media only screen and (max-width:768px) {
   .c8 {
-    margin: 0px;
+    padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
-    padding: 0px;
+  .c9 {
+    margin: 0px;
   }
 }
 
@@ -2337,13 +2343,13 @@ exports[`Box border 1`] = `
 
 @media only screen and (max-width:768px) {
   .c9 {
-    margin: 0px;
+    padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
-    padding: 0px;
+  .c10 {
+    margin: 0px;
   }
 }
 
@@ -2355,13 +2361,13 @@ exports[`Box border 1`] = `
 
 @media only screen and (max-width:768px) {
   .c10 {
-    margin: 0px;
+    padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
-    padding: 0px;
+  .c11 {
+    margin: 0px;
   }
 }
 
@@ -2373,25 +2379,19 @@ exports[`Box border 1`] = `
 
 @media only screen and (max-width:768px) {
   .c11 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c11 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c12 {
-    border: solid 12px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c12 {
-    margin: 0px;
+    border: solid 12px rgba(0,0,0,0.33);
   }
 }
 
@@ -2468,12 +2468,12 @@ exports[`Box default 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2517,12 +2517,12 @@ exports[`Box direction 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2534,12 +2534,12 @@ exports[`Box direction 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2551,12 +2551,12 @@ exports[`Box direction 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2581,6 +2581,12 @@ exports[`Box direction 1`] = `
 @media only screen and (max-width:768px) {
   .c1 {
     padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
   }
 }
 
@@ -2600,12 +2606,6 @@ exports[`Box direction 1`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c2 {
-    margin: 0px;
   }
 }
 
@@ -2649,12 +2649,12 @@ exports[`Box elevation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: none;
 }
@@ -2667,12 +2667,12 @@ exports[`Box elevation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 1px 2px rgba(100,100,100,0.50);
 }
@@ -2685,12 +2685,12 @@ exports[`Box elevation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -2703,12 +2703,12 @@ exports[`Box elevation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 3px 8px rgba(100,100,100,0.50);
 }
@@ -2721,12 +2721,12 @@ exports[`Box elevation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 6px 12px rgba(100,100,100,0.50);
 }
@@ -2739,12 +2739,12 @@ exports[`Box elevation 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 8px 16px rgba(100,100,100,0.50);
 }
@@ -2864,12 +2864,12 @@ exports[`Box fill 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2881,6 +2881,7 @@ exports[`Box fill 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -2888,7 +2889,6 @@ exports[`Box fill 1`] = `
   flex-direction: column;
   width: 100%;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2900,13 +2900,13 @@ exports[`Box fill 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   width: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2918,13 +2918,13 @@ exports[`Box fill 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3017,12 +3017,12 @@ exports[`Box flex 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3034,6 +3034,7 @@ exports[`Box flex 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3042,7 +3043,6 @@ exports[`Box flex 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3054,6 +3054,7 @@ exports[`Box flex 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3062,7 +3063,6 @@ exports[`Box flex 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3074,6 +3074,7 @@ exports[`Box flex 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3082,7 +3083,6 @@ exports[`Box flex 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3094,6 +3094,7 @@ exports[`Box flex 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3102,7 +3103,6 @@ exports[`Box flex 1`] = `
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3207,12 +3207,12 @@ exports[`Box gap 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3224,12 +3224,12 @@ exports[`Box gap 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3310,13 +3310,13 @@ exports[`Box gridArea 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  grid-area: header;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  grid-area: header;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3360,13 +3360,13 @@ exports[`Box height 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   height: 96px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3378,13 +3378,13 @@ exports[`Box height 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   height: 192px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3396,13 +3396,13 @@ exports[`Box height 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   height: 384px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3414,13 +3414,13 @@ exports[`Box height 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   height: 768px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3432,13 +3432,13 @@ exports[`Box height 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   height: 1152px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3450,13 +3450,13 @@ exports[`Box height 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   height: 111px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3575,6 +3575,7 @@ exports[`Box justify 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3584,7 +3585,6 @@ exports[`Box justify 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3596,6 +3596,7 @@ exports[`Box justify 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3605,7 +3606,6 @@ exports[`Box justify 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3617,6 +3617,7 @@ exports[`Box justify 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3626,7 +3627,6 @@ exports[`Box justify 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3638,6 +3638,7 @@ exports[`Box justify 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3647,7 +3648,6 @@ exports[`Box justify 1`] = `
   -webkit-justify-content: flex-end;
   -ms-flex-pack: end;
   justify-content: flex-end;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3736,12 +3736,12 @@ exports[`Box margin 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 12px;
   padding: 0px;
 }
 
@@ -3753,12 +3753,12 @@ exports[`Box margin 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 24px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 24px;
   padding: 0px;
 }
 
@@ -3770,12 +3770,12 @@ exports[`Box margin 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 48px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 48px;
   padding: 0px;
 }
 
@@ -3787,13 +3787,13 @@ exports[`Box margin 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-left: 12px;
-  margin-right: 12px;
   padding: 0px;
 }
 
@@ -3805,13 +3805,13 @@ exports[`Box margin 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-top: 12px;
+  margin-bottom: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-top: 12px;
-  margin-bottom: 12px;
   padding: 0px;
 }
 
@@ -3823,12 +3823,12 @@ exports[`Box margin 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-bottom: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-bottom: 12px;
   padding: 0px;
 }
 
@@ -3840,12 +3840,12 @@ exports[`Box margin 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-left: 12px;
   padding: 0px;
 }
 
@@ -3857,12 +3857,12 @@ exports[`Box margin 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-right: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-right: 12px;
   padding: 0px;
 }
 
@@ -3874,12 +3874,12 @@ exports[`Box margin 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-top: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-top: 12px;
   padding: 0px;
 }
 
@@ -4045,12 +4045,12 @@ exports[`Box pad 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -4062,12 +4062,12 @@ exports[`Box pad 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 24px;
 }
 
@@ -4079,12 +4079,12 @@ exports[`Box pad 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 48px;
 }
 
@@ -4096,12 +4096,12 @@ exports[`Box pad 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -4114,12 +4114,12 @@ exports[`Box pad 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-top: 12px;
   padding-bottom: 12px;
 }
@@ -4132,12 +4132,12 @@ exports[`Box pad 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-bottom: 12px;
 }
 
@@ -4149,12 +4149,12 @@ exports[`Box pad 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
 }
 
@@ -4166,12 +4166,12 @@ exports[`Box pad 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-right: 12px;
 }
 
@@ -4183,12 +4183,12 @@ exports[`Box pad 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-top: 12px;
 }
 
@@ -4354,12 +4354,12 @@ exports[`Box responsive 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -4371,12 +4371,12 @@ exports[`Box responsive 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -4423,12 +4423,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 24px;
 }
@@ -4441,12 +4441,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 6px;
 }
@@ -4459,12 +4459,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -4477,12 +4477,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 48px;
 }
@@ -4495,12 +4495,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 100%;
 }
@@ -4513,12 +4513,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-top-left-radius: 24px;
   border-bottom-left-radius: 24px;
@@ -4532,12 +4532,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-top-left-radius: 24px;
   border-top-right-radius: 24px;
@@ -4551,12 +4551,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-top-right-radius: 24px;
   border-bottom-right-radius: 24px;
@@ -4570,12 +4570,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-bottom-left-radius: 24px;
   border-bottom-right-radius: 24px;
@@ -4589,12 +4589,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-top-left-radius: 24px;
 }
@@ -4607,12 +4607,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-top-right-radius: 24px;
 }
@@ -4625,12 +4625,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-bottom-left-radius: 24px;
 }
@@ -4643,12 +4643,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-bottom-right-radius: 24px;
 }
@@ -4661,12 +4661,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 6px;
 }
@@ -4679,12 +4679,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -4697,12 +4697,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 24px;
 }
@@ -4715,12 +4715,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 48px;
 }
@@ -4733,12 +4733,12 @@ exports[`Box round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 96px;
 }
@@ -5095,12 +5095,12 @@ exports[`Box tag 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5144,13 +5144,13 @@ exports[`Box width 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   width: 96px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5162,13 +5162,13 @@ exports[`Box width 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   width: 192px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5180,13 +5180,13 @@ exports[`Box width 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   width: 384px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5198,13 +5198,13 @@ exports[`Box width 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   width: 768px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5216,13 +5216,13 @@ exports[`Box width 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   width: 1152px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5234,13 +5234,13 @@ exports[`Box width 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   width: 111px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5359,12 +5359,12 @@ exports[`Box wrap 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5376,12 +5376,12 @@ exports[`Box wrap 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { a11yTitlePropType, getAvailableAtBadge } from '../../utils';
+import { getAvailableAtBadge, genericProps } from '../../utils';
 
 const PAD_SIZES = ['xxsmall', 'xsmall', 'small', 'medium', 'large', 'xlarge'];
 const OVERFLOW_VALUES = ['auto', 'hidden', 'scroll', 'visible'];
@@ -26,7 +26,7 @@ export const doc = (Box) => {
       "import { Box } from 'grommet';\n<Box />"
     );
   DocumentedBox.propTypes = {
-    a11yTitle: a11yTitlePropType,
+    ...genericProps,
     align: PropTypes.oneOf(['start', 'center', 'end', 'baseline', 'stretch'])
       .description('How to align the contents along the cross axis.'),
     alignContent: PropTypes.oneOf([
@@ -35,9 +35,6 @@ export const doc = (Box) => {
       .description(`How to align the contents when there is extra space in
         the cross axis.`)
       .defaultValue('stretch'),
-    alignSelf: PropTypes.oneOf(['start', 'center', 'end', 'stretch'])
-      .description(`How to align along the cross axis when contained in
-        a Box or along the column axis when contained in a Grid.`),
     animation: PropTypes.oneOfType([
       ANIMATION_TYPE,
       ANIMATION_SHAPE,
@@ -117,8 +114,6 @@ export const doc = (Box) => {
       .description(`The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
         will not wrap gracefully.`),
-    gridArea: PropTypes.string.description(`The name of the area to place
-      this Box in inside a parent Grid.`),
     height: PropTypes.oneOfType([
       PropTypes.oneOf([
         'xsmall', 'small', 'medium', 'large', 'xlarge',
@@ -128,39 +123,6 @@ export const doc = (Box) => {
       .description('A fixed height.'),
     justify: PropTypes.oneOf(['start', 'center', 'between', 'end'])
       .description('How to align the contents along the main axis.'),
-    margin: PropTypes.oneOfType([
-      PropTypes.oneOf(['none', ...PAD_SIZES]),
-      PropTypes.shape({
-        bottom: PropTypes.oneOfType([
-          PropTypes.oneOf(PAD_SIZES),
-          PropTypes.string,
-        ]),
-        horizontal: PropTypes.oneOfType([
-          PropTypes.oneOf(PAD_SIZES),
-          PropTypes.string,
-        ]),
-        left: PropTypes.oneOfType([
-          PropTypes.oneOf(PAD_SIZES),
-          PropTypes.string,
-        ]),
-        right: PropTypes.oneOfType([
-          PropTypes.oneOf(PAD_SIZES),
-          PropTypes.string,
-        ]),
-        top: PropTypes.oneOfType([
-          PropTypes.oneOf(PAD_SIZES),
-          PropTypes.string,
-        ]),
-        vertical: PropTypes.oneOfType([
-          PropTypes.oneOf(PAD_SIZES),
-          PropTypes.string,
-        ]),
-      }),
-      PropTypes.string,
-    ])
-      .description(`The amount of margin around the box. An object can
-        be specified to distinguish horizontal margin, vertical margin, and
-        margin on a particular side of the box`),
     overflow: PropTypes.oneOfType([
       PropTypes.oneOf(OVERFLOW_VALUES),
       PropTypes.shape({

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -2,9 +2,11 @@ import * as React from "react";
 
 export interface BoxProps {
   a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   align?: "start" | "center" | "end" | "baseline" | "stretch";
   alignContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
-  alignSelf?: "start" | "center" | "end" | "stretch";
   animation?: "fadeIn" | "fadeOut" | "jiggle" | "pulse" | "slideUp" | "slideDown" | "slideLeft" | "slideRight" | "zoomIn" | "zoomOut" | {type: "fadeIn" | "fadeOut" | "jiggle" | "pulse" | "slideUp" | "slideDown" | "slideLeft" | "slideRight" | "zoomIn" | "zoomOut",delay: number,duration: number,size: "xsmall" | "small" | "medium" | "large" | "xlarge"} | "fadeIn" | "fadeOut" | "jiggle" | "pulse" | "slideUp" | "slideDown" | "slideLeft" | "slideRight" | "zoomIn" | "zoomOut" | {type: "fadeIn" | "fadeOut" | "jiggle" | "pulse" | "slideUp" | "slideDown" | "slideLeft" | "slideRight" | "zoomIn" | "zoomOut",delay: number,duration: number,size: "xsmall" | "small" | "medium" | "large" | "xlarge"}[];
   background?: string | {color: string,dark: boolean | string,image: string,position: string,opacity: "weak" | "medium" | "strong" | boolean,light: string};
   basis?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "auto" | string;
@@ -14,10 +16,8 @@ export interface BoxProps {
   flex?: "grow" | "shrink" | "true" | "false";
   fill?: "horizontal" | "vertical" | "true" | "false";
   gap?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
-  gridArea?: string;
   height?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   justify?: "start" | "center" | "between" | "end";
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   overflow?: "auto" | "hidden" | "scroll" | "visible" | {horizontal: "auto" | "hidden" | "scroll" | "visible",vertical: "auto" | "hidden" | "scroll" | "visible"} | string;
   pad?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge",horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge",left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge",right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge",top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge",vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge"} | string;
   responsive?: boolean;

--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -19,6 +19,94 @@ Custom title to be used by screen readers.
 string
 ```
 
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **active**
 
 Whether the button is active.

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -4,6 +4,7 @@ import {
   activeStyle,
   backgroundStyle,
   focusStyle,
+  genericStyles,
   normalizeColor,
 } from '../../utils';
 
@@ -96,6 +97,7 @@ export const StyledButton = styled.button`
   overflow: visible;
   text-transform: none;
 
+  ${genericStyles}
   ${props => props.plain && plainStyle}
   ${props => !props.plain && basicStyle(props)}
   ${props => props.primary && primaryStyle(props)}

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -9,6 +9,7 @@ exports[`Button color renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -22,7 +23,6 @@ exports[`Button color renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -192,6 +192,7 @@ exports[`Button focus renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -205,7 +206,6 @@ exports[`Button focus renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -680,6 +680,7 @@ exports[`Button icon label renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -693,7 +694,6 @@ exports[`Button icon label renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -784,6 +784,7 @@ exports[`Button primary renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -797,7 +798,6 @@ exports[`Button primary renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -880,6 +880,7 @@ exports[`Button renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -893,7 +894,6 @@ exports[`Button renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -973,6 +973,7 @@ exports[`Button reverse icon label renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -986,7 +987,6 @@ exports[`Button reverse icon label renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1077,6 +1077,7 @@ exports[`Button warns about invalid icon render 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1090,7 +1091,6 @@ exports[`Button warns about invalid icon render 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1163,6 +1163,7 @@ exports[`Button warns about invalid label render 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1176,7 +1177,6 @@ exports[`Button warns about invalid label render 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Button) => {
   const DocumentedButton = describe(Button)
@@ -14,7 +14,7 @@ export const doc = (Button) => {
     );
 
   DocumentedButton.propTypes = {
-    a11yTitle: PropTypes.string.description('Custom title to be used by screen readers.'),
+    ...genericProps,
     active: PropTypes.bool.description('Whether the button is active.'),
     color: PropTypes.string.description('Fill color for primary, border color otherwise.'),
     disabled: PropTypes.bool.description('Whether the button is disabled.'),

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -2,6 +2,9 @@ import * as React from "react";
 
 export interface ButtonProps {
   a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   active?: boolean;
   color?: string;
   disabled?: boolean;

--- a/src/js/components/Calendar/README.md
+++ b/src/js/components/Calendar/README.md
@@ -13,6 +13,102 @@ import { Calendar } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **animate**
 
 

--- a/src/js/components/Calendar/StyledCalendar.js
+++ b/src/js/components/Calendar/StyledCalendar.js
@@ -1,5 +1,5 @@
 import styled, { css, keyframes } from 'styled-components';
-import { backgroundStyle, parseMetricToNum } from '../../utils';
+import { backgroundStyle, genericStyles, parseMetricToNum } from '../../utils';
 
 const sizeStyle = (props) => {
   const data = props.theme.calendar[props.sizeProp];
@@ -11,6 +11,7 @@ const sizeStyle = (props) => {
 };
 
 export const StyledCalendar = styled.div`
+  ${genericStyles}
   ${props => sizeStyle(props)}
   ${props => props.theme.calendar && props.theme.calendar.extend}
 `;

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -41,12 +41,12 @@ exports[`Calendar date 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -58,6 +58,7 @@ exports[`Calendar date 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -71,7 +72,6 @@ exports[`Calendar date 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -83,6 +83,7 @@ exports[`Calendar date 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -91,7 +92,6 @@ exports[`Calendar date 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -104,6 +104,7 @@ exports[`Calendar date 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -116,7 +117,6 @@ exports[`Calendar date 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -128,6 +128,7 @@ exports[`Calendar date 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -141,7 +142,6 @@ exports[`Calendar date 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -288,12 +288,11 @@ exports[`Calendar date 1`] = `
 }
 
 .c5 {
+  margin: 0px;
   font-size: 22px;
   line-height: 28px;
   max-width: 528px;
   font-weight: 600;
-  margin-top: 0px;
-  margin-bottom: 0px;
 }
 
 @media only screen and (max-width:768px) {
@@ -359,16 +358,15 @@ exports[`Calendar date 1`] = `
 
 @media only screen and (max-width:768px) {
   .c5 {
-    font-size: 18px;
-    line-height: 24px;
-    max-width: 432px;
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c5 {
-    margin-top: 0px;
-    margin-bottom: 0px;
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
   }
 }
 
@@ -1297,12 +1295,12 @@ exports[`Calendar dates 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1314,6 +1312,7 @@ exports[`Calendar dates 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1327,7 +1326,6 @@ exports[`Calendar dates 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1339,6 +1337,7 @@ exports[`Calendar dates 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1347,7 +1346,6 @@ exports[`Calendar dates 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -1360,6 +1358,7 @@ exports[`Calendar dates 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1372,7 +1371,6 @@ exports[`Calendar dates 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1384,6 +1382,7 @@ exports[`Calendar dates 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1397,7 +1396,6 @@ exports[`Calendar dates 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1544,12 +1542,11 @@ exports[`Calendar dates 1`] = `
 }
 
 .c5 {
+  margin: 0px;
   font-size: 22px;
   line-height: 28px;
   max-width: 528px;
   font-weight: 600;
-  margin-top: 0px;
-  margin-bottom: 0px;
 }
 
 @media only screen and (max-width:768px) {
@@ -1615,16 +1612,15 @@ exports[`Calendar dates 1`] = `
 
 @media only screen and (max-width:768px) {
   .c5 {
-    font-size: 18px;
-    line-height: 24px;
-    max-width: 432px;
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c5 {
-    margin-top: 0px;
-    margin-bottom: 0px;
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
   }
 }
 
@@ -2553,12 +2549,12 @@ exports[`Calendar firstDayOfWeek 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2570,6 +2566,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2583,7 +2580,6 @@ exports[`Calendar firstDayOfWeek 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2595,6 +2591,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -2603,7 +2600,6 @@ exports[`Calendar firstDayOfWeek 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -2616,6 +2612,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2628,7 +2625,6 @@ exports[`Calendar firstDayOfWeek 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2640,6 +2636,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2653,7 +2650,6 @@ exports[`Calendar firstDayOfWeek 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2800,12 +2796,11 @@ exports[`Calendar firstDayOfWeek 1`] = `
 }
 
 .c5 {
+  margin: 0px;
   font-size: 22px;
   line-height: 28px;
   max-width: 528px;
   font-weight: 600;
-  margin-top: 0px;
-  margin-bottom: 0px;
 }
 
 @media only screen and (max-width:768px) {
@@ -2871,16 +2866,15 @@ exports[`Calendar firstDayOfWeek 1`] = `
 
 @media only screen and (max-width:768px) {
   .c5 {
-    font-size: 18px;
-    line-height: 24px;
-    max-width: 432px;
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c5 {
-    margin-top: 0px;
-    margin-bottom: 0px;
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
   }
 }
 
@@ -4687,12 +4681,12 @@ exports[`Calendar header 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -4704,6 +4698,7 @@ exports[`Calendar header 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4717,7 +4712,6 @@ exports[`Calendar header 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5826,12 +5820,12 @@ exports[`Calendar reference 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5843,6 +5837,7 @@ exports[`Calendar reference 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5856,7 +5851,6 @@ exports[`Calendar reference 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5868,6 +5862,7 @@ exports[`Calendar reference 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -5876,7 +5871,6 @@ exports[`Calendar reference 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -5889,6 +5883,7 @@ exports[`Calendar reference 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5901,7 +5896,6 @@ exports[`Calendar reference 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5913,6 +5907,7 @@ exports[`Calendar reference 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5926,7 +5921,6 @@ exports[`Calendar reference 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -6053,12 +6047,11 @@ exports[`Calendar reference 1`] = `
 }
 
 .c5 {
+  margin: 0px;
   font-size: 22px;
   line-height: 28px;
   max-width: 528px;
   font-weight: 600;
-  margin-top: 0px;
-  margin-bottom: 0px;
 }
 
 @media only screen and (max-width:768px) {
@@ -6124,16 +6117,15 @@ exports[`Calendar reference 1`] = `
 
 @media only screen and (max-width:768px) {
   .c5 {
-    font-size: 18px;
-    line-height: 24px;
-    max-width: 432px;
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c5 {
-    margin-top: 0px;
-    margin-bottom: 0px;
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
   }
 }
 
@@ -7096,12 +7088,12 @@ exports[`Calendar size 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -7113,6 +7105,7 @@ exports[`Calendar size 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -7126,7 +7119,6 @@ exports[`Calendar size 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -7138,6 +7130,7 @@ exports[`Calendar size 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -7146,7 +7139,6 @@ exports[`Calendar size 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -7159,6 +7151,7 @@ exports[`Calendar size 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -7171,7 +7164,6 @@ exports[`Calendar size 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -7183,6 +7175,7 @@ exports[`Calendar size 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -7196,7 +7189,6 @@ exports[`Calendar size 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -7208,6 +7200,7 @@ exports[`Calendar size 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -7216,7 +7209,6 @@ exports[`Calendar size 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding-left: 6px;
   padding-right: 6px;
 }
@@ -7229,6 +7221,7 @@ exports[`Calendar size 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -7237,7 +7230,6 @@ exports[`Calendar size 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding-left: 24px;
   padding-right: 24px;
 }
@@ -7517,30 +7509,27 @@ exports[`Calendar size 1`] = `
 }
 
 .c20 {
+  margin: 0px;
   font-size: 22px;
   line-height: 28px;
   max-width: 528px;
   font-weight: 600;
-  margin-top: 0px;
-  margin-bottom: 0px;
 }
 
 .c27 {
+  margin: 0px;
   font-size: 34px;
   line-height: 40px;
   max-width: 816px;
   font-weight: 600;
-  margin-top: 0px;
-  margin-bottom: 0px;
 }
 
 .c5 {
+  margin: 0px;
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
   font-weight: 600;
-  margin-top: 0px;
-  margin-bottom: 0px;
 }
 
 @media only screen and (max-width:768px) {
@@ -7632,16 +7621,21 @@ exports[`Calendar size 1`] = `
 
 @media only screen and (max-width:768px) {
   .c20 {
-    font-size: 18px;
-    line-height: 24px;
-    max-width: 432px;
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c20 {
-    margin-top: 0px;
-    margin-bottom: 0px;
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c27 {
+    margin: 0px;
   }
 }
 
@@ -7654,9 +7648,8 @@ exports[`Calendar size 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c27 {
-    margin-top: 0px;
-    margin-bottom: 0px;
+  .c5 {
+    margin: 0px;
   }
 }
 
@@ -7665,13 +7658,6 @@ exports[`Calendar size 1`] = `
     font-size: 18px;
     line-height: 24px;
     max-width: 432px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
-    margin-top: 0px;
-    margin-bottom: 0px;
   }
 }
 

--- a/src/js/components/Calendar/doc.js
+++ b/src/js/components/Calendar/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Calendar) => {
   const DocumentedCalendar = describe(Calendar)
@@ -14,6 +14,7 @@ export const doc = (Calendar) => {
     );
 
   DocumentedCalendar.propTypes = {
+    ...genericProps,
     animate: PropTypes.bool.description(`
       Whether to animate the calender as the user interacts with it.
     `).defaultValue(true),

--- a/src/js/components/Calendar/index.d.ts
+++ b/src/js/components/Calendar/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
 export interface CalendarProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   animate?: boolean;
   bounds?: string[];
   date?: string;

--- a/src/js/components/Carousel/README.md
+++ b/src/js/components/Carousel/README.md
@@ -13,6 +13,102 @@ import { Carousel } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **fill**
 
 Whether to expand to fill

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -83,12 +83,12 @@ exports[`Carousel basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: hidden;
 }
@@ -101,12 +101,12 @@ exports[`Carousel basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -118,12 +118,12 @@ exports[`Carousel basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   opacity: 1;
   -webkit-animation: gmgyXe 1s 0s forwards;
@@ -138,6 +138,7 @@ exports[`Carousel basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -149,7 +150,6 @@ exports[`Carousel basic 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -161,13 +161,13 @@ exports[`Carousel basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -179,6 +179,7 @@ exports[`Carousel basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -188,7 +189,6 @@ exports[`Carousel basic 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -200,6 +200,7 @@ exports[`Carousel basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -209,7 +210,6 @@ exports[`Carousel basic 1`] = `
   -webkit-justify-content: flex-end;
   -ms-flex-pack: end;
   justify-content: flex-end;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -221,6 +221,7 @@ exports[`Carousel basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -230,7 +231,6 @@ exports[`Carousel basic 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -242,6 +242,7 @@ exports[`Carousel basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -255,7 +256,6 @@ exports[`Carousel basic 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -726,12 +726,12 @@ exports[`Carousel navigate 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: hidden;
 }
@@ -744,12 +744,12 @@ exports[`Carousel navigate 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -761,12 +761,12 @@ exports[`Carousel navigate 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   opacity: 1;
   -webkit-animation: gmgyXe 1s 0s forwards;
@@ -781,6 +781,7 @@ exports[`Carousel navigate 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -792,7 +793,6 @@ exports[`Carousel navigate 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -804,13 +804,13 @@ exports[`Carousel navigate 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -822,6 +822,7 @@ exports[`Carousel navigate 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -831,7 +832,6 @@ exports[`Carousel navigate 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -843,6 +843,7 @@ exports[`Carousel navigate 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -852,7 +853,6 @@ exports[`Carousel navigate 1`] = `
   -webkit-justify-content: flex-end;
   -ms-flex-pack: end;
   justify-content: flex-end;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -864,6 +864,7 @@ exports[`Carousel navigate 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -873,7 +874,6 @@ exports[`Carousel navigate 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -885,6 +885,7 @@ exports[`Carousel navigate 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -898,7 +899,6 @@ exports[`Carousel navigate 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1277,20 +1277,20 @@ exports[`Carousel navigate 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledStack-ajspsk-0 hKZWLd"
+    class="StyledStack-ajspsk-0 cBSAEZ"
     data-testid="test-carousel"
   >
     <div
       class="StyledStack__StyledStackLayer-ajspsk-1 hFvDUx"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 VBjYZ"
+        class="StyledBox-sc-13pk1d4-0 ciYFmy"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fCVIfX"
+          class="StyledBox-sc-13pk1d4-0 lbyJo"
         >
           <img
-            class="StyledImage-ey4zx9-0 inKPek"
+            class="StyledImage-ey4zx9-0 jtkYbl"
             src="//v2.grommet.io/assets/IMG_4245.jpg"
           />
         </div>
@@ -1300,13 +1300,13 @@ exports[`Carousel navigate 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 fNScQY"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 VBjYZ"
+        class="StyledBox-sc-13pk1d4-0 ciYFmy"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jwmvWh"
+          class="StyledBox-sc-13pk1d4-0 jLaWmC"
         >
           <img
-            class="StyledImage-ey4zx9-0 inKPek"
+            class="StyledImage-ey4zx9-0 jtkYbl"
             src="//v2.grommet.io/assets/IMG_4210.jpg"
           />
         </div>
@@ -1316,18 +1316,18 @@ exports[`Carousel navigate 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 hFvDUx"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bmKCc"
+        class="StyledBox-sc-13pk1d4-0 slWYm"
         tabindex="0"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fgHUSC"
+          class="StyledBox-sc-13pk1d4-0 ccsSgS"
         >
           <button
-            class="StyledButton-sc-323bzc-0 iXKwVW"
+            class="StyledButton-sc-323bzc-0 bQCefD"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 fCLTxM"
+              class="StyledBox-sc-13pk1d4-0 fwNyEe"
             >
               <svg
                 aria-label="Previous"
@@ -1350,17 +1350,17 @@ exports[`Carousel navigate 2`] = `
           </button>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 hmSALZ"
+          class="StyledBox-sc-13pk1d4-0 jELVcM"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eFNGfS"
+            class="StyledBox-sc-13pk1d4-0 dhsCHd"
           >
             <button
-              class="StyledButton-sc-323bzc-0 faxefe"
+              class="StyledButton-sc-323bzc-0 iOWKkb"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gYYddl"
+                class="StyledBox-sc-13pk1d4-0 MJmug"
               >
                 <svg
                   aria-label="Subtract"
@@ -1381,11 +1381,11 @@ exports[`Carousel navigate 2`] = `
               </div>
             </button>
             <button
-              class="StyledButton-sc-323bzc-0 faxefe"
+              class="StyledButton-sc-323bzc-0 iOWKkb"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gYYddl"
+                class="StyledBox-sc-13pk1d4-0 MJmug"
               >
                 <svg
                   aria-label="Subtract"
@@ -1408,15 +1408,15 @@ exports[`Carousel navigate 2`] = `
           </div>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 fgHUSC"
+          class="StyledBox-sc-13pk1d4-0 ccsSgS"
         >
           <button
-            class="StyledButton-sc-323bzc-0 kSKXxu"
+            class="StyledButton-sc-323bzc-0 fzQtuL"
             disabled=""
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 fCLTxM"
+              class="StyledBox-sc-13pk1d4-0 fwNyEe"
             >
               <svg
                 aria-label="Next"
@@ -1448,20 +1448,20 @@ exports[`Carousel navigate 3`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledStack-ajspsk-0 hKZWLd"
+    class="StyledStack-ajspsk-0 cBSAEZ"
     data-testid="test-carousel"
   >
     <div
       class="StyledStack__StyledStackLayer-ajspsk-1 fNScQY"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 VBjYZ"
+        class="StyledBox-sc-13pk1d4-0 ciYFmy"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 iSomxg"
+          class="StyledBox-sc-13pk1d4-0 diAMWg"
         >
           <img
-            class="StyledImage-ey4zx9-0 inKPek"
+            class="StyledImage-ey4zx9-0 jtkYbl"
             src="//v2.grommet.io/assets/IMG_4245.jpg"
           />
         </div>
@@ -1471,13 +1471,13 @@ exports[`Carousel navigate 3`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 hFvDUx"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 VBjYZ"
+        class="StyledBox-sc-13pk1d4-0 ciYFmy"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fCVIfX"
+          class="StyledBox-sc-13pk1d4-0 lbyJo"
         >
           <img
-            class="StyledImage-ey4zx9-0 inKPek"
+            class="StyledImage-ey4zx9-0 jtkYbl"
             src="//v2.grommet.io/assets/IMG_4210.jpg"
           />
         </div>
@@ -1487,19 +1487,19 @@ exports[`Carousel navigate 3`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 hFvDUx"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bmKCc"
+        class="StyledBox-sc-13pk1d4-0 slWYm"
         tabindex="0"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fgHUSC"
+          class="StyledBox-sc-13pk1d4-0 ccsSgS"
         >
           <button
-            class="StyledButton-sc-323bzc-0 kSKXxu"
+            class="StyledButton-sc-323bzc-0 fzQtuL"
             disabled=""
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 fCLTxM"
+              class="StyledBox-sc-13pk1d4-0 fwNyEe"
             >
               <svg
                 aria-label="Previous"
@@ -1522,17 +1522,17 @@ exports[`Carousel navigate 3`] = `
           </button>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 hmSALZ"
+          class="StyledBox-sc-13pk1d4-0 jELVcM"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eFNGfS"
+            class="StyledBox-sc-13pk1d4-0 dhsCHd"
           >
             <button
-              class="StyledButton-sc-323bzc-0 faxefe"
+              class="StyledButton-sc-323bzc-0 iOWKkb"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gYYddl"
+                class="StyledBox-sc-13pk1d4-0 MJmug"
               >
                 <svg
                   aria-label="Subtract"
@@ -1553,11 +1553,11 @@ exports[`Carousel navigate 3`] = `
               </div>
             </button>
             <button
-              class="StyledButton-sc-323bzc-0 faxefe"
+              class="StyledButton-sc-323bzc-0 iOWKkb"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gYYddl"
+                class="StyledBox-sc-13pk1d4-0 MJmug"
               >
                 <svg
                   aria-label="Subtract"
@@ -1580,14 +1580,14 @@ exports[`Carousel navigate 3`] = `
           </div>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 fgHUSC"
+          class="StyledBox-sc-13pk1d4-0 ccsSgS"
         >
           <button
-            class="StyledButton-sc-323bzc-0 iXKwVW"
+            class="StyledButton-sc-323bzc-0 bQCefD"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 fCLTxM"
+              class="StyledBox-sc-13pk1d4-0 fwNyEe"
             >
               <svg
                 aria-label="Next"
@@ -1697,12 +1697,12 @@ exports[`Carousel play 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: hidden;
 }
@@ -1715,12 +1715,12 @@ exports[`Carousel play 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1732,12 +1732,12 @@ exports[`Carousel play 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   opacity: 1;
   -webkit-animation: gmgyXe 1s 0s forwards;
@@ -1752,6 +1752,7 @@ exports[`Carousel play 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -1763,7 +1764,6 @@ exports[`Carousel play 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1775,13 +1775,13 @@ exports[`Carousel play 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1793,6 +1793,7 @@ exports[`Carousel play 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1802,7 +1803,6 @@ exports[`Carousel play 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1814,6 +1814,7 @@ exports[`Carousel play 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1823,7 +1824,6 @@ exports[`Carousel play 1`] = `
   -webkit-justify-content: flex-end;
   -ms-flex-pack: end;
   justify-content: flex-end;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1835,6 +1835,7 @@ exports[`Carousel play 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -1844,7 +1845,6 @@ exports[`Carousel play 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1856,6 +1856,7 @@ exports[`Carousel play 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1869,7 +1870,6 @@ exports[`Carousel play 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2247,19 +2247,19 @@ exports[`Carousel play 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledStack-ajspsk-0 hKZWLd"
+    class="StyledStack-ajspsk-0 cBSAEZ"
   >
     <div
       class="StyledStack__StyledStackLayer-ajspsk-1 hFvDUx"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 VBjYZ"
+        class="StyledBox-sc-13pk1d4-0 ciYFmy"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fCVIfX"
+          class="StyledBox-sc-13pk1d4-0 lbyJo"
         >
           <img
-            class="StyledImage-ey4zx9-0 inKPek"
+            class="StyledImage-ey4zx9-0 jtkYbl"
             src="//v2.grommet.io/assets/IMG_4245.jpg"
           />
         </div>
@@ -2269,13 +2269,13 @@ exports[`Carousel play 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 fNScQY"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 VBjYZ"
+        class="StyledBox-sc-13pk1d4-0 ciYFmy"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jwmvWh"
+          class="StyledBox-sc-13pk1d4-0 jLaWmC"
         >
           <img
-            class="StyledImage-ey4zx9-0 inKPek"
+            class="StyledImage-ey4zx9-0 jtkYbl"
             src="//v2.grommet.io/assets/IMG_4210.jpg"
           />
         </div>
@@ -2285,18 +2285,18 @@ exports[`Carousel play 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 hFvDUx"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bmKCc"
+        class="StyledBox-sc-13pk1d4-0 slWYm"
         tabindex="0"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fgHUSC"
+          class="StyledBox-sc-13pk1d4-0 ccsSgS"
         >
           <button
-            class="StyledButton-sc-323bzc-0 iXKwVW"
+            class="StyledButton-sc-323bzc-0 bQCefD"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 fCLTxM"
+              class="StyledBox-sc-13pk1d4-0 fwNyEe"
             >
               <svg
                 aria-label="Previous"
@@ -2319,17 +2319,17 @@ exports[`Carousel play 2`] = `
           </button>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 hmSALZ"
+          class="StyledBox-sc-13pk1d4-0 jELVcM"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eFNGfS"
+            class="StyledBox-sc-13pk1d4-0 dhsCHd"
           >
             <button
-              class="StyledButton-sc-323bzc-0 faxefe"
+              class="StyledButton-sc-323bzc-0 iOWKkb"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gYYddl"
+                class="StyledBox-sc-13pk1d4-0 MJmug"
               >
                 <svg
                   aria-label="Subtract"
@@ -2350,11 +2350,11 @@ exports[`Carousel play 2`] = `
               </div>
             </button>
             <button
-              class="StyledButton-sc-323bzc-0 faxefe"
+              class="StyledButton-sc-323bzc-0 iOWKkb"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gYYddl"
+                class="StyledBox-sc-13pk1d4-0 MJmug"
               >
                 <svg
                   aria-label="Subtract"
@@ -2377,15 +2377,15 @@ exports[`Carousel play 2`] = `
           </div>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 fgHUSC"
+          class="StyledBox-sc-13pk1d4-0 ccsSgS"
         >
           <button
-            class="StyledButton-sc-323bzc-0 kSKXxu"
+            class="StyledButton-sc-323bzc-0 fzQtuL"
             disabled=""
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 fCLTxM"
+              class="StyledBox-sc-13pk1d4-0 fwNyEe"
             >
               <svg
                 aria-label="Next"

--- a/src/js/components/Carousel/doc.js
+++ b/src/js/components/Carousel/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Carousel) => {
   const DocumentedCarousel = describe(Carousel)
@@ -14,6 +14,7 @@ export const doc = (Carousel) => {
       );
 
   DocumentedCarousel.propTypes = {
+    ...genericProps,
     fill: PropTypes.bool.description(`Whether to expand to fill
       all of the available width and height in the parent container.`),
     play: PropTypes.number.description(`If specified, the number of

--- a/src/js/components/Carousel/index.d.ts
+++ b/src/js/components/Carousel/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
 export interface CarouselProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   fill?: boolean;
   play?: number;
 }

--- a/src/js/components/Chart/Chart.js
+++ b/src/js/components/Chart/Chart.js
@@ -192,6 +192,7 @@ class Chart extends Component {
         preserveAspectRatio='none'
         width={size === 'full' ? '100%' : width}
         height={size === 'full' ? '100%' : height}
+        theme={theme}
         {...rest}
       >
         <g

--- a/src/js/components/Chart/README.md
+++ b/src/js/components/Chart/README.md
@@ -11,6 +11,102 @@ import { Chart } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **bounds**
 
 The limits for the values, specified as a two dimensional array.

--- a/src/js/components/Chart/StyledChart.js
+++ b/src/js/components/Chart/StyledChart.js
@@ -1,9 +1,12 @@
 import styled from 'styled-components';
 
+import { genericStyles } from '../../utils';
+
 export const StyledChart = styled.svg`
   display: block;
   max-width: 100%;
   overflow: visible;
 
+  ${genericStyles}
   ${props => props.theme.chart && props.theme.chart.extend}
 `;

--- a/src/js/components/Chart/doc.js
+++ b/src/js/components/Chart/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Chart) => {
   const DocumentedChart = describe(Chart)
@@ -9,6 +9,7 @@ export const doc = (Chart) => {
     .usage("import { Chart } from 'grommet';\n<Chart />");
 
   DocumentedChart.propTypes = {
+    ...genericProps,
     bounds: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)).description(
       `The limits for the values, specified as a two dimensional array.
       If not specified, the bounds will automatically be set to fit

--- a/src/js/components/Chart/index.d.ts
+++ b/src/js/components/Chart/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
 export interface ChartProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   bounds?: number[][];
   color?: string | {color: string,opacity: "weak" | "medium" | "strong" | boolean};
   onClick?: (...args: any[]) => any;

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -19,6 +19,7 @@ exports[`CheckBox checked renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -32,7 +33,6 @@ exports[`CheckBox checked renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -44,6 +44,7 @@ exports[`CheckBox checked renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   height: 24px;
   width: 24px;
   -webkit-align-items: center;
@@ -60,7 +61,6 @@ exports[`CheckBox checked renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
   border-radius: 4px;
 }
@@ -114,6 +114,7 @@ exports[`CheckBox checked renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -123,7 +124,6 @@ exports[`CheckBox checked renders 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -141,13 +141,13 @@ exports[`CheckBox checked renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c6 {
-    border: solid 2px #7D4CDB;
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c6 {
-    margin: 0px;
+    border: solid 2px #7D4CDB;
   }
 }
 
@@ -226,6 +226,7 @@ exports[`CheckBox disabled renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -239,7 +240,6 @@ exports[`CheckBox disabled renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -251,6 +251,7 @@ exports[`CheckBox disabled renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   height: 24px;
   width: 24px;
   -webkit-align-items: center;
@@ -267,7 +268,6 @@ exports[`CheckBox disabled renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
   border-radius: 4px;
 }
@@ -280,6 +280,7 @@ exports[`CheckBox disabled renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   height: 24px;
   width: 24px;
   -webkit-align-items: center;
@@ -296,7 +297,6 @@ exports[`CheckBox disabled renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
   border-radius: 4px;
 }
@@ -352,6 +352,7 @@ exports[`CheckBox disabled renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -361,7 +362,6 @@ exports[`CheckBox disabled renders 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -379,13 +379,13 @@ exports[`CheckBox disabled renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c6 {
-    border: solid 2px rgba(0,0,0,0.15);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c6 {
-    margin: 0px;
+    border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
@@ -397,13 +397,13 @@ exports[`CheckBox disabled renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c7 {
-    border: solid 2px #7D4CDB;
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c7 {
-    margin: 0px;
+    border: solid 2px #7D4CDB;
   }
 }
 
@@ -507,6 +507,7 @@ exports[`CheckBox label renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -520,7 +521,6 @@ exports[`CheckBox label renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -532,6 +532,7 @@ exports[`CheckBox label renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   height: 24px;
   width: 24px;
   -webkit-align-items: center;
@@ -548,7 +549,6 @@ exports[`CheckBox label renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
   border-radius: 4px;
 }
@@ -602,6 +602,7 @@ exports[`CheckBox label renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -611,7 +612,6 @@ exports[`CheckBox label renders 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -629,13 +629,13 @@ exports[`CheckBox label renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c6 {
-    border: solid 2px rgba(0,0,0,0.15);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c6 {
-    margin: 0px;
+    border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
@@ -728,6 +728,7 @@ exports[`CheckBox renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -741,7 +742,6 @@ exports[`CheckBox renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -753,6 +753,7 @@ exports[`CheckBox renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   height: 24px;
   width: 24px;
   -webkit-align-items: center;
@@ -769,7 +770,6 @@ exports[`CheckBox renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
   border-radius: 4px;
 }
@@ -816,6 +816,7 @@ exports[`CheckBox renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -825,7 +826,6 @@ exports[`CheckBox renders 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -843,13 +843,13 @@ exports[`CheckBox renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c6 {
-    border: solid 2px rgba(0,0,0,0.15);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c6 {
-    margin: 0px;
+    border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
@@ -933,6 +933,7 @@ exports[`CheckBox reverse renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -946,7 +947,6 @@ exports[`CheckBox reverse renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -958,6 +958,7 @@ exports[`CheckBox reverse renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   height: 24px;
   width: 24px;
   -webkit-align-items: center;
@@ -974,7 +975,6 @@ exports[`CheckBox reverse renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
   border-radius: 4px;
 }
@@ -1028,6 +1028,7 @@ exports[`CheckBox reverse renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1037,7 +1038,6 @@ exports[`CheckBox reverse renders 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1055,13 +1055,13 @@ exports[`CheckBox reverse renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c7 {
-    border: solid 2px rgba(0,0,0,0.15);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c7 {
-    margin: 0px;
+    border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
@@ -1131,6 +1131,7 @@ exports[`CheckBox toggle renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1144,7 +1145,6 @@ exports[`CheckBox toggle renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1223,6 +1223,7 @@ exports[`CheckBox toggle renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1232,7 +1233,6 @@ exports[`CheckBox toggle renders 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 

--- a/src/js/components/Clock/README.md
+++ b/src/js/components/Clock/README.md
@@ -11,6 +11,102 @@ import { Clock } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **hourLimit**
 
 Whether to roll over the hours after 12 or after 24. Defaults to `24`.

--- a/src/js/components/Clock/StyledClock.js
+++ b/src/js/components/Clock/StyledClock.js
@@ -1,5 +1,7 @@
 import styled, { css, keyframes } from 'styled-components';
 
+import { genericStyles } from '../../utils';
+
 export const StyledHour = styled.line`
   stroke-width: ${props => props.theme.clock.analog.hour.width};
   stroke: ${props => (
@@ -25,6 +27,7 @@ export const StyledAnalog = styled.svg`
   width: ${props => props.theme.clock.analog.size[props.size]};
   height: ${props => props.theme.clock.analog.size[props.size]};
 
+  ${genericStyles}
   ${props => props.theme.clock.analog && props.theme.clock.analog.extend}
 `;
 

--- a/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
+++ b/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
@@ -28,12 +28,12 @@ exports[`Clock hourLimit 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -213,12 +213,12 @@ exports[`Clock run 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -411,7 +411,7 @@ exports[`Clock run 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <svg
-    class="StyledClock__StyledAnalog-y4xw8s-3 hXAQyQ"
+    class="StyledClock__StyledAnalog-y4xw8s-3 fObQOf"
     height="96"
     preserveAspectRatio="xMidYMid meet"
     version="1.1"
@@ -450,7 +450,7 @@ exports[`Clock run 2`] = `
     />
   </svg>
   <svg
-    class="StyledClock__StyledAnalog-y4xw8s-3 hXAQyQ"
+    class="StyledClock__StyledAnalog-y4xw8s-3 fObQOf"
     height="96"
     preserveAspectRatio="xMidYMid meet"
     version="1.1"
@@ -489,7 +489,7 @@ exports[`Clock run 2`] = `
     />
   </svg>
   <div
-    class="StyledBox-sc-13pk1d4-0 btbQcB"
+    class="StyledBox-sc-13pk1d4-0 iAECQg"
   >
     <div
       class="StyledClock__StyledDigitalDigit-y4xw8s-4 eZuFeM"
@@ -533,7 +533,7 @@ exports[`Clock run 2`] = `
     </div>
   </div>
   <div
-    class="StyledBox-sc-13pk1d4-0 btbQcB"
+    class="StyledBox-sc-13pk1d4-0 iAECQg"
   >
     <div
       class="StyledClock__StyledDigitalDigit-y4xw8s-4 eZuFeM"
@@ -607,12 +607,12 @@ exports[`Clock time 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1995,12 +1995,12 @@ exports[`Clock type digital precision hours size large 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2066,12 +2066,12 @@ exports[`Clock type digital precision hours size medium 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2137,12 +2137,12 @@ exports[`Clock type digital precision hours size small 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2208,12 +2208,12 @@ exports[`Clock type digital precision hours size xlarge 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2279,12 +2279,12 @@ exports[`Clock type digital precision hours size xsmall 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2350,12 +2350,12 @@ exports[`Clock type digital precision minutes size large 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2439,12 +2439,12 @@ exports[`Clock type digital precision minutes size medium 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2528,12 +2528,12 @@ exports[`Clock type digital precision minutes size small 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2617,12 +2617,12 @@ exports[`Clock type digital precision minutes size xlarge 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2706,12 +2706,12 @@ exports[`Clock type digital precision minutes size xsmall 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2795,12 +2795,12 @@ exports[`Clock type digital precision seconds size large 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2902,12 +2902,12 @@ exports[`Clock type digital precision seconds size medium 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3009,12 +3009,12 @@ exports[`Clock type digital precision seconds size small 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3116,12 +3116,12 @@ exports[`Clock type digital precision seconds size xlarge 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3223,12 +3223,12 @@ exports[`Clock type digital precision seconds size xsmall 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 

--- a/src/js/components/Clock/doc.js
+++ b/src/js/components/Clock/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Clock) => {
   const DocumentedClock = describe(Clock)
@@ -12,6 +12,7 @@ export const doc = (Clock) => {
     );
 
   DocumentedClock.propTypes = {
+    ...genericProps,
     hourLimit: PropTypes.oneOf([12, 24, '12', '24']).description(
       'Whether to roll over the hours after 12 or after 24.'
     ).defaultValue(24),

--- a/src/js/components/Clock/index.d.ts
+++ b/src/js/components/Clock/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
 export interface ClockProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   hourLimit?: "12" | "24" | "12" | "24";
   onChange?: (...args: any[]) => any;
   precision?: "hours" | "minutes" | "seconds";

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -77,7 +77,7 @@ class DataTable extends Component {
   render() {
     const {
       /* eslint-disable-next-line react/prop-types */
-      columns, groupBy, onMore, resizeable, size, sortable, theme,
+      columns, groupBy, onMore, resizeable, size, sortable, theme, ...rest
      } = this.props;
     const {
       data, filtering, filters, footerValues, groups, groupState, primaryProperty,
@@ -89,7 +89,7 @@ class DataTable extends Component {
     }
 
     return (
-      <StyledDataTable>
+      <StyledDataTable theme={theme} {...rest}>
         <Header
           columns={columns}
           filtering={filtering}

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -11,6 +11,102 @@ import { DataTable } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **columns**
 
 

--- a/src/js/components/DataTable/StyledDataTable.js
+++ b/src/js/components/DataTable/StyledDataTable.js
@@ -1,9 +1,12 @@
 import styled from 'styled-components';
 
+import { genericStyles } from '../../utils';
+
 export const StyledDataTable = styled.table`
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
+  ${genericStyles}
 `;
 
 export const StyledDataTableRow = styled.tr`

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -19,6 +19,7 @@ exports[`DataTable aggregate 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #F6F6F6;
   color: #444444;
   border-bottom: solid 2px rgba(0,0,0,0.33);
@@ -33,7 +34,6 @@ exports[`DataTable aggregate 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -48,13 +48,13 @@ exports[`DataTable aggregate 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -69,6 +69,7 @@ exports[`DataTable aggregate 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-top: solid 2px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
@@ -76,7 +77,6 @@ exports[`DataTable aggregate 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -114,18 +114,18 @@ exports[`DataTable aggregate 1`] = `
 
 @media only screen and (max-width:768px) {
   .c3 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
     border-bottom: solid 2px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
   .c3 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
     padding-left: 6px;
     padding-right: 6px;
   }
@@ -155,18 +155,18 @@ exports[`DataTable aggregate 1`] = `
   .c6 {
     padding-top: 3px;
     padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c7 {
     border-top: solid 2px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    margin: 0px;
   }
 }
 
@@ -189,6 +189,18 @@ exports[`DataTable aggregate 1`] = `
 >
   <table
     className="c1"
+    data={
+      Array [
+        Object {
+          "a": "one",
+          "b": 1,
+        },
+        Object {
+          "a": "two",
+          "b": 2,
+        },
+      ]
+    }
   >
     <thead
       className=""
@@ -341,6 +353,7 @@ exports[`DataTable basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #F6F6F6;
   color: #444444;
   border-bottom: solid 2px rgba(0,0,0,0.33);
@@ -355,7 +368,6 @@ exports[`DataTable basic 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -370,13 +382,13 @@ exports[`DataTable basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -414,13 +426,13 @@ exports[`DataTable basic 1`] = `
 
 @media only screen and (max-width:768px) {
   .c3 {
-    border-bottom: solid 2px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c3 {
-    margin: 0px;
+    border-bottom: solid 2px rgba(0,0,0,0.33);
   }
 }
 
@@ -463,6 +475,18 @@ exports[`DataTable basic 1`] = `
 >
   <table
     className="c1"
+    data={
+      Array [
+        Object {
+          "a": "one",
+          "b": 1,
+        },
+        Object {
+          "a": "two",
+          "b": 2,
+        },
+      ]
+    }
   >
     <thead
       className=""
@@ -590,6 +614,7 @@ exports[`DataTable empty 1`] = `
 >
   <table
     className="c1"
+    data={Array []}
   >
     <thead
       className=""
@@ -624,6 +649,7 @@ exports[`DataTable footer 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #F6F6F6;
   color: #444444;
   border-bottom: solid 2px rgba(0,0,0,0.33);
@@ -638,7 +664,6 @@ exports[`DataTable footer 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -653,13 +678,13 @@ exports[`DataTable footer 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -674,6 +699,7 @@ exports[`DataTable footer 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-top: solid 2px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
@@ -681,7 +707,6 @@ exports[`DataTable footer 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -719,18 +744,18 @@ exports[`DataTable footer 1`] = `
 
 @media only screen and (max-width:768px) {
   .c3 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
     border-bottom: solid 2px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
   .c3 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
     padding-left: 6px;
     padding-right: 6px;
   }
@@ -760,18 +785,18 @@ exports[`DataTable footer 1`] = `
   .c6 {
     padding-top: 3px;
     padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c7 {
     border-top: solid 2px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    margin: 0px;
   }
 }
 
@@ -794,6 +819,18 @@ exports[`DataTable footer 1`] = `
 >
   <table
     className="c1"
+    data={
+      Array [
+        Object {
+          "a": "one",
+          "b": 1,
+        },
+        Object {
+          "a": "two",
+          "b": 2,
+        },
+      ]
+    }
   >
     <thead
       className=""
@@ -978,6 +1015,7 @@ exports[`DataTable groupBy 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #F6F6F6;
   color: #444444;
   border-bottom: solid 2px rgba(0,0,0,0.33);
@@ -992,7 +1030,6 @@ exports[`DataTable groupBy 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -1007,13 +1044,13 @@ exports[`DataTable groupBy 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -1028,6 +1065,7 @@ exports[`DataTable groupBy 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #F6F6F6;
   color: #444444;
   border-bottom: solid 2px rgba(0,0,0,0.33);
@@ -1036,7 +1074,6 @@ exports[`DataTable groupBy 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 6px;
 }
 
@@ -1048,12 +1085,12 @@ exports[`DataTable groupBy 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 6px;
 }
 
@@ -1139,13 +1176,13 @@ exports[`DataTable groupBy 1`] = `
 
 @media only screen and (max-width:768px) {
   .c7 {
-    border-bottom: solid 2px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c7 {
-    margin: 0px;
+    border-bottom: solid 2px rgba(0,0,0,0.33);
   }
 }
 
@@ -1185,13 +1222,13 @@ exports[`DataTable groupBy 1`] = `
 
 @media only screen and (max-width:768px) {
   .c4 {
-    border-bottom: solid 2px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c4 {
-    margin: 0px;
+    border-bottom: solid 2px rgba(0,0,0,0.33);
   }
 }
 
@@ -1218,6 +1255,7 @@ exports[`DataTable groupBy 1`] = `
 >
   <table
     class="c1"
+    data="[object Object],[object Object],[object Object],[object Object]"
   >
     <thead
       class=""
@@ -1408,7 +1446,8 @@ exports[`DataTable groupBy 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <table
-    class="StyledDataTable-xrlyjm-0 DHZmE"
+    class="StyledDataTable-xrlyjm-0 eBJFIh"
+    data="[object Object],[object Object],[object Object],[object Object]"
   >
     <thead
       class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 gtdqEW"
@@ -1421,11 +1460,11 @@ exports[`DataTable groupBy 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 iXKwVW"
+            class="StyledButton-sc-323bzc-0 bQCefD"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 FrSQX"
+              class="StyledBox-sc-13pk1d4-0 gKSfrT"
             >
               <svg
                 aria-label="FormDown"
@@ -1451,10 +1490,10 @@ exports[`DataTable groupBy 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 jHrpsm"
+            class="StyledBox-sc-13pk1d4-0 fFqjDo"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 eWZOWJ"
+              class="StyledText-sc-1sadyjn-0 fWSbXS"
             >
               A
             </span>
@@ -1465,10 +1504,10 @@ exports[`DataTable groupBy 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 jHrpsm"
+            class="StyledBox-sc-13pk1d4-0 fFqjDo"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 eWZOWJ"
+              class="StyledText-sc-1sadyjn-0 fWSbXS"
             >
               B
             </span>
@@ -1487,11 +1526,11 @@ exports[`DataTable groupBy 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 iXKwVW"
+            class="StyledButton-sc-323bzc-0 bQCefD"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 iflIZZ"
+              class="StyledBox-sc-13pk1d4-0 dRGBoa"
             >
               <svg
                 aria-label="FormDown"
@@ -1517,10 +1556,10 @@ exports[`DataTable groupBy 2`] = `
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iKUajp"
+            class="StyledBox-sc-13pk1d4-0 lgOdJe"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 eWZOWJ"
+              class="StyledText-sc-1sadyjn-0 fWSbXS"
             >
               one
             </span>
@@ -1530,7 +1569,7 @@ exports[`DataTable groupBy 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kKCqZI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iKUajp"
+            class="StyledBox-sc-13pk1d4-0 lgOdJe"
           />
         </td>
       </tr>
@@ -1542,11 +1581,11 @@ exports[`DataTable groupBy 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 iXKwVW"
+            class="StyledButton-sc-323bzc-0 bQCefD"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 iflIZZ"
+              class="StyledBox-sc-13pk1d4-0 dRGBoa"
             >
               <svg
                 aria-label="FormDown"
@@ -1572,10 +1611,10 @@ exports[`DataTable groupBy 2`] = `
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iKUajp"
+            class="StyledBox-sc-13pk1d4-0 lgOdJe"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 eWZOWJ"
+              class="StyledText-sc-1sadyjn-0 fWSbXS"
             >
               two
             </span>
@@ -1585,7 +1624,7 @@ exports[`DataTable groupBy 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kKCqZI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iKUajp"
+            class="StyledBox-sc-13pk1d4-0 lgOdJe"
           />
         </td>
       </tr>
@@ -1613,6 +1652,7 @@ exports[`DataTable resizeable 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #F6F6F6;
   color: #444444;
   border-bottom: solid 2px rgba(0,0,0,0.33);
@@ -1627,7 +1667,6 @@ exports[`DataTable resizeable 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -1642,13 +1681,13 @@ exports[`DataTable resizeable 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -1663,6 +1702,7 @@ exports[`DataTable resizeable 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -1670,7 +1710,6 @@ exports[`DataTable resizeable 1`] = `
   flex-direction: row;
   width: 100%;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1682,6 +1721,7 @@ exports[`DataTable resizeable 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-right: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
@@ -1691,7 +1731,6 @@ exports[`DataTable resizeable 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1730,13 +1769,13 @@ exports[`DataTable resizeable 1`] = `
 
 @media only screen and (max-width:768px) {
   .c4 {
-    border-bottom: solid 2px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c4 {
-    margin: 0px;
+    border-bottom: solid 2px rgba(0,0,0,0.33);
   }
 }
 
@@ -1788,13 +1827,13 @@ exports[`DataTable resizeable 1`] = `
 
 @media only screen and (max-width:768px) {
   .c7 {
-    border-right: solid 1px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c7 {
-    margin: 0px;
+    border-right: solid 1px rgba(0,0,0,0.33);
   }
 }
 
@@ -1809,6 +1848,18 @@ exports[`DataTable resizeable 1`] = `
 >
   <table
     className="c1"
+    data={
+      Array [
+        Object {
+          "a": "one",
+          "b": 1,
+        },
+        Object {
+          "a": "two",
+          "b": 2,
+        },
+      ]
+    }
   >
     <thead
       className=""
@@ -1949,13 +2000,13 @@ exports[`DataTable sort 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -1970,6 +2021,7 @@ exports[`DataTable sort 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1987,7 +2039,6 @@ exports[`DataTable sort 1`] = `
   flex: 0 1 auto;
   width: 100%;
   height: 100%;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -2082,13 +2133,13 @@ exports[`DataTable sort 1`] = `
 
 @media only screen and (max-width:768px) {
   .c5 {
-    border-bottom: solid 2px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c5 {
-    margin: 0px;
+    border-bottom: solid 2px rgba(0,0,0,0.33);
   }
 }
 
@@ -2111,6 +2162,7 @@ exports[`DataTable sort 1`] = `
 >
   <table
     class="c1"
+    data="[object Object],[object Object],[object Object]"
   >
     <thead
       class=""
@@ -2255,7 +2307,8 @@ exports[`DataTable sort 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <table
-    class="StyledDataTable-xrlyjm-0 DHZmE"
+    class="StyledDataTable-xrlyjm-0 eBJFIh"
+    data="[object Object],[object Object],[object Object]"
   >
     <thead
       class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 gtdqEW"
@@ -2303,6 +2356,7 @@ exports[`DataTable sort 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2320,7 +2374,6 @@ exports[`DataTable sort 2`] = `
   flex: 0 1 auto;
   width: 100%;
   height: 100%;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -2387,13 +2440,13 @@ exports[`DataTable sort 2`] = `
 
 @media only screen and (max-width:768px) {
   .c3 {
-    border-bottom: solid 2px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c3 {
-    margin: 0px;
+    border-bottom: solid 2px rgba(0,0,0,0.33);
   }
 }
 
@@ -2457,6 +2510,7 @@ exports[`DataTable sort 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2474,7 +2528,6 @@ exports[`DataTable sort 2`] = `
   flex: 0 1 auto;
   width: 100%;
   height: 100%;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -2534,13 +2587,13 @@ exports[`DataTable sort 2`] = `
 
 @media only screen and (max-width:768px) {
   .c3 {
-    border-bottom: solid 2px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c3 {
-    margin: 0px;
+    border-bottom: solid 2px rgba(0,0,0,0.33);
   }
 }
 
@@ -2589,10 +2642,10 @@ exports[`DataTable sort 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kKCqZI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iKUajp"
+            class="StyledBox-sc-13pk1d4-0 lgOdJe"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 eWZOWJ"
+              class="StyledText-sc-1sadyjn-0 fWSbXS"
             >
               one
             </span>
@@ -2602,10 +2655,10 @@ exports[`DataTable sort 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kKCqZI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iKUajp"
+            class="StyledBox-sc-13pk1d4-0 lgOdJe"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 eWZOWJ"
+              class="StyledText-sc-1sadyjn-0 fWSbXS"
             >
               1
             </span>
@@ -2619,10 +2672,10 @@ exports[`DataTable sort 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kKCqZI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iKUajp"
+            class="StyledBox-sc-13pk1d4-0 lgOdJe"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 eWZOWJ"
+              class="StyledText-sc-1sadyjn-0 fWSbXS"
             >
               two
             </span>
@@ -2632,10 +2685,10 @@ exports[`DataTable sort 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kKCqZI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iKUajp"
+            class="StyledBox-sc-13pk1d4-0 lgOdJe"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 eWZOWJ"
+              class="StyledText-sc-1sadyjn-0 fWSbXS"
             >
               2
             </span>
@@ -2649,10 +2702,10 @@ exports[`DataTable sort 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kKCqZI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iKUajp"
+            class="StyledBox-sc-13pk1d4-0 lgOdJe"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 eWZOWJ"
+              class="StyledText-sc-1sadyjn-0 fWSbXS"
             >
               zero
             </span>
@@ -2662,7 +2715,7 @@ exports[`DataTable sort 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kKCqZI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iKUajp"
+            class="StyledBox-sc-13pk1d4-0 lgOdJe"
           />
         </td>
       </tr>

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (DataTable) => {
   const DocumentedDataTable = describe(DataTable)
@@ -12,6 +12,7 @@ export const doc = (DataTable) => {
       );
 
   DocumentedDataTable.propTypes = {
+    ...genericProps,
     columns: PropTypes.arrayOf(PropTypes.shape({
       align: PropTypes.oneOf(['center', 'start', 'end']),
       aggregate: PropTypes.oneOf(['avg', 'max', 'min', 'sum']),

--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
 export interface DataTableProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   columns?: {align: "center" | "start" | "end",aggregate: "avg" | "max" | "min" | "sum",footer: React.ReactNode | {aggregate: boolean},header: string | React.ReactNode | {aggregate: boolean},property: string,render: (...args: any[]) => any,search: boolean}[];
   data?: {}[];
   groupBy?: string;

--- a/src/js/components/Diagram/__tests__/__snapshots__/Diagram-test.js.snap
+++ b/src/js/components/Diagram/__tests__/__snapshots__/Diagram-test.js.snap
@@ -9,12 +9,12 @@ exports[`Diagram anchor 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -26,12 +26,12 @@ exports[`Diagram anchor 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 24px;
 }
 
@@ -163,12 +163,12 @@ exports[`Diagram basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -180,12 +180,12 @@ exports[`Diagram basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 24px;
 }
 
@@ -301,12 +301,12 @@ exports[`Diagram color 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -318,12 +318,12 @@ exports[`Diagram color 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 24px;
 }
 
@@ -439,12 +439,12 @@ exports[`Diagram offset 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -456,12 +456,12 @@ exports[`Diagram offset 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 24px;
 }
 
@@ -593,12 +593,12 @@ exports[`Diagram thickness 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -610,12 +610,12 @@ exports[`Diagram thickness 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 24px;
 }
 
@@ -771,12 +771,12 @@ exports[`Diagram type 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -788,12 +788,12 @@ exports[`Diagram type 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 24px;
 }
 

--- a/src/js/components/Distribution/README.md
+++ b/src/js/components/Distribution/README.md
@@ -15,6 +15,102 @@ import { Distribution } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **children**
 
 Function that will be called when each value is rendered.

--- a/src/js/components/Distribution/__tests__/__snapshots__/Distribution-test.js.snap
+++ b/src/js/components/Distribution/__tests__/__snapshots__/Distribution-test.js.snap
@@ -19,6 +19,7 @@ exports[`Distribution gap renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -27,7 +28,6 @@ exports[`Distribution gap renders 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding: 0px;
   overflow: hidden;
 }
@@ -39,6 +39,7 @@ exports[`Distribution gap renders 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -50,7 +51,6 @@ exports[`Distribution gap renders 1`] = `
   -webkit-flex-basis: 50%;
   -ms-flex-preferred-size: 50%;
   flex-basis: 50%;
-  margin: 0px;
   padding: 0px;
   overflow: hidden;
 }
@@ -62,6 +62,7 @@ exports[`Distribution gap renders 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -73,7 +74,6 @@ exports[`Distribution gap renders 1`] = `
   -webkit-flex-basis: 66.66%;
   -ms-flex-preferred-size: 66.66%;
   flex-basis: 66.66%;
-  margin: 0px;
   padding: 0px;
   overflow: hidden;
 }
@@ -85,6 +85,7 @@ exports[`Distribution gap renders 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -96,7 +97,6 @@ exports[`Distribution gap renders 1`] = `
   -webkit-flex-basis: 33.33%;
   -ms-flex-preferred-size: 33.33%;
   flex-basis: 33.33%;
-  margin: 0px;
   padding: 0px;
   overflow: hidden;
 }
@@ -410,6 +410,7 @@ exports[`Distribution values renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -418,7 +419,6 @@ exports[`Distribution values renders 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding: 0px;
   overflow: hidden;
 }
@@ -430,6 +430,7 @@ exports[`Distribution values renders 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -441,7 +442,6 @@ exports[`Distribution values renders 1`] = `
   -webkit-flex-basis: 75%;
   -ms-flex-preferred-size: 75%;
   flex-basis: 75%;
-  margin: 0px;
   padding: 0px;
   overflow: hidden;
 }
@@ -453,6 +453,7 @@ exports[`Distribution values renders 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -464,7 +465,6 @@ exports[`Distribution values renders 1`] = `
   -webkit-flex-basis: 25%;
   -ms-flex-preferred-size: 25%;
   flex-basis: 25%;
-  margin: 0px;
   padding: 0px;
   overflow: hidden;
 }
@@ -476,6 +476,7 @@ exports[`Distribution values renders 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -487,7 +488,6 @@ exports[`Distribution values renders 1`] = `
   -webkit-flex-basis: 50%;
   -ms-flex-preferred-size: 50%;
   flex-basis: 50%;
-  margin: 0px;
   padding: 0px;
   overflow: hidden;
 }
@@ -499,6 +499,7 @@ exports[`Distribution values renders 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -510,7 +511,6 @@ exports[`Distribution values renders 1`] = `
   -webkit-flex-basis: 50%;
   -ms-flex-preferred-size: 50%;
   flex-basis: 50%;
-  margin: 0px;
   padding: 0px;
   overflow: hidden;
 }
@@ -522,6 +522,7 @@ exports[`Distribution values renders 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -533,7 +534,6 @@ exports[`Distribution values renders 1`] = `
   -webkit-flex-basis: 66.66%;
   -ms-flex-preferred-size: 66.66%;
   flex-basis: 66.66%;
-  margin: 0px;
   padding: 0px;
   overflow: hidden;
 }
@@ -545,6 +545,7 @@ exports[`Distribution values renders 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -556,7 +557,6 @@ exports[`Distribution values renders 1`] = `
   -webkit-flex-basis: 33.33%;
   -ms-flex-preferred-size: 33.33%;
   flex-basis: 33.33%;
-  margin: 0px;
   padding: 0px;
   overflow: hidden;
 }

--- a/src/js/components/Distribution/doc.js
+++ b/src/js/components/Distribution/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Distribution) => {
   const DocumentedDistribution = describe(Distribution)
@@ -13,6 +13,7 @@ export const doc = (Distribution) => {
     .usage("import { Distribution } from 'grommet';\n<Distribution />");
 
   DocumentedDistribution.propTypes = {
+    ...genericProps,
     children: PropTypes.func.description(
       'Function that will be called when each value is rendered.'
     ),

--- a/src/js/components/Distribution/index.d.ts
+++ b/src/js/components/Distribution/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
 export interface DistributionProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   children?: (...args: any[]) => any;
   gap?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   values: {value: number}[];

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -9,12 +9,12 @@ exports[`Drop align left random 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -81,7 +81,7 @@ exports[`Drop align left random 1`] = `
 exports[`Drop align left random 2`] = `
 "
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -89,24 +89,24 @@ exports[`Drop align left random 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
@@ -186,12 +186,12 @@ exports[`Drop align left right top bottom 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -258,7 +258,7 @@ exports[`Drop align left right top bottom 1`] = `
 exports[`Drop align left right top bottom 2`] = `
 "
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -266,24 +266,24 @@ exports[`Drop align left right top bottom 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
@@ -337,12 +337,12 @@ exports[`Drop align right left top top 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -409,7 +409,7 @@ exports[`Drop align right left top top 1`] = `
 exports[`Drop align right left top top 2`] = `
 "
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -417,24 +417,24 @@ exports[`Drop align right left top top 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
@@ -527,12 +527,12 @@ exports[`Drop align right random 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -599,7 +599,7 @@ exports[`Drop align right random 1`] = `
 exports[`Drop align right random 2`] = `
 "
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -607,24 +607,24 @@ exports[`Drop align right random 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
@@ -717,12 +717,12 @@ exports[`Drop align right right bottom top 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -789,7 +789,7 @@ exports[`Drop align right right bottom top 1`] = `
 exports[`Drop align right right bottom top 2`] = `
 "
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -797,24 +797,24 @@ exports[`Drop align right right bottom top 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
@@ -881,12 +881,12 @@ exports[`Drop align right right bottom top 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -953,7 +953,7 @@ exports[`Drop align right right bottom top 3`] = `
 exports[`Drop align right right bottom top 4`] = `
 "
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -961,24 +961,24 @@ exports[`Drop align right right bottom top 4`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
@@ -1071,12 +1071,12 @@ exports[`Drop basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -1143,7 +1143,7 @@ exports[`Drop basic 1`] = `
 exports[`Drop basic 2`] = `
 "
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1151,24 +1151,24 @@ exports[`Drop basic 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
@@ -1222,12 +1222,12 @@ exports[`Drop close 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -1294,7 +1294,7 @@ exports[`Drop close 1`] = `
 exports[`Drop close 2`] = `
 "
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1302,24 +1302,24 @@ exports[`Drop close 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
@@ -1412,12 +1412,12 @@ exports[`Drop invalid align 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -1484,7 +1484,7 @@ exports[`Drop invalid align 1`] = `
 exports[`Drop invalid align 2`] = `
 "
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1492,24 +1492,24 @@ exports[`Drop invalid align 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
@@ -1602,12 +1602,12 @@ exports[`Drop invoke onClickOutside 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -1674,7 +1674,7 @@ exports[`Drop invoke onClickOutside 1`] = `
 exports[`Drop invoke onClickOutside 2`] = `
 "
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1682,24 +1682,24 @@ exports[`Drop invoke onClickOutside 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
@@ -1792,12 +1792,12 @@ exports[`Drop no stretch 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -1864,7 +1864,7 @@ exports[`Drop no stretch 1`] = `
 exports[`Drop no stretch 2`] = `
 "
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1872,24 +1872,24 @@ exports[`Drop no stretch 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
@@ -1982,12 +1982,12 @@ exports[`Drop resize 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -2054,7 +2054,7 @@ exports[`Drop resize 1`] = `
 exports[`Drop resize 2`] = `
 "
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2062,24 +2062,24 @@ exports[`Drop resize 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
@@ -2172,12 +2172,12 @@ exports[`Drop restrict focus 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -2243,7 +2243,7 @@ exports[`Drop restrict focus 1`] = `
 
 exports[`Drop restrict focus 2`] = `
 <div
-  class="StyledDrop-sc-16s5rx8-0 cShzna StyledBox-sc-13pk1d4-0 gZcqrw"
+  class="StyledDrop-sc-16s5rx8-0 cShzna StyledBox-sc-13pk1d4-0 dJDrdW"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
   tabindex="-1"
@@ -2255,7 +2255,7 @@ exports[`Drop restrict focus 2`] = `
 exports[`Drop restrict focus 3`] = `
 "
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2263,24 +2263,24 @@ exports[`Drop restrict focus 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }

--- a/src/js/components/DropButton/README.md
+++ b/src/js/components/DropButton/README.md
@@ -22,6 +22,94 @@ Custom title to be used by screen readers.
 string
 ```
 
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **disabled**
 
 Whether the button should be disabled.

--- a/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
+++ b/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
@@ -9,6 +9,7 @@ exports[`DropButton close by clicking outside 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -22,7 +23,6 @@ exports[`DropButton close by clicking outside 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -87,25 +87,25 @@ exports[`DropButton close by clicking outside 2`] = `
 
 exports[`DropButton close by clicking outside 3`] = `
 "@media only screen and (max-width:768px) {
-  .gYYddl {
+  .MJmug {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gYYddl {
+  .MJmug {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
@@ -133,6 +133,7 @@ exports[`DropButton closed 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -146,7 +147,6 @@ exports[`DropButton closed 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -213,6 +213,7 @@ exports[`DropButton disabled 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -226,7 +227,6 @@ exports[`DropButton disabled 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -289,6 +289,7 @@ exports[`DropButton open and close 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -302,7 +303,6 @@ exports[`DropButton open and close 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -367,25 +367,25 @@ exports[`DropButton open and close 2`] = `
 
 exports[`DropButton open and close 3`] = `
 "@media only screen and (max-width:768px) {
-  .gYYddl {
+  .MJmug {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gYYddl {
+  .MJmug {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
@@ -413,6 +413,7 @@ exports[`DropButton opened 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -426,7 +427,6 @@ exports[`DropButton opened 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -493,6 +493,7 @@ exports[`DropButton opened ref 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -506,7 +507,6 @@ exports[`DropButton opened ref 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -571,25 +571,25 @@ exports[`DropButton opened ref 2`] = `
 
 exports[`DropButton opened ref 3`] = `
 "@media only screen and (max-width:768px) {
-  .gYYddl {
+  .MJmug {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gYYddl {
+  .MJmug {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }

--- a/src/js/components/DropButton/doc.js
+++ b/src/js/components/DropButton/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (DropButton) => {
   const DocumentedDropButton = describe(DropButton)
@@ -16,8 +16,7 @@ export const doc = (DropButton) => {
     );
 
   DocumentedDropButton.propTypes = {
-    a11yTitle: PropTypes.string
-      .description('Custom title to be used by screen readers.'),
+    ...genericProps,
     disabled: PropTypes.bool
       .description('Whether the button should be disabled.'),
     dropAlign: PropTypes.shape({

--- a/src/js/components/DropButton/index.d.ts
+++ b/src/js/components/DropButton/index.d.ts
@@ -2,6 +2,9 @@ import * as React from "react";
 
 export interface DropButtonProps {
   a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   disabled?: boolean;
   dropAlign?: {top: "top" | "bottom",bottom: "top" | "bottom",right: "left" | "right",left: "left" | "right"};
   dropContent: JSX.Element;

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -19,12 +19,12 @@ exports[`renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-bottom: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-bottom: 12px;
   padding: 0px;
 }
 
@@ -36,13 +36,13 @@ exports[`renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -103,13 +103,13 @@ exports[`renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c2 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c2 {
-    margin: 0px;
+    border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
@@ -175,12 +175,12 @@ exports[`renders error 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-bottom: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-bottom: 12px;
   padding: 0px;
 }
 
@@ -192,15 +192,15 @@ exports[`renders error 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 6px;
-  margin-bottom: 6px;
   padding: 0px;
 }
 
@@ -212,13 +212,13 @@ exports[`renders error 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-bottom: solid 1px #EB6060;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -262,13 +262,13 @@ exports[`renders error 1`] = `
 
 @media only screen and (max-width:768px) {
   .c2 {
-    border-bottom: solid 1px #EB6060;
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c2 {
-    margin: 0px;
+    border-bottom: solid 1px #EB6060;
   }
 }
 
@@ -321,12 +321,12 @@ exports[`renders help 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-bottom: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-bottom: 12px;
   padding: 0px;
 }
 
@@ -338,13 +338,13 @@ exports[`renders help 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -356,15 +356,15 @@ exports[`renders help 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 6px;
-  margin-bottom: 6px;
   padding: 0px;
 }
 
@@ -388,13 +388,13 @@ exports[`renders help 1`] = `
 
 @media only screen and (max-width:768px) {
   .c4 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c4 {
-    margin: 0px;
+    border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
@@ -467,12 +467,12 @@ exports[`renders htmlFor 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-bottom: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-bottom: 12px;
   padding: 0px;
 }
 
@@ -484,13 +484,13 @@ exports[`renders htmlFor 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -508,13 +508,13 @@ exports[`renders htmlFor 1`] = `
 
 @media only screen and (max-width:768px) {
   .c2 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c2 {
-    margin: 0px;
+    border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
@@ -558,12 +558,12 @@ exports[`renders label 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-bottom: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-bottom: 12px;
   padding: 0px;
 }
 
@@ -575,13 +575,13 @@ exports[`renders label 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -593,15 +593,15 @@ exports[`renders label 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 6px;
-  margin-bottom: 6px;
   padding: 0px;
 }
 
@@ -624,13 +624,13 @@ exports[`renders label 1`] = `
 
 @media only screen and (max-width:768px) {
   .c4 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
+    margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c4 {
-    margin: 0px;
+    border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 

--- a/src/js/components/Grid/README.md
+++ b/src/js/components/Grid/README.md
@@ -16,6 +16,102 @@ import { Grid } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **align**
 
 How to align the individual items inside the grid when there is extra

--- a/src/js/components/Grid/StyledGrid.js
+++ b/src/js/components/Grid/StyledGrid.js
@@ -1,5 +1,7 @@
 import styled, { css } from 'styled-components';
 
+import { genericStyles } from '../../utils';
+
 const fillStyle = (fill) => {
   if (fill === 'horizontal') {
     return 'width: 100%;';
@@ -168,6 +170,7 @@ export const StyledGrid = styled.div`
   display: grid;
   box-sizing: border-box;
 
+  ${genericStyles}
   ${props => props.fillContainer && fillStyle(props.fillContainer)}
   ${props => props.align && alignStyle}
   ${props => props.alignContent && alignContentStyle}

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 const fixedSizes = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
 const sizes = ['xsmall', 'small', 'medium', 'large', 'xlarge',
@@ -23,6 +23,7 @@ to create fallback rendering for older browsers, like ie11.`
     );
 
   DocumentedGrid.propTypes = {
+    ...genericProps,
     align: PropTypes.oneOf(['start', 'center', 'end', 'stretch']).description(
       `How to align the individual items inside the grid when there is extra
 space in the column axis.`

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
 export interface GridProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   align?: "start" | "center" | "end" | "stretch";
   alignContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
   areas?: {name: string,start: number[],end: number[]}[];

--- a/src/js/components/Heading/README.md
+++ b/src/js/components/Heading/README.md
@@ -11,6 +11,102 @@ import { Heading } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **color**
 
 A color identifier to use for the text color. For example:
@@ -35,39 +131,6 @@ The sizing can be further adjusted using the size property.
 2
 3
 4
-```
-
-**margin**
-
-The amount of margin above and/or below the heading. An object can be
-specified to distinguish top margin and bottom margin.
-
-```
-none
-xsmall
-small
-medium
-large
-xlarge
-{
-  bottom: 
-    none
-    xsmall
-    small
-    medium
-    large
-    xlarge
-    string,
-  top: 
-    none
-    xsmall
-    small
-    medium
-    large
-    xlarge
-    string
-}
-string
 ```
 
 **responsive**

--- a/src/js/components/Heading/StyledHeading.js
+++ b/src/js/components/Heading/StyledHeading.js
@@ -1,66 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { normalizeColor, breakpointStyle } from '../../utils';
-
-const marginStyle = (props) => {
-  if (typeof props.margin === 'string') {
-    const margin = props.theme.global.edgeSize[props.margin];
-    const styles = [css`
-      margin-top: ${margin};
-      margin-bottom: ${margin};
-    `];
-    if (props.responsive) {
-      Object.keys(props.theme.global.breakpoints).forEach((name) => {
-        const breakpoint = props.theme.global.breakpoints[name];
-        if (breakpoint.edgeSize
-          && breakpoint.edgeSize[props.margin] !== undefined) {
-          const responsiveMargin = breakpoint.edgeSize[props.margin];
-          styles.push(breakpointStyle(breakpoint, `
-            margin-top: ${responsiveMargin};
-            margin-bottom: ${responsiveMargin};
-          `));
-        }
-      });
-    }
-    return styles;
-  }
-  const styles = [];
-  if (props.margin.top) {
-    if (props.margin.top === 'none') {
-      styles.push(css`margin-top: 0;`);
-    } else {
-      styles.push(css`margin-top: ${props.theme.global.edgeSize[props.margin.top]};`);
-      if (props.responsive) {
-        Object.keys(props.theme.global.breakpoints).forEach((name) => {
-          const breakpoint = props.theme.global.breakpoints[name];
-          if (breakpoint.edgeSize
-            && breakpoint.edgeSize[props.margin.top] !== undefined) {
-            styles.push(breakpointStyle(breakpoint,
-              `margin-top: ${breakpoint.edgeSize[props.margin.top]};`));
-          }
-        });
-      }
-    }
-  }
-  if (props.margin.bottom) {
-    if (props.margin.bottom === 'none') {
-      styles.push(css`margin-bottom: 0;`);
-    } else {
-      styles.push(css`margin-bottom: ${props.theme.global.edgeSize[props.margin.bottom]};`);
-      if (props.responsive) {
-        Object.keys(props.theme.global.breakpoints).forEach((name) => {
-          const breakpoint = props.theme.global.breakpoints[name];
-          if (breakpoint.edgeSize
-            && breakpoint.edgeSize[props.margin.bottom] !== undefined) {
-            styles.push(breakpointStyle(breakpoint,
-              `margin-bottom: ${breakpoint.edgeSize[props.margin.bottom]};`));
-          }
-        });
-      }
-    }
-  }
-  return styles;
-};
+import { breakpointStyle, genericStyles, normalizeColor } from '../../utils';
 
 const sizeStyle = (props) => {
   // size is a combination of the level and size properties
@@ -108,11 +48,11 @@ const colorStyle = css`
 `;
 
 export const StyledHeading = styled.h1`
+  ${genericStyles}
   ${props => props.theme.heading.font && css`
     font-family: ${props.theme.heading.font.family};
   `}
   ${props => sizeStyle(props)}
-  ${props => props.margin && marginStyle(props)}
   ${props => props.textAlign && textAlignStyle}
   ${props => props.truncate && truncateStyle}
   ${props => props.colorValue && colorStyle}

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -149,71 +149,73 @@ exports[`Heading margin renders 1`] = `
 }
 
 .c1 {
+  margin: 12px;
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
   font-weight: 600;
-  margin-top: 12px;
-  margin-bottom: 12px;
 }
 
 .c2 {
+  margin: 24px;
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
   font-weight: 600;
-  margin-top: 24px;
-  margin-bottom: 24px;
 }
 
 .c3 {
+  margin: 48px;
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
   font-weight: 600;
-  margin-top: 48px;
-  margin-bottom: 48px;
 }
 
 .c4 {
+  margin: 0px;
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
   font-weight: 600;
-  margin-top: 0px;
-  margin-bottom: 0px;
 }
 
 .c5 {
+  margin-bottom: 12px;
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
   font-weight: 600;
-  margin-bottom: 12px;
 }
 
 .c6 {
+  margin-top: 12px;
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
   font-weight: 600;
-  margin-top: 12px;
 }
 
 .c7 {
+  margin-bottom: 0px;
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
   font-weight: 600;
-  margin-bottom: 0;
 }
 
 .c8 {
+  margin-top: 0px;
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
   font-weight: 600;
-  margin-top: 0;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 6px;
+  }
 }
 
 @media only screen and (max-width:768px) {
@@ -225,14 +227,55 @@ exports[`Heading margin renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
-    margin-top: 6px;
+  .c2 {
+    margin: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    font-size: 34px;
+    line-height: 40px;
+    max-width: 816px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    margin: 24px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    font-size: 34px;
+    line-height: 40px;
+    max-width: 816px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    font-size: 34px;
+    line-height: 40px;
+    max-width: 816px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c5 {
     font-size: 34px;
     line-height: 40px;
     max-width: 816px;
@@ -240,14 +283,13 @@ exports[`Heading margin renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
-    margin-top: 12px;
-    margin-bottom: 12px;
+  .c6 {
+    margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c6 {
     font-size: 34px;
     line-height: 40px;
     max-width: 816px;
@@ -255,52 +297,8 @@ exports[`Heading margin renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
-    margin-top: 24px;
-    margin-bottom: 24px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c4 {
-    font-size: 34px;
-    line-height: 40px;
-    max-width: 816px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c4 {
-    margin-top: 0px;
+  .c7 {
     margin-bottom: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
-    font-size: 34px;
-    line-height: 40px;
-    max-width: 816px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    font-size: 34px;
-    line-height: 40px;
-    max-width: 816px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    margin-top: 6px;
   }
 }
 
@@ -309,6 +307,12 @@ exports[`Heading margin renders 1`] = `
     font-size: 34px;
     line-height: 40px;
     max-width: 816px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    margin-top: 0px;
   }
 }
 

--- a/src/js/components/Heading/doc.js
+++ b/src/js/components/Heading/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Heading) => {
   const DocumentedHeading = describe(Heading)
@@ -12,6 +12,7 @@ export const doc = (Heading) => {
     );
 
   DocumentedHeading.propTypes = {
+    ...genericProps,
     color: PropTypes.string.description(
       `A color identifier to use for the text color. For example:
       'brand'.`
@@ -20,23 +21,6 @@ export const doc = (Heading) => {
       `The heading level. It corresponds to the number after the 'H' for
 the DOM tag. Set the level for semantic accuracy and accessibility.
 The sizing can be further adjusted using the size property.`
-    ),
-    margin: PropTypes.oneOfType([
-      PropTypes.oneOf(['none', 'xsmall', 'small', 'medium', 'large', 'xlarge']),
-      PropTypes.shape({
-        bottom: PropTypes.oneOfType([
-          PropTypes.oneOf(['none', 'xsmall', 'small', 'medium', 'large', 'xlarge']),
-          PropTypes.string,
-        ]),
-        top: PropTypes.oneOfType([
-          PropTypes.oneOf(['none', 'xsmall', 'small', 'medium', 'large', 'xlarge']),
-          PropTypes.string,
-        ]),
-      }),
-      PropTypes.string,
-    ]).description(
-      `The amount of margin above and/or below the heading. An object can be
-specified to distinguish top margin and bottom margin.`
     ),
     responsive: PropTypes.bool.description(
       `Whether the font size should be scaled for

--- a/src/js/components/Heading/index.d.ts
+++ b/src/js/components/Heading/index.d.ts
@@ -1,9 +1,12 @@
 import * as React from "react";
 
 export interface HeadingProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   color?: string;
   level?: "1" | "2" | "3" | "4" | "1" | "2" | "3" | "4";
-  margin?: "none" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "none" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "none" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   responsive?: boolean;
   size?: "small" | "medium" | "large" | string;
   textAlign?: "start" | "center" | "end";

--- a/src/js/components/Image/README.md
+++ b/src/js/components/Image/README.md
@@ -11,6 +11,102 @@ import { Image } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **fit**
 
 How the image fills its container.

--- a/src/js/components/Image/StyledImage.js
+++ b/src/js/components/Image/StyledImage.js
@@ -1,5 +1,7 @@
 import styled, { css } from 'styled-components';
 
+import { genericStyles } from '../../utils';
+
 const FIT_MAP = {
   cover: 'cover',
   contain: 'contain',
@@ -12,6 +14,7 @@ const fitStyle = css`
 `;
 
 export const StyledImage = styled.img`
+  ${genericStyles}
   ${props => props.fit && fitStyle}
   ${props => props.theme.image && props.theme.image.extend}
 `;

--- a/src/js/components/Image/doc.js
+++ b/src/js/components/Image/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Image) => {
   const DocumentedImage = describe(Image)
@@ -12,6 +12,7 @@ export const doc = (Image) => {
     );
 
   DocumentedImage.propTypes = {
+    ...genericProps,
     fit: PropTypes.oneOf(['cover', 'contain']).description(
       'How the image fills its container.'
     ),

--- a/src/js/components/Image/image.stories.js
+++ b/src/js/components/Image/image.stories.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { Grommet, Image } from 'grommet';
+import { grommet } from 'grommet/themes';
+
+const Simple = () => (
+  <Grommet theme={grommet}>
+    <Image src='//v2.grommet.io/assets/IMG_4245.jpg' />
+  </Grommet>
+);
+
+storiesOf('Image', module)
+  .add('Simple', () => <Simple />);

--- a/src/js/components/Image/index.d.ts
+++ b/src/js/components/Image/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
 export interface ImageProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   fit?: "cover" | "contain";
 }
 

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -63,13 +63,13 @@ exports[`Layer dark context 1`] = `
 
 exports[`Layer dark context 2`] = `
 "@media only screen and (max-width:768px) {
-  .ifqBeJ {
+  .dwiZmN {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ifqBeJ {
+  .dwiZmN {
     padding: 0px;
   }
 }"

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -142,55 +142,54 @@ class Menu extends Component {
         onTab={this.onDropClose}
         onKeyDown={onKeyDown}
       >
-        <div>
-          <DropButton
-            ref={forwardRef}
-            {...rest}
-            a11yTitle={messages.openMenu || 'Open Menu'}
-            disabled={disabled}
-            dropAlign={dropAlign}
-            dropTarget={dropTarget}
-            open={open}
-            onOpen={() => this.setState({ open: true })}
-            onClose={() => this.setState({ open: false })}
-            dropContent={(
-              <ContainerBox background={dropBackground}>
-                {dropAlign.top === 'top' ? controlMirror : undefined}
-                <Box overflow='auto'>
-                  {items.map(
-                    (item, index) => (
-                      <Box key={`menuItem_${index + 0}`} flex={false}>
-                        <Button
-                          ref={(ref) => {
-                            this.buttonRefs[index] = ref;
-                          }}
-                          active={activeItemIndex === index}
-                          hoverIndicator='background'
-                          disabled={!item.onClick && !item.href}
-                          onClick={(...args) => {
-                            item.onClick(...args);
-                            if (item.close !== false) {
-                              this.onDropClose();
-                            }
-                          }}
-                          href={item.href}
-                        >
-                          <Box align='start' pad='small' direction='row'>
-                            {item.icon}
-                            {item.label}
-                          </Box>
-                        </Button>
-                      </Box>
-                    )
-                  )}
-                </Box>
-                {dropAlign.bottom === 'bottom' ? controlMirror : undefined }
-              </ContainerBox>
-            )}
-          >
-            {content}
-          </DropButton>
-        </div>
+        <DropButton
+          ref={forwardRef}
+          {...rest}
+          a11yTitle={messages.openMenu || 'Open Menu'}
+          disabled={disabled}
+          dropAlign={dropAlign}
+          dropTarget={dropTarget}
+          open={open}
+          theme={theme}
+          onOpen={() => this.setState({ open: true })}
+          onClose={() => this.setState({ open: false })}
+          dropContent={(
+            <ContainerBox background={dropBackground}>
+              {dropAlign.top === 'top' ? controlMirror : undefined}
+              <Box overflow='auto'>
+                {items.map(
+                  (item, index) => (
+                    <Box key={`menuItem_${index + 0}`} flex={false}>
+                      <Button
+                        ref={(ref) => {
+                          this.buttonRefs[index] = ref;
+                        }}
+                        active={activeItemIndex === index}
+                        hoverIndicator='background'
+                        disabled={!item.onClick && !item.href}
+                        onClick={(...args) => {
+                          item.onClick(...args);
+                          if (item.close !== false) {
+                            this.onDropClose();
+                          }
+                        }}
+                        href={item.href}
+                      >
+                        <Box align='start' pad='small' direction='row'>
+                          {item.icon}
+                          {item.label}
+                        </Box>
+                      </Button>
+                    </Box>
+                  )
+                )}
+              </Box>
+              {dropAlign.bottom === 'bottom' ? controlMirror : undefined }
+            </ContainerBox>
+          )}
+        >
+          {content}
+        </DropButton>
       </Keyboard>
     );
   }

--- a/src/js/components/Menu/README.md
+++ b/src/js/components/Menu/README.md
@@ -12,6 +12,102 @@ import { Menu } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **disabled**
 
 Whether the menu should be disabled.

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -9,6 +9,7 @@ exports[`Menu basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -22,7 +23,6 @@ exports[`Menu basic 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -81,33 +81,30 @@ exports[`Menu basic 1`] = `
 <div
   className="c0"
 >
-  <div
+  <button
+    aria-label="Open Menu"
+    className="c1"
+    id="test-menu"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
+    type="button"
   >
-    <button
-      aria-label="Open Menu"
-      className="c1"
-      id="test-menu"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      type="button"
+    <div
+      className="c2"
     >
-      <div
-        className="c2"
+      <span
+        className="c3"
       >
-        <span
-          className="c3"
-        >
-          Test Menu
-        </span>
-        <div
-          className="c4"
-        />
-        <svg />
-      </div>
-    </button>
-  </div>
+        Test Menu
+      </span>
+      <div
+        className="c4"
+      />
+      <svg />
+    </div>
+  </button>
 </div>
 `;
 
@@ -152,6 +149,7 @@ exports[`Menu close by clicking outside 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -165,7 +163,6 @@ exports[`Menu close by clicking outside 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -224,43 +221,41 @@ exports[`Menu close by clicking outside 1`] = `
 <div
   class="c0"
 >
-  <div>
-    <button
-      aria-label="Open Menu"
-      class="c1"
-      id="test-menu"
-      type="button"
+  <button
+    aria-label="Open Menu"
+    class="c1"
+    id="test-menu"
+    type="button"
+  >
+    <div
+      class="c2"
     >
-      <div
-        class="c2"
+      <span
+        class="c3"
       >
-        <span
-          class="c3"
-        >
-          Test
-        </span>
-        <div
-          class="c4"
+        Test
+      </span>
+      <div
+        class="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        class="c5"
+        height="24px"
+        role="img"
+        version="1.1"
+        viewBox="0 0 24 24"
+        width="24px"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          stroke-width="2"
         />
-        <svg
-          aria-label="FormDown"
-          class="c5"
-          height="24px"
-          role="img"
-          version="1.1"
-          viewBox="0 0 24 24"
-          width="24px"
-        >
-          <polyline
-            fill="none"
-            points="18 9 12 15 6 9"
-            stroke="#000"
-            stroke-width="2"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
+      </svg>
+    </div>
+  </button>
 </div>
 `;
 
@@ -305,6 +300,7 @@ exports[`Menu close by clicking outside 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -318,7 +314,6 @@ exports[`Menu close by clicking outside 2`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -330,12 +325,12 @@ exports[`Menu close by clicking outside 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -348,12 +343,12 @@ exports[`Menu close by clicking outside 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -365,6 +360,7 @@ exports[`Menu close by clicking outside 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -373,7 +369,6 @@ exports[`Menu close by clicking outside 2`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -385,12 +380,12 @@ exports[`Menu close by clicking outside 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -403,6 +398,7 @@ exports[`Menu close by clicking outside 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -412,7 +408,6 @@ exports[`Menu close by clicking outside 2`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -674,18 +669,18 @@ exports[`Menu close by clicking outside 3`] = `
 "
 
 @media only screen and (max-width:768px) {
-  .iFQIIs {
+  .bSNzLY {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .iFQIIs {
+  .bSNzLY {
     padding: 6px;
   }
 }
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -693,72 +688,72 @@ exports[`Menu close by clicking outside 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kWLcGV {
+  .cJEczh {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kWLcGV {
+  .cJEczh {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hOiaYa {
+  .dUQcVP {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hOiaYa {
+  .dUQcVP {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .blARAh {
+  .gFbzfm {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .blARAh {
+  .gFbzfm {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fwWSQs {
+  .cIGhQH {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fwWSQs {
+  .cIGhQH {
     padding: 6px;
   }
 }
@@ -844,6 +839,7 @@ exports[`Menu close on esc 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -857,7 +853,6 @@ exports[`Menu close on esc 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -916,43 +911,41 @@ exports[`Menu close on esc 1`] = `
 <div
   class="c0"
 >
-  <div>
-    <button
-      aria-label="Open Menu"
-      class="c1"
-      id="test-menu"
-      type="button"
+  <button
+    aria-label="Open Menu"
+    class="c1"
+    id="test-menu"
+    type="button"
+  >
+    <div
+      class="c2"
     >
-      <div
-        class="c2"
+      <span
+        class="c3"
       >
-        <span
-          class="c3"
-        >
-          Test
-        </span>
-        <div
-          class="c4"
+        Test
+      </span>
+      <div
+        class="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        class="c5"
+        height="24px"
+        role="img"
+        version="1.1"
+        viewBox="0 0 24 24"
+        width="24px"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          stroke-width="2"
         />
-        <svg
-          aria-label="FormDown"
-          class="c5"
-          height="24px"
-          role="img"
-          version="1.1"
-          viewBox="0 0 24 24"
-          width="24px"
-        >
-          <polyline
-            fill="none"
-            points="18 9 12 15 6 9"
-            stroke="#000"
-            stroke-width="2"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
+      </svg>
+    </div>
+  </button>
 </div>
 `;
 
@@ -997,6 +990,7 @@ exports[`Menu close on tab 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1010,7 +1004,6 @@ exports[`Menu close on tab 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -1069,43 +1062,41 @@ exports[`Menu close on tab 1`] = `
 <div
   class="c0"
 >
-  <div>
-    <button
-      aria-label="Open Menu"
-      class="c1"
-      id="test-menu"
-      type="button"
+  <button
+    aria-label="Open Menu"
+    class="c1"
+    id="test-menu"
+    type="button"
+  >
+    <div
+      class="c2"
     >
-      <div
-        class="c2"
+      <span
+        class="c3"
       >
-        <span
-          class="c3"
-        >
-          Test
-        </span>
-        <div
-          class="c4"
+        Test
+      </span>
+      <div
+        class="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        class="c5"
+        height="24px"
+        role="img"
+        version="1.1"
+        viewBox="0 0 24 24"
+        width="24px"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          stroke-width="2"
         />
-        <svg
-          aria-label="FormDown"
-          class="c5"
-          height="24px"
-          role="img"
-          version="1.1"
-          viewBox="0 0 24 24"
-          width="24px"
-        >
-          <polyline
-            fill="none"
-            points="18 9 12 15 6 9"
-            stroke="#000"
-            stroke-width="2"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
+      </svg>
+    </div>
+  </button>
 </div>
 `;
 
@@ -1150,6 +1141,7 @@ exports[`Menu custom message 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1163,7 +1155,6 @@ exports[`Menu custom message 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -1222,47 +1213,44 @@ exports[`Menu custom message 1`] = `
 <div
   className="c0"
 >
-  <div
+  <button
+    aria-label="Abrir Menu"
+    className="c1"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
+    type="button"
   >
-    <button
-      aria-label="Abrir Menu"
-      className="c1"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      type="button"
+    <div
+      className="c2"
     >
-      <div
-        className="c2"
+      <span
+        className="c3"
       >
-        <span
-          className="c3"
-        >
-          Test Menu
-        </span>
-        <div
-          className="c4"
+        Test Menu
+      </span>
+      <div
+        className="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        className="c5"
+        height="24px"
+        role="img"
+        version="1.1"
+        viewBox="0 0 24 24"
+        width="24px"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          strokeWidth="2"
         />
-        <svg
-          aria-label="FormDown"
-          className="c5"
-          height="24px"
-          role="img"
-          version="1.1"
-          viewBox="0 0 24 24"
-          width="24px"
-        >
-          <polyline
-            fill="none"
-            points="18 9 12 15 6 9"
-            stroke="#000"
-            strokeWidth="2"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
+      </svg>
+    </div>
+  </button>
 </div>
 `;
 
@@ -1307,6 +1295,7 @@ exports[`Menu disabled 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1320,7 +1309,6 @@ exports[`Menu disabled 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -1381,44 +1369,42 @@ exports[`Menu disabled 1`] = `
 <div
   class="c0"
 >
-  <div>
-    <button
-      aria-label="Open Menu"
-      class="c1"
-      disabled=""
-      id="test-menu"
-      type="button"
+  <button
+    aria-label="Open Menu"
+    class="c1"
+    disabled=""
+    id="test-menu"
+    type="button"
+  >
+    <div
+      class="c2"
     >
-      <div
-        class="c2"
+      <span
+        class="c3"
       >
-        <span
-          class="c3"
-        >
-          Test
-        </span>
-        <div
-          class="c4"
+        Test
+      </span>
+      <div
+        class="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        class="c5"
+        height="24px"
+        role="img"
+        version="1.1"
+        viewBox="0 0 24 24"
+        width="24px"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          stroke-width="2"
         />
-        <svg
-          aria-label="FormDown"
-          class="c5"
-          height="24px"
-          role="img"
-          version="1.1"
-          viewBox="0 0 24 24"
-          width="24px"
-        >
-          <polyline
-            fill="none"
-            points="18 9 12 15 6 9"
-            stroke="#000"
-            stroke-width="2"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
+      </svg>
+    </div>
+  </button>
 </div>
 `;
 
@@ -1463,6 +1449,7 @@ exports[`Menu navigate through suggestions and select 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1476,7 +1463,6 @@ exports[`Menu navigate through suggestions and select 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -1535,43 +1521,41 @@ exports[`Menu navigate through suggestions and select 1`] = `
 <div
   class="c0"
 >
-  <div>
-    <button
-      aria-label="Open Menu"
-      class="c1"
-      id="test-menu"
-      type="button"
+  <button
+    aria-label="Open Menu"
+    class="c1"
+    id="test-menu"
+    type="button"
+  >
+    <div
+      class="c2"
     >
-      <div
-        class="c2"
+      <span
+        class="c3"
       >
-        <span
-          class="c3"
-        >
-          Test
-        </span>
-        <div
-          class="c4"
+        Test
+      </span>
+      <div
+        class="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        class="c5"
+        height="24px"
+        role="img"
+        version="1.1"
+        viewBox="0 0 24 24"
+        width="24px"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          stroke-width="2"
         />
-        <svg
-          aria-label="FormDown"
-          class="c5"
-          height="24px"
-          role="img"
-          version="1.1"
-          viewBox="0 0 24 24"
-          width="24px"
-        >
-          <polyline
-            fill="none"
-            points="18 9 12 15 6 9"
-            stroke="#000"
-            stroke-width="2"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
+      </svg>
+    </div>
+  </button>
 </div>
 `;
 
@@ -1616,6 +1600,7 @@ exports[`Menu open and close on click 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1629,7 +1614,6 @@ exports[`Menu open and close on click 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -1688,43 +1672,41 @@ exports[`Menu open and close on click 1`] = `
 <div
   class="c0"
 >
-  <div>
-    <button
-      aria-label="Open Menu"
-      class="c1"
-      id="test-menu"
-      type="button"
+  <button
+    aria-label="Open Menu"
+    class="c1"
+    id="test-menu"
+    type="button"
+  >
+    <div
+      class="c2"
     >
-      <div
-        class="c2"
+      <span
+        class="c3"
       >
-        <span
-          class="c3"
-        >
-          Test
-        </span>
-        <div
-          class="c4"
+        Test
+      </span>
+      <div
+        class="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        class="c5"
+        height="24px"
+        role="img"
+        version="1.1"
+        viewBox="0 0 24 24"
+        width="24px"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          stroke-width="2"
         />
-        <svg
-          aria-label="FormDown"
-          class="c5"
-          height="24px"
-          role="img"
-          version="1.1"
-          viewBox="0 0 24 24"
-          width="24px"
-        >
-          <polyline
-            fill="none"
-            points="18 9 12 15 6 9"
-            stroke="#000"
-            stroke-width="2"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
+      </svg>
+    </div>
+  </button>
 </div>
 `;
 
@@ -1732,43 +1714,41 @@ exports[`Menu open and close on click 2`] = `
 <div
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
-  <div>
-    <button
-      aria-label="Open Menu"
-      class="StyledButton-sc-323bzc-0 hFTHco"
-      id="test-menu"
-      type="button"
+  <button
+    aria-label="Open Menu"
+    class="StyledButton-sc-323bzc-0 ktlKXq"
+    id="test-menu"
+    type="button"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 bSNzLY"
     >
-      <div
-        class="StyledBox-sc-13pk1d4-0 iFQIIs"
+      <span
+        class="StyledText-sc-1sadyjn-0 fWSbXS"
       >
-        <span
-          class="StyledText-sc-1sadyjn-0 eWZOWJ"
-        >
-          Test
-        </span>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iChEkS"
+        Test
+      </span>
+      <div
+        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iChEkS"
+      />
+      <svg
+        aria-label="FormDown"
+        class="StyledIcon-ofa7kd-0 dtlWir"
+        height="24px"
+        role="img"
+        version="1.1"
+        viewBox="0 0 24 24"
+        width="24px"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          stroke-width="2"
         />
-        <svg
-          aria-label="FormDown"
-          class="StyledIcon-ofa7kd-0 dtlWir"
-          height="24px"
-          role="img"
-          version="1.1"
-          viewBox="0 0 24 24"
-          width="24px"
-        >
-          <polyline
-            fill="none"
-            points="18 9 12 15 6 9"
-            stroke="#000"
-            stroke-width="2"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
+      </svg>
+    </div>
+  </button>
 </div>
 `;
 
@@ -1813,6 +1793,7 @@ exports[`Menu open and close on click 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1826,7 +1807,6 @@ exports[`Menu open and close on click 3`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -1838,12 +1818,12 @@ exports[`Menu open and close on click 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -1856,12 +1836,12 @@ exports[`Menu open and close on click 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1873,6 +1853,7 @@ exports[`Menu open and close on click 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1881,7 +1862,6 @@ exports[`Menu open and close on click 3`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1893,12 +1873,12 @@ exports[`Menu open and close on click 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -1911,6 +1891,7 @@ exports[`Menu open and close on click 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -1920,7 +1901,6 @@ exports[`Menu open and close on click 3`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -2219,18 +2199,18 @@ exports[`Menu open and close on click 4`] = `
 "
 
 @media only screen and (max-width:768px) {
-  .iFQIIs {
+  .bSNzLY {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .iFQIIs {
+  .bSNzLY {
     padding: 6px;
   }
 }
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2238,72 +2218,72 @@ exports[`Menu open and close on click 4`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kWLcGV {
+  .cJEczh {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kWLcGV {
+  .cJEczh {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hOiaYa {
+  .dUQcVP {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hOiaYa {
+  .dUQcVP {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .blARAh {
+  .gFbzfm {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .blARAh {
+  .gFbzfm {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fwWSQs {
+  .cIGhQH {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fwWSQs {
+  .cIGhQH {
     padding: 6px;
   }
 }
@@ -2389,6 +2369,7 @@ exports[`Menu select an item 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2402,7 +2383,6 @@ exports[`Menu select an item 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -2461,43 +2441,41 @@ exports[`Menu select an item 1`] = `
 <div
   class="c0"
 >
-  <div>
-    <button
-      aria-label="Open Menu"
-      class="c1"
-      id="test-menu"
-      type="button"
+  <button
+    aria-label="Open Menu"
+    class="c1"
+    id="test-menu"
+    type="button"
+  >
+    <div
+      class="c2"
     >
-      <div
-        class="c2"
+      <span
+        class="c3"
       >
-        <span
-          class="c3"
-        >
-          Test
-        </span>
-        <div
-          class="c4"
+        Test
+      </span>
+      <div
+        class="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        class="c5"
+        height="24px"
+        role="img"
+        version="1.1"
+        viewBox="0 0 24 24"
+        width="24px"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          stroke-width="2"
         />
-        <svg
-          aria-label="FormDown"
-          class="c5"
-          height="24px"
-          role="img"
-          version="1.1"
-          viewBox="0 0 24 24"
-          width="24px"
-        >
-          <polyline
-            fill="none"
-            points="18 9 12 15 6 9"
-            stroke="#000"
-            stroke-width="2"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
+      </svg>
+    </div>
+  </button>
 </div>
 `;
 
@@ -2542,6 +2520,7 @@ exports[`Menu with dropAlign renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2555,7 +2534,6 @@ exports[`Menu with dropAlign renders 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -2614,43 +2592,41 @@ exports[`Menu with dropAlign renders 1`] = `
 <div
   class="c0"
 >
-  <div>
-    <button
-      aria-label="Open Menu"
-      class="c1"
-      id="test-menu"
-      type="button"
+  <button
+    aria-label="Open Menu"
+    class="c1"
+    id="test-menu"
+    type="button"
+  >
+    <div
+      class="c2"
     >
-      <div
-        class="c2"
+      <span
+        class="c3"
       >
-        <span
-          class="c3"
-        >
-          Test
-        </span>
-        <div
-          class="c4"
+        Test
+      </span>
+      <div
+        class="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        class="c5"
+        height="24px"
+        role="img"
+        version="1.1"
+        viewBox="0 0 24 24"
+        width="24px"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          stroke-width="2"
         />
-        <svg
-          aria-label="FormDown"
-          class="c5"
-          height="24px"
-          role="img"
-          version="1.1"
-          viewBox="0 0 24 24"
-          width="24px"
-        >
-          <polyline
-            fill="none"
-            points="18 9 12 15 6 9"
-            stroke="#000"
-            stroke-width="2"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
+      </svg>
+    </div>
+  </button>
 </div>
 `;
 
@@ -2695,6 +2671,7 @@ exports[`Menu with dropAlign renders 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2708,7 +2685,6 @@ exports[`Menu with dropAlign renders 2`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -2720,12 +2696,12 @@ exports[`Menu with dropAlign renders 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -2738,12 +2714,12 @@ exports[`Menu with dropAlign renders 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2755,6 +2731,7 @@ exports[`Menu with dropAlign renders 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -2763,7 +2740,6 @@ exports[`Menu with dropAlign renders 2`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2775,12 +2751,12 @@ exports[`Menu with dropAlign renders 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -2793,6 +2769,7 @@ exports[`Menu with dropAlign renders 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -2802,7 +2779,6 @@ exports[`Menu with dropAlign renders 2`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -3064,18 +3040,18 @@ exports[`Menu with dropAlign renders 3`] = `
 "
 
 @media only screen and (max-width:768px) {
-  .iFQIIs {
+  .bSNzLY {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .iFQIIs {
+  .bSNzLY {
     padding: 6px;
   }
 }
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3083,72 +3059,72 @@ exports[`Menu with dropAlign renders 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kWLcGV {
+  .cJEczh {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kWLcGV {
+  .cJEczh {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hOiaYa {
+  .dUQcVP {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hOiaYa {
+  .dUQcVP {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .blARAh {
+  .gFbzfm {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .blARAh {
+  .gFbzfm {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fwWSQs {
+  .cIGhQH {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fwWSQs {
+  .cIGhQH {
     padding: 6px;
   }
 }

--- a/src/js/components/Menu/doc.js
+++ b/src/js/components/Menu/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 const VERTICAL_ALIGN_OPTIONS = ['top', 'bottom'];
 const HORIZONTAL_ALIGN_OPTIONS = ['right', 'left'];
@@ -17,6 +17,7 @@ export const doc = (Menu) => {
     );
 
   DocumentedMenu.propTypes = {
+    ...genericProps,
     disabled: PropTypes.bool
       .description('Whether the menu should be disabled.'),
     dropAlign: PropTypes.shape({

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
 export interface MenuProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   disabled?: boolean;
   dropAlign?: {top: "top" | "bottom",bottom: "top" | "bottom",left: "right" | "left",right: "right" | "left"};
   dropBackground?: string | {color: string,opacity: "weak" | "medium" | "strong" | boolean};

--- a/src/js/components/Meter/README.md
+++ b/src/js/components/Meter/README.md
@@ -11,6 +11,102 @@ import { Meter } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **background**
 
 Background color

--- a/src/js/components/Meter/StyledMeter.js
+++ b/src/js/components/Meter/StyledMeter.js
@@ -1,5 +1,7 @@
 import styled, { css } from 'styled-components';
 
+import { genericStyles } from '../../utils';
+
 const roundStyle = css`
   border-radius: ${props => props.theme.global.edgeSize[props.round.size]};
 `;
@@ -7,8 +9,10 @@ const roundStyle = css`
 // overflow: hidden is needed for ie11
 export const StyledMeter = styled.svg`
   max-width: 100%;
-  ${props => props.round && roundStyle}
   overflow: hidden;
+
+  ${genericStyles}
+  ${props => props.round && roundStyle}
 
   path {
     transition: all 0.3s;

--- a/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
+++ b/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
@@ -344,8 +344,8 @@ exports[`Meter round 1`] = `
 
 .c1 {
   max-width: 100%;
-  border-radius: 24px;
   overflow: hidden;
+  border-radius: 24px;
 }
 
 .c1 path {

--- a/src/js/components/Meter/doc.js
+++ b/src/js/components/Meter/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { backgroundPropType, getAvailableAtBadge } from '../../utils';
+import { backgroundPropType, genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Meter) => {
   const DocumentedMeter = describe(Meter)
@@ -12,6 +12,7 @@ export const doc = (Meter) => {
     );
 
   DocumentedMeter.propTypes = {
+    ...genericProps,
     background: backgroundPropType,
     round: PropTypes.bool.description('Whether to round the line ends'),
     size: PropTypes.oneOfType([

--- a/src/js/components/Meter/index.d.ts
+++ b/src/js/components/Meter/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
 export interface MeterProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   background?: string | {color: string,opacity: "weak" | "medium" | "strong" | boolean};
   round?: boolean;
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | string;

--- a/src/js/components/Paragraph/README.md
+++ b/src/js/components/Paragraph/README.md
@@ -11,10 +11,30 @@ import { Paragraph } from 'grommet';
 
 ## Properties
 
-**color**
+**a11yTitle**
 
-A color identifier to use for the text color. For example:
-'status-critical'.
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
 
 ```
 string
@@ -22,26 +42,77 @@ string
 
 **margin**
 
-The amount of margin above and/or below the paragraph. An object can be
-specified to distinguish top margin and bottom margin.
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
 
 ```
 none
+xxsmall
+xsmall
 small
 medium
 large
+xlarge
 {
   bottom: 
+    xxsmall
+    xsmall
     small
     medium
     large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
     string,
   top: 
+    xxsmall
+    xsmall
     small
     medium
     large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
     string
 }
+string
+```
+
+**color**
+
+A color identifier to use for the text color. For example:
+'status-critical'.
+
+```
 string
 ```
 

--- a/src/js/components/Paragraph/StyledParagraph.js
+++ b/src/js/components/Paragraph/StyledParagraph.js
@@ -1,27 +1,10 @@
 import styled, { css } from 'styled-components';
 
-import { normalizeColor } from '../../utils';
+import { genericStyles, normalizeColor } from '../../utils';
 
 const colorStyle = css`
   color: ${props => normalizeColor(props.color, props.theme)};
 `;
-
-const marginStyle = (props) => {
-  if (typeof props.margin === 'string') {
-    const margin = props.theme.global.edgeSize[props.margin];
-    return `
-      margin-top: ${margin};
-      margin-bottom: ${margin};
-    `;
-  }
-  if (props.margin.top) {
-    return `margin-top: ${props.theme.global.edgeSize[props.margin.top]};`;
-  }
-  if (props.margin.bottom) {
-    return `margin-bottom: ${props.theme.global.edgeSize[props.margin.bottom]};`;
-  }
-  return '';
-};
 
 const sizeStyle = (props) => {
   const size = props.size || 'medium';
@@ -44,8 +27,8 @@ const textAlignStyle = css`
 `;
 
 export const StyledParagraph = styled.p`
+  ${genericStyles}
   ${props => sizeStyle(props)}
-  ${props => props.margin && marginStyle(props)}
   ${props => props.textAlign && textAlignStyle}
   ${props => props.color && colorStyle}
 

--- a/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.js.snap
+++ b/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.js.snap
@@ -12,49 +12,45 @@ exports[`Paragraph margin renders 1`] = `
 }
 
 .c1 {
+  margin: 12px;
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
-  margin-top: 12px;
-  margin-bottom: 12px;
 }
 
 .c2 {
+  margin: 24px;
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
-  margin-top: 24px;
-  margin-bottom: 24px;
 }
 
 .c3 {
+  margin: 48px;
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
-  margin-top: 48px;
-  margin-bottom: 48px;
 }
 
 .c4 {
+  margin: 0px;
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
-  margin-top: 0px;
-  margin-bottom: 0px;
 }
 
 .c5 {
+  margin-bottom: 12px;
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
-  margin-bottom: 12px;
 }
 
 .c6 {
+  margin-top: 12px;
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
-  margin-top: 12px;
 }
 
 <div

--- a/src/js/components/Paragraph/doc.js
+++ b/src/js/components/Paragraph/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { getAvailableAtBadge, genericProps } from '../../utils';
 
 export const doc = (Paragraph) => {
   const DocumentedParagraph = describe(Paragraph)
@@ -12,26 +12,10 @@ export const doc = (Paragraph) => {
     );
 
   DocumentedParagraph.propTypes = {
+    ...genericProps,
     color: PropTypes.string.description(
       `A color identifier to use for the text color. For example:
 'status-critical'.`
-    ),
-    margin: PropTypes.oneOfType([
-      PropTypes.oneOf(['none', 'small', 'medium', 'large']),
-      PropTypes.shape({
-        bottom: PropTypes.oneOfType([
-          PropTypes.oneOf(['small', 'medium', 'large']),
-          PropTypes.string,
-        ]),
-        top: PropTypes.oneOfType([
-          PropTypes.oneOf(['small', 'medium', 'large']),
-          PropTypes.string,
-        ]),
-      }),
-      PropTypes.string,
-    ]).description(
-      `The amount of margin above and/or below the paragraph. An object can be
-specified to distinguish top margin and bottom margin.`
     ),
     size: PropTypes.oneOfType([
       PropTypes.oneOf(['small', 'medium', 'large', 'xlarge']),

--- a/src/js/components/Paragraph/index.d.ts
+++ b/src/js/components/Paragraph/index.d.ts
@@ -1,8 +1,11 @@
 import * as React from "react";
 
 export interface ParagraphProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   color?: string;
-  margin?: "none" | "small" | "medium" | "large" | {bottom: "small" | "medium" | "large" | string,top: "small" | "medium" | "large" | string} | string;
   size?: "small" | "medium" | "large" | "xlarge" | string;
   textAlign?: "start" | "center" | "end";
 }

--- a/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
+++ b/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
@@ -19,13 +19,13 @@ exports[`RangeSelector basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -37,13 +37,13 @@ exports[`RangeSelector basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -55,6 +55,7 @@ exports[`RangeSelector basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -64,7 +65,6 @@ exports[`RangeSelector basic 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: visible;
 }
@@ -77,6 +77,7 @@ exports[`RangeSelector basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 6px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -91,7 +92,6 @@ exports[`RangeSelector basic 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 6px;
   padding: 0px;
 }
 
@@ -103,12 +103,12 @@ exports[`RangeSelector basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -121,6 +121,7 @@ exports[`RangeSelector basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.4);
   color: #f8f8f8;
   min-width: 0;
@@ -129,7 +130,6 @@ exports[`RangeSelector basic 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -349,13 +349,13 @@ exports[`RangeSelector color 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -367,13 +367,13 @@ exports[`RangeSelector color 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -385,6 +385,7 @@ exports[`RangeSelector color 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -394,7 +395,6 @@ exports[`RangeSelector color 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: visible;
 }
@@ -407,6 +407,7 @@ exports[`RangeSelector color 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 6px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -421,7 +422,6 @@ exports[`RangeSelector color 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 6px;
   padding: 0px;
 }
 
@@ -433,12 +433,12 @@ exports[`RangeSelector color 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -451,6 +451,7 @@ exports[`RangeSelector color 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(253,111,255,0.4);
   color: #444444;
   min-width: 0;
@@ -459,7 +460,6 @@ exports[`RangeSelector color 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -679,13 +679,13 @@ exports[`RangeSelector direction 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -697,13 +697,13 @@ exports[`RangeSelector direction 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -715,6 +715,7 @@ exports[`RangeSelector direction 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -724,7 +725,6 @@ exports[`RangeSelector direction 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: visible;
 }
@@ -737,6 +737,7 @@ exports[`RangeSelector direction 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 6px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -751,7 +752,6 @@ exports[`RangeSelector direction 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 6px;
   padding: 0px;
 }
 
@@ -763,12 +763,12 @@ exports[`RangeSelector direction 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -781,6 +781,7 @@ exports[`RangeSelector direction 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.4);
   color: #f8f8f8;
   min-width: 0;
@@ -789,7 +790,6 @@ exports[`RangeSelector direction 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -801,13 +801,13 @@ exports[`RangeSelector direction 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   width: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -819,6 +819,7 @@ exports[`RangeSelector direction 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -828,7 +829,6 @@ exports[`RangeSelector direction 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
   overflow: visible;
 }
@@ -841,6 +841,7 @@ exports[`RangeSelector direction 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 6px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -855,7 +856,6 @@ exports[`RangeSelector direction 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 6px;
   padding: 0px;
 }
 
@@ -867,12 +867,12 @@ exports[`RangeSelector direction 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -885,6 +885,7 @@ exports[`RangeSelector direction 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.4);
   color: #f8f8f8;
   min-width: 0;
@@ -893,7 +894,6 @@ exports[`RangeSelector direction 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   width: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1292,13 +1292,13 @@ exports[`RangeSelector handle keyboard 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1310,13 +1310,13 @@ exports[`RangeSelector handle keyboard 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1328,6 +1328,7 @@ exports[`RangeSelector handle keyboard 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1337,7 +1338,6 @@ exports[`RangeSelector handle keyboard 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: visible;
 }
@@ -1350,6 +1350,7 @@ exports[`RangeSelector handle keyboard 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 6px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1364,7 +1365,6 @@ exports[`RangeSelector handle keyboard 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 6px;
   padding: 0px;
 }
 
@@ -1376,12 +1376,12 @@ exports[`RangeSelector handle keyboard 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -1394,6 +1394,7 @@ exports[`RangeSelector handle keyboard 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.4);
   color: #f8f8f8;
   min-width: 0;
@@ -1402,7 +1403,6 @@ exports[`RangeSelector handle keyboard 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1577,13 +1577,13 @@ exports[`RangeSelector handle mouse 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1595,13 +1595,13 @@ exports[`RangeSelector handle mouse 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1613,6 +1613,7 @@ exports[`RangeSelector handle mouse 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1622,7 +1623,6 @@ exports[`RangeSelector handle mouse 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: visible;
 }
@@ -1635,6 +1635,7 @@ exports[`RangeSelector handle mouse 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 6px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1649,7 +1650,6 @@ exports[`RangeSelector handle mouse 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 6px;
   padding: 0px;
 }
 
@@ -1661,12 +1661,12 @@ exports[`RangeSelector handle mouse 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -1679,6 +1679,7 @@ exports[`RangeSelector handle mouse 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.4);
   color: #f8f8f8;
   min-width: 0;
@@ -1687,7 +1688,6 @@ exports[`RangeSelector handle mouse 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1862,13 +1862,13 @@ exports[`RangeSelector invert 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1880,13 +1880,13 @@ exports[`RangeSelector invert 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1898,6 +1898,7 @@ exports[`RangeSelector invert 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1907,7 +1908,6 @@ exports[`RangeSelector invert 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: visible;
 }
@@ -1920,6 +1920,7 @@ exports[`RangeSelector invert 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 6px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1934,7 +1935,6 @@ exports[`RangeSelector invert 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 6px;
   padding: 0px;
 }
 
@@ -1946,12 +1946,12 @@ exports[`RangeSelector invert 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -1964,6 +1964,7 @@ exports[`RangeSelector invert 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.4);
   color: #f8f8f8;
   min-width: 0;
@@ -1972,7 +1973,6 @@ exports[`RangeSelector invert 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1984,6 +1984,7 @@ exports[`RangeSelector invert 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(204,204,204,0.4);
   color: #444444;
   min-width: 0;
@@ -1992,7 +1993,6 @@ exports[`RangeSelector invert 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2337,13 +2337,13 @@ exports[`RangeSelector max 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2355,13 +2355,13 @@ exports[`RangeSelector max 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2373,6 +2373,7 @@ exports[`RangeSelector max 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2382,7 +2383,6 @@ exports[`RangeSelector max 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: visible;
 }
@@ -2395,6 +2395,7 @@ exports[`RangeSelector max 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 6px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2409,7 +2410,6 @@ exports[`RangeSelector max 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 6px;
   padding: 0px;
 }
 
@@ -2421,12 +2421,12 @@ exports[`RangeSelector max 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -2439,6 +2439,7 @@ exports[`RangeSelector max 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.4);
   color: #f8f8f8;
   min-width: 0;
@@ -2447,7 +2448,6 @@ exports[`RangeSelector max 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2667,13 +2667,13 @@ exports[`RangeSelector min 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2685,13 +2685,13 @@ exports[`RangeSelector min 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2703,6 +2703,7 @@ exports[`RangeSelector min 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2712,7 +2713,6 @@ exports[`RangeSelector min 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: visible;
 }
@@ -2725,6 +2725,7 @@ exports[`RangeSelector min 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 6px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2739,7 +2740,6 @@ exports[`RangeSelector min 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 6px;
   padding: 0px;
 }
 
@@ -2751,12 +2751,12 @@ exports[`RangeSelector min 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -2769,6 +2769,7 @@ exports[`RangeSelector min 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.4);
   color: #f8f8f8;
   min-width: 0;
@@ -2777,7 +2778,6 @@ exports[`RangeSelector min 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2997,13 +2997,13 @@ exports[`RangeSelector opacity 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3015,13 +3015,13 @@ exports[`RangeSelector opacity 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3033,6 +3033,7 @@ exports[`RangeSelector opacity 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3042,7 +3043,6 @@ exports[`RangeSelector opacity 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: visible;
 }
@@ -3055,6 +3055,7 @@ exports[`RangeSelector opacity 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 6px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3069,7 +3070,6 @@ exports[`RangeSelector opacity 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 6px;
   padding: 0px;
 }
 
@@ -3081,12 +3081,12 @@ exports[`RangeSelector opacity 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -3099,6 +3099,7 @@ exports[`RangeSelector opacity 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.4);
   color: #f8f8f8;
   min-width: 0;
@@ -3107,7 +3108,6 @@ exports[`RangeSelector opacity 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3119,6 +3119,7 @@ exports[`RangeSelector opacity 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.1);
   min-width: 0;
   min-height: 0;
@@ -3126,7 +3127,6 @@ exports[`RangeSelector opacity 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3138,6 +3138,7 @@ exports[`RangeSelector opacity 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.8);
   color: #f8f8f8;
   min-width: 0;
@@ -3146,7 +3147,6 @@ exports[`RangeSelector opacity 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3616,13 +3616,13 @@ exports[`RangeSelector round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3634,6 +3634,7 @@ exports[`RangeSelector round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3643,7 +3644,6 @@ exports[`RangeSelector round 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: visible;
 }
@@ -3656,6 +3656,7 @@ exports[`RangeSelector round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 6px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3670,7 +3671,6 @@ exports[`RangeSelector round 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 6px;
   padding: 0px;
 }
 
@@ -3682,12 +3682,12 @@ exports[`RangeSelector round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -3700,13 +3700,13 @@ exports[`RangeSelector round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
   border-radius: 6px;
 }
@@ -3719,6 +3719,7 @@ exports[`RangeSelector round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.4);
   color: #f8f8f8;
   min-width: 0;
@@ -3727,7 +3728,6 @@ exports[`RangeSelector round 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
   border-radius: 6px;
 }
@@ -3740,13 +3740,13 @@ exports[`RangeSelector round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -3759,6 +3759,7 @@ exports[`RangeSelector round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.4);
   color: #f8f8f8;
   min-width: 0;
@@ -3767,7 +3768,6 @@ exports[`RangeSelector round 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -3780,13 +3780,13 @@ exports[`RangeSelector round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
   border-radius: 24px;
 }
@@ -3799,6 +3799,7 @@ exports[`RangeSelector round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.4);
   color: #f8f8f8;
   min-width: 0;
@@ -3807,7 +3808,6 @@ exports[`RangeSelector round 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
   border-radius: 24px;
 }
@@ -3820,13 +3820,13 @@ exports[`RangeSelector round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
   border-radius: 48px;
 }
@@ -3839,6 +3839,7 @@ exports[`RangeSelector round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.4);
   color: #f8f8f8;
   min-width: 0;
@@ -3847,7 +3848,6 @@ exports[`RangeSelector round 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
   border-radius: 48px;
 }
@@ -3860,13 +3860,13 @@ exports[`RangeSelector round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
   border-radius: 100%;
 }
@@ -3879,6 +3879,7 @@ exports[`RangeSelector round 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.4);
   color: #f8f8f8;
   min-width: 0;
@@ -3887,7 +3888,6 @@ exports[`RangeSelector round 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
   border-radius: 100%;
 }
@@ -4704,13 +4704,13 @@ exports[`RangeSelector size 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -4722,13 +4722,13 @@ exports[`RangeSelector size 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -4740,6 +4740,7 @@ exports[`RangeSelector size 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4749,7 +4750,6 @@ exports[`RangeSelector size 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: visible;
 }
@@ -4762,6 +4762,7 @@ exports[`RangeSelector size 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 6px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4776,7 +4777,6 @@ exports[`RangeSelector size 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 6px;
   padding: 0px;
 }
 
@@ -4788,12 +4788,12 @@ exports[`RangeSelector size 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -4806,6 +4806,7 @@ exports[`RangeSelector size 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.4);
   color: #f8f8f8;
   min-width: 0;
@@ -4814,7 +4815,6 @@ exports[`RangeSelector size 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5712,13 +5712,13 @@ exports[`RangeSelector step 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5730,13 +5730,13 @@ exports[`RangeSelector step 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5748,6 +5748,7 @@ exports[`RangeSelector step 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5757,7 +5758,6 @@ exports[`RangeSelector step 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: visible;
 }
@@ -5770,6 +5770,7 @@ exports[`RangeSelector step 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 6px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5784,7 +5785,6 @@ exports[`RangeSelector step 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 6px;
   padding: 0px;
 }
 
@@ -5796,12 +5796,12 @@ exports[`RangeSelector step 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   border-radius: 12px;
 }
@@ -5814,6 +5814,7 @@ exports[`RangeSelector step 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background-color: rgba(125,76,219,0.4);
   color: #f8f8f8;
   min-width: 0;
@@ -5822,7 +5823,6 @@ exports[`RangeSelector step 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   height: 100%;
-  margin: 0px;
   padding: 0px;
 }
 

--- a/src/js/components/RoutedAnchor/__tests__/__snapshots__/RoutedAnchor-test.js.snap
+++ b/src/js/components/RoutedAnchor/__tests__/__snapshots__/RoutedAnchor-test.js.snap
@@ -40,6 +40,7 @@ exports[`RoutedAnchor renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -49,7 +50,6 @@ exports[`RoutedAnchor renders 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin: 0px;
   padding: 0px;
 }
 

--- a/src/js/components/RoutedButton/__tests__/__snapshots__/RoutedButton-test.js.snap
+++ b/src/js/components/RoutedButton/__tests__/__snapshots__/RoutedButton-test.js.snap
@@ -9,6 +9,7 @@ exports[`RoutedButton renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -22,7 +23,6 @@ exports[`RoutedButton renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 

--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -19,6 +19,94 @@ Custom title to be used by screen readers.
 string
 ```
 
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **children**
 
 Function that will be called when each option is rendered.

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -47,13 +47,16 @@ class Select extends Component {
   render() {
     const {
       a11yTitle,
+      alignSelf,
       children,
       closeOnChange,
       disabled,
       dropAlign,
       dropTarget,
       forwardRef,
+      gridArea,
       id,
+      margin,
       messages,
       onChange,
       onClose,
@@ -116,6 +119,9 @@ class Select extends Component {
           dropAlign={dropAlign}
           dropTarget={dropTarget}
           open={open}
+          alignSelf={alignSelf}
+          gridArea={gridArea}
+          margin={margin}
           onOpen={this.onOpen}
           onClose={this.onClose}
           dropContent={<SelectContainer {...this.props} onChange={onSelectChange} />}

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -41,6 +41,7 @@ exports[`Select basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -54,7 +55,6 @@ exports[`Select basic 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -65,6 +65,7 @@ exports[`Select basic 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -76,7 +77,6 @@ exports[`Select basic 1`] = `
   -webkit-flex-basis: auto;
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -88,6 +88,8 @@ exports[`Select basic 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -96,8 +98,6 @@ exports[`Select basic 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin-left: 12px;
-  margin-right: 12px;
   padding: 0px;
 }
 
@@ -312,6 +312,7 @@ exports[`Select complex options and children 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -325,7 +326,6 @@ exports[`Select complex options and children 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -336,6 +336,7 @@ exports[`Select complex options and children 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -347,7 +348,6 @@ exports[`Select complex options and children 1`] = `
   -webkit-flex-basis: auto;
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -359,6 +359,8 @@ exports[`Select complex options and children 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -367,8 +369,6 @@ exports[`Select complex options and children 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin-left: 12px;
-  margin-right: 12px;
   padding: 0px;
 }
 
@@ -534,15 +534,15 @@ exports[`Select complex options and children 1`] = `
 exports[`Select complex options and children 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 hFTHco"
+  class="StyledButton-sc-323bzc-0 ktlKXq"
   id="test-select"
   type="button"
 >
   <div
-    class="Select__StyledSelectBox-sc-17idtfo-1 fLPrsm StyledBox-sc-13pk1d4-0 RiBtR"
+    class="Select__StyledSelectBox-sc-17idtfo-1 fLPrsm StyledBox-sc-13pk1d4-0 dzfHcI"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 krpJTk"
+      class="StyledBox-sc-13pk1d4-0 jdXamm"
     >
       <div
         class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 yIdXy"
@@ -560,7 +560,7 @@ exports[`Select complex options and children 2`] = `
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hnbMHr"
+      class="StyledBox-sc-13pk1d4-0 eQriQh"
       style="min-width: auto;"
     >
       <svg
@@ -593,12 +593,12 @@ exports[`Select complex options and children 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -611,12 +611,12 @@ exports[`Select complex options and children 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -628,6 +628,7 @@ exports[`Select complex options and children 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -636,7 +637,6 @@ exports[`Select complex options and children 3`] = `
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -649,6 +649,7 @@ exports[`Select complex options and children 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -657,7 +658,6 @@ exports[`Select complex options and children 3`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -837,43 +837,43 @@ exports[`Select complex options and children 4`] = `
 "
 
 @media only screen and (max-width:768px) {
-  .RiBtR {
+  .dzfHcI {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .RiBtR {
+  .dzfHcI {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .krpJTk {
+  .jdXamm {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .krpJTk {
+  .jdXamm {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hnbMHr {
+  .eQriQh {
     margin-left: 6px;
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hnbMHr {
+  .eQriQh {
     padding: 0px;
   }
 }
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -881,72 +881,72 @@ exports[`Select complex options and children 4`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kWLcGV {
+  .cJEczh {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kWLcGV {
+  .cJEczh {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bCYZgZ {
+  .cNYfdo {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bCYZgZ {
+  .cNYfdo {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hOiaYa {
+  .dUQcVP {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hOiaYa {
+  .dUQcVP {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bgCyUq {
+  .easKzl {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bgCyUq {
+  .easKzl {
     padding: 6px;
   }
 }
@@ -1038,6 +1038,7 @@ exports[`Select deselect an option 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1051,7 +1052,6 @@ exports[`Select deselect an option 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1062,6 +1062,7 @@ exports[`Select deselect an option 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -1073,7 +1074,6 @@ exports[`Select deselect an option 1`] = `
   -webkit-flex-basis: auto;
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1085,6 +1085,8 @@ exports[`Select deselect an option 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1093,8 +1095,6 @@ exports[`Select deselect an option 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin-left: 12px;
-  margin-right: 12px;
   padding: 0px;
 }
 
@@ -1299,6 +1299,7 @@ exports[`Select disabled 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1312,7 +1313,6 @@ exports[`Select disabled 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1323,6 +1323,7 @@ exports[`Select disabled 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -1334,7 +1335,6 @@ exports[`Select disabled 1`] = `
   -webkit-flex-basis: auto;
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1346,6 +1346,8 @@ exports[`Select disabled 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1354,8 +1356,6 @@ exports[`Select disabled 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin-left: 12px;
-  margin-right: 12px;
   padding: 0px;
 }
 
@@ -1524,16 +1524,16 @@ exports[`Select disabled 1`] = `
 exports[`Select disabled 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 eDLckV"
+  class="StyledButton-sc-323bzc-0 giLeBY"
   disabled=""
   id="test-select"
   type="button"
 >
   <div
-    class="Select__StyledSelectBox-sc-17idtfo-1 fLPrsm StyledBox-sc-13pk1d4-0 RiBtR"
+    class="Select__StyledSelectBox-sc-17idtfo-1 fLPrsm StyledBox-sc-13pk1d4-0 dzfHcI"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 krpJTk"
+      class="StyledBox-sc-13pk1d4-0 jdXamm"
     >
       <div
         class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 yIdXy"
@@ -1551,7 +1551,7 @@ exports[`Select disabled 2`] = `
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hnbMHr"
+      class="StyledBox-sc-13pk1d4-0 eQriQh"
       style="min-width: auto;"
     >
       <svg
@@ -1616,6 +1616,7 @@ exports[`Select multiple 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1629,7 +1630,6 @@ exports[`Select multiple 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1640,6 +1640,7 @@ exports[`Select multiple 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -1651,7 +1652,6 @@ exports[`Select multiple 1`] = `
   -webkit-flex-basis: auto;
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1663,6 +1663,8 @@ exports[`Select multiple 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1671,8 +1673,6 @@ exports[`Select multiple 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin-left: 12px;
-  margin-right: 12px;
   padding: 0px;
 }
 
@@ -1890,6 +1890,7 @@ exports[`Select multiple values 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1903,7 +1904,6 @@ exports[`Select multiple values 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1914,6 +1914,7 @@ exports[`Select multiple values 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -1925,7 +1926,6 @@ exports[`Select multiple values 1`] = `
   -webkit-flex-basis: auto;
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1937,6 +1937,8 @@ exports[`Select multiple values 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1945,8 +1947,6 @@ exports[`Select multiple values 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin-left: 12px;
-  margin-right: 12px;
   padding: 0px;
 }
 
@@ -2113,15 +2113,15 @@ exports[`Select multiple values 1`] = `
 exports[`Select multiple values 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 hFTHco"
+  class="StyledButton-sc-323bzc-0 ktlKXq"
   id="test-select"
   type="button"
 >
   <div
-    class="Select__StyledSelectBox-sc-17idtfo-1 fLPrsm StyledBox-sc-13pk1d4-0 RiBtR"
+    class="Select__StyledSelectBox-sc-17idtfo-1 fLPrsm StyledBox-sc-13pk1d4-0 dzfHcI"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 krpJTk"
+      class="StyledBox-sc-13pk1d4-0 jdXamm"
     >
       <div
         class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 yIdXy"
@@ -2140,7 +2140,7 @@ exports[`Select multiple values 2`] = `
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hnbMHr"
+      class="StyledBox-sc-13pk1d4-0 eQriQh"
       style="min-width: auto;"
     >
       <svg
@@ -2173,12 +2173,12 @@ exports[`Select multiple values 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -2191,12 +2191,12 @@ exports[`Select multiple values 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2208,6 +2208,7 @@ exports[`Select multiple values 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -2216,7 +2217,6 @@ exports[`Select multiple values 3`] = `
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -2229,6 +2229,7 @@ exports[`Select multiple values 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -2237,7 +2238,6 @@ exports[`Select multiple values 3`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2249,6 +2249,7 @@ exports[`Select multiple values 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -2258,7 +2259,6 @@ exports[`Select multiple values 3`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -2314,6 +2314,7 @@ exports[`Select multiple values 3`] = `
 }
 
 .c9 {
+  margin: 0px;
   font-size: 18px;
   line-height: 24px;
   margin-top: 0px;
@@ -2474,43 +2475,43 @@ exports[`Select multiple values 4`] = `
 "
 
 @media only screen and (max-width:768px) {
-  .RiBtR {
+  .dzfHcI {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .RiBtR {
+  .dzfHcI {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .krpJTk {
+  .jdXamm {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .krpJTk {
+  .jdXamm {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hnbMHr {
+  .eQriQh {
     margin-left: 6px;
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hnbMHr {
+  .eQriQh {
     padding: 0px;
   }
 }
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2518,84 +2519,84 @@ exports[`Select multiple values 4`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kWLcGV {
+  .cJEczh {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kWLcGV {
+  .cJEczh {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bCYZgZ {
+  .cNYfdo {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bCYZgZ {
+  .cNYfdo {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hOiaYa {
+  .dUQcVP {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hOiaYa {
+  .dUQcVP {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bgCyUq {
+  .easKzl {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bgCyUq {
+  .easKzl {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cDsQRL {
+  .jrNnll {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cDsQRL {
+  .jrNnll {
     padding: 3px;
   }
 }
@@ -2687,6 +2688,7 @@ exports[`Select opens 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2700,7 +2702,6 @@ exports[`Select opens 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2711,6 +2712,7 @@ exports[`Select opens 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -2722,7 +2724,6 @@ exports[`Select opens 1`] = `
   -webkit-flex-basis: auto;
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2734,6 +2735,8 @@ exports[`Select opens 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -2742,8 +2745,6 @@ exports[`Select opens 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin-left: 12px;
-  margin-right: 12px;
   padding: 0px;
 }
 
@@ -2909,15 +2910,15 @@ exports[`Select opens 1`] = `
 exports[`Select opens 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 hFTHco"
+  class="StyledButton-sc-323bzc-0 ktlKXq"
   id="test-select"
   type="button"
 >
   <div
-    class="Select__StyledSelectBox-sc-17idtfo-1 fLPrsm StyledBox-sc-13pk1d4-0 RiBtR"
+    class="Select__StyledSelectBox-sc-17idtfo-1 fLPrsm StyledBox-sc-13pk1d4-0 dzfHcI"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 krpJTk"
+      class="StyledBox-sc-13pk1d4-0 jdXamm"
     >
       <div
         class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 yIdXy"
@@ -2935,7 +2936,7 @@ exports[`Select opens 2`] = `
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hnbMHr"
+      class="StyledBox-sc-13pk1d4-0 eQriQh"
       style="min-width: auto;"
     >
       <svg
@@ -2968,12 +2969,12 @@ exports[`Select opens 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -2986,12 +2987,12 @@ exports[`Select opens 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3003,6 +3004,7 @@ exports[`Select opens 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3011,7 +3013,6 @@ exports[`Select opens 3`] = `
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -3024,6 +3025,7 @@ exports[`Select opens 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3032,7 +3034,6 @@ exports[`Select opens 3`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3044,6 +3045,7 @@ exports[`Select opens 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -3053,7 +3055,6 @@ exports[`Select opens 3`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -3106,6 +3107,7 @@ exports[`Select opens 3`] = `
 }
 
 .c9 {
+  margin: 0px;
   font-size: 18px;
   line-height: 24px;
   margin-top: 0px;
@@ -3266,43 +3268,43 @@ exports[`Select opens 4`] = `
 "
 
 @media only screen and (max-width:768px) {
-  .RiBtR {
+  .dzfHcI {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .RiBtR {
+  .dzfHcI {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .krpJTk {
+  .jdXamm {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .krpJTk {
+  .jdXamm {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hnbMHr {
+  .eQriQh {
     margin-left: 6px;
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hnbMHr {
+  .eQriQh {
     padding: 0px;
   }
 }
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3310,72 +3312,72 @@ exports[`Select opens 4`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kWLcGV {
+  .cJEczh {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kWLcGV {
+  .cJEczh {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bCYZgZ {
+  .cNYfdo {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bCYZgZ {
+  .cNYfdo {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hOiaYa {
+  .dUQcVP {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hOiaYa {
+  .dUQcVP {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bgCyUq {
+  .easKzl {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bgCyUq {
+  .easKzl {
     padding: 6px;
   }
 }
@@ -3428,23 +3430,23 @@ exports[`Select opens 4`] = `
 
 exports[`Select opens 5`] = `
 <div
-  class="SelectContainer__OptionsBox-sc-1wi0ul8-1 jZWhdj StyledBox-sc-13pk1d4-0 bCYZgZ"
+  class="SelectContainer__OptionsBox-sc-1wi0ul8-1 jZWhdj StyledBox-sc-13pk1d4-0 cNYfdo"
   role="menubar"
   tabindex="-1"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 hOiaYa"
+    class="StyledBox-sc-13pk1d4-0 dUQcVP"
   >
     <button
-      class="StyledButton-sc-323bzc-0 kYseQn"
+      class="StyledButton-sc-323bzc-0 qPFWG"
       role="menuitem"
       type="button"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bgCyUq"
+        class="StyledBox-sc-13pk1d4-0 easKzl"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 bumlP"
+          class="StyledText-sc-1sadyjn-0 ouimt"
         >
           one
         </span>
@@ -3452,18 +3454,18 @@ exports[`Select opens 5`] = `
     </button>
   </div>
   <div
-    class="StyledBox-sc-13pk1d4-0 hOiaYa"
+    class="StyledBox-sc-13pk1d4-0 dUQcVP"
   >
     <button
-      class="StyledButton-sc-323bzc-0 kYseQn"
+      class="StyledButton-sc-323bzc-0 qPFWG"
       role="menuitem"
       type="button"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bgCyUq"
+        class="StyledBox-sc-13pk1d4-0 easKzl"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 bumlP"
+          class="StyledText-sc-1sadyjn-0 ouimt"
         >
           two
         </span>
@@ -3514,6 +3516,7 @@ exports[`Select search 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3527,7 +3530,6 @@ exports[`Select search 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3538,6 +3540,7 @@ exports[`Select search 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -3549,7 +3552,6 @@ exports[`Select search 1`] = `
   -webkit-flex-basis: auto;
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3561,6 +3563,8 @@ exports[`Select search 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3569,8 +3573,6 @@ exports[`Select search 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin-left: 12px;
-  margin-right: 12px;
   padding: 0px;
 }
 
@@ -3742,12 +3744,12 @@ exports[`Select search 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -3760,12 +3762,12 @@ exports[`Select search 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3777,6 +3779,7 @@ exports[`Select search 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3785,7 +3788,6 @@ exports[`Select search 2`] = `
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -3798,6 +3800,7 @@ exports[`Select search 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3806,7 +3809,6 @@ exports[`Select search 2`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3818,6 +3820,7 @@ exports[`Select search 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -3827,7 +3830,6 @@ exports[`Select search 2`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -3839,6 +3841,7 @@ exports[`Select search 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3847,7 +3850,6 @@ exports[`Select search 2`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin: 0px;
   padding: 6px;
 }
 
@@ -3944,6 +3946,7 @@ exports[`Select search 2`] = `
 }
 
 .c12 {
+  margin: 0px;
   font-size: 18px;
   line-height: 24px;
   margin-top: 0px;
@@ -4130,43 +4133,43 @@ exports[`Select search 3`] = `
 "
 
 @media only screen and (max-width:768px) {
-  .RiBtR {
+  .dzfHcI {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .RiBtR {
+  .dzfHcI {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .krpJTk {
+  .jdXamm {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .krpJTk {
+  .jdXamm {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hnbMHr {
+  .eQriQh {
     margin-left: 6px;
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hnbMHr {
+  .eQriQh {
     padding: 0px;
   }
 }
 
-.gZcqrw {
+.dJDrdW {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4174,84 +4177,84 @@ exports[`Select search 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .gZcqrw {
+  .dJDrdW {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kWLcGV {
+  .cJEczh {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kWLcGV {
+  .cJEczh {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bCYZgZ {
+  .cNYfdo {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bCYZgZ {
+  .cNYfdo {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hOiaYa {
+  .dUQcVP {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hOiaYa {
+  .dUQcVP {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bgCyUq {
+  .easKzl {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bgCyUq {
+  .easKzl {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cDsQRL {
+  .jrNnll {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cDsQRL {
+  .jrNnll {
     padding: 3px;
   }
 }
@@ -4343,6 +4346,7 @@ exports[`Select select an option 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4356,7 +4360,6 @@ exports[`Select select an option 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -4367,6 +4370,7 @@ exports[`Select select an option 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -4378,7 +4382,6 @@ exports[`Select select an option 1`] = `
   -webkit-flex-basis: auto;
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -4390,6 +4393,8 @@ exports[`Select select an option 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -4398,8 +4403,6 @@ exports[`Select select an option 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin-left: 12px;
-  margin-right: 12px;
   padding: 0px;
 }
 
@@ -4603,6 +4606,7 @@ exports[`Select select an option with complex options 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4616,7 +4620,6 @@ exports[`Select select an option with complex options 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -4627,6 +4630,7 @@ exports[`Select select an option with complex options 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -4638,7 +4642,6 @@ exports[`Select select an option with complex options 1`] = `
   -webkit-flex-basis: auto;
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -4650,6 +4653,8 @@ exports[`Select select an option with complex options 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -4658,8 +4663,6 @@ exports[`Select select an option with complex options 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin-left: 12px;
-  margin-right: 12px;
   padding: 0px;
 }
 
@@ -4800,6 +4803,7 @@ exports[`Select select an option with enter 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4813,7 +4817,6 @@ exports[`Select select an option with enter 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -4824,6 +4827,7 @@ exports[`Select select an option with enter 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -4835,7 +4839,6 @@ exports[`Select select an option with enter 1`] = `
   -webkit-flex-basis: auto;
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -4847,6 +4850,8 @@ exports[`Select select an option with enter 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -4855,8 +4860,6 @@ exports[`Select select an option with enter 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin-left: 12px;
-  margin-right: 12px;
   padding: 0px;
 }
 
@@ -5060,6 +5063,7 @@ exports[`Select select another option 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5073,7 +5077,6 @@ exports[`Select select another option 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5084,6 +5087,7 @@ exports[`Select select another option 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -5095,7 +5099,6 @@ exports[`Select select another option 1`] = `
   -webkit-flex-basis: auto;
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5107,6 +5110,8 @@ exports[`Select select another option 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -5115,8 +5120,6 @@ exports[`Select select another option 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin-left: 12px;
-  margin-right: 12px;
   padding: 0px;
 }
 
@@ -5323,6 +5326,7 @@ exports[`Select size 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5336,7 +5340,6 @@ exports[`Select size 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5347,6 +5350,7 @@ exports[`Select size 1`] = `
   display: flex;
   box-sizing: border-box;
   outline: none;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -5358,7 +5362,6 @@ exports[`Select size 1`] = `
   -webkit-flex-basis: auto;
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -5370,6 +5373,8 @@ exports[`Select size 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -5378,8 +5383,6 @@ exports[`Select size 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  margin-left: 12px;
-  margin-right: 12px;
   padding: 0px;
 }
 

--- a/src/js/components/Select/doc.js
+++ b/src/js/components/Select/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { a11yTitlePropType, getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Select) => {
   const DocumentedSelect = describe(Select)
@@ -13,7 +13,7 @@ export const doc = (Select) => {
     );
 
   DocumentedSelect.propTypes = {
-    a11yTitle: a11yTitlePropType,
+    ...genericProps,
     children: PropTypes.func.description(
       'Function that will be called when each option is rendered.'
     ),

--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -2,6 +2,9 @@ import * as React from "react";
 
 export interface SelectProps {
   a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   children?: (...args: any[]) => any;
   closeOnChange?: boolean;
   disabled?: boolean;

--- a/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
+++ b/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
@@ -67,7 +67,7 @@ exports[`SkipLink basic 2`] = `
   <div>
     <a
       aria-hidden="true"
-      class="StyledAnchor-sc-1rp7lwl-0 kcggOX"
+      class="StyledAnchor-sc-1rp7lwl-0 kPVGRd"
       id="main"
       style="width: 0px; height: 0px; overflow: hidden; position: absolute;"
       tabindex="-1"
@@ -81,7 +81,7 @@ exports[`SkipLink basic 2`] = `
   <footer>
     <a
       aria-hidden="true"
-      class="StyledAnchor-sc-1rp7lwl-0 kcggOX"
+      class="StyledAnchor-sc-1rp7lwl-0 kPVGRd"
       id="footer"
       style="width: 0px; height: 0px; overflow: hidden; position: absolute;"
       tabindex="-1"
@@ -101,7 +101,7 @@ exports[`SkipLink basic 3`] = `
   <div>
     <a
       aria-hidden="true"
-      class="StyledAnchor-sc-1rp7lwl-0 kcggOX"
+      class="StyledAnchor-sc-1rp7lwl-0 kPVGRd"
       id="main"
       style="width: 0px; height: 0px; overflow: hidden; position: absolute;"
       tabindex="-1"
@@ -115,7 +115,7 @@ exports[`SkipLink basic 3`] = `
   <footer>
     <a
       aria-hidden="true"
-      class="StyledAnchor-sc-1rp7lwl-0 kcggOX"
+      class="StyledAnchor-sc-1rp7lwl-0 kPVGRd"
       id="footer"
       style="width: 0px; height: 0px; overflow: hidden; position: absolute;"
       tabindex="-1"

--- a/src/js/components/Stack/README.md
+++ b/src/js/components/Stack/README.md
@@ -11,6 +11,102 @@ import { Stack } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **anchor**
 
 Where to anchor children from. If not specified, children

--- a/src/js/components/Stack/StyledStack.js
+++ b/src/js/components/Stack/StyledStack.js
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
+import { genericStyles } from '../../utils';
+
 const fillStyle = `
   width: 100%;
   height: 100%;
@@ -10,6 +12,7 @@ const fillStyle = `
 
 export const StyledStack = styled.div`
   position: relative;
+  ${genericStyles}
   ${props => props.fillContainer && fillStyle}
   ${props => props.theme.stack && props.theme.stack.extend}
 `;

--- a/src/js/components/Stack/doc.js
+++ b/src/js/components/Stack/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Stack) => {
   const DocumentedStack = describe(Stack)
@@ -13,6 +13,7 @@ export const doc = (Stack) => {
     );
 
   DocumentedStack.propTypes = {
+    ...genericProps,
     anchor: PropTypes.oneOf([
       'center', 'left', 'right', 'top', 'bottom',
       'top-left', 'bottom-left', 'top-right', 'bottom-right',

--- a/src/js/components/Stack/index.d.ts
+++ b/src/js/components/Stack/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
 export interface StackProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   anchor?: "center" | "left" | "right" | "top" | "bottom" | "top-left" | "bottom-left" | "top-right" | "bottom-right";
   fill?: boolean;
   guidingChild?: number | "first" | "last";

--- a/src/js/components/Table/README.md
+++ b/src/js/components/Table/README.md
@@ -11,6 +11,102 @@ import { Table, TableHeader, TableFooter, TableBody, TableRow } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **caption**
 
 One line description.

--- a/src/js/components/Table/StyledTable.js
+++ b/src/js/components/Table/StyledTable.js
@@ -1,5 +1,7 @@
 import styled, { css } from 'styled-components';
 
+import { genericStyles } from '../../utils';
+
 const SIZE_MAP = {
   '1/2': '50%',
   '1/4': '25%',
@@ -48,5 +50,6 @@ export const StyledTable = styled.table`
   border-spacing: 0;
   border-collapse: collapse;
 
+  ${genericStyles}
   ${props => props.theme.table && props.theme.table.extend}
 `;

--- a/src/js/components/Table/__tests__/__snapshots__/Table-test.js.snap
+++ b/src/js/components/Table/__tests__/__snapshots__/Table-test.js.snap
@@ -144,6 +144,7 @@ exports[`TableCell renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -153,7 +154,6 @@ exports[`TableCell renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -285,6 +285,7 @@ exports[`TableCell scope renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -294,7 +295,6 @@ exports[`TableCell scope renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -404,6 +404,7 @@ exports[`TableCell size renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -413,7 +414,6 @@ exports[`TableCell size renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -697,6 +697,7 @@ exports[`TableCell verticalAlign renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -706,7 +707,6 @@ exports[`TableCell verticalAlign renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;

--- a/src/js/components/Table/doc.js
+++ b/src/js/components/Table/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Table) => {
   const DocumentedTable = describe(Table)
@@ -12,6 +12,7 @@ export const doc = (Table) => {
     );
 
   DocumentedTable.propTypes = {
+    ...genericProps,
     caption: PropTypes.string.description('One line description.'),
   };
 

--- a/src/js/components/Table/index.d.ts
+++ b/src/js/components/Table/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
 export interface TableProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   caption?: string;
 }
 

--- a/src/js/components/Tabs/README.md
+++ b/src/js/components/Tabs/README.md
@@ -14,6 +14,102 @@ import { Tabs, Tab } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **activeIndex**
 
 Active tab index. If specified, Tabs will be a controlled component. This means that future

--- a/src/js/components/Tabs/StyledTabs.js
+++ b/src/js/components/Tabs/StyledTabs.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+import { genericStyles } from '../../utils';
+
+export const StyledTabs = styled.div`
+  ${genericStyles}
+`;

--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -1,6 +1,10 @@
 import React, { cloneElement, Children, Component } from 'react';
+import { compose } from 'recompose';
 
 import { Box } from '../Box';
+import { withTheme } from '../hocs';
+
+import { StyledTabs } from './StyledTabs';
 
 class Tabs extends Component {
   static defaultProps = {
@@ -70,19 +74,18 @@ class Tabs extends Component {
     const tabContentTitle = `${activeTitle || ''} ${tabContents}`;
 
     return (
-      <div role='tablist'>
+      <StyledTabs role='tablist' {...rest}>
         <Box
           direction='row'
           justify={justify}
           wrap
-          {...rest}
         >
           {tabs}
         </Box>
         <div aria-label={tabContentTitle} role='tabpanel'>
           {activeContent}
         </div>
-      </div>
+      </StyledTabs>
     );
   }
 }
@@ -91,6 +94,8 @@ let TabsDoc;
 if (process.env.NODE_ENV !== 'production') {
   TabsDoc = require('./doc').doc(Tabs); // eslint-disable-line global-require
 }
-const TabsWrapper = (TabsDoc || Tabs);
+const TabsWrapper = compose(
+  withTheme,
+)(TabsDoc || Tabs);
 
 export { TabsWrapper as Tabs };

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -9,6 +9,7 @@ exports[`Tabs Tab 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -18,7 +19,6 @@ exports[`Tabs Tab 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
@@ -33,16 +33,16 @@ exports[`Tabs Tab 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
   border-bottom: solid 2px #000000;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 3px;
-  margin-bottom: 3px;
   padding-bottom: 6px;
 }
 
@@ -54,16 +54,16 @@ exports[`Tabs Tab 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
   border-bottom: solid 2px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 3px;
-  margin-bottom: 3px;
   padding-bottom: 6px;
 }
 
@@ -121,12 +121,6 @@ exports[`Tabs Tab 1`] = `
 
 @media only screen and (max-width:768px) {
   .c3 {
-    border-bottom: solid 2px #000000;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -136,6 +130,12 @@ exports[`Tabs Tab 1`] = `
   .c3 {
     margin-top: 2px;
     margin-bottom: 2px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    border-bottom: solid 2px #000000;
   }
 }
 
@@ -147,12 +147,6 @@ exports[`Tabs Tab 1`] = `
 
 @media only screen and (max-width:768px) {
   .c5 {
-    border-bottom: solid 2px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -162,6 +156,12 @@ exports[`Tabs Tab 1`] = `
   .c5 {
     margin-top: 2px;
     margin-bottom: 2px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    border-bottom: solid 2px rgba(0,0,0,0.33);
   }
 }
 
@@ -175,6 +175,7 @@ exports[`Tabs Tab 1`] = `
   className="c0"
 >
   <div
+    className=""
     role="tablist"
   >
     <div
@@ -244,6 +245,7 @@ exports[`Tabs change to second tab 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -253,7 +255,6 @@ exports[`Tabs change to second tab 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
@@ -268,16 +269,16 @@ exports[`Tabs change to second tab 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
   border-bottom: solid 2px #000000;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 3px;
-  margin-bottom: 3px;
   padding-bottom: 6px;
 }
 
@@ -289,16 +290,16 @@ exports[`Tabs change to second tab 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
   border-bottom: solid 2px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 3px;
-  margin-bottom: 3px;
   padding-bottom: 6px;
 }
 
@@ -356,12 +357,6 @@ exports[`Tabs change to second tab 1`] = `
 
 @media only screen and (max-width:768px) {
   .c3 {
-    border-bottom: solid 2px #000000;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -371,6 +366,12 @@ exports[`Tabs change to second tab 1`] = `
   .c3 {
     margin-top: 2px;
     margin-bottom: 2px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    border-bottom: solid 2px #000000;
   }
 }
 
@@ -382,12 +383,6 @@ exports[`Tabs change to second tab 1`] = `
 
 @media only screen and (max-width:768px) {
   .c5 {
-    border-bottom: solid 2px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -397,6 +392,12 @@ exports[`Tabs change to second tab 1`] = `
   .c5 {
     margin-top: 2px;
     margin-bottom: 2px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    border-bottom: solid 2px rgba(0,0,0,0.33);
   }
 }
 
@@ -410,6 +411,7 @@ exports[`Tabs change to second tab 1`] = `
   class="c0"
 >
   <div
+    class=""
     role="tablist"
   >
     <div
@@ -465,23 +467,24 @@ exports[`Tabs change to second tab 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
+    class="StyledTabs-a4fwxl-0 gPxemO"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kAGbJW"
+      class="StyledBox-sc-13pk1d4-0 iFPWFz"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 gtShfg"
+          class="StyledBox-sc-13pk1d4-0 judqYk"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 iCreHd"
+            class="StyledText-sc-1sadyjn-0 iEgnbY"
           >
             Tab 1
           </span>
@@ -490,15 +493,15 @@ exports[`Tabs change to second tab 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fZyUde"
+          class="StyledBox-sc-13pk1d4-0 fsvkMZ"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 hJZqIs"
+            class="StyledText-sc-1sadyjn-0 dndifk"
           >
             Tab 2
           </span>
@@ -524,6 +527,7 @@ exports[`Tabs complex title 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -533,7 +537,6 @@ exports[`Tabs complex title 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
@@ -548,16 +551,16 @@ exports[`Tabs complex title 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
   border-bottom: solid 2px #000000;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 3px;
-  margin-bottom: 3px;
   padding-bottom: 6px;
 }
 
@@ -569,16 +572,16 @@ exports[`Tabs complex title 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
   border-bottom: solid 2px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 3px;
-  margin-bottom: 3px;
   padding-bottom: 6px;
 }
 
@@ -624,12 +627,6 @@ exports[`Tabs complex title 1`] = `
 
 @media only screen and (max-width:768px) {
   .c3 {
-    border-bottom: solid 2px #000000;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -639,6 +636,12 @@ exports[`Tabs complex title 1`] = `
   .c3 {
     margin-top: 2px;
     margin-bottom: 2px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    border-bottom: solid 2px #000000;
   }
 }
 
@@ -650,12 +653,6 @@ exports[`Tabs complex title 1`] = `
 
 @media only screen and (max-width:768px) {
   .c4 {
-    border-bottom: solid 2px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c4 {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -665,6 +662,12 @@ exports[`Tabs complex title 1`] = `
   .c4 {
     margin-top: 2px;
     margin-bottom: 2px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    border-bottom: solid 2px rgba(0,0,0,0.33);
   }
 }
 
@@ -678,6 +681,7 @@ exports[`Tabs complex title 1`] = `
   className="c0"
 >
   <div
+    className=""
     role="tablist"
   >
     <div
@@ -743,6 +747,7 @@ exports[`Tabs no Tab 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -752,7 +757,6 @@ exports[`Tabs no Tab 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
@@ -785,6 +789,7 @@ exports[`Tabs no Tab 1`] = `
   className="c0"
 >
   <div
+    className=""
     role="tablist"
   >
     <div
@@ -807,6 +812,7 @@ exports[`Tabs set on hover 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -816,7 +822,6 @@ exports[`Tabs set on hover 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
@@ -831,16 +836,16 @@ exports[`Tabs set on hover 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
   border-bottom: solid 2px #000000;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 3px;
-  margin-bottom: 3px;
   padding-bottom: 6px;
 }
 
@@ -852,16 +857,16 @@ exports[`Tabs set on hover 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
   border-bottom: solid 2px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 3px;
-  margin-bottom: 3px;
   padding-bottom: 6px;
 }
 
@@ -919,12 +924,6 @@ exports[`Tabs set on hover 1`] = `
 
 @media only screen and (max-width:768px) {
   .c3 {
-    border-bottom: solid 2px #000000;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -934,6 +933,12 @@ exports[`Tabs set on hover 1`] = `
   .c3 {
     margin-top: 2px;
     margin-bottom: 2px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    border-bottom: solid 2px #000000;
   }
 }
 
@@ -945,12 +950,6 @@ exports[`Tabs set on hover 1`] = `
 
 @media only screen and (max-width:768px) {
   .c5 {
-    border-bottom: solid 2px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -960,6 +959,12 @@ exports[`Tabs set on hover 1`] = `
   .c5 {
     margin-top: 2px;
     margin-bottom: 2px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    border-bottom: solid 2px rgba(0,0,0,0.33);
   }
 }
 
@@ -973,6 +978,7 @@ exports[`Tabs set on hover 1`] = `
   class="c0"
 >
   <div
+    class=""
     role="tablist"
   >
     <div
@@ -1028,23 +1034,24 @@ exports[`Tabs set on hover 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
+    class="StyledTabs-a4fwxl-0 gPxemO"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kAGbJW"
+      class="StyledBox-sc-13pk1d4-0 iFPWFz"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fZyUde"
+          class="StyledBox-sc-13pk1d4-0 fsvkMZ"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 hJZqIs"
+            class="StyledText-sc-1sadyjn-0 dndifk"
           >
             Tab 1
           </span>
@@ -1053,15 +1060,15 @@ exports[`Tabs set on hover 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 gtShfg"
+          class="StyledBox-sc-13pk1d4-0 judqYk"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 iCreHd"
+            class="StyledText-sc-1sadyjn-0 iEgnbY"
           >
             Tab 2
           </span>
@@ -1083,23 +1090,24 @@ exports[`Tabs set on hover 3`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
+    class="StyledTabs-a4fwxl-0 gPxemO"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kAGbJW"
+      class="StyledBox-sc-13pk1d4-0 iFPWFz"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fZyUde"
+          class="StyledBox-sc-13pk1d4-0 fsvkMZ"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 hJZqIs"
+            class="StyledText-sc-1sadyjn-0 dndifk"
           >
             Tab 1
           </span>
@@ -1108,15 +1116,15 @@ exports[`Tabs set on hover 3`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 gtShfg"
+          class="StyledBox-sc-13pk1d4-0 judqYk"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 iCreHd"
+            class="StyledText-sc-1sadyjn-0 iEgnbY"
           >
             Tab 2
           </span>
@@ -1138,23 +1146,24 @@ exports[`Tabs set on hover 4`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
+    class="StyledTabs-a4fwxl-0 gPxemO"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kAGbJW"
+      class="StyledBox-sc-13pk1d4-0 iFPWFz"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fZyUde"
+          class="StyledBox-sc-13pk1d4-0 fsvkMZ"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 hJZqIs"
+            class="StyledText-sc-1sadyjn-0 dndifk"
           >
             Tab 1
           </span>
@@ -1163,15 +1172,15 @@ exports[`Tabs set on hover 4`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 gtShfg"
+          class="StyledBox-sc-13pk1d4-0 judqYk"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 iCreHd"
+            class="StyledText-sc-1sadyjn-0 iEgnbY"
           >
             Tab 2
           </span>
@@ -1193,23 +1202,24 @@ exports[`Tabs set on hover 5`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
+    class="StyledTabs-a4fwxl-0 gPxemO"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kAGbJW"
+      class="StyledBox-sc-13pk1d4-0 iFPWFz"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fZyUde"
+          class="StyledBox-sc-13pk1d4-0 fsvkMZ"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 hJZqIs"
+            class="StyledText-sc-1sadyjn-0 dndifk"
           >
             Tab 1
           </span>
@@ -1218,15 +1228,15 @@ exports[`Tabs set on hover 5`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 hFTHco"
+        class="StyledButton-sc-323bzc-0 ktlKXq"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 gtShfg"
+          class="StyledBox-sc-13pk1d4-0 judqYk"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 iCreHd"
+            class="StyledText-sc-1sadyjn-0 iEgnbY"
           >
             Tab 2
           </span>

--- a/src/js/components/Tabs/doc.js
+++ b/src/js/components/Tabs/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Tabs) => {
   const DocumentedTabs = describe(Tabs)
@@ -15,6 +15,7 @@ export const doc = (Tabs) => {
     );
 
   DocumentedTabs.propTypes = {
+    ...genericProps,
     activeIndex: PropTypes.number.description(
       `Active tab index. If specified, Tabs will be a controlled component. This means that future
 tab changes will not work unless you subscribe to onActive function and update activeIndex

--- a/src/js/components/Tabs/index.d.ts
+++ b/src/js/components/Tabs/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
 export interface TabsProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   activeIndex?: number;
   children: React.ReactNode;
   justify?: "start" | "center" | "end";

--- a/src/js/components/Text/README.md
+++ b/src/js/components/Text/README.md
@@ -11,10 +11,30 @@ import { Text } from 'grommet';
 
 ## Properties
 
-**color**
+**a11yTitle**
 
-A color identifier to use for the text color. For example:
-'status-critical'.
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
 
 ```
 string
@@ -42,6 +62,15 @@ large
     large
     string
 }
+string
+```
+
+**color**
+
+A color identifier to use for the text color. For example:
+'status-critical'.
+
+```
 string
 ```
 

--- a/src/js/components/Text/StyledText.js
+++ b/src/js/components/Text/StyledText.js
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { normalizeColor } from '../../utils';
+import { genericStyles, normalizeColor } from '../../utils';
 
 const marginStyle = (props) => {
   if (typeof props.margin === 'string') {
@@ -74,6 +74,7 @@ const weightStyle = css`
 `;
 
 export const StyledText = styled.span`
+  ${genericStyles}
   ${props => sizeStyle(props)}
   ${props => props.margin && marginStyle(props)}
   ${props => props.textAlign && textAlignStyle}

--- a/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
+++ b/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
@@ -65,6 +65,7 @@ exports[`renders margin 1`] = `
 }
 
 .c1 {
+  margin: 12px;
   font-size: 18px;
   line-height: 24px;
   margin-top: 12px;
@@ -74,6 +75,7 @@ exports[`renders margin 1`] = `
 }
 
 .c2 {
+  margin: 24px;
   font-size: 18px;
   line-height: 24px;
   margin-top: 24px;
@@ -83,6 +85,7 @@ exports[`renders margin 1`] = `
 }
 
 .c3 {
+  margin: 48px;
   font-size: 18px;
   line-height: 24px;
   margin-top: 48px;
@@ -92,6 +95,7 @@ exports[`renders margin 1`] = `
 }
 
 .c4 {
+  margin: 0px;
   font-size: 18px;
   line-height: 24px;
   margin-top: 0px;
@@ -101,6 +105,8 @@ exports[`renders margin 1`] = `
 }
 
 .c5 {
+  margin-top: 12px;
+  margin-bottom: 12px;
   font-size: 18px;
   line-height: 24px;
   margin-top: 12px;
@@ -108,6 +114,8 @@ exports[`renders margin 1`] = `
 }
 
 .c6 {
+  margin-left: 12px;
+  margin-right: 12px;
   font-size: 18px;
   line-height: 24px;
   margin-left: 12px;
@@ -115,24 +123,28 @@ exports[`renders margin 1`] = `
 }
 
 .c7 {
+  margin-bottom: 12px;
   font-size: 18px;
   line-height: 24px;
   margin-bottom: 12px;
 }
 
 .c8 {
+  margin-top: 12px;
   font-size: 18px;
   line-height: 24px;
   margin-top: 12px;
 }
 
 .c9 {
+  margin-left: 12px;
   font-size: 18px;
   line-height: 24px;
   margin-left: 12px;
 }
 
 .c10 {
+  margin-right: 12px;
   font-size: 18px;
   line-height: 24px;
   margin-right: 12px;

--- a/src/js/components/Text/doc.js
+++ b/src/js/components/Text/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Text) => {
   const DocumentedText = describe(Text)
@@ -12,6 +12,7 @@ export const doc = (Text) => {
     );
 
   DocumentedText.propTypes = {
+    ...genericProps,
     color: PropTypes.string.description(
       `A color identifier to use for the text color. For example:
 'status-critical'.`

--- a/src/js/components/Text/index.d.ts
+++ b/src/js/components/Text/index.d.ts
@@ -1,8 +1,11 @@
 import * as React from "react";
 
 export interface TextProps {
-  color?: string;
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
   margin?: "none" | "small" | "medium" | "large" | {bottom: "small" | "medium" | "large" | string,top: "small" | "medium" | "large" | string} | string;
+  color?: string;
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
   tag?: string;
   textAlign?: "start" | "center" | "end";

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -135,12 +135,12 @@ exports[`TextInput close suggestion drop 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -153,12 +153,12 @@ exports[`TextInput close suggestion drop 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -171,6 +171,7 @@ exports[`TextInput close suggestion drop 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -180,7 +181,6 @@ exports[`TextInput close suggestion drop 2`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -337,7 +337,7 @@ exports[`TextInput close suggestion drop 2`] = `
 exports[`TextInput close suggestion drop 3`] = `
 "
 
-.fLSTbo {
+.cpQPlH {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -345,36 +345,36 @@ exports[`TextInput close suggestion drop 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .blARAh {
+  .gFbzfm {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .blARAh {
+  .gFbzfm {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bgCyUq {
+  .easKzl {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bgCyUq {
+  .easKzl {
     padding: 6px;
   }
 }
@@ -524,12 +524,12 @@ exports[`TextInput complex suggestions 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -542,12 +542,12 @@ exports[`TextInput complex suggestions 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -685,7 +685,7 @@ exports[`TextInput complex suggestions 2`] = `
 exports[`TextInput complex suggestions 3`] = `
 "
 
-.fLSTbo {
+.cpQPlH {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -693,36 +693,36 @@ exports[`TextInput complex suggestions 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .blARAh {
+  .gFbzfm {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .blARAh {
+  .gFbzfm {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bgCyUq {
+  .easKzl {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bgCyUq {
+  .easKzl {
     padding: 6px;
   }
 }
@@ -1017,12 +1017,12 @@ exports[`TextInput select suggestion 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -1035,12 +1035,12 @@ exports[`TextInput select suggestion 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -1053,6 +1053,7 @@ exports[`TextInput select suggestion 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -1062,7 +1063,6 @@ exports[`TextInput select suggestion 2`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -1219,7 +1219,7 @@ exports[`TextInput select suggestion 2`] = `
 exports[`TextInput select suggestion 3`] = `
 "
 
-.fLSTbo {
+.cpQPlH {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1227,36 +1227,36 @@ exports[`TextInput select suggestion 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .blARAh {
+  .gFbzfm {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .blARAh {
+  .gFbzfm {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bgCyUq {
+  .easKzl {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bgCyUq {
+  .easKzl {
     padding: 6px;
   }
 }
@@ -1392,12 +1392,12 @@ exports[`TextInput suggestions 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
@@ -1410,12 +1410,12 @@ exports[`TextInput suggestions 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   overflow: auto;
 }
@@ -1428,6 +1428,7 @@ exports[`TextInput suggestions 2`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -1437,7 +1438,6 @@ exports[`TextInput suggestions 2`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -1594,7 +1594,7 @@ exports[`TextInput suggestions 2`] = `
 exports[`TextInput suggestions 3`] = `
 "
 
-.fLSTbo {
+.cpQPlH {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1602,36 +1602,36 @@ exports[`TextInput suggestions 3`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
   box-shadow: 0px 2px 4px rgba(100,100,100,0.50);
 }
 
 @media only screen and (max-width:768px) {
-  .blARAh {
+  .gFbzfm {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .blARAh {
+  .gFbzfm {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bgCyUq {
+  .easKzl {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bgCyUq {
+  .easKzl {
     padding: 6px;
   }
 }

--- a/src/js/components/Video/README.md
+++ b/src/js/components/Video/README.md
@@ -11,6 +11,102 @@ import { Video } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **autoPlay**
 
 Enables automatic playback of the video as soon as it is loaded.

--- a/src/js/components/Video/StyledVideo.js
+++ b/src/js/components/Video/StyledVideo.js
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { normalizeColor } from '../../utils';
+import { genericStyles, normalizeColor } from '../../utils';
 
 const FIT_MAP = {
   cover: 'cover',
@@ -29,6 +29,7 @@ export const StyledVideoContainer = styled.div`
   flex-direction: column;
   overflow: hidden;
   position: relative;
+  ${genericStyles}
 `;
 
 const positionStyle = css`

--- a/src/js/components/Video/Video.js
+++ b/src/js/components/Video/Video.js
@@ -411,7 +411,7 @@ class Video extends Component {
 
   render() {
     const {
-      autoPlay, children, controls, loop, theme, ...rest
+      alignSelf, autoPlay, children, controls, gridArea, loop, margin, theme, ...rest
     } = this.props;
     const { height, videoRef, width } = this.state;
 
@@ -437,7 +437,14 @@ class Video extends Component {
     }
 
     return (
-      <StyledVideoContainer {...mouseEventListeners} theme={theme} style={style}>
+      <StyledVideoContainer
+        {...mouseEventListeners}
+        alignSelf={alignSelf}
+        gridArea={gridArea}
+        margin={margin}
+        theme={theme}
+        style={style}
+      >
         <StyledVideo
           {...rest}
           ref={videoRef}

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -41,6 +41,7 @@ exports[`Video autoPlay renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -56,7 +57,6 @@ exports[`Video autoPlay renders 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -68,6 +68,7 @@ exports[`Video autoPlay renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -81,7 +82,6 @@ exports[`Video autoPlay renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -93,6 +93,7 @@ exports[`Video autoPlay renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -105,7 +106,6 @@ exports[`Video autoPlay renders 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -117,6 +117,7 @@ exports[`Video autoPlay renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -125,7 +126,6 @@ exports[`Video autoPlay renders 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -137,12 +137,12 @@ exports[`Video autoPlay renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -155,6 +155,7 @@ exports[`Video autoPlay renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -168,7 +169,6 @@ exports[`Video autoPlay renders 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -216,6 +216,7 @@ exports[`Video autoPlay renders 1`] = `
 }
 
 .c16 {
+  margin: 0px;
   font-size: 18px;
   line-height: 24px;
   margin-top: 0px;
@@ -507,42 +508,39 @@ exports[`Video autoPlay renders 1`] = `
             </span>
           </div>
         </div>
-        <div
+        <button
+          aria-label="Open Menu"
+          className="c17"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
           onKeyDown={[Function]}
+          type="button"
         >
-          <button
-            aria-label="Open Menu"
-            className="c17"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            type="button"
+          <div
+            className="c18"
           >
-            <div
-              className="c18"
+            <span
+              className="c19"
+            />
+            <svg
+              aria-label="Actions"
+              className="c7"
+              height="24px"
+              role="img"
+              version="1.1"
+              viewBox="0 0 24 24"
+              width="24px"
             >
-              <span
-                className="c19"
+              <path
+                d="M12,17.5 C15.0375661,17.5 17.5,15.0375661 17.5,12 C17.5,8.96243388 15.0375661,6.5 12,6.5 C8.96243388,6.5 6.5,8.96243388 6.5,12 C6.5,15.0375661 8.96243388,17.5 12,17.5 Z M12,6.5 L12,1 M12,23 L12,17.5 M1,12 L6.5,12 M17.5,12 L23,12 M4.4375,4.4375 L8.5625,8.5625 M15.4375,15.4375 L19.5625,19.5625 M19.5625,4.4375 L15.4375,8.5625 M8.5625,15.4375 L4.4375,19.5625"
+                fill="none"
+                stroke="#000"
+                strokeWidth="2"
               />
-              <svg
-                aria-label="Actions"
-                className="c7"
-                height="24px"
-                role="img"
-                version="1.1"
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M12,17.5 C15.0375661,17.5 17.5,15.0375661 17.5,12 C17.5,8.96243388 15.0375661,6.5 12,6.5 C8.96243388,6.5 6.5,8.96243388 6.5,12 C6.5,15.0375661 8.96243388,17.5 12,17.5 Z M12,6.5 L12,1 M12,23 L12,17.5 M1,12 L6.5,12 M17.5,12 L23,12 M4.4375,4.4375 L8.5625,8.5625 M15.4375,15.4375 L19.5625,19.5625 M19.5625,4.4375 L15.4375,8.5625 M8.5625,15.4375 L4.4375,19.5625"
-                  fill="none"
-                  stroke="#000"
-                  strokeWidth="2"
-                />
-              </svg>
-            </div>
-          </button>
-        </div>
+            </svg>
+          </div>
+        </button>
       </div>
     </div>
   </div>
@@ -622,6 +620,7 @@ exports[`Video controls renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -637,7 +636,6 @@ exports[`Video controls renders 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -649,6 +647,7 @@ exports[`Video controls renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -662,7 +661,6 @@ exports[`Video controls renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -674,6 +672,7 @@ exports[`Video controls renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -686,7 +685,6 @@ exports[`Video controls renders 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -698,6 +696,7 @@ exports[`Video controls renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -706,7 +705,6 @@ exports[`Video controls renders 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -718,12 +716,12 @@ exports[`Video controls renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -736,6 +734,7 @@ exports[`Video controls renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -749,7 +748,6 @@ exports[`Video controls renders 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -761,6 +759,7 @@ exports[`Video controls renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -774,7 +773,6 @@ exports[`Video controls renders 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -847,6 +845,7 @@ exports[`Video controls renders 1`] = `
 }
 
 .c16 {
+  margin: 0px;
   font-size: 18px;
   line-height: 24px;
   margin-top: 0px;
@@ -1160,42 +1159,39 @@ exports[`Video controls renders 1`] = `
             </span>
           </div>
         </div>
-        <div
+        <button
+          aria-label="Open Menu"
+          className="c17"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
           onKeyDown={[Function]}
+          type="button"
         >
-          <button
-            aria-label="Open Menu"
-            className="c17"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            type="button"
+          <div
+            className="c18"
           >
-            <div
-              className="c18"
+            <span
+              className="c19"
+            />
+            <svg
+              aria-label="Actions"
+              className="c7"
+              height="24px"
+              role="img"
+              version="1.1"
+              viewBox="0 0 24 24"
+              width="24px"
             >
-              <span
-                className="c19"
+              <path
+                d="M12,17.5 C15.0375661,17.5 17.5,15.0375661 17.5,12 C17.5,8.96243388 15.0375661,6.5 12,6.5 C8.96243388,6.5 6.5,8.96243388 6.5,12 C6.5,15.0375661 8.96243388,17.5 12,17.5 Z M12,6.5 L12,1 M12,23 L12,17.5 M1,12 L6.5,12 M17.5,12 L23,12 M4.4375,4.4375 L8.5625,8.5625 M15.4375,15.4375 L19.5625,19.5625 M19.5625,4.4375 L15.4375,8.5625 M8.5625,15.4375 L4.4375,19.5625"
+                fill="none"
+                stroke="#000"
+                strokeWidth="2"
               />
-              <svg
-                aria-label="Actions"
-                className="c7"
-                height="24px"
-                role="img"
-                version="1.1"
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M12,17.5 C15.0375661,17.5 17.5,15.0375661 17.5,12 C17.5,8.96243388 15.0375661,6.5 12,6.5 C8.96243388,6.5 6.5,8.96243388 6.5,12 C6.5,15.0375661 8.96243388,17.5 12,17.5 Z M12,6.5 L12,1 M12,23 L12,17.5 M1,12 L6.5,12 M17.5,12 L23,12 M4.4375,4.4375 L8.5625,8.5625 M15.4375,15.4375 L19.5625,19.5625 M19.5625,4.4375 L15.4375,8.5625 M8.5625,15.4375 L4.4375,19.5625"
-                  fill="none"
-                  stroke="#000"
-                  strokeWidth="2"
-                />
-              </svg>
-            </div>
-          </button>
-        </div>
+            </svg>
+          </div>
+        </button>
       </div>
     </div>
   </div>
@@ -1319,42 +1315,39 @@ exports[`Video controls renders 1`] = `
             </span>
           </div>
         </div>
-        <div
+        <button
+          aria-label="Open Menu"
+          className="c17"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
           onKeyDown={[Function]}
+          type="button"
         >
-          <button
-            aria-label="Open Menu"
-            className="c17"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            type="button"
+          <div
+            className="c18"
           >
-            <div
-              className="c18"
+            <span
+              className="c19"
+            />
+            <svg
+              aria-label="Actions"
+              className="c23"
+              height="24px"
+              role="img"
+              version="1.1"
+              viewBox="0 0 24 24"
+              width="24px"
             >
-              <span
-                className="c19"
+              <path
+                d="M12,17.5 C15.0375661,17.5 17.5,15.0375661 17.5,12 C17.5,8.96243388 15.0375661,6.5 12,6.5 C8.96243388,6.5 6.5,8.96243388 6.5,12 C6.5,15.0375661 8.96243388,17.5 12,17.5 Z M12,6.5 L12,1 M12,23 L12,17.5 M1,12 L6.5,12 M17.5,12 L23,12 M4.4375,4.4375 L8.5625,8.5625 M15.4375,15.4375 L19.5625,19.5625 M19.5625,4.4375 L15.4375,8.5625 M8.5625,15.4375 L4.4375,19.5625"
+                fill="none"
+                stroke="#000"
+                strokeWidth="2"
               />
-              <svg
-                aria-label="Actions"
-                className="c23"
-                height="24px"
-                role="img"
-                version="1.1"
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M12,17.5 C15.0375661,17.5 17.5,15.0375661 17.5,12 C17.5,8.96243388 15.0375661,6.5 12,6.5 C8.96243388,6.5 6.5,8.96243388 6.5,12 C6.5,15.0375661 8.96243388,17.5 12,17.5 Z M12,6.5 L12,1 M12,23 L12,17.5 M1,12 L6.5,12 M17.5,12 L23,12 M4.4375,4.4375 L8.5625,8.5625 M15.4375,15.4375 L19.5625,19.5625 M19.5625,4.4375 L15.4375,8.5625 M8.5625,15.4375 L4.4375,19.5625"
-                  fill="none"
-                  stroke="#000"
-                  strokeWidth="2"
-                />
-              </svg>
-            </div>
-          </button>
-        </div>
+            </svg>
+          </div>
+        </button>
       </div>
     </div>
   </div>
@@ -1402,6 +1395,7 @@ exports[`Video fit renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1417,7 +1411,6 @@ exports[`Video fit renders 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1429,6 +1422,7 @@ exports[`Video fit renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1442,7 +1436,6 @@ exports[`Video fit renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1454,6 +1447,7 @@ exports[`Video fit renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1466,7 +1460,6 @@ exports[`Video fit renders 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1478,6 +1471,7 @@ exports[`Video fit renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1486,7 +1480,6 @@ exports[`Video fit renders 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1498,12 +1491,12 @@ exports[`Video fit renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -1516,6 +1509,7 @@ exports[`Video fit renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1529,7 +1523,6 @@ exports[`Video fit renders 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -1577,6 +1570,7 @@ exports[`Video fit renders 1`] = `
 }
 
 .c16 {
+  margin: 0px;
   font-size: 18px;
   line-height: 24px;
   margin-top: 0px;
@@ -1886,42 +1880,39 @@ exports[`Video fit renders 1`] = `
             </span>
           </div>
         </div>
-        <div
+        <button
+          aria-label="Open Menu"
+          className="c17"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
           onKeyDown={[Function]}
+          type="button"
         >
-          <button
-            aria-label="Open Menu"
-            className="c17"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            type="button"
+          <div
+            className="c18"
           >
-            <div
-              className="c18"
+            <span
+              className="c19"
+            />
+            <svg
+              aria-label="Actions"
+              className="c7"
+              height="24px"
+              role="img"
+              version="1.1"
+              viewBox="0 0 24 24"
+              width="24px"
             >
-              <span
-                className="c19"
+              <path
+                d="M12,17.5 C15.0375661,17.5 17.5,15.0375661 17.5,12 C17.5,8.96243388 15.0375661,6.5 12,6.5 C8.96243388,6.5 6.5,8.96243388 6.5,12 C6.5,15.0375661 8.96243388,17.5 12,17.5 Z M12,6.5 L12,1 M12,23 L12,17.5 M1,12 L6.5,12 M17.5,12 L23,12 M4.4375,4.4375 L8.5625,8.5625 M15.4375,15.4375 L19.5625,19.5625 M19.5625,4.4375 L15.4375,8.5625 M8.5625,15.4375 L4.4375,19.5625"
+                fill="none"
+                stroke="#000"
+                strokeWidth="2"
               />
-              <svg
-                aria-label="Actions"
-                className="c7"
-                height="24px"
-                role="img"
-                version="1.1"
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M12,17.5 C15.0375661,17.5 17.5,15.0375661 17.5,12 C17.5,8.96243388 15.0375661,6.5 12,6.5 C8.96243388,6.5 6.5,8.96243388 6.5,12 C6.5,15.0375661 8.96243388,17.5 12,17.5 Z M12,6.5 L12,1 M12,23 L12,17.5 M1,12 L6.5,12 M17.5,12 L23,12 M4.4375,4.4375 L8.5625,8.5625 M15.4375,15.4375 L19.5625,19.5625 M19.5625,4.4375 L15.4375,8.5625 M8.5625,15.4375 L4.4375,19.5625"
-                  fill="none"
-                  stroke="#000"
-                  strokeWidth="2"
-                />
-              </svg>
-            </div>
-          </button>
-        </div>
+            </svg>
+          </div>
+        </button>
       </div>
     </div>
   </div>
@@ -2049,42 +2040,39 @@ exports[`Video fit renders 1`] = `
             </span>
           </div>
         </div>
-        <div
+        <button
+          aria-label="Open Menu"
+          className="c17"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
           onKeyDown={[Function]}
+          type="button"
         >
-          <button
-            aria-label="Open Menu"
-            className="c17"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            type="button"
+          <div
+            className="c18"
           >
-            <div
-              className="c18"
+            <span
+              className="c19"
+            />
+            <svg
+              aria-label="Actions"
+              className="c7"
+              height="24px"
+              role="img"
+              version="1.1"
+              viewBox="0 0 24 24"
+              width="24px"
             >
-              <span
-                className="c19"
+              <path
+                d="M12,17.5 C15.0375661,17.5 17.5,15.0375661 17.5,12 C17.5,8.96243388 15.0375661,6.5 12,6.5 C8.96243388,6.5 6.5,8.96243388 6.5,12 C6.5,15.0375661 8.96243388,17.5 12,17.5 Z M12,6.5 L12,1 M12,23 L12,17.5 M1,12 L6.5,12 M17.5,12 L23,12 M4.4375,4.4375 L8.5625,8.5625 M15.4375,15.4375 L19.5625,19.5625 M19.5625,4.4375 L15.4375,8.5625 M8.5625,15.4375 L4.4375,19.5625"
+                fill="none"
+                stroke="#000"
+                strokeWidth="2"
               />
-              <svg
-                aria-label="Actions"
-                className="c7"
-                height="24px"
-                role="img"
-                version="1.1"
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M12,17.5 C15.0375661,17.5 17.5,15.0375661 17.5,12 C17.5,8.96243388 15.0375661,6.5 12,6.5 C8.96243388,6.5 6.5,8.96243388 6.5,12 C6.5,15.0375661 8.96243388,17.5 12,17.5 Z M12,6.5 L12,1 M12,23 L12,17.5 M1,12 L6.5,12 M17.5,12 L23,12 M4.4375,4.4375 L8.5625,8.5625 M15.4375,15.4375 L19.5625,19.5625 M19.5625,4.4375 L15.4375,8.5625 M8.5625,15.4375 L4.4375,19.5625"
-                  fill="none"
-                  stroke="#000"
-                  strokeWidth="2"
-                />
-              </svg>
-            </div>
-          </button>
-        </div>
+            </svg>
+          </div>
+        </button>
       </div>
     </div>
   </div>
@@ -2132,6 +2120,7 @@ exports[`Video loop renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2147,7 +2136,6 @@ exports[`Video loop renders 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2159,6 +2147,7 @@ exports[`Video loop renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2172,7 +2161,6 @@ exports[`Video loop renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2184,6 +2172,7 @@ exports[`Video loop renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2196,7 +2185,6 @@ exports[`Video loop renders 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2208,6 +2196,7 @@ exports[`Video loop renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -2216,7 +2205,6 @@ exports[`Video loop renders 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2228,12 +2216,12 @@ exports[`Video loop renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -2246,6 +2234,7 @@ exports[`Video loop renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2259,7 +2248,6 @@ exports[`Video loop renders 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -2307,6 +2295,7 @@ exports[`Video loop renders 1`] = `
 }
 
 .c16 {
+  margin: 0px;
   font-size: 18px;
   line-height: 24px;
   margin-top: 0px;
@@ -2598,42 +2587,39 @@ exports[`Video loop renders 1`] = `
             </span>
           </div>
         </div>
-        <div
+        <button
+          aria-label="Open Menu"
+          className="c17"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
           onKeyDown={[Function]}
+          type="button"
         >
-          <button
-            aria-label="Open Menu"
-            className="c17"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            type="button"
+          <div
+            className="c18"
           >
-            <div
-              className="c18"
+            <span
+              className="c19"
+            />
+            <svg
+              aria-label="Actions"
+              className="c7"
+              height="24px"
+              role="img"
+              version="1.1"
+              viewBox="0 0 24 24"
+              width="24px"
             >
-              <span
-                className="c19"
+              <path
+                d="M12,17.5 C15.0375661,17.5 17.5,15.0375661 17.5,12 C17.5,8.96243388 15.0375661,6.5 12,6.5 C8.96243388,6.5 6.5,8.96243388 6.5,12 C6.5,15.0375661 8.96243388,17.5 12,17.5 Z M12,6.5 L12,1 M12,23 L12,17.5 M1,12 L6.5,12 M17.5,12 L23,12 M4.4375,4.4375 L8.5625,8.5625 M15.4375,15.4375 L19.5625,19.5625 M19.5625,4.4375 L15.4375,8.5625 M8.5625,15.4375 L4.4375,19.5625"
+                fill="none"
+                stroke="#000"
+                strokeWidth="2"
               />
-              <svg
-                aria-label="Actions"
-                className="c7"
-                height="24px"
-                role="img"
-                version="1.1"
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M12,17.5 C15.0375661,17.5 17.5,15.0375661 17.5,12 C17.5,8.96243388 15.0375661,6.5 12,6.5 C8.96243388,6.5 6.5,8.96243388 6.5,12 C6.5,15.0375661 8.96243388,17.5 12,17.5 Z M12,6.5 L12,1 M12,23 L12,17.5 M1,12 L6.5,12 M17.5,12 L23,12 M4.4375,4.4375 L8.5625,8.5625 M15.4375,15.4375 L19.5625,19.5625 M19.5625,4.4375 L15.4375,8.5625 M8.5625,15.4375 L4.4375,19.5625"
-                  fill="none"
-                  stroke="#000"
-                  strokeWidth="2"
-                />
-              </svg>
-            </div>
-          </button>
-        </div>
+            </svg>
+          </div>
+        </button>
       </div>
     </div>
   </div>
@@ -2681,6 +2667,7 @@ exports[`Video mute renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2696,7 +2683,6 @@ exports[`Video mute renders 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2708,6 +2694,7 @@ exports[`Video mute renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2721,7 +2708,6 @@ exports[`Video mute renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2733,6 +2719,7 @@ exports[`Video mute renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2745,7 +2732,6 @@ exports[`Video mute renders 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2757,6 +2743,7 @@ exports[`Video mute renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -2765,7 +2752,6 @@ exports[`Video mute renders 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2777,12 +2763,12 @@ exports[`Video mute renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -2795,6 +2781,7 @@ exports[`Video mute renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2808,7 +2795,6 @@ exports[`Video mute renders 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -2856,6 +2842,7 @@ exports[`Video mute renders 1`] = `
 }
 
 .c16 {
+  margin: 0px;
   font-size: 18px;
   line-height: 24px;
   margin-top: 0px;
@@ -3147,42 +3134,39 @@ exports[`Video mute renders 1`] = `
             </span>
           </div>
         </div>
-        <div
+        <button
+          aria-label="Open Menu"
+          className="c17"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
           onKeyDown={[Function]}
+          type="button"
         >
-          <button
-            aria-label="Open Menu"
-            className="c17"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            type="button"
+          <div
+            className="c18"
           >
-            <div
-              className="c18"
+            <span
+              className="c19"
+            />
+            <svg
+              aria-label="Actions"
+              className="c7"
+              height="24px"
+              role="img"
+              version="1.1"
+              viewBox="0 0 24 24"
+              width="24px"
             >
-              <span
-                className="c19"
+              <path
+                d="M12,17.5 C15.0375661,17.5 17.5,15.0375661 17.5,12 C17.5,8.96243388 15.0375661,6.5 12,6.5 C8.96243388,6.5 6.5,8.96243388 6.5,12 C6.5,15.0375661 8.96243388,17.5 12,17.5 Z M12,6.5 L12,1 M12,23 L12,17.5 M1,12 L6.5,12 M17.5,12 L23,12 M4.4375,4.4375 L8.5625,8.5625 M15.4375,15.4375 L19.5625,19.5625 M19.5625,4.4375 L15.4375,8.5625 M8.5625,15.4375 L4.4375,19.5625"
+                fill="none"
+                stroke="#000"
+                strokeWidth="2"
               />
-              <svg
-                aria-label="Actions"
-                className="c7"
-                height="24px"
-                role="img"
-                version="1.1"
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M12,17.5 C15.0375661,17.5 17.5,15.0375661 17.5,12 C17.5,8.96243388 15.0375661,6.5 12,6.5 C8.96243388,6.5 6.5,8.96243388 6.5,12 C6.5,15.0375661 8.96243388,17.5 12,17.5 Z M12,6.5 L12,1 M12,23 L12,17.5 M1,12 L6.5,12 M17.5,12 L23,12 M4.4375,4.4375 L8.5625,8.5625 M15.4375,15.4375 L19.5625,19.5625 M19.5625,4.4375 L15.4375,8.5625 M8.5625,15.4375 L4.4375,19.5625"
-                  fill="none"
-                  stroke="#000"
-                  strokeWidth="2"
-                />
-              </svg>
-            </div>
-          </button>
-        </div>
+            </svg>
+          </div>
+        </button>
       </div>
     </div>
   </div>
@@ -3230,6 +3214,7 @@ exports[`Video renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3245,7 +3230,6 @@ exports[`Video renders 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3257,6 +3241,7 @@ exports[`Video renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3270,7 +3255,6 @@ exports[`Video renders 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3282,6 +3266,7 @@ exports[`Video renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3294,7 +3279,6 @@ exports[`Video renders 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3306,6 +3290,7 @@ exports[`Video renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3314,7 +3299,6 @@ exports[`Video renders 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -3326,12 +3310,12 @@ exports[`Video renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -3344,6 +3328,7 @@ exports[`Video renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3357,7 +3342,6 @@ exports[`Video renders 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  margin: 0px;
   padding: 12px;
 }
 
@@ -3405,6 +3389,7 @@ exports[`Video renders 1`] = `
 }
 
 .c16 {
+  margin: 0px;
   font-size: 18px;
   line-height: 24px;
   margin-top: 0px;
@@ -3696,42 +3681,39 @@ exports[`Video renders 1`] = `
             </span>
           </div>
         </div>
-        <div
+        <button
+          aria-label="Open Menu"
+          className="c17"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
           onKeyDown={[Function]}
+          type="button"
         >
-          <button
-            aria-label="Open Menu"
-            className="c17"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            type="button"
+          <div
+            className="c18"
           >
-            <div
-              className="c18"
+            <span
+              className="c19"
+            />
+            <svg
+              aria-label="Actions"
+              className="c7"
+              height="24px"
+              role="img"
+              version="1.1"
+              viewBox="0 0 24 24"
+              width="24px"
             >
-              <span
-                className="c19"
+              <path
+                d="M12,17.5 C15.0375661,17.5 17.5,15.0375661 17.5,12 C17.5,8.96243388 15.0375661,6.5 12,6.5 C8.96243388,6.5 6.5,8.96243388 6.5,12 C6.5,15.0375661 8.96243388,17.5 12,17.5 Z M12,6.5 L12,1 M12,23 L12,17.5 M1,12 L6.5,12 M17.5,12 L23,12 M4.4375,4.4375 L8.5625,8.5625 M15.4375,15.4375 L19.5625,19.5625 M19.5625,4.4375 L15.4375,8.5625 M8.5625,15.4375 L4.4375,19.5625"
+                fill="none"
+                stroke="#000"
+                strokeWidth="2"
               />
-              <svg
-                aria-label="Actions"
-                className="c7"
-                height="24px"
-                role="img"
-                version="1.1"
-                viewBox="0 0 24 24"
-                width="24px"
-              >
-                <path
-                  d="M12,17.5 C15.0375661,17.5 17.5,15.0375661 17.5,12 C17.5,8.96243388 15.0375661,6.5 12,6.5 C8.96243388,6.5 6.5,8.96243388 6.5,12 C6.5,15.0375661 8.96243388,17.5 12,17.5 Z M12,6.5 L12,1 M12,23 L12,17.5 M1,12 L6.5,12 M17.5,12 L23,12 M4.4375,4.4375 L8.5625,8.5625 M15.4375,15.4375 L19.5625,19.5625 M19.5625,4.4375 L15.4375,8.5625 M8.5625,15.4375 L4.4375,19.5625"
-                  fill="none"
-                  stroke="#000"
-                  strokeWidth="2"
-                />
-              </svg>
-            </div>
-          </button>
-        </div>
+            </svg>
+          </div>
+        </button>
       </div>
     </div>
   </div>

--- a/src/js/components/Video/doc.js
+++ b/src/js/components/Video/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (Video) => {
   const DocumentedVideo = describe(Video)
@@ -12,6 +12,7 @@ export const doc = (Video) => {
     );
 
   DocumentedVideo.propTypes = {
+    ...genericProps,
     autoPlay: PropTypes.bool.description(
       'Enables automatic playback of the video as soon as it is loaded.'
     ),

--- a/src/js/components/Video/index.d.ts
+++ b/src/js/components/Video/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
 export interface VideoProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   autoPlay?: boolean;
   controls?: "false" | "over" | "below";
   fit?: "cover" | "contain";

--- a/src/js/components/WorldMap/README.md
+++ b/src/js/components/WorldMap/README.md
@@ -11,6 +11,102 @@ import { WorldMap } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **color**
 
 Default color

--- a/src/js/components/WorldMap/StyledWorldMap.js
+++ b/src/js/components/WorldMap/StyledWorldMap.js
@@ -1,7 +1,10 @@
 import styled from 'styled-components';
 
+import { genericStyles } from '../../utils';
+
 export const StyledWorldMap = styled.svg`
   width: 100%;
 
-  ${props => props.theme.diagram && props.theme.diagram.extend}
+  ${genericStyles}
+  ${props => props.theme.worldMap && props.theme.worldMap.extend}
 `;

--- a/src/js/components/WorldMap/WorldMap.js
+++ b/src/js/components/WorldMap/WorldMap.js
@@ -400,6 +400,7 @@ class WorldMap extends Component {
         preserveAspectRatio='xMinYMin meet'
         width={width}
         height={height}
+        theme={theme}
         {...interactiveProps}
         {...rest}
       >

--- a/src/js/components/WorldMap/doc.js
+++ b/src/js/components/WorldMap/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { genericProps, getAvailableAtBadge } from '../../utils';
 
 export const doc = (WorldMap) => {
   const DocumentedWorldMap = describe(WorldMap)
@@ -9,6 +9,7 @@ export const doc = (WorldMap) => {
     .usage("import { WorldMap } from 'grommet';\n<WorldMap />");
 
   DocumentedWorldMap.propTypes = {
+    ...genericProps,
     color: PropTypes.string.description('Default color'),
     continents: PropTypes.arrayOf(PropTypes.shape({
       color: PropTypes.string,

--- a/src/js/components/WorldMap/index.d.ts
+++ b/src/js/components/WorldMap/index.d.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
 export interface WorldMapProps {
+  a11yTitle?: string;
+  alignSelf?: "start" | "center" | "end" | "stretch";
+  gridArea?: string;
+  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   color?: string;
   continents?: {color: string,name: "Africa" | "Asia" | "Australia" | "Europe" | "North America" | "South America",onClick: (...args: any[]) => any,onHover: (...args: any[]) => any}[];
   onSelectPlace?: (...args: any[]) => any;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -18,6 +18,102 @@ import { Accordion, AccordionPanel } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **activeIndex**
 
 Active panel index. If specified, Accordion will be a controlled component. This means that future
@@ -120,6 +216,94 @@ Custom title to be used by screen readers.
 string
 \`\`\`
 
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **href**
 
 Hyperlink reference to place in the anchor.
@@ -190,6 +374,94 @@ Custom title to be used by screen readers.
 string
 \`\`\`
 
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **align**
 
 How to align the contents along the cross axis.
@@ -213,18 +485,6 @@ center
 end
 between
 around
-stretch
-\`\`\`
-
-**alignSelf**
-
-How to align along the cross axis when contained in
-        a Box or along the column axis when contained in a Grid.
-
-\`\`\`
-start
-center
-end
 stretch
 \`\`\`
 
@@ -447,15 +707,6 @@ xlarge
 string
 \`\`\`
 
-**gridArea**
-
-The name of the area to place
-      this Box in inside a parent Grid.
-
-\`\`\`
-string
-\`\`\`
-
 **height**
 
 A fixed height.
@@ -478,73 +729,6 @@ start
 center
 between
 end
-\`\`\`
-
-**margin**
-
-The amount of margin around the box. An object can
-        be specified to distinguish horizontal margin, vertical margin, and
-        margin on a particular side of the box
-
-\`\`\`
-none
-xxsmall
-xsmall
-small
-medium
-large
-xlarge
-{
-  bottom: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge
-    string,
-  horizontal: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge
-    string,
-  left: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge
-    string,
-  right: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge
-    string,
-  top: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge
-    string,
-  vertical: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge
-    string
-}
-string
 \`\`\`
 
 **overflow**
@@ -725,6 +909,94 @@ Custom title to be used by screen readers.
 string
 \`\`\`
 
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **active**
 
 Whether the button is active.
@@ -864,6 +1136,102 @@ import { Calendar } from 'grommet';
 \`\`\`
 
 ## Properties
+
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
 
 **animate**
 
@@ -1037,6 +1405,102 @@ import { Carousel } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **fill**
 
 Whether to expand to fill
@@ -1068,6 +1532,102 @@ import { Chart } from 'grommet';
 \`\`\`
 
 ## Properties
+
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
 
 **bounds**
 
@@ -1312,6 +1872,102 @@ import { Clock } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **hourLimit**
 
 Whether to roll over the hours after 12 or after 24. Defaults to \`24\`.
@@ -1426,6 +2082,102 @@ import { DataTable } from 'grommet';
 \`\`\`
 
 ## Properties
+
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
 
 **columns**
 
@@ -1621,6 +2373,102 @@ import { Distribution } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **children**
 
 Function that will be called when each value is rendered.
@@ -1768,6 +2616,94 @@ Custom title to be used by screen readers.
 string
 \`\`\`
 
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **disabled**
 
 Whether the button should be disabled.
@@ -1908,6 +2844,102 @@ import { Grid } from 'grommet';
 \`\`\`
 
 ## Properties
+
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
 
 **align**
 
@@ -2182,6 +3214,102 @@ import { Heading } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **color**
 
 A color identifier to use for the text color. For example:
@@ -2206,39 +3334,6 @@ The sizing can be further adjusted using the size property.
 2
 3
 4
-\`\`\`
-
-**margin**
-
-The amount of margin above and/or below the heading. An object can be
-specified to distinguish top margin and bottom margin.
-
-\`\`\`
-none
-xsmall
-small
-medium
-large
-xlarge
-{
-  bottom: 
-    none
-    xsmall
-    small
-    medium
-    large
-    xlarge
-    string,
-  top: 
-    none
-    xsmall
-    small
-    medium
-    large
-    xlarge
-    string
-}
-string
 \`\`\`
 
 **responsive**
@@ -2295,6 +3390,102 @@ import { Image } from 'grommet';
 \`\`\`
 
 ## Properties
+
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
 
 **fit**
 
@@ -2664,6 +3855,102 @@ import { Menu } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **disabled**
 
 Whether the menu should be disabled.
@@ -2786,6 +4073,102 @@ import { Meter } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **background**
 
 Background color
@@ -2882,10 +4265,30 @@ import { Paragraph } from 'grommet';
 
 ## Properties
 
-**color**
+**a11yTitle**
 
-A color identifier to use for the text color. For example:
-'status-critical'.
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
 
 \`\`\`
 string
@@ -2893,26 +4296,77 @@ string
 
 **margin**
 
-The amount of margin above and/or below the paragraph. An object can be
-specified to distinguish top margin and bottom margin.
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
 
 \`\`\`
 none
+xxsmall
+xsmall
 small
 medium
 large
+xlarge
 {
   bottom: 
+    xxsmall
+    xsmall
     small
     medium
     large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
     string,
   top: 
+    xxsmall
+    xsmall
     small
     medium
     large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
     string
 }
+string
+\`\`\`
+
+**color**
+
+A color identifier to use for the text color. For example:
+'status-critical'.
+
+\`\`\`
 string
 \`\`\`
 
@@ -3286,6 +4740,94 @@ Custom title to be used by screen readers.
 string
 \`\`\`
 
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **children**
 
 Function that will be called when each option is rendered.
@@ -3517,6 +5059,102 @@ import { Stack } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **anchor**
 
 Where to anchor children from. If not specified, children
@@ -3587,6 +5225,102 @@ import { Table, TableHeader, TableFooter, TableBody, TableRow } from 'grommet';
 \`\`\`
 
 ## Properties
+
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
 
 **caption**
 
@@ -3726,6 +5460,102 @@ import { Tabs, Tab } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **activeIndex**
 
 Active tab index. If specified, Tabs will be a controlled component. This means that future
@@ -3788,10 +5618,30 @@ import { Text } from 'grommet';
 
 ## Properties
 
-**color**
+**a11yTitle**
 
-A color identifier to use for the text color. For example:
-'status-critical'.
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
 
 \`\`\`
 string
@@ -3819,6 +5669,15 @@ large
     large
     string
 }
+string
+\`\`\`
+
+**color**
+
+A color identifier to use for the text color. For example:
+'status-critical'.
+
+\`\`\`
 string
 \`\`\`
 
@@ -4126,6 +5985,102 @@ import { Video } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **autoPlay**
 
 Enables automatic playback of the video as soon as it is loaded.
@@ -4181,6 +6136,102 @@ import { WorldMap } from 'grommet';
 \`\`\`
 
 ## Properties
+
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
 
 **color**
 

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -213,7 +213,12 @@ Object {
   "TableFooter": [Function],
   "TableHeader": [Function],
   "TableRow": [Function],
-  "Tabs": [Function],
+  "Tabs": Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "displayName": "Tabs",
+    "name": "Tabs",
+    "render": [Function],
+  },
   "Text": Object {
     "$$typeof": Symbol(react.forward_ref),
     "displayName": "Text",

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -5,6 +5,10 @@ Object {
   "Accordion": "import * as React from \\"react\\";
 
 export interface AccordionProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   activeIndex?: number | number[];
   animate?: boolean;
   children: React.ReactNode;
@@ -32,6 +36,9 @@ export { AccordionPanel };
 
 export interface AnchorProps {
   a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   href?: string;
   icon?: JSX.Element;
   label?: React.ReactNode;
@@ -48,9 +55,11 @@ export { Anchor };
 
 export interface BoxProps {
   a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   align?: \\"start\\" | \\"center\\" | \\"end\\" | \\"baseline\\" | \\"stretch\\";
   alignContent?: \\"start\\" | \\"center\\" | \\"end\\" | \\"between\\" | \\"around\\" | \\"stretch\\";
-  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
   animation?: \\"fadeIn\\" | \\"fadeOut\\" | \\"jiggle\\" | \\"pulse\\" | \\"slideUp\\" | \\"slideDown\\" | \\"slideLeft\\" | \\"slideRight\\" | \\"zoomIn\\" | \\"zoomOut\\" | {type: \\"fadeIn\\" | \\"fadeOut\\" | \\"jiggle\\" | \\"pulse\\" | \\"slideUp\\" | \\"slideDown\\" | \\"slideLeft\\" | \\"slideRight\\" | \\"zoomIn\\" | \\"zoomOut\\",delay: number,duration: number,size: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\"} | \\"fadeIn\\" | \\"fadeOut\\" | \\"jiggle\\" | \\"pulse\\" | \\"slideUp\\" | \\"slideDown\\" | \\"slideLeft\\" | \\"slideRight\\" | \\"zoomIn\\" | \\"zoomOut\\" | {type: \\"fadeIn\\" | \\"fadeOut\\" | \\"jiggle\\" | \\"pulse\\" | \\"slideUp\\" | \\"slideDown\\" | \\"slideLeft\\" | \\"slideRight\\" | \\"zoomIn\\" | \\"zoomOut\\",delay: number,duration: number,size: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\"}[];
   background?: string | {color: string,dark: boolean | string,image: string,position: string,opacity: \\"weak\\" | \\"medium\\" | \\"strong\\" | boolean,light: string};
   basis?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | \\"full\\" | \\"1/2\\" | \\"1/3\\" | \\"2/3\\" | \\"1/4\\" | \\"2/4\\" | \\"3/4\\" | \\"auto\\" | string;
@@ -60,10 +69,8 @@ export interface BoxProps {
   flex?: \\"grow\\" | \\"shrink\\" | \\"true\\" | \\"false\\";
   fill?: \\"horizontal\\" | \\"vertical\\" | \\"true\\" | \\"false\\";
   gap?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string;
-  gridArea?: string;
   height?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string;
   justify?: \\"start\\" | \\"center\\" | \\"between\\" | \\"end\\";
-  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   overflow?: \\"auto\\" | \\"hidden\\" | \\"scroll\\" | \\"visible\\" | {horizontal: \\"auto\\" | \\"hidden\\" | \\"scroll\\" | \\"visible\\",vertical: \\"auto\\" | \\"hidden\\" | \\"scroll\\" | \\"visible\\"} | string;
   pad?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\",horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\",left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\",right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\",top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\",vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\"} | string;
   responsive?: boolean;
@@ -81,6 +88,9 @@ export { Box };
 
 export interface ButtonProps {
   a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   active?: boolean;
   color?: string;
   disabled?: boolean;
@@ -104,6 +114,10 @@ export { Button };
   "Calendar": "import * as React from \\"react\\";
 
 export interface CalendarProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   animate?: boolean;
   bounds?: string[];
   date?: string;
@@ -127,6 +141,10 @@ export { Calendar };
   "Carousel": "import * as React from \\"react\\";
 
 export interface CarouselProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   fill?: boolean;
   play?: number;
 }
@@ -138,6 +156,10 @@ export { Carousel };
   "Chart": "import * as React from \\"react\\";
 
 export interface ChartProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   bounds?: number[][];
   color?: string | {color: string,opacity: \\"weak\\" | \\"medium\\" | \\"strong\\" | boolean};
   onClick?: (...args: any[]) => any;
@@ -174,6 +196,10 @@ export { CheckBox };
   "Clock": "import * as React from \\"react\\";
 
 export interface ClockProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   hourLimit?: \\"12\\" | \\"24\\" | \\"12\\" | \\"24\\";
   onChange?: (...args: any[]) => any;
   precision?: \\"hours\\" | \\"minutes\\" | \\"seconds\\";
@@ -201,6 +227,10 @@ export { Collapsible };
   "DataTable": "import * as React from \\"react\\";
 
 export interface DataTableProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   columns?: {align: \\"center\\" | \\"start\\" | \\"end\\",aggregate: \\"avg\\" | \\"max\\" | \\"min\\" | \\"sum\\",footer: React.ReactNode | {aggregate: boolean},header: string | React.ReactNode | {aggregate: boolean},property: string,render: (...args: any[]) => any,search: boolean}[];
   data?: {}[];
   groupBy?: string;
@@ -228,6 +258,10 @@ export { Diagram };
   "Distribution": "import * as React from \\"react\\";
 
 export interface DistributionProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   children?: (...args: any[]) => any;
   gap?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string;
   values: {value: number}[];
@@ -257,6 +291,9 @@ export { Drop };
 
 export interface DropButtonProps {
   a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   disabled?: boolean;
   dropAlign?: {top: \\"top\\" | \\"bottom\\",bottom: \\"top\\" | \\"bottom\\",right: \\"left\\" | \\"right\\",left: \\"left\\" | \\"right\\"};
   dropContent: JSX.Element;
@@ -286,6 +323,10 @@ export { FormField };
   "Grid": "import * as React from \\"react\\";
 
 export interface GridProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   align?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
   alignContent?: \\"start\\" | \\"center\\" | \\"end\\" | \\"between\\" | \\"around\\" | \\"stretch\\";
   areas?: {name: string,start: number[],end: number[]}[];
@@ -316,9 +357,12 @@ export { Grommet };
   "Heading": "import * as React from \\"react\\";
 
 export interface HeadingProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   color?: string;
   level?: \\"1\\" | \\"2\\" | \\"3\\" | \\"4\\" | \\"1\\" | \\"2\\" | \\"3\\" | \\"4\\";
-  margin?: \\"none\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"none\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"none\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   responsive?: boolean;
   size?: \\"small\\" | \\"medium\\" | \\"large\\" | string;
   textAlign?: \\"start\\" | \\"center\\" | \\"end\\";
@@ -332,6 +376,10 @@ export { Heading };
   "Image": "import * as React from \\"react\\";
 
 export interface ImageProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   fit?: \\"cover\\" | \\"contain\\";
 }
 
@@ -406,6 +454,10 @@ export { Markdown };
   "Menu": "import * as React from \\"react\\";
 
 export interface MenuProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   disabled?: boolean;
   dropAlign?: {top: \\"top\\" | \\"bottom\\",bottom: \\"top\\" | \\"bottom\\",left: \\"right\\" | \\"left\\",right: \\"right\\" | \\"left\\"};
   dropBackground?: string | {color: string,opacity: \\"weak\\" | \\"medium\\" | \\"strong\\" | boolean};
@@ -424,6 +476,10 @@ export { Menu };
   "Meter": "import * as React from \\"react\\";
 
 export interface MeterProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   background?: string | {color: string,opacity: \\"weak\\" | \\"medium\\" | \\"strong\\" | boolean};
   round?: boolean;
   size?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | \\"full\\" | string;
@@ -439,8 +495,11 @@ export { Meter };
   "Paragraph": "import * as React from \\"react\\";
 
 export interface ParagraphProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   color?: string;
-  margin?: \\"none\\" | \\"small\\" | \\"medium\\" | \\"large\\" | {bottom: \\"small\\" | \\"medium\\" | \\"large\\" | string,top: \\"small\\" | \\"medium\\" | \\"large\\" | string} | string;
   size?: \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string;
   textAlign?: \\"start\\" | \\"center\\" | \\"end\\";
 }
@@ -527,6 +586,9 @@ export { RoutedButton };
 
 export interface SelectProps {
   a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   children?: (...args: any[]) => any;
   closeOnChange?: boolean;
   disabled?: boolean;
@@ -565,6 +627,10 @@ export { SkipLinks };
   "Stack": "import * as React from \\"react\\";
 
 export interface StackProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   anchor?: \\"center\\" | \\"left\\" | \\"right\\" | \\"top\\" | \\"bottom\\" | \\"top-left\\" | \\"bottom-left\\" | \\"top-right\\" | \\"bottom-right\\";
   fill?: boolean;
   guidingChild?: number | \\"first\\" | \\"last\\";
@@ -587,6 +653,10 @@ export { Tab };
   "Table": "import * as React from \\"react\\";
 
 export interface TableProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   caption?: string;
 }
 
@@ -650,6 +720,10 @@ export { TableRow };
   "Tabs": "import * as React from \\"react\\";
 
 export interface TabsProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   activeIndex?: number;
   children: React.ReactNode;
   justify?: \\"start\\" | \\"center\\" | \\"end\\";
@@ -664,8 +738,11 @@ export { Tabs };
   "Text": "import * as React from \\"react\\";
 
 export interface TextProps {
-  color?: string;
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
   margin?: \\"none\\" | \\"small\\" | \\"medium\\" | \\"large\\" | {bottom: \\"small\\" | \\"medium\\" | \\"large\\" | string,top: \\"small\\" | \\"medium\\" | \\"large\\" | string} | string;
+  color?: string;
   size?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | \\"xxlarge\\" | string;
   tag?: string;
   textAlign?: \\"start\\" | \\"center\\" | \\"end\\";
@@ -719,6 +796,10 @@ export { TextInput };
   "Video": "import * as React from \\"react\\";
 
 export interface VideoProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   autoPlay?: boolean;
   controls?: \\"false\\" | \\"over\\" | \\"below\\";
   fit?: \\"cover\\" | \\"contain\\";
@@ -733,6 +814,10 @@ export { Video };
   "WorldMap": "import * as React from \\"react\\";
 
 export interface WorldMapProps {
+  a11yTitle?: string;
+  alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
+  gridArea?: string;
+  margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   color?: string;
   continents?: {color: string,name: \\"Africa\\" | \\"Asia\\" | \\"Australia\\" | \\"Europe\\" | \\"North America\\" | \\"South America\\",onClick: (...args: any[]) => any,onHover: (...args: any[]) => any}[];
   onSelectPlace?: (...args: any[]) => any;

--- a/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
+++ b/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
@@ -9,13 +9,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #FD6FFF;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -27,13 +27,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #60EB9F;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -45,13 +45,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #60EBE1;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -63,13 +63,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #FFCA58;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -81,13 +81,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #333333;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -99,13 +99,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #444444;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -117,13 +117,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #555555;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -135,13 +135,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #666666;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -153,13 +153,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #777777;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -171,13 +171,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #F6F6F6;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -189,13 +189,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #EEEEEE;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -207,13 +207,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #DDDDDD;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -225,13 +225,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #CCCCCC;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -243,13 +243,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #BBBBBB;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -261,13 +261,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #EB6060;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -279,13 +279,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #01C781;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -297,13 +297,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #6095EB;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -315,13 +315,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #FF3333;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -333,13 +333,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #a8a8a8;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -351,13 +351,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #7DD892;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -369,13 +369,13 @@ exports[`dark renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #F7E464;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -871,6 +871,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #FD6FFF;
   color: #444444;
   min-width: 0;
@@ -878,7 +879,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -890,6 +890,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #61EC9F;
   color: #444444;
   min-width: 0;
@@ -897,7 +898,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -909,6 +909,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #60EBE1;
   color: #444444;
   min-width: 0;
@@ -916,7 +917,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -928,6 +928,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
@@ -935,7 +936,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -947,6 +947,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #333333;
   color: #f8f8f8;
   min-width: 0;
@@ -954,7 +955,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -966,6 +966,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #444444;
   color: #f8f8f8;
   min-width: 0;
@@ -973,7 +974,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -985,6 +985,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #555555;
   color: #f8f8f8;
   min-width: 0;
@@ -992,7 +993,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1004,6 +1004,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #666666;
   color: #f8f8f8;
   min-width: 0;
@@ -1011,7 +1012,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1023,6 +1023,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #777777;
   color: #f8f8f8;
   min-width: 0;
@@ -1030,7 +1031,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1042,6 +1042,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #F6F6F6;
   color: #444444;
   min-width: 0;
@@ -1049,7 +1050,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1061,6 +1061,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #EEEEEE;
   color: #444444;
   min-width: 0;
@@ -1068,7 +1069,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1080,6 +1080,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #DDDDDD;
   color: #444444;
   min-width: 0;
@@ -1087,7 +1088,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1099,6 +1099,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #CCCCCC;
   color: #444444;
   min-width: 0;
@@ -1106,7 +1107,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1118,6 +1118,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #BBBBBB;
   color: #444444;
   min-width: 0;
@@ -1125,7 +1126,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1137,6 +1137,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #3D138D;
   color: #f8f8f8;
   min-width: 0;
@@ -1144,7 +1145,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1156,6 +1156,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #BE60EB;
   color: #444444;
   min-width: 0;
@@ -1163,7 +1164,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1175,6 +1175,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #00C781;
   color: #444444;
   min-width: 0;
@@ -1182,7 +1183,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1194,6 +1194,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #EB6060;
   color: #444444;
   min-width: 0;
@@ -1201,7 +1202,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1213,6 +1213,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #a8a8a8;
   color: #444444;
   min-width: 0;
@@ -1220,7 +1221,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1232,6 +1232,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #7CD992;
   color: #444444;
   min-width: 0;
@@ -1239,7 +1240,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1251,6 +1251,7 @@ exports[`default renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #F7E463;
   color: #444444;
   min-width: 0;
@@ -1258,7 +1259,6 @@ exports[`default renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1751,6 +1751,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #333333;
   color: #f8f8f8;
   min-width: 0;
@@ -1758,7 +1759,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1770,6 +1770,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #444444;
   color: #f8f8f8;
   min-width: 0;
@@ -1777,7 +1778,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1789,6 +1789,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #555555;
   color: #f8f8f8;
   min-width: 0;
@@ -1796,7 +1797,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1808,6 +1808,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #666666;
   color: #f8f8f8;
   min-width: 0;
@@ -1815,7 +1816,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1827,6 +1827,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #777777;
   color: #f8f8f8;
   min-width: 0;
@@ -1834,7 +1835,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1846,6 +1846,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #F6F6F6;
   color: #444444;
   min-width: 0;
@@ -1853,7 +1854,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1865,6 +1865,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #EEEEEE;
   color: #444444;
   min-width: 0;
@@ -1872,7 +1873,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1884,6 +1884,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #DDDDDD;
   color: #444444;
   min-width: 0;
@@ -1891,7 +1892,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1903,6 +1903,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #CCCCCC;
   color: #444444;
   min-width: 0;
@@ -1910,7 +1911,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1922,6 +1922,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #BBBBBB;
   color: #444444;
   min-width: 0;
@@ -1929,7 +1930,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1941,6 +1941,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #2AD2C9;
   color: #444444;
   min-width: 0;
@@ -1948,7 +1949,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1960,6 +1960,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #614767;
   color: #f8f8f8;
   min-width: 0;
@@ -1967,7 +1968,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1979,6 +1979,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #ff8d6d;
   color: #444444;
   min-width: 0;
@@ -1986,7 +1987,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -1998,6 +1998,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #01a982;
   color: #f8f8f8;
   min-width: 0;
@@ -2005,7 +2006,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2017,6 +2017,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #425563;
   color: #f8f8f8;
   min-width: 0;
@@ -2024,7 +2025,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2036,6 +2036,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #5F7A76;
   color: #f8f8f8;
   min-width: 0;
@@ -2043,7 +2044,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2055,6 +2055,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #80746E;
   color: #f8f8f8;
   min-width: 0;
@@ -2062,7 +2063,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2074,6 +2074,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #F04953;
   color: #f8f8f8;
   min-width: 0;
@@ -2081,7 +2082,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 
@@ -2093,6 +2093,7 @@ exports[`hpe renders 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  margin: 0px;
   background: #FFD144;
   color: #444444;
   min-width: 0;
@@ -2100,7 +2101,6 @@ exports[`hpe renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin: 0px;
   padding: 0px;
 }
 

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -158,6 +158,7 @@ export const generate = (baseSpacing = 24, scale = 6) => { // 24
         medium: `${baseSpacing}px`, // 24
         large: `${baseSpacing * 2}px`, // 48
         xlarge: `${baseSpacing * 4}px`, // 96
+        responsiveBreakpoint: 'small',
       },
       elevation: {
         light: {

--- a/src/js/utils/prop-types.js
+++ b/src/js/utils/prop-types.js
@@ -12,3 +12,47 @@ export const backgroundPropType = PropTypes.oneOfType([
     ]),
   }),
 ]).description('Background color');
+
+const MARGIN_SIZES = ['xxsmall', 'xsmall', 'small', 'medium', 'large', 'xlarge'];
+
+export const genericProps = {
+  a11yTitle: a11yTitlePropType,
+  alignSelf: PropTypes.oneOf(['start', 'center', 'end', 'stretch'])
+    .description(`How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.`),
+  gridArea: PropTypes.string.description(`The name of the area to place
+    this inside a parent Grid.`),
+  margin: PropTypes.oneOfType([
+    PropTypes.oneOf(['none', ...MARGIN_SIZES]),
+    PropTypes.shape({
+      bottom: PropTypes.oneOfType([
+        PropTypes.oneOf(MARGIN_SIZES),
+        PropTypes.string,
+      ]),
+      horizontal: PropTypes.oneOfType([
+        PropTypes.oneOf(MARGIN_SIZES),
+        PropTypes.string,
+      ]),
+      left: PropTypes.oneOfType([
+        PropTypes.oneOf(MARGIN_SIZES),
+        PropTypes.string,
+      ]),
+      right: PropTypes.oneOfType([
+        PropTypes.oneOf(MARGIN_SIZES),
+        PropTypes.string,
+      ]),
+      top: PropTypes.oneOfType([
+        PropTypes.oneOf(MARGIN_SIZES),
+        PropTypes.string,
+      ]),
+      vertical: PropTypes.oneOfType([
+        PropTypes.oneOf(MARGIN_SIZES),
+        PropTypes.string,
+      ]),
+    }),
+    PropTypes.string,
+  ])
+    .description(`The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.`),
+};

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -160,3 +160,18 @@ export const evalStyle = (arg, theme) => {
   }
   return arg;
 };
+
+const ALIGN_SELF_MAP = {
+  center: 'center',
+  end: 'flex-end',
+  start: 'flex-start',
+  stretch: 'stretch',
+};
+
+export const genericStyles = css`
+  ${props => props.alignSelf && `align-self: ${ALIGN_SELF_MAP[props.alignSelf]};`}
+  ${props => props.gridArea && `grid-area: ${props.gridArea};`}
+  ${props => (props.margin
+    && edgeStyle('margin', props.margin, props.responsive,
+      props.theme.global.edgeSize.responsiveBreakpoint, props.theme))}
+`;


### PR DESCRIPTION
#### What does this PR do?

Added generic styling to most components: a11yTitle, alignSelf, gridArea, margin

#### Where should the reviewer start?

styles.js

#### What testing has been done on this PR?

storybook

#### How should this be manually tested?

storybook

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/2335

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

BREAKING CHANGE: The `margin` property of `Heading`, `Paragraph`, and `Text` used to only set margin on the top and bottom when a single size value was provided. Now, the `margin` property of those components has been aligned with how `margin` worked with `Box`. 