### PR TITLE
Added the right system-ui font config for grommet theme.

### DIFF
--- a/src/js/themes/grommet.js
+++ b/src/js/themes/grommet.js
@@ -9,7 +9,7 @@ export const grommet = deepFreeze({
     },
     font: {
       family:
-        '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans",  "Helvetica Neue", Arial, sans-serif,  "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";',
+        '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans",  "Helvetica Neue", Arial, sans-serif,  "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
     },
   },
   anchor: {

--- a/src/js/themes/grommet.js
+++ b/src/js/themes/grommet.js
@@ -8,7 +8,8 @@ export const grommet = deepFreeze({
       background: '#ffffff',
     },
     font: {
-      family: '"San Francisco", "Helvetica Neue", Helvetica, Arial, sans-serif',
+      family:
+        '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans",  "Helvetica Neue", Arial, sans-serif,  "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";',
     },
   },
   anchor: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changes Grommet theme to properly definitely all system fonts across different devices
#### Where should the reviewer start?
base.js
#### What testing has been done on this PR?
manual
#### How should this be manually tested?
open storybook
#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards