### PR TITLE
Changed Anchor to add `color`, update styling, and fix some theme issues

### DIFF
--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { cloneElement, Component } from 'react';
 import { compose } from 'recompose';
 
 import { Box } from '../Box';
@@ -6,6 +6,7 @@ import { Text } from '../Text';
 import { withFocus, withForwardRef, withTheme } from '../hocs';
 
 import { StyledAnchor } from './StyledAnchor';
+import { normalizeColor } from '../../utils';
 
 class Anchor extends Component {
   constructor(props) {
@@ -21,38 +22,43 @@ class Anchor extends Component {
     const {
       a11yTitle,
       children,
+      color,
       disabled,
       forwardRef,
       href,
       icon,
       focus,
       label,
-      primary,
       onClick,
       reverse,
       theme,
       ...rest
     } = this.props;
 
-    const anchorLabel = typeof label === 'string' ? (
-      <Text>
-        <strong>{label}</strong>
-      </Text>
-    ) : label;
+    const anchorLabel = typeof label === 'string'
+      ? <Text>{label}</Text>
+      : label;
 
-    const first = reverse ? anchorLabel : icon;
-    const second = reverse ? icon : anchorLabel;
+    let coloredIcon = icon;
+    if (icon && !icon.props.color) {
+      coloredIcon = cloneElement(
+        icon, { color: normalizeColor(color || theme.anchor.color, theme) }
+      );
+    }
+
+    const first = reverse ? anchorLabel : coloredIcon;
+    const second = reverse ? coloredIcon : anchorLabel;
 
     return (
       <StyledAnchor
         {...rest}
         ref={forwardRef}
         aria-label={a11yTitle}
+        color={color}
         disabled={disabled}
         hasIcon={!!icon}
         focus={focus}
         hasLabel={label}
-        primary={primary}
         reverse={reverse}
         theme={theme}
         href={!disabled ? href : undefined}

--- a/src/js/components/Anchor/README.md
+++ b/src/js/components/Anchor/README.md
@@ -109,6 +109,16 @@ xlarge
 string
 ```
 
+**color**
+
+
+      Label color and icon color, if not specified on the icon.
+    
+
+```
+string
+```
+
 **href**
 
 Hyperlink reference to place in the anchor.

--- a/src/js/components/Anchor/StyledAnchor.js
+++ b/src/js/components/Anchor/StyledAnchor.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { focusStyle, genericStyles, normalizeColor } from '../../utils';
 
@@ -12,25 +12,26 @@ export const StyledAnchor = styled.a`
   box-sizing: border-box;
   font-size: inherit;
   line-height: inherit;
-  color: ${props => normalizeColor(props.theme.anchor.color, props.theme)};
+  color: ${props => normalizeColor(props.color || props.theme.anchor.color, props.theme)};
+  ${props => props.theme.anchor.fontWeight
+    && `font-weight: ${props.theme.anchor.fontWeight};`}
   text-decoration: ${props => (props.hasIcon ? 'none' : props.theme.anchor.textDecoration)};
   cursor: pointer;
   outline: none;
   ${genericStyles}
 
-  ${props => !props.disabled && `
+  ${props => !props.disabled && props.theme.anchor.hover && css`
     &:hover {
-      text-decoration: underline;
+      ${props.theme.anchor.hover.textDecoration
+        && `text-decoration: ${props.theme.anchor.hover.textDecoration};`}
+      ${props.theme.anchor.hover.fontWeight
+        && `font-weight: ${props.theme.anchor.hover.fontWeight};`}
+      ${props.theme.anchor.hover.extend}
     }
-  `}
-
-  ${props => !props.primary && props.hasIcon && props.hasLabel && `
-    color: ${normalizeColor('text', props.theme)};
   `}
   ${props => props.hasIcon && !props.hasLabel && `
     padding: ${props.theme.global.edgeSize.small};
   `}
-
   ${props => props.disabled && disabledStyle}
   ${props => props.focus && focusStyle}
   ${props => props.theme.anchor.extend}

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
@@ -16,6 +16,7 @@ exports[`Anchor disabled renders 1`] = `
   font-size: inherit;
   line-height: inherit;
   color: #1D67E3;
+  font-weight: 600;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -59,6 +60,7 @@ exports[`Anchor focus renders 1`] = `
   font-size: inherit;
   line-height: inherit;
   color: #1D67E3;
+  font-weight: 600;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -135,9 +137,7 @@ exports[`Anchor focus renders 1`] = `
       <span
         className="c3"
       >
-        <strong>
-          Test
-        </strong>
+        Test
       </span>
     </span>
   </a>
@@ -172,11 +172,11 @@ exports[`Anchor icon label renders 1`] = `
   font-size: inherit;
   line-height: inherit;
   color: #1D67E3;
+  font-weight: 600;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
   outline: none;
-  color: #444444;
 }
 
 .c1:hover {
@@ -234,16 +234,16 @@ exports[`Anchor icon label renders 1`] = `
         }
       }
     >
-      <svg />
+      <svg
+        color="#1D67E3"
+      />
       <div
         className="c3"
       />
       <span
         className="c4"
       >
-        <strong>
-          Test
-        </strong>
+        Test
       </span>
     </span>
   </a>
@@ -271,6 +271,7 @@ exports[`Anchor primary renders 1`] = `
   font-size: inherit;
   line-height: inherit;
   color: #1D67E3;
+  font-weight: 600;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -335,9 +336,7 @@ exports[`Anchor primary renders 1`] = `
       <span
         className="c3"
       >
-        <strong>
-          Test
-        </strong>
+        Test
       </span>
     </span>
   </a>
@@ -360,6 +359,7 @@ exports[`Anchor renders 1`] = `
   font-size: inherit;
   line-height: inherit;
   color: #1D67E3;
+  font-weight: 600;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -398,6 +398,7 @@ exports[`Anchor renders with children 1`] = `
   font-size: inherit;
   line-height: inherit;
   color: #1D67E3;
+  font-weight: 600;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -451,11 +452,11 @@ exports[`Anchor reverse icon label renders 1`] = `
   font-size: inherit;
   line-height: inherit;
   color: #1D67E3;
+  font-weight: 600;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
   outline: none;
-  color: #444444;
 }
 
 .c1:hover {
@@ -516,14 +517,14 @@ exports[`Anchor reverse icon label renders 1`] = `
       <span
         className="c3"
       >
-        <strong>
-          Test
-        </strong>
+        Test
       </span>
       <div
         className="c4"
       />
-      <svg />
+      <svg
+        color="#1D67E3"
+      />
     </span>
   </a>
 </div>
@@ -545,6 +546,7 @@ exports[`Anchor warns about invalid icon render 1`] = `
   font-size: inherit;
   line-height: inherit;
   color: #1D67E3;
+  font-weight: 600;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -607,7 +609,9 @@ exports[`Anchor warns about invalid icon render 1`] = `
         }
       }
     >
-      <svg />
+      <svg
+        color="#1D67E3"
+      />
     </span>
   </a>
 </div>
@@ -634,6 +638,7 @@ exports[`Anchor warns about invalid label render 1`] = `
   font-size: inherit;
   line-height: inherit;
   color: #1D67E3;
+  font-weight: 600;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -698,9 +703,7 @@ exports[`Anchor warns about invalid label render 1`] = `
       <span
         className="c3"
       >
-        <strong>
-          Test
-        </strong>
+        Test
       </span>
     </span>
   </a>

--- a/src/js/components/Anchor/anchor.stories.js
+++ b/src/js/components/Anchor/anchor.stories.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 
 import { Add } from 'grommet-icons';
 
-import { Anchor, Grommet } from 'grommet';
+import { Anchor, Box, Grommet } from 'grommet';
 import { grommet } from 'grommet/themes';
 
 storiesOf('Anchor', module)
@@ -12,13 +12,23 @@ storiesOf('Anchor', module)
       <Anchor href='#'>Link</Anchor>
     </Grommet>
   ))
-  .add('Icon', () => (
+  .add('Colors', () => (
     <Grommet theme={grommet}>
-      <Anchor icon={<Add />} label='Add' href='#' />
+      <Box pad='medium' gap='medium'>
+        <Anchor icon={<Add />} href='#' />
+        <Anchor icon={<Add />} label='Add' href='#' />
+        <Anchor label='Add' href='#' />
+      </Box>
+      <Box background='dark-1' pad='medium' gap='medium'>
+        <Anchor icon={<Add />} href='#' />
+        <Anchor icon={<Add />} label='Add' href='#' />
+        <Anchor icon={<Add />} label='Add' href='#' />
+        <Anchor label='Add' href='#' />
+      </Box>
     </Grommet>
   ))
-  .add('With Text', () => (
+  .add('Inline', () => (
     <Grommet theme={grommet}>
-      This is a <Anchor label='link' href='#' /> with text.
+      This is <Anchor label='an inline link' href='#' /> with surrounding text.
     </Grommet>
   ));

--- a/src/js/components/Anchor/doc.js
+++ b/src/js/components/Anchor/doc.js
@@ -17,6 +17,9 @@ or just use children.`
   DocumentedAnchor.propTypes = {
     ...genericProps,
     a11yTitle: PropTypes.string.description('Custom title to be used by screen readers.'),
+    color: PropTypes.string.description(`
+      Label color and icon color, if not specified on the icon.
+    `),
     href: PropTypes.string.description('Hyperlink reference to place in the anchor.'),
     icon: PropTypes.element.description('Icon element to place in the anchor.'),
     label: PropTypes.node.description('Label text to place in the anchor.'),

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -5,6 +5,7 @@ export interface AnchorProps {
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  color?: string;
   href?: string;
   icon?: JSX.Element;
   label?: React.ReactNode;

--- a/src/js/components/RoutedAnchor/__tests__/__snapshots__/RoutedAnchor-test.js.snap
+++ b/src/js/components/RoutedAnchor/__tests__/__snapshots__/RoutedAnchor-test.js.snap
@@ -21,6 +21,7 @@ exports[`RoutedAnchor renders 1`] = `
   font-size: inherit;
   line-height: inherit;
   color: #1D67E3;
+  font-weight: 600;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -87,9 +88,7 @@ exports[`RoutedAnchor renders 1`] = `
         <span
           className="c3"
         >
-          <strong>
-            Test
-          </strong>
+          Test
         </span>
       </span>
     </a>

--- a/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
+++ b/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
@@ -6,6 +6,7 @@ exports[`SkipLink basic 1`] = `
   font-size: inherit;
   line-height: inherit;
   color: #1D67E3;
+  font-weight: 600;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -67,7 +68,7 @@ exports[`SkipLink basic 2`] = `
   <div>
     <a
       aria-hidden="true"
-      class="StyledAnchor-sc-1rp7lwl-0 kPVGRd"
+      class="StyledAnchor-sc-1rp7lwl-0 kXgTZT"
       id="main"
       style="width: 0px; height: 0px; overflow: hidden; position: absolute;"
       tabindex="-1"
@@ -81,7 +82,7 @@ exports[`SkipLink basic 2`] = `
   <footer>
     <a
       aria-hidden="true"
-      class="StyledAnchor-sc-1rp7lwl-0 kPVGRd"
+      class="StyledAnchor-sc-1rp7lwl-0 kXgTZT"
       id="footer"
       style="width: 0px; height: 0px; overflow: hidden; position: absolute;"
       tabindex="-1"
@@ -101,7 +102,7 @@ exports[`SkipLink basic 3`] = `
   <div>
     <a
       aria-hidden="true"
-      class="StyledAnchor-sc-1rp7lwl-0 kPVGRd"
+      class="StyledAnchor-sc-1rp7lwl-0 kXgTZT"
       id="main"
       style="width: 0px; height: 0px; overflow: hidden; position: absolute;"
       tabindex="-1"
@@ -115,7 +116,7 @@ exports[`SkipLink basic 3`] = `
   <footer>
     <a
       aria-hidden="true"
-      class="StyledAnchor-sc-1rp7lwl-0 kPVGRd"
+      class="StyledAnchor-sc-1rp7lwl-0 kXgTZT"
       id="footer"
       style="width: 0px; height: 0px; overflow: hidden; position: absolute;"
       tabindex="-1"

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -304,6 +304,16 @@ xlarge
 string
 \`\`\`
 
+**color**
+
+
+      Label color and icon color, if not specified on the icon.
+    
+
+\`\`\`
+string
+\`\`\`
+
 **href**
 
 Hyperlink reference to place in the anchor.

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -39,6 +39,7 @@ export interface AnchorProps {
   alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
   gridArea?: string;
   margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
+  color?: string;
   href?: string;
   icon?: JSX.Element;
   label?: React.ReactNode;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -234,6 +234,11 @@ export const generate = (baseSpacing = 24, scale = 6) => { // 24
         dark: '#6194EB',
         light: '#1D67E3',
       },
+      hover: {
+        textDecoration: 'underline',
+        // fontWeight: undefined,
+        // extend: undefined,
+      },
     },
     box: {
       responsiveBreakpoint: 'small', // when we switch rows to columns

--- a/src/js/themes/grommet.js
+++ b/src/js/themes/grommet.js
@@ -56,7 +56,6 @@ export const grommet = deepFreeze({
     },
   },
   anchor: {
-    textDecoration: 'underline',
     color: {
       dark: '#FD6FFF',
       light: '#9060EB',


### PR DESCRIPTION
#### What does this PR do?

Changed Anchor to add `color`, update styling, and fix some theme issues.
Of note, Anchors with `icon` will now render the icon and any label using the same color as label-only anchors.

Also fixed an issue with how `grommet-icons` colors were being setup by Grommet.js.

#### Where should the reviewer start?

Anchor/doc.js

#### What testing has been done on this PR?

storybook

#### How should this be manually tested?

storybook

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/2264
https://github.com/grommet/grommet/issues/2209

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

Visually, this will render Anchors with icons using the same color as label-only Anchors.
