### PR TITLE
Added theme documentation for Accordion and Box.

### DIFF
--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -828,11 +828,11 @@ exports[`Accordion change active index 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cHrFaK"
+    class="StyledBox-sc-13pk1d4-0 cYihDV"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="false"
@@ -842,10 +842,10 @@ exports[`Accordion change active index 2`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -854,7 +854,7 @@ exports[`Accordion change active index 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             <svg
               aria-label="FormDown"
@@ -876,11 +876,11 @@ exports[`Accordion change active index 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       />
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="true"
@@ -890,10 +890,10 @@ exports[`Accordion change active index 2`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -902,7 +902,7 @@ exports[`Accordion change active index 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             <svg
               aria-label="FormUp"
@@ -925,7 +925,7 @@ exports[`Accordion change active index 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       >
         Panel body 2
       </div>
@@ -1367,11 +1367,11 @@ exports[`Accordion change to second Panel 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cHrFaK"
+    class="StyledBox-sc-13pk1d4-0 cYihDV"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="false"
@@ -1381,10 +1381,10 @@ exports[`Accordion change to second Panel 2`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -1393,7 +1393,7 @@ exports[`Accordion change to second Panel 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             <svg
               aria-label="FormDown"
@@ -1415,18 +1415,18 @@ exports[`Accordion change to second Panel 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 fsIpUF"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="true"
@@ -1436,10 +1436,10 @@ exports[`Accordion change to second Panel 2`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -1448,7 +1448,7 @@ exports[`Accordion change to second Panel 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             .c0 {
   display: inline-block;
@@ -1503,11 +1503,11 @@ exports[`Accordion change to second Panel 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       >
         <div
           aria-hidden="false"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 dMYckW StyledBox-sc-13pk1d4-0 fsIpUF"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 dMYckW StyledBox-sc-13pk1d4-0 IRSNj"
           open=""
         >
           Panel body 2
@@ -1903,11 +1903,11 @@ exports[`Accordion change to second Panel without onActive 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cHrFaK"
+    class="StyledBox-sc-13pk1d4-0 cYihDV"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="false"
@@ -1917,10 +1917,10 @@ exports[`Accordion change to second Panel without onActive 2`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -1929,7 +1929,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             <svg
               aria-label="FormDown"
@@ -1951,11 +1951,11 @@ exports[`Accordion change to second Panel without onActive 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       />
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="true"
@@ -1965,10 +1965,10 @@ exports[`Accordion change to second Panel without onActive 2`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -1977,7 +1977,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             .c0 {
   display: inline-block;
@@ -2032,7 +2032,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       >
         Panel body 2
       </div>
@@ -3029,11 +3029,11 @@ exports[`Accordion multiple panels 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cHrFaK"
+    class="StyledBox-sc-13pk1d4-0 cYihDV"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="false"
@@ -3043,10 +3043,10 @@ exports[`Accordion multiple panels 2`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -3055,7 +3055,7 @@ exports[`Accordion multiple panels 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             <svg
               aria-label="FormDown"
@@ -3077,11 +3077,11 @@ exports[`Accordion multiple panels 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       />
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="true"
@@ -3091,10 +3091,10 @@ exports[`Accordion multiple panels 2`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -3103,7 +3103,7 @@ exports[`Accordion multiple panels 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             .c0 {
   display: inline-block;
@@ -3158,7 +3158,7 @@ exports[`Accordion multiple panels 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       >
         Panel body 2
       </div>
@@ -3172,11 +3172,11 @@ exports[`Accordion multiple panels 3`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cHrFaK"
+    class="StyledBox-sc-13pk1d4-0 cYihDV"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="true"
@@ -3186,10 +3186,10 @@ exports[`Accordion multiple panels 3`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -3198,7 +3198,7 @@ exports[`Accordion multiple panels 3`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             .c0 {
   display: inline-block;
@@ -3253,13 +3253,13 @@ exports[`Accordion multiple panels 3`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       >
         Panel body 1
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="true"
@@ -3269,10 +3269,10 @@ exports[`Accordion multiple panels 3`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -3281,7 +3281,7 @@ exports[`Accordion multiple panels 3`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             <svg
               aria-label="FormUp"
@@ -3304,7 +3304,7 @@ exports[`Accordion multiple panels 3`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       >
         Panel body 2
       </div>
@@ -3318,11 +3318,11 @@ exports[`Accordion multiple panels 4`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cHrFaK"
+    class="StyledBox-sc-13pk1d4-0 cYihDV"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="true"
@@ -3332,10 +3332,10 @@ exports[`Accordion multiple panels 4`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -3344,7 +3344,7 @@ exports[`Accordion multiple panels 4`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             <svg
               aria-label="FormUp"
@@ -3367,13 +3367,13 @@ exports[`Accordion multiple panels 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       >
         Panel body 1
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="false"
@@ -3383,10 +3383,10 @@ exports[`Accordion multiple panels 4`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -3395,7 +3395,7 @@ exports[`Accordion multiple panels 4`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             .c0 {
   display: inline-block;
@@ -3449,7 +3449,7 @@ exports[`Accordion multiple panels 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       />
     </div>
   </div>
@@ -3461,11 +3461,11 @@ exports[`Accordion multiple panels 5`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cHrFaK"
+    class="StyledBox-sc-13pk1d4-0 cYihDV"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="false"
@@ -3475,10 +3475,10 @@ exports[`Accordion multiple panels 5`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -3487,7 +3487,7 @@ exports[`Accordion multiple panels 5`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             .c0 {
   display: inline-block;
@@ -3541,11 +3541,11 @@ exports[`Accordion multiple panels 5`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       />
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="false"
@@ -3555,10 +3555,10 @@ exports[`Accordion multiple panels 5`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -3567,7 +3567,7 @@ exports[`Accordion multiple panels 5`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             <svg
               aria-label="FormDown"
@@ -3589,7 +3589,7 @@ exports[`Accordion multiple panels 5`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       />
     </div>
   </div>
@@ -4080,11 +4080,11 @@ exports[`Accordion set on hover 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cHrFaK"
+    class="StyledBox-sc-13pk1d4-0 cYihDV"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="false"
@@ -4094,10 +4094,10 @@ exports[`Accordion set on hover 2`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 QduAt"
@@ -4106,7 +4106,7 @@ exports[`Accordion set on hover 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             <svg
               aria-label="FormDown"
@@ -4128,18 +4128,18 @@ exports[`Accordion set on hover 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 fsIpUF"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="false"
@@ -4149,10 +4149,10 @@ exports[`Accordion set on hover 2`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -4161,7 +4161,7 @@ exports[`Accordion set on hover 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             <svg
               aria-label="FormDown"
@@ -4183,11 +4183,11 @@ exports[`Accordion set on hover 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 fsIpUF"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 2
         </div>
@@ -4202,11 +4202,11 @@ exports[`Accordion set on hover 3`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cHrFaK"
+    class="StyledBox-sc-13pk1d4-0 cYihDV"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="false"
@@ -4216,10 +4216,10 @@ exports[`Accordion set on hover 3`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 QduAt"
@@ -4228,7 +4228,7 @@ exports[`Accordion set on hover 3`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             <svg
               aria-label="FormDown"
@@ -4250,18 +4250,18 @@ exports[`Accordion set on hover 3`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 fsIpUF"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="false"
@@ -4271,10 +4271,10 @@ exports[`Accordion set on hover 3`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 QduAt"
@@ -4283,7 +4283,7 @@ exports[`Accordion set on hover 3`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             <svg
               aria-label="FormDown"
@@ -4305,11 +4305,11 @@ exports[`Accordion set on hover 3`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 fsIpUF"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 2
         </div>
@@ -4324,11 +4324,11 @@ exports[`Accordion set on hover 4`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cHrFaK"
+    class="StyledBox-sc-13pk1d4-0 cYihDV"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="false"
@@ -4338,10 +4338,10 @@ exports[`Accordion set on hover 4`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -4350,7 +4350,7 @@ exports[`Accordion set on hover 4`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             <svg
               aria-label="FormDown"
@@ -4372,18 +4372,18 @@ exports[`Accordion set on hover 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 fsIpUF"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="false"
@@ -4393,10 +4393,10 @@ exports[`Accordion set on hover 4`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 QduAt"
@@ -4405,7 +4405,7 @@ exports[`Accordion set on hover 4`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             <svg
               aria-label="FormDown"
@@ -4427,11 +4427,11 @@ exports[`Accordion set on hover 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 fsIpUF"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 2
         </div>
@@ -4446,11 +4446,11 @@ exports[`Accordion set on hover 5`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cHrFaK"
+    class="StyledBox-sc-13pk1d4-0 cYihDV"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="false"
@@ -4460,10 +4460,10 @@ exports[`Accordion set on hover 5`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -4472,7 +4472,7 @@ exports[`Accordion set on hover 5`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             <svg
               aria-label="FormDown"
@@ -4494,18 +4494,18 @@ exports[`Accordion set on hover 5`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 fsIpUF"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bQWGDI"
+      class="StyledBox-sc-13pk1d4-0 jqGCfM"
     >
       <button
         aria-expanded="false"
@@ -4515,10 +4515,10 @@ exports[`Accordion set on hover 5`] = `
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kbpcIQ"
+          class="StyledBox-sc-13pk1d4-0 erazuK"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dWtyJH"
+            class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
@@ -4527,7 +4527,7 @@ exports[`Accordion set on hover 5`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 ejkTTp"
+            class="StyledBox-sc-13pk1d4-0 kFjquy"
           >
             <svg
               aria-label="FormDown"
@@ -4549,11 +4549,11 @@ exports[`Accordion set on hover 5`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 jiwgKv"
+        class="StyledBox-sc-13pk1d4-0 gZSidW"
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 fsIpUF"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 2
         </div>

--- a/src/js/components/AccordionPanel/README.md
+++ b/src/js/components/AccordionPanel/README.md
@@ -21,3 +21,24 @@ If specified, the entire panel header will be managed by the caller.
 node
 ```
   
+## Theme
+  
+**accordion.icons.collapse**
+
+The icon to use when the panel is expanded. Expects `React.element`.
+
+Defaults to
+
+```
+<FormUp />
+```
+
+**accordion.icons.expand**
+
+The icon to use when the panel is collapsed. Expects `React.element`.
+
+Defaults to
+
+```
+<FormDown />
+```

--- a/src/js/components/AccordionPanel/doc.js
+++ b/src/js/components/AccordionPanel/doc.js
@@ -1,5 +1,18 @@
 import { describe, PropTypes } from 'react-desc';
 
+export const themeDoc = {
+  'accordion.icons.collapse': {
+    description: 'The icon to use when the panel is expanded.',
+    type: 'React.element',
+    defaultValue: '<FormUp />',
+  },
+  'accordion.icons.expand': {
+    description: 'The icon to use when the panel is collapsed.',
+    type: 'React.element',
+    defaultValue: '<FormDown />',
+  },
+};
+
 export function doc(Panel) {
   const DocumentedAccordionPanel = describe(Panel).description(
     'An Accordion panel.',

--- a/src/js/components/Anchor/README.md
+++ b/src/js/components/Anchor/README.md
@@ -174,64 +174,80 @@ boolean
   
 **global.focus.border.color**
 
-The color around the Anchor when in focus. Defaults to `#FD6FFF`.
+The color around the Anchor when in focus. Expects `string | { dark: string, light: string }`.
+
+Defaults to
 
 ```
-string | { dark: string, light: string }
+#FD6FFF
 ```
 
 **anchor.color**
 
-The color of the label text and icon strokes. Defaults to `{ light: '#1D67E3', dark: '#6194EB' }`.
+The color of the label text and icon strokes. Expects `string | { dark: string, light: string }`.
+
+Defaults to
 
 ```
-string | { dark: string, light: string }
+{ light: '#1D67E3', dark: '#6194EB' }
 ```
 
 **anchor.fontWeight**
 
-The font weight of the label. Defaults to `600`.
+The font weight of the label. Expects `number`.
+
+Defaults to
 
 ```
-number
+600
 ```
 
 **anchor.textDecoration**
 
-The text decoration of the label. Refer to https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration for possible values. Defaults to `none`.
+The text decoration of the label. Refer to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration) for possible values. Expects `string`.
+
+Defaults to
 
 ```
-string
+none
 ```
 
 **anchor.hover.fontWeight**
 
-The font weight of the label when hovering. Defaults to `undefined`.
+The font weight of the label when hovering. Expects `number`.
+
+Defaults to
 
 ```
-number
+undefined
 ```
 
 **anchor.hover.textDecoration**
 
-The text decoration of the label when hovering. Refer to https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration for possible values. Defaults to `underline`.
+The text decoration of the label when hovering. Refer to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration) for possible values. Expects `string`.
+
+Defaults to
 
 ```
-string
+underline
 ```
 
 **anchor.hover.extend**
 
-Any additional style for the Anchor when hovering. Defaults to `undefined`.
+Any additional style for the Anchor when hovering. Expects `string | (props) => {}`.
+
+Defaults to
 
 ```
-string | (props) => {}
+undefined
 ```
 
 **anchor.extend**
 
-Any additional style for the Anchor. Defaults to `undefined`.
+Any additional style for the Anchor. Expects `string | (props) => {}`.
+
+Defaults to
 
 ```
-string | (props) => {}
+undefined
 ```

--- a/src/js/components/Anchor/doc.js
+++ b/src/js/components/Anchor/doc.js
@@ -20,7 +20,7 @@ export const themeDoc = {
   },
   'anchor.textDecoration': {
     description:
-      'The text decoration of the label. Refer to https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration for possible values.',
+      'The text decoration of the label. Refer to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration) for possible values.',
     type: 'string',
     defaultValue: 'none',
   },
@@ -31,7 +31,7 @@ export const themeDoc = {
   },
   'anchor.hover.textDecoration': {
     description:
-      'The text decoration of the label when hovering. Refer to https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration for possible values.',
+      'The text decoration of the label when hovering. Refer to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration) for possible values.',
     type: 'string',
     defaultValue: 'underline',
   },

--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -539,3 +539,187 @@ Whether children can wrap if they
 boolean
 ```
   
+## Theme
+  
+**global.animation**
+
+The animation configuration for the Box. Expects `object`.
+
+Defaults to
+
+```
+{
+  duration: '1s',
+  jiggle: {
+    duration: '0.1s',
+  },
+}
+```
+
+**global.border.size**
+
+The possible border sizes in the Box. Expects `object`.
+
+Defaults to
+
+```
+{
+  xsmall: '1px',
+  small: '2px',
+  medium: '4px',
+  large: '12px',
+  xlarge: '24px,
+}
+```
+
+**global.breakpoints**
+
+The possible breakpoints that could affect border, direction, gap, margin, pad, and round. Expects `object`.
+
+Defaults to
+
+```
+{
+  small: {
+    value: '768px',
+    borderSize: {
+      xsmall: '1px',
+      small: '2px',
+      medium: '4px',
+      large: '6px',
+      xlarge: '12px',
+    },
+    edgeSize: {
+      none: '0px',
+      hair: '1px',
+      xxsmall: '2px',
+      xsmall: '3px',
+      small: '6px',
+      medium: '12px',
+      large: '24px',
+      xlarge: '48px',
+    },
+    size: {
+      xxsmall: '24px',
+      xsmall: '48px',
+      small: '96px',
+      medium: '192px',
+      large: '384px',
+      xlarge: '768px',
+      full: '100%',
+    },
+  },
+  medium: {
+    value: '1536px',
+  },
+  large: {},
+}
+```
+
+**global.edgeSize**
+
+The possible sizes for gap, margin, and pad. Expects `object`.
+
+Defaults to
+
+```
+{
+  edgeSize: {
+    none: '0px',
+    hair: '1px',
+    xxsmall: '3px',
+    xsmall: '6px',
+    small: '12px',
+    medium: '24px',
+    large: '48px',
+    xlarge: '96px',
+    responsiveBreakpoint: 'small',
+  },
+}
+```
+
+**global.elevation**
+
+The possible shadows in Box elevation. Expects `object`.
+
+Defaults to
+
+```
+{
+  light: {
+    none: 'none',
+    xsmall: '0px 1px 2px rgba(100, 100, 100, 0.50)',
+    small: '0px 2px 4px rgba(100, 100, 100, 0.50)',
+    medium: '0px 3px 8px rgba(100, 100, 100, 0.50)',
+    large: '0px 6px 12px rgba(100, 100, 100, 0.50)',
+    xlarge: '0px 8px 16px rgba(100, 100, 100, 0.50)',
+  },
+  dark: {
+    none: 'none',
+    xsmall: '0px 2px 2px rgba(255, 255, 255, 0.40)',
+    small: '0px 4px 4px rgba(255, 255, 255, 0.40)',
+    medium: '0px 6px 8px rgba(255, 255, 255, 0.40)',
+    large: '0px 8px 16px rgba(255, 255, 255, 0.40)',
+    xlarge: '0px 10px 24px rgba(255, 255, 255, 0.40)',
+  },
+}
+```
+
+**global.colors.text**
+
+The text color used inside the Box. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+{ dark: '#f8f8f8', light: '#444444' }
+```
+
+**global.opacity.medium**
+
+The value used when background opacity is set to true. Expects `number`.
+
+Defaults to
+
+```
+0.4
+```
+
+**global.size**
+
+The possible sizes for width, height, and basis. Expects `object`.
+
+Defaults to
+
+```
+{
+  xxsmall: '48px',
+  xsmall: '96px',
+  small: '192px',
+  medium: '384px',
+  large: '768px',
+  xlarge: '1152px',
+  xxlarge: '1536px',
+  full: '100%',
+}
+```
+
+**box.extend**
+
+Any additional style for the Box. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```
+
+**box.responsiveBreakpoint**
+
+The actual breakpoint to trigger changes in the border, direction, gap, margin, pad, and round. Expects `string`.
+
+Defaults to
+
+```
+small
+```

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -4,7 +4,6 @@ import {
   backgroundStyle,
   breakpointStyle,
   edgeStyle,
-  focusStyle,
   genericStyles,
   normalizeColor,
   overflowStyle,
@@ -560,7 +559,6 @@ export const StyledBox = styled.div`
   ${props => props.overflowProp && overflowStyle(props.overflowProp)}
   ${props => props.elevationProp && elevationStyle}
   ${props => props.animation && animationStyle}
-  ${props => props.focus && focusStyle}
   ${props => props.theme.box && props.theme.box.extend}
 `;
 

--- a/src/js/components/Box/box.stories.js
+++ b/src/js/components/Box/box.stories.js
@@ -37,28 +37,16 @@ const SimpleBox = () => (
   </Grommet>
 );
 
-const customColorBox = {
-  global: {
-    colors: {
-      'brand-gradient':
-        'linear-gradient(102.77deg, #865ED6 -9.18%, #18BAB9 209.09%)',
-    },
-    font: {
-      family: 'Arial',
-    },
-  },
-};
-
 const CustomColorBox = () => (
-  <Grommet theme={customColorBox}>
+  <Grommet theme={grommet}>
     <Box
       justify="center"
       align="center"
       pad="xlarge"
-      background={{ color: 'brand-gradient', dark: true }}
+      background="linear-gradient(102.77deg, #865ED6 -9.18%, #18BAB9 209.09%)"
       round="large"
     >
-      <Text>I have a linear gradient background</Text>
+      <Text color="white">I have a linear gradient background</Text>
     </Box>
   </Grommet>
 );
@@ -170,6 +158,13 @@ const RoundBox = () => (
 const BackgroundBox = () => (
   <Grommet theme={grommet}>
     <Box pad="small" gap="small" align="start">
+      <Box
+        pad="small"
+        background={{ color: 'brand', opacity: true }}
+        elevation="large"
+      >
+        brand opacity
+      </Box>
       <Box pad="small" background="brand" elevation="large">
         brand
       </Box>

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -24,6 +24,144 @@ const ANIMATION_SHAPE = PropTypes.shape({
   size: PropTypes.oneOf(['xsmall', 'small', 'medium', 'large', 'xlarge']),
 });
 
+export const themeDoc = {
+  'global.animation': {
+    description: 'The animation configuration for the Box.',
+    type: 'object',
+    defaultValue: `{
+  duration: '1s',
+  jiggle: {
+    duration: '0.1s',
+  },
+}`,
+  },
+  'global.border.size': {
+    description: 'The possible border sizes in the Box.',
+    type: 'object',
+    defaultValue: `{
+  xsmall: '1px',
+  small: '2px',
+  medium: '4px',
+  large: '12px',
+  xlarge: '24px,
+}`,
+  },
+  'global.breakpoints': {
+    description:
+      'The possible breakpoints that could affect border, direction, gap, margin, pad, and round.',
+    type: 'object',
+    defaultValue: `{
+  small: {
+    value: '768px',
+    borderSize: {
+      xsmall: '1px',
+      small: '2px',
+      medium: '4px',
+      large: '6px',
+      xlarge: '12px',
+    },
+    edgeSize: {
+      none: '0px',
+      hair: '1px',
+      xxsmall: '2px',
+      xsmall: '3px',
+      small: '6px',
+      medium: '12px',
+      large: '24px',
+      xlarge: '48px',
+    },
+    size: {
+      xxsmall: '24px',
+      xsmall: '48px',
+      small: '96px',
+      medium: '192px',
+      large: '384px',
+      xlarge: '768px',
+      full: '100%',
+    },
+  },
+  medium: {
+    value: '1536px',
+  },
+  large: {},
+}`,
+  },
+  'global.edgeSize': {
+    description: 'The possible sizes for gap, margin, and pad.',
+    type: 'object',
+    defaultValue: `{
+  edgeSize: {
+    none: '0px',
+    hair: '1px',
+    xxsmall: '3px',
+    xsmall: '6px',
+    small: '12px',
+    medium: '24px',
+    large: '48px',
+    xlarge: '96px',
+    responsiveBreakpoint: 'small',
+  },
+}`,
+  },
+  'global.elevation': {
+    description: 'The possible shadows in Box elevation.',
+    type: 'object',
+    defaultValue: `{
+  light: {
+    none: 'none',
+    xsmall: '0px 1px 2px rgba(100, 100, 100, 0.50)',
+    small: '0px 2px 4px rgba(100, 100, 100, 0.50)',
+    medium: '0px 3px 8px rgba(100, 100, 100, 0.50)',
+    large: '0px 6px 12px rgba(100, 100, 100, 0.50)',
+    xlarge: '0px 8px 16px rgba(100, 100, 100, 0.50)',
+  },
+  dark: {
+    none: 'none',
+    xsmall: '0px 2px 2px rgba(255, 255, 255, 0.40)',
+    small: '0px 4px 4px rgba(255, 255, 255, 0.40)',
+    medium: '0px 6px 8px rgba(255, 255, 255, 0.40)',
+    large: '0px 8px 16px rgba(255, 255, 255, 0.40)',
+    xlarge: '0px 10px 24px rgba(255, 255, 255, 0.40)',
+  },
+}`,
+  },
+  'global.colors.text': {
+    description: 'The text color used inside the Box.',
+    type: 'string | { dark: string, light: string }',
+    defaultValue: "{ dark: '#f8f8f8', light: '#444444' }",
+  },
+  'global.opacity.medium': {
+    description: 'The value used when background opacity is set to true.',
+    type: 'number',
+    defaultValue: '0.4',
+  },
+  'global.size': {
+    description: 'The possible sizes for width, height, and basis.',
+    type: 'object',
+    defaultValue: `{
+  xxsmall: '48px',
+  xsmall: '96px',
+  small: '192px',
+  medium: '384px',
+  large: '768px',
+  xlarge: '1152px',
+  xxlarge: '1536px',
+  full: '100%',
+}`,
+  },
+  'box.extend': {
+    description: 'Any additional style for the Box.',
+    type: 'string | (props) => {}',
+    defaultValue: undefined,
+  },
+  'box.responsiveBreakpoint': {
+    description:
+      'The actual breakpoint to trigger changes in the border, direction, gap, margin, pad, and round.',
+    type: 'string',
+    defaultValue: 'small',
+  },
+};
+
 export const doc = Box => {
   const DocumentedBox = describe(Box)
     .availableAt(getAvailableAtBadge('Box'))

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -6,8 +6,6 @@ exports[`Calendar date 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
   fill: #666666;
   stroke: #666666;
 }
@@ -1262,8 +1260,6 @@ exports[`Calendar dates 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
   fill: #666666;
   stroke: #666666;
 }
@@ -2518,8 +2514,6 @@ exports[`Calendar firstDayOfWeek 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
   fill: #666666;
   stroke: #666666;
 }
@@ -5791,8 +5785,6 @@ exports[`Calendar reference 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
   fill: #666666;
   stroke: #666666;
 }
@@ -7022,40 +7014,6 @@ exports[`Calendar reference 1`] = `
 `;
 
 exports[`Calendar size 1`] = `
-.c21 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c21 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c21 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c21 *[stroke*="#"],
-.c21 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c21 *[fill-rule],
-.c21 *[FILL-RULE],
-.c21 *[fill*="#"],
-.c21 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
 .c9 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -7088,7 +7046,7 @@ exports[`Calendar size 1`] = `
   stroke: none;
 }
 
-.c29 {
+.c28 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -7099,25 +7057,25 @@ exports[`Calendar size 1`] = `
   stroke: #666666;
 }
 
-.c29 g {
+.c28 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c29 *:not([stroke])[fill="none"] {
+.c28 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c29 *[stroke*="#"],
-.c29 *[STROKE*="#"] {
+.c28 *[stroke*="#"],
+.c28 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c29 *[fill-rule],
-.c29 *[FILL-RULE],
-.c29 *[fill*="#"],
-.c29 *[FILL*="#"] {
+.c28 *[fill-rule],
+.c28 *[FILL-RULE],
+.c28 *[fill*="#"],
+.c28 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -7255,7 +7213,7 @@ exports[`Calendar size 1`] = `
   padding-right: 6px;
 }
 
-.c27 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7331,13 +7289,13 @@ exports[`Calendar size 1`] = `
   width: 192px;
 }
 
-.c26 {
+.c25 {
   font-size: 30px;
   line-height: 1.11;
   width: 768px;
 }
 
-.c22 {
+.c21 {
   overflow: hidden;
   height: 329.1428571428571px;
 }
@@ -7347,7 +7305,7 @@ exports[`Calendar size 1`] = `
   height: 164.57142857142856px;
 }
 
-.c30 {
+.c29 {
   overflow: hidden;
   height: 658.2857142857142px;
 }
@@ -7375,7 +7333,7 @@ exports[`Calendar size 1`] = `
   flex: 0 0 auto;
 }
 
-.c23 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7393,7 +7351,7 @@ exports[`Calendar size 1`] = `
   opacity: 0.5;
 }
 
-.c24 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7410,7 +7368,7 @@ exports[`Calendar size 1`] = `
   height: 54.857142857142854px;
 }
 
-.c25 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7485,7 +7443,7 @@ exports[`Calendar size 1`] = `
   font-weight: bold;
 }
 
-.c31 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7503,7 +7461,7 @@ exports[`Calendar size 1`] = `
   opacity: 0.5;
 }
 
-.c32 {
+.c31 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7520,7 +7478,7 @@ exports[`Calendar size 1`] = `
   height: 109.71428571428571px;
 }
 
-.c33 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7558,7 +7516,7 @@ exports[`Calendar size 1`] = `
   font-weight: 600;
 }
 
-.c28 {
+.c27 {
   margin: 0px;
   font-size: 34px;
   line-height: 40px;
@@ -7649,13 +7607,13 @@ exports[`Calendar size 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c27 {
+  .c26 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c27 {
+  .c26 {
     padding-left: 12px;
     padding-right: 12px;
   }
@@ -7676,13 +7634,13 @@ exports[`Calendar size 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c28 {
+  .c27 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c28 {
+  .c27 {
     font-size: 18px;
     line-height: 24px;
     max-width: 432px;
@@ -8619,7 +8577,7 @@ exports[`Calendar size 1`] = `
             >
               <svg
                 aria-label="Previous"
-                className="c21"
+                className="c9"
                 height="24px"
                 role="img"
                 size="medium"
@@ -8651,7 +8609,7 @@ exports[`Calendar size 1`] = `
             >
               <svg
                 aria-label="Next"
-                className="c21"
+                className="c9"
                 height="24px"
                 role="img"
                 size="medium"
@@ -8671,7 +8629,7 @@ exports[`Calendar size 1`] = `
         </div>
       </div>
       <div
-        className="c22"
+        className="c21"
       >
         <div
           className="c11"
@@ -8691,7 +8649,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c22"
                 >
                   31
                 </div>
@@ -8709,7 +8667,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   1
                 </div>
@@ -8727,7 +8685,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   2
                 </div>
@@ -8745,7 +8703,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   3
                 </div>
@@ -8763,7 +8721,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   4
                 </div>
@@ -8781,7 +8739,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   5
                 </div>
@@ -8799,7 +8757,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   6
                 </div>
@@ -8821,7 +8779,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   7
                 </div>
@@ -8839,7 +8797,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   8
                 </div>
@@ -8857,7 +8815,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   9
                 </div>
@@ -8875,7 +8833,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   10
                 </div>
@@ -8893,7 +8851,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   11
                 </div>
@@ -8911,7 +8869,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   12
                 </div>
@@ -8929,7 +8887,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   13
                 </div>
@@ -8951,7 +8909,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   14
                 </div>
@@ -8969,7 +8927,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c25"
+                  className="c24"
                 >
                   15
                 </div>
@@ -8987,7 +8945,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   16
                 </div>
@@ -9005,7 +8963,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   17
                 </div>
@@ -9023,7 +8981,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   18
                 </div>
@@ -9041,7 +8999,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   19
                 </div>
@@ -9059,7 +9017,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   20
                 </div>
@@ -9081,7 +9039,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   21
                 </div>
@@ -9099,7 +9057,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   22
                 </div>
@@ -9117,7 +9075,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   23
                 </div>
@@ -9135,7 +9093,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   24
                 </div>
@@ -9153,7 +9111,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   25
                 </div>
@@ -9171,7 +9129,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   26
                 </div>
@@ -9189,7 +9147,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   27
                 </div>
@@ -9211,7 +9169,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   28
                 </div>
@@ -9229,7 +9187,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   29
                 </div>
@@ -9247,7 +9205,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   30
                 </div>
@@ -9265,7 +9223,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c23"
                 >
                   31
                 </div>
@@ -9283,7 +9241,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c22"
                 >
                   1
                 </div>
@@ -9301,7 +9259,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c22"
                 >
                   2
                 </div>
@@ -9319,7 +9277,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c22"
                 >
                   3
                 </div>
@@ -9341,7 +9299,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c22"
                 >
                   4
                 </div>
@@ -9359,7 +9317,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c22"
                 >
                   5
                 </div>
@@ -9377,7 +9335,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c22"
                 >
                   6
                 </div>
@@ -9395,7 +9353,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c22"
                 >
                   7
                 </div>
@@ -9413,7 +9371,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c22"
                 >
                   8
                 </div>
@@ -9431,7 +9389,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c22"
                 >
                   9
                 </div>
@@ -9449,7 +9407,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c22"
                 >
                   10
                 </div>
@@ -9461,7 +9419,7 @@ exports[`Calendar size 1`] = `
     </div>
   </div>
   <div
-    className="c26"
+    className="c25"
   >
     <div
       className="c2"
@@ -9471,10 +9429,10 @@ exports[`Calendar size 1`] = `
         className="c3"
       >
         <div
-          className="c27"
+          className="c26"
         >
           <h3
-            className="-h3 c28"
+            className="-h3 c27"
             size="large"
           >
             January 2018
@@ -9497,7 +9455,7 @@ exports[`Calendar size 1`] = `
             >
               <svg
                 aria-label="Previous"
-                className="c29"
+                className="c28"
                 height="24px"
                 role="img"
                 size="large"
@@ -9529,7 +9487,7 @@ exports[`Calendar size 1`] = `
             >
               <svg
                 aria-label="Next"
-                className="c29"
+                className="c28"
                 height="24px"
                 role="img"
                 size="large"
@@ -9549,7 +9507,7 @@ exports[`Calendar size 1`] = `
         </div>
       </div>
       <div
-        className="c30"
+        className="c29"
       >
         <div
           className="c11"
@@ -9569,7 +9527,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c30"
                 >
                   31
                 </div>
@@ -9587,7 +9545,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   1
                 </div>
@@ -9605,7 +9563,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   2
                 </div>
@@ -9623,7 +9581,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   3
                 </div>
@@ -9641,7 +9599,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   4
                 </div>
@@ -9659,7 +9617,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   5
                 </div>
@@ -9677,7 +9635,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   6
                 </div>
@@ -9699,7 +9657,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   7
                 </div>
@@ -9717,7 +9675,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   8
                 </div>
@@ -9735,7 +9693,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   9
                 </div>
@@ -9753,7 +9711,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   10
                 </div>
@@ -9771,7 +9729,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   11
                 </div>
@@ -9789,7 +9747,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   12
                 </div>
@@ -9807,7 +9765,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   13
                 </div>
@@ -9829,7 +9787,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   14
                 </div>
@@ -9847,7 +9805,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   15
                 </div>
@@ -9865,7 +9823,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   16
                 </div>
@@ -9883,7 +9841,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   17
                 </div>
@@ -9901,7 +9859,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   18
                 </div>
@@ -9919,7 +9877,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   19
                 </div>
@@ -9937,7 +9895,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   20
                 </div>
@@ -9959,7 +9917,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   21
                 </div>
@@ -9977,7 +9935,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   22
                 </div>
@@ -9995,7 +9953,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   23
                 </div>
@@ -10013,7 +9971,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   24
                 </div>
@@ -10031,7 +9989,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   25
                 </div>
@@ -10049,7 +10007,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   26
                 </div>
@@ -10067,7 +10025,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   27
                 </div>
@@ -10089,7 +10047,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   28
                 </div>
@@ -10107,7 +10065,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   29
                 </div>
@@ -10125,7 +10083,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   30
                 </div>
@@ -10143,7 +10101,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c31"
                 >
                   31
                 </div>
@@ -10161,7 +10119,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c30"
                 >
                   1
                 </div>
@@ -10179,7 +10137,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c30"
                 >
                   2
                 </div>
@@ -10197,7 +10155,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c30"
                 >
                   3
                 </div>
@@ -10219,7 +10177,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c30"
                 >
                   4
                 </div>
@@ -10237,7 +10195,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c30"
                 >
                   5
                 </div>
@@ -10255,7 +10213,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c30"
                 >
                   6
                 </div>
@@ -10273,7 +10231,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c30"
                 >
                   7
                 </div>
@@ -10291,7 +10249,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c30"
                 >
                   8
                 </div>
@@ -10309,7 +10267,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c30"
                 >
                   9
                 </div>
@@ -10327,7 +10285,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c30"
                 >
                   10
                 </div>

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -6,6 +6,8 @@ exports[`Calendar date 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
   fill: #666666;
   stroke: #666666;
 }
@@ -1260,6 +1262,8 @@ exports[`Calendar dates 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
   fill: #666666;
   stroke: #666666;
 }
@@ -2514,6 +2518,8 @@ exports[`Calendar firstDayOfWeek 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
   fill: #666666;
   stroke: #666666;
 }
@@ -4912,7 +4918,7 @@ exports[`Calendar header 1`] = `
           size="small"
         >
           <strong>
-            October 2018
+            November 2018
           </strong>
         </span>
         <button
@@ -4957,554 +4963,6 @@ exports[`Calendar header 1`] = `
               className="c10"
             >
               <button
-                aria-label="Sun Sep 30 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c12"
-                >
-                  30
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Mon Oct 01 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  1
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Tue Oct 02 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  2
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Wed Oct 03 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  3
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Thu Oct 04 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  4
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Fri Oct 05 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  5
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Sat Oct 06 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  6
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            className="c9"
-          >
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Sun Oct 07 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  7
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Mon Oct 08 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  8
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Tue Oct 09 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  9
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Wed Oct 10 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  10
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Thu Oct 11 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  11
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Fri Oct 12 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  12
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Sat Oct 13 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  13
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            className="c9"
-          >
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Sun Oct 14 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  14
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Mon Oct 15 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  15
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Tue Oct 16 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  16
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Wed Oct 17 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  17
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Thu Oct 18 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  18
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Fri Oct 19 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  19
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Sat Oct 20 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  20
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            className="c9"
-          >
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Sun Oct 21 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  21
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Mon Oct 22 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  22
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Tue Oct 23 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  23
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Wed Oct 24 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  24
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Thu Oct 25 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  25
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Fri Oct 26 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  26
-                </div>
-              </button>
-            </div>
-            <div
-              className="c10"
-            >
-              <button
-                aria-label="Sat Oct 27 2018"
-                className="c11"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                type="button"
-              >
-                <div
-                  className="c13"
-                >
-                  27
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            className="c9"
-          >
-            <div
-              className="c10"
-            >
-              <button
                 aria-label="Sun Oct 28 2018"
                 className="c11"
                 disabled={false}
@@ -5514,7 +4972,7 @@ exports[`Calendar header 1`] = `
                 type="button"
               >
                 <div
-                  className="c13"
+                  className="c12"
                 >
                   28
                 </div>
@@ -5533,7 +4991,7 @@ exports[`Calendar header 1`] = `
                 type="button"
               >
                 <div
-                  className="c13"
+                  className="c12"
                 >
                   29
                 </div>
@@ -5552,7 +5010,7 @@ exports[`Calendar header 1`] = `
                 type="button"
               >
                 <div
-                  className="c13"
+                  className="c12"
                 >
                   30
                 </div>
@@ -5571,7 +5029,7 @@ exports[`Calendar header 1`] = `
                 type="button"
               >
                 <div
-                  className="c13"
+                  className="c12"
                 >
                   31
                 </div>
@@ -5590,7 +5048,7 @@ exports[`Calendar header 1`] = `
                 type="button"
               >
                 <div
-                  className="c12"
+                  className="c13"
                 >
                   1
                 </div>
@@ -5609,7 +5067,7 @@ exports[`Calendar header 1`] = `
                 type="button"
               >
                 <div
-                  className="c12"
+                  className="c13"
                 >
                   2
                 </div>
@@ -5628,7 +5086,7 @@ exports[`Calendar header 1`] = `
                 type="button"
               >
                 <div
-                  className="c12"
+                  className="c13"
                 >
                   3
                 </div>
@@ -5651,7 +5109,7 @@ exports[`Calendar header 1`] = `
                 type="button"
               >
                 <div
-                  className="c12"
+                  className="c13"
                 >
                   4
                 </div>
@@ -5670,7 +5128,7 @@ exports[`Calendar header 1`] = `
                 type="button"
               >
                 <div
-                  className="c12"
+                  className="c13"
                 >
                   5
                 </div>
@@ -5689,7 +5147,7 @@ exports[`Calendar header 1`] = `
                 type="button"
               >
                 <div
-                  className="c12"
+                  className="c13"
                 >
                   6
                 </div>
@@ -5708,7 +5166,7 @@ exports[`Calendar header 1`] = `
                 type="button"
               >
                 <div
-                  className="c12"
+                  className="c13"
                 >
                   7
                 </div>
@@ -5727,7 +5185,7 @@ exports[`Calendar header 1`] = `
                 type="button"
               >
                 <div
-                  className="c12"
+                  className="c13"
                 >
                   8
                 </div>
@@ -5746,7 +5204,7 @@ exports[`Calendar header 1`] = `
                 type="button"
               >
                 <div
-                  className="c12"
+                  className="c13"
                 >
                   9
                 </div>
@@ -5765,9 +5223,557 @@ exports[`Calendar header 1`] = `
                 type="button"
               >
                 <div
-                  className="c12"
+                  className="c13"
                 >
                   10
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            className="c9"
+          >
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Sun Nov 11 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  11
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Mon Nov 12 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  12
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Tue Nov 13 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  13
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Wed Nov 14 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  14
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Thu Nov 15 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  15
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Fri Nov 16 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  16
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Sat Nov 17 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  17
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            className="c9"
+          >
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Sun Nov 18 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  18
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Mon Nov 19 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  19
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Tue Nov 20 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  20
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Wed Nov 21 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  21
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Thu Nov 22 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  22
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Fri Nov 23 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  23
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Sat Nov 24 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  24
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            className="c9"
+          >
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Sun Nov 25 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  25
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Mon Nov 26 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  26
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Tue Nov 27 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  27
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Wed Nov 28 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  28
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Thu Nov 29 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  29
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Fri Nov 30 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c13"
+                >
+                  30
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Sat Dec 01 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c12"
+                >
+                  1
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            className="c9"
+          >
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Sun Dec 02 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c12"
+                >
+                  2
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Mon Dec 03 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c12"
+                >
+                  3
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Tue Dec 04 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c12"
+                >
+                  4
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Wed Dec 05 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c12"
+                >
+                  5
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Thu Dec 06 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c12"
+                >
+                  6
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Fri Dec 07 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c12"
+                >
+                  7
+                </div>
+              </button>
+            </div>
+            <div
+              className="c10"
+            >
+              <button
+                aria-label="Sat Dec 08 2018"
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                type="button"
+              >
+                <div
+                  className="c12"
+                >
+                  8
                 </div>
               </button>
             </div>
@@ -5785,6 +5791,8 @@ exports[`Calendar reference 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
   fill: #666666;
   stroke: #666666;
 }
@@ -7014,6 +7022,40 @@ exports[`Calendar reference 1`] = `
 `;
 
 exports[`Calendar size 1`] = `
+.c21 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c21 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c21 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c21 *[stroke*="#"],
+.c21 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c21 *[fill-rule],
+.c21 *[FILL-RULE],
+.c21 *[fill*="#"],
+.c21 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
 .c9 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -7046,7 +7088,7 @@ exports[`Calendar size 1`] = `
   stroke: none;
 }
 
-.c28 {
+.c29 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -7057,25 +7099,25 @@ exports[`Calendar size 1`] = `
   stroke: #666666;
 }
 
-.c28 g {
+.c29 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c28 *:not([stroke])[fill="none"] {
+.c29 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c28 *[stroke*="#"],
-.c28 *[STROKE*="#"] {
+.c29 *[stroke*="#"],
+.c29 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c28 *[fill-rule],
-.c28 *[FILL-RULE],
-.c28 *[fill*="#"],
-.c28 *[FILL*="#"] {
+.c29 *[fill-rule],
+.c29 *[FILL-RULE],
+.c29 *[fill*="#"],
+.c29 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -7213,7 +7255,7 @@ exports[`Calendar size 1`] = `
   padding-right: 6px;
 }
 
-.c26 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7289,13 +7331,13 @@ exports[`Calendar size 1`] = `
   width: 192px;
 }
 
-.c25 {
+.c26 {
   font-size: 30px;
   line-height: 1.11;
   width: 768px;
 }
 
-.c21 {
+.c22 {
   overflow: hidden;
   height: 329.1428571428571px;
 }
@@ -7305,7 +7347,7 @@ exports[`Calendar size 1`] = `
   height: 164.57142857142856px;
 }
 
-.c29 {
+.c30 {
   overflow: hidden;
   height: 658.2857142857142px;
 }
@@ -7333,7 +7375,7 @@ exports[`Calendar size 1`] = `
   flex: 0 0 auto;
 }
 
-.c22 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7351,7 +7393,7 @@ exports[`Calendar size 1`] = `
   opacity: 0.5;
 }
 
-.c23 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7368,7 +7410,7 @@ exports[`Calendar size 1`] = `
   height: 54.857142857142854px;
 }
 
-.c24 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7443,7 +7485,7 @@ exports[`Calendar size 1`] = `
   font-weight: bold;
 }
 
-.c30 {
+.c31 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7461,7 +7503,7 @@ exports[`Calendar size 1`] = `
   opacity: 0.5;
 }
 
-.c31 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7478,7 +7520,7 @@ exports[`Calendar size 1`] = `
   height: 109.71428571428571px;
 }
 
-.c32 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7516,7 +7558,7 @@ exports[`Calendar size 1`] = `
   font-weight: 600;
 }
 
-.c27 {
+.c28 {
   margin: 0px;
   font-size: 34px;
   line-height: 40px;
@@ -7607,13 +7649,13 @@ exports[`Calendar size 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c26 {
+  .c27 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c26 {
+  .c27 {
     padding-left: 12px;
     padding-right: 12px;
   }
@@ -7634,13 +7676,13 @@ exports[`Calendar size 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c27 {
+  .c28 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c27 {
+  .c28 {
     font-size: 18px;
     line-height: 24px;
     max-width: 432px;
@@ -8577,7 +8619,7 @@ exports[`Calendar size 1`] = `
             >
               <svg
                 aria-label="Previous"
-                className="c9"
+                className="c21"
                 height="24px"
                 role="img"
                 size="medium"
@@ -8609,7 +8651,7 @@ exports[`Calendar size 1`] = `
             >
               <svg
                 aria-label="Next"
-                className="c9"
+                className="c21"
                 height="24px"
                 role="img"
                 size="medium"
@@ -8629,7 +8671,7 @@ exports[`Calendar size 1`] = `
         </div>
       </div>
       <div
-        className="c21"
+        className="c22"
       >
         <div
           className="c11"
@@ -8649,7 +8691,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c22"
+                  className="c23"
                 >
                   31
                 </div>
@@ -8667,7 +8709,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   1
                 </div>
@@ -8685,7 +8727,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   2
                 </div>
@@ -8703,7 +8745,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   3
                 </div>
@@ -8721,7 +8763,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   4
                 </div>
@@ -8739,7 +8781,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   5
                 </div>
@@ -8757,7 +8799,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   6
                 </div>
@@ -8779,7 +8821,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   7
                 </div>
@@ -8797,7 +8839,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   8
                 </div>
@@ -8815,7 +8857,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   9
                 </div>
@@ -8833,7 +8875,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   10
                 </div>
@@ -8851,7 +8893,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   11
                 </div>
@@ -8869,7 +8911,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   12
                 </div>
@@ -8887,7 +8929,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   13
                 </div>
@@ -8909,7 +8951,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   14
                 </div>
@@ -8927,7 +8969,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c24"
+                  className="c25"
                 >
                   15
                 </div>
@@ -8945,7 +8987,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   16
                 </div>
@@ -8963,7 +9005,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   17
                 </div>
@@ -8981,7 +9023,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   18
                 </div>
@@ -8999,7 +9041,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   19
                 </div>
@@ -9017,7 +9059,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   20
                 </div>
@@ -9039,7 +9081,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   21
                 </div>
@@ -9057,7 +9099,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   22
                 </div>
@@ -9075,7 +9117,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   23
                 </div>
@@ -9093,7 +9135,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   24
                 </div>
@@ -9111,7 +9153,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   25
                 </div>
@@ -9129,7 +9171,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   26
                 </div>
@@ -9147,7 +9189,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   27
                 </div>
@@ -9169,7 +9211,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   28
                 </div>
@@ -9187,7 +9229,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   29
                 </div>
@@ -9205,7 +9247,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   30
                 </div>
@@ -9223,7 +9265,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c23"
+                  className="c24"
                 >
                   31
                 </div>
@@ -9241,7 +9283,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c22"
+                  className="c23"
                 >
                   1
                 </div>
@@ -9259,7 +9301,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c22"
+                  className="c23"
                 >
                   2
                 </div>
@@ -9277,7 +9319,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c22"
+                  className="c23"
                 >
                   3
                 </div>
@@ -9299,7 +9341,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c22"
+                  className="c23"
                 >
                   4
                 </div>
@@ -9317,7 +9359,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c22"
+                  className="c23"
                 >
                   5
                 </div>
@@ -9335,7 +9377,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c22"
+                  className="c23"
                 >
                   6
                 </div>
@@ -9353,7 +9395,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c22"
+                  className="c23"
                 >
                   7
                 </div>
@@ -9371,7 +9413,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c22"
+                  className="c23"
                 >
                   8
                 </div>
@@ -9389,7 +9431,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c22"
+                  className="c23"
                 >
                   9
                 </div>
@@ -9407,7 +9449,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c22"
+                  className="c23"
                 >
                   10
                 </div>
@@ -9419,7 +9461,7 @@ exports[`Calendar size 1`] = `
     </div>
   </div>
   <div
-    className="c25"
+    className="c26"
   >
     <div
       className="c2"
@@ -9429,10 +9471,10 @@ exports[`Calendar size 1`] = `
         className="c3"
       >
         <div
-          className="c26"
+          className="c27"
         >
           <h3
-            className="-h3 c27"
+            className="-h3 c28"
             size="large"
           >
             January 2018
@@ -9455,7 +9497,7 @@ exports[`Calendar size 1`] = `
             >
               <svg
                 aria-label="Previous"
-                className="c28"
+                className="c29"
                 height="24px"
                 role="img"
                 size="large"
@@ -9487,7 +9529,7 @@ exports[`Calendar size 1`] = `
             >
               <svg
                 aria-label="Next"
-                className="c28"
+                className="c29"
                 height="24px"
                 role="img"
                 size="large"
@@ -9507,7 +9549,7 @@ exports[`Calendar size 1`] = `
         </div>
       </div>
       <div
-        className="c29"
+        className="c30"
       >
         <div
           className="c11"
@@ -9527,7 +9569,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c30"
+                  className="c31"
                 >
                   31
                 </div>
@@ -9545,7 +9587,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   1
                 </div>
@@ -9563,7 +9605,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   2
                 </div>
@@ -9581,7 +9623,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   3
                 </div>
@@ -9599,7 +9641,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   4
                 </div>
@@ -9617,7 +9659,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   5
                 </div>
@@ -9635,7 +9677,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   6
                 </div>
@@ -9657,7 +9699,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   7
                 </div>
@@ -9675,7 +9717,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   8
                 </div>
@@ -9693,7 +9735,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   9
                 </div>
@@ -9711,7 +9753,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   10
                 </div>
@@ -9729,7 +9771,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   11
                 </div>
@@ -9747,7 +9789,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   12
                 </div>
@@ -9765,7 +9807,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   13
                 </div>
@@ -9787,7 +9829,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   14
                 </div>
@@ -9805,7 +9847,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c32"
+                  className="c33"
                 >
                   15
                 </div>
@@ -9823,7 +9865,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   16
                 </div>
@@ -9841,7 +9883,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   17
                 </div>
@@ -9859,7 +9901,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   18
                 </div>
@@ -9877,7 +9919,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   19
                 </div>
@@ -9895,7 +9937,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   20
                 </div>
@@ -9917,7 +9959,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   21
                 </div>
@@ -9935,7 +9977,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   22
                 </div>
@@ -9953,7 +9995,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   23
                 </div>
@@ -9971,7 +10013,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   24
                 </div>
@@ -9989,7 +10031,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   25
                 </div>
@@ -10007,7 +10049,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   26
                 </div>
@@ -10025,7 +10067,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   27
                 </div>
@@ -10047,7 +10089,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   28
                 </div>
@@ -10065,7 +10107,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   29
                 </div>
@@ -10083,7 +10125,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   30
                 </div>
@@ -10101,7 +10143,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c31"
+                  className="c32"
                 >
                   31
                 </div>
@@ -10119,7 +10161,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c30"
+                  className="c31"
                 >
                   1
                 </div>
@@ -10137,7 +10179,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c30"
+                  className="c31"
                 >
                   2
                 </div>
@@ -10155,7 +10197,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c30"
+                  className="c31"
                 >
                   3
                 </div>
@@ -10177,7 +10219,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c30"
+                  className="c31"
                 >
                   4
                 </div>
@@ -10195,7 +10237,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c30"
+                  className="c31"
                 >
                   5
                 </div>
@@ -10213,7 +10255,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c30"
+                  className="c31"
                 >
                   6
                 </div>
@@ -10231,7 +10273,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c30"
+                  className="c31"
                 >
                   7
                 </div>
@@ -10249,7 +10291,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c30"
+                  className="c31"
                 >
                   8
                 </div>
@@ -10267,7 +10309,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c30"
+                  className="c31"
                 >
                   9
                 </div>
@@ -10285,7 +10327,7 @@ exports[`Calendar size 1`] = `
                 type="button"
               >
                 <div
-                  className="c30"
+                  className="c31"
                 >
                   10
                 </div>

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -1284,10 +1284,10 @@ exports[`Carousel navigate 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 hFvDUx"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 dxIGjQ"
+        class="StyledBox-sc-13pk1d4-0 gSqlow"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 czMnnp"
+          class="StyledBox-sc-13pk1d4-0 eMweLo"
         >
           <img
             class="StyledImage-ey4zx9-0 jtkYbl"
@@ -1300,10 +1300,10 @@ exports[`Carousel navigate 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 fNScQY"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 dxIGjQ"
+        class="StyledBox-sc-13pk1d4-0 gSqlow"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jIhKgp"
+          class="StyledBox-sc-13pk1d4-0 kyLFAf"
         >
           <img
             class="StyledImage-ey4zx9-0 jtkYbl"
@@ -1316,18 +1316,18 @@ exports[`Carousel navigate 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 hFvDUx"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cReTwb"
+        class="StyledBox-sc-13pk1d4-0 eKHNGK"
         tabindex="0"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 iowLfJ"
+          class="StyledBox-sc-13pk1d4-0 dkhTXm"
         >
           <button
             class="StyledButton-sc-323bzc-0 kjdfHK"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 lceJRa"
+              class="StyledBox-sc-13pk1d4-0 VhefZ"
             >
               <svg
                 aria-label="Previous"
@@ -1350,17 +1350,17 @@ exports[`Carousel navigate 2`] = `
           </button>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 gBxQUn"
+          class="StyledBox-sc-13pk1d4-0 JUlfQ"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iUmMfM"
+            class="StyledBox-sc-13pk1d4-0 exddWn"
           >
             <button
               class="StyledButton-sc-323bzc-0 dcpWVY"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jewLfw"
+                class="StyledBox-sc-13pk1d4-0 hHwlHq"
               >
                 <svg
                   aria-label="Subtract"
@@ -1385,7 +1385,7 @@ exports[`Carousel navigate 2`] = `
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jewLfw"
+                class="StyledBox-sc-13pk1d4-0 hHwlHq"
               >
                 <svg
                   aria-label="Subtract"
@@ -1408,7 +1408,7 @@ exports[`Carousel navigate 2`] = `
           </div>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 iowLfJ"
+          class="StyledBox-sc-13pk1d4-0 dkhTXm"
         >
           <button
             class="StyledButton-sc-323bzc-0 fzQtuL"
@@ -1416,7 +1416,7 @@ exports[`Carousel navigate 2`] = `
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 lceJRa"
+              class="StyledBox-sc-13pk1d4-0 VhefZ"
             >
               <svg
                 aria-label="Next"
@@ -1455,10 +1455,10 @@ exports[`Carousel navigate 3`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 fNScQY"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 dxIGjQ"
+        class="StyledBox-sc-13pk1d4-0 gSqlow"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 iGhyrd"
+          class="StyledBox-sc-13pk1d4-0 iDtakW"
         >
           <img
             class="StyledImage-ey4zx9-0 jtkYbl"
@@ -1471,10 +1471,10 @@ exports[`Carousel navigate 3`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 hFvDUx"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 dxIGjQ"
+        class="StyledBox-sc-13pk1d4-0 gSqlow"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 czMnnp"
+          class="StyledBox-sc-13pk1d4-0 eMweLo"
         >
           <img
             class="StyledImage-ey4zx9-0 jtkYbl"
@@ -1487,11 +1487,11 @@ exports[`Carousel navigate 3`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 hFvDUx"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cReTwb"
+        class="StyledBox-sc-13pk1d4-0 eKHNGK"
         tabindex="0"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 iowLfJ"
+          class="StyledBox-sc-13pk1d4-0 dkhTXm"
         >
           <button
             class="StyledButton-sc-323bzc-0 fzQtuL"
@@ -1499,7 +1499,7 @@ exports[`Carousel navigate 3`] = `
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 lceJRa"
+              class="StyledBox-sc-13pk1d4-0 VhefZ"
             >
               <svg
                 aria-label="Previous"
@@ -1522,17 +1522,17 @@ exports[`Carousel navigate 3`] = `
           </button>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 gBxQUn"
+          class="StyledBox-sc-13pk1d4-0 JUlfQ"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iUmMfM"
+            class="StyledBox-sc-13pk1d4-0 exddWn"
           >
             <button
               class="StyledButton-sc-323bzc-0 dcpWVY"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jewLfw"
+                class="StyledBox-sc-13pk1d4-0 hHwlHq"
               >
                 <svg
                   aria-label="Subtract"
@@ -1557,7 +1557,7 @@ exports[`Carousel navigate 3`] = `
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jewLfw"
+                class="StyledBox-sc-13pk1d4-0 hHwlHq"
               >
                 <svg
                   aria-label="Subtract"
@@ -1580,14 +1580,14 @@ exports[`Carousel navigate 3`] = `
           </div>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 iowLfJ"
+          class="StyledBox-sc-13pk1d4-0 dkhTXm"
         >
           <button
             class="StyledButton-sc-323bzc-0 kjdfHK"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 lceJRa"
+              class="StyledBox-sc-13pk1d4-0 VhefZ"
             >
               <svg
                 aria-label="Next"
@@ -2253,10 +2253,10 @@ exports[`Carousel play 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 hFvDUx"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 dxIGjQ"
+        class="StyledBox-sc-13pk1d4-0 gSqlow"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 czMnnp"
+          class="StyledBox-sc-13pk1d4-0 eMweLo"
         >
           <img
             class="StyledImage-ey4zx9-0 jtkYbl"
@@ -2269,10 +2269,10 @@ exports[`Carousel play 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 fNScQY"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 dxIGjQ"
+        class="StyledBox-sc-13pk1d4-0 gSqlow"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jIhKgp"
+          class="StyledBox-sc-13pk1d4-0 kyLFAf"
         >
           <img
             class="StyledImage-ey4zx9-0 jtkYbl"
@@ -2285,18 +2285,18 @@ exports[`Carousel play 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 hFvDUx"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cReTwb"
+        class="StyledBox-sc-13pk1d4-0 eKHNGK"
         tabindex="0"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 iowLfJ"
+          class="StyledBox-sc-13pk1d4-0 dkhTXm"
         >
           <button
             class="StyledButton-sc-323bzc-0 kjdfHK"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 lceJRa"
+              class="StyledBox-sc-13pk1d4-0 VhefZ"
             >
               <svg
                 aria-label="Previous"
@@ -2319,17 +2319,17 @@ exports[`Carousel play 2`] = `
           </button>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 gBxQUn"
+          class="StyledBox-sc-13pk1d4-0 JUlfQ"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iUmMfM"
+            class="StyledBox-sc-13pk1d4-0 exddWn"
           >
             <button
               class="StyledButton-sc-323bzc-0 dcpWVY"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jewLfw"
+                class="StyledBox-sc-13pk1d4-0 hHwlHq"
               >
                 <svg
                   aria-label="Subtract"
@@ -2354,7 +2354,7 @@ exports[`Carousel play 2`] = `
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jewLfw"
+                class="StyledBox-sc-13pk1d4-0 hHwlHq"
               >
                 <svg
                   aria-label="Subtract"
@@ -2377,7 +2377,7 @@ exports[`Carousel play 2`] = `
           </div>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 iowLfJ"
+          class="StyledBox-sc-13pk1d4-0 dkhTXm"
         >
           <button
             class="StyledButton-sc-323bzc-0 fzQtuL"
@@ -2385,7 +2385,7 @@ exports[`Carousel play 2`] = `
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 lceJRa"
+              class="StyledBox-sc-13pk1d4-0 VhefZ"
             >
               <svg
                 aria-label="Next"

--- a/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
+++ b/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
@@ -489,7 +489,7 @@ exports[`Clock run 2`] = `
     />
   </svg>
   <div
-    class="StyledBox-sc-13pk1d4-0 jeVABx"
+    class="StyledBox-sc-13pk1d4-0 ffeAql"
   >
     <div
       class="StyledClock__StyledDigitalDigit-y4xw8s-4 hQDjOB"
@@ -533,7 +533,7 @@ exports[`Clock run 2`] = `
     </div>
   </div>
   <div
-    class="StyledBox-sc-13pk1d4-0 jeVABx"
+    class="StyledBox-sc-13pk1d4-0 ffeAql"
   >
     <div
       class="StyledClock__StyledDigitalDigit-y4xw8s-4 hQDjOB"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -1469,7 +1469,7 @@ exports[`DataTable groupBy 2`] = `
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 dABIiJ"
+              class="StyledBox-sc-13pk1d4-0 gFEOoP"
             >
               <svg
                 aria-label="FormDown"
@@ -1495,7 +1495,7 @@ exports[`DataTable groupBy 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dASSBP"
+            class="StyledBox-sc-13pk1d4-0 folWQp"
           >
             <span
               class="StyledText-sc-1sadyjn-0 fWSbXS"
@@ -1509,7 +1509,7 @@ exports[`DataTable groupBy 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 dASSBP"
+            class="StyledBox-sc-13pk1d4-0 folWQp"
           >
             <span
               class="StyledText-sc-1sadyjn-0 fWSbXS"
@@ -1535,7 +1535,7 @@ exports[`DataTable groupBy 2`] = `
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 jaSYLZ"
+              class="StyledBox-sc-13pk1d4-0 emftoK"
             >
               <svg
                 aria-label="FormDown"
@@ -1561,7 +1561,7 @@ exports[`DataTable groupBy 2`] = `
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fhPkOK"
+            class="StyledBox-sc-13pk1d4-0 eAAZJM"
           >
             <span
               class="StyledText-sc-1sadyjn-0 fWSbXS"
@@ -1574,7 +1574,7 @@ exports[`DataTable groupBy 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fhPkOK"
+            class="StyledBox-sc-13pk1d4-0 eAAZJM"
           />
         </td>
       </tr>
@@ -1590,7 +1590,7 @@ exports[`DataTable groupBy 2`] = `
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 jaSYLZ"
+              class="StyledBox-sc-13pk1d4-0 emftoK"
             >
               <svg
                 aria-label="FormDown"
@@ -1616,7 +1616,7 @@ exports[`DataTable groupBy 2`] = `
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fhPkOK"
+            class="StyledBox-sc-13pk1d4-0 eAAZJM"
           >
             <span
               class="StyledText-sc-1sadyjn-0 fWSbXS"
@@ -1629,7 +1629,7 @@ exports[`DataTable groupBy 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fhPkOK"
+            class="StyledBox-sc-13pk1d4-0 eAAZJM"
           />
         </td>
       </tr>
@@ -2324,7 +2324,7 @@ exports[`DataTable sort 2`] = `
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 ggYZyV"
+              class="StyledBox-sc-13pk1d4-0 fAhsMq"
             >
               <span
                 class="StyledText-sc-1sadyjn-0 fWSbXS"
@@ -2401,7 +2401,7 @@ exports[`DataTable sort 2`] = `
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 ggYZyV"
+              class="StyledBox-sc-13pk1d4-0 fAhsMq"
             >
               <span
                 class="StyledText-sc-1sadyjn-0 fWSbXS"
@@ -2423,7 +2423,7 @@ exports[`DataTable sort 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fhPkOK"
+            class="StyledBox-sc-13pk1d4-0 eAAZJM"
           >
             <span
               class="StyledText-sc-1sadyjn-0 fWSbXS"
@@ -2436,7 +2436,7 @@ exports[`DataTable sort 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fhPkOK"
+            class="StyledBox-sc-13pk1d4-0 eAAZJM"
           >
             <span
               class="StyledText-sc-1sadyjn-0 fWSbXS"
@@ -2453,7 +2453,7 @@ exports[`DataTable sort 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fhPkOK"
+            class="StyledBox-sc-13pk1d4-0 eAAZJM"
           >
             <span
               class="StyledText-sc-1sadyjn-0 fWSbXS"
@@ -2466,7 +2466,7 @@ exports[`DataTable sort 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fhPkOK"
+            class="StyledBox-sc-13pk1d4-0 eAAZJM"
           >
             <span
               class="StyledText-sc-1sadyjn-0 fWSbXS"
@@ -2483,7 +2483,7 @@ exports[`DataTable sort 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fhPkOK"
+            class="StyledBox-sc-13pk1d4-0 eAAZJM"
           >
             <span
               class="StyledText-sc-1sadyjn-0 fWSbXS"
@@ -2496,7 +2496,7 @@ exports[`DataTable sort 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fhPkOK"
+            class="StyledBox-sc-13pk1d4-0 eAAZJM"
           />
         </td>
       </tr>

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -81,7 +81,7 @@ exports[`Drop align left random 1`] = `
 exports[`Drop align left random 2`] = `
 "
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -100,13 +100,13 @@ exports[`Drop align left random 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
@@ -258,7 +258,7 @@ exports[`Drop align left right top bottom 1`] = `
 exports[`Drop align left right top bottom 2`] = `
 "
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -277,13 +277,13 @@ exports[`Drop align left right top bottom 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
@@ -409,7 +409,7 @@ exports[`Drop align right left top top 1`] = `
 exports[`Drop align right left top top 2`] = `
 "
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -428,13 +428,13 @@ exports[`Drop align right left top top 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
@@ -599,7 +599,7 @@ exports[`Drop align right random 1`] = `
 exports[`Drop align right random 2`] = `
 "
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -618,13 +618,13 @@ exports[`Drop align right random 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
@@ -789,7 +789,7 @@ exports[`Drop align right right bottom top 1`] = `
 exports[`Drop align right right bottom top 2`] = `
 "
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -808,13 +808,13 @@ exports[`Drop align right right bottom top 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
@@ -953,7 +953,7 @@ exports[`Drop align right right bottom top 3`] = `
 exports[`Drop align right right bottom top 4`] = `
 "
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -972,13 +972,13 @@ exports[`Drop align right right bottom top 4`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
@@ -1143,7 +1143,7 @@ exports[`Drop basic 1`] = `
 exports[`Drop basic 2`] = `
 "
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1162,13 +1162,13 @@ exports[`Drop basic 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
@@ -1294,7 +1294,7 @@ exports[`Drop close 1`] = `
 exports[`Drop close 2`] = `
 "
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1313,13 +1313,13 @@ exports[`Drop close 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
@@ -1484,7 +1484,7 @@ exports[`Drop invalid align 1`] = `
 exports[`Drop invalid align 2`] = `
 "
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1503,13 +1503,13 @@ exports[`Drop invalid align 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
@@ -1674,7 +1674,7 @@ exports[`Drop invoke onClickOutside 1`] = `
 exports[`Drop invoke onClickOutside 2`] = `
 "
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1693,13 +1693,13 @@ exports[`Drop invoke onClickOutside 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
@@ -1864,7 +1864,7 @@ exports[`Drop no stretch 1`] = `
 exports[`Drop no stretch 2`] = `
 "
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1883,13 +1883,13 @@ exports[`Drop no stretch 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
@@ -2054,7 +2054,7 @@ exports[`Drop resize 1`] = `
 exports[`Drop resize 2`] = `
 "
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2073,13 +2073,13 @@ exports[`Drop resize 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
@@ -2243,7 +2243,7 @@ exports[`Drop restrict focus 1`] = `
 
 exports[`Drop restrict focus 2`] = `
 <div
-  class="StyledDrop-sc-16s5rx8-0 cShzna StyledBox-sc-13pk1d4-0 dhsUIZ"
+  class="StyledDrop-sc-16s5rx8-0 cShzna StyledBox-sc-13pk1d4-0 bXSDsi"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
   tabindex="-1"
@@ -2255,7 +2255,7 @@ exports[`Drop restrict focus 2`] = `
 exports[`Drop restrict focus 3`] = `
 "
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2274,13 +2274,13 @@ exports[`Drop restrict focus 3`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }

--- a/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
+++ b/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
@@ -87,25 +87,25 @@ exports[`DropButton close by clicking outside 2`] = `
 
 exports[`DropButton close by clicking outside 3`] = `
 "@media only screen and (max-width:768px) {
-  .jewLfw {
+  .hHwlHq {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .jewLfw {
+  .hHwlHq {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
@@ -367,25 +367,25 @@ exports[`DropButton open and close 2`] = `
 
 exports[`DropButton open and close 3`] = `
 "@media only screen and (max-width:768px) {
-  .jewLfw {
+  .hHwlHq {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .jewLfw {
+  .hHwlHq {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
@@ -571,25 +571,25 @@ exports[`DropButton opened ref 2`] = `
 
 exports[`DropButton opened ref 3`] = `
 "@media only screen and (max-width:768px) {
-  .jewLfw {
+  .hHwlHq {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .jewLfw {
+  .hHwlHq {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -63,13 +63,13 @@ exports[`Layer dark context 1`] = `
 
 exports[`Layer dark context 2`] = `
 "@media only screen and (max-width:768px) {
-  .hNJwIq {
+  .iWUbCl {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hNJwIq {
+  .iWUbCl {
     padding: 0px;
   }
 }"

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -669,18 +669,18 @@ exports[`Menu close by clicking outside 3`] = `
 "
 
 @media only screen and (max-width:768px) {
-  .hZxMRS {
+  .lgRCHI {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hZxMRS {
+  .lgRCHI {
     padding: 6px;
   }
 }
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -699,61 +699,61 @@ exports[`Menu close by clicking outside 3`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fsIpUF {
+  .IRSNj {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fsIpUF {
+  .IRSNj {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bQWGDI {
+  .jqGCfM {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bQWGDI {
+  .jqGCfM {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cHrFaK {
+  .cYihDV {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cHrFaK {
+  .cYihDV {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kDqOeu {
+  .iVyWoM {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kDqOeu {
+  .iVyWoM {
     padding: 6px;
   }
 }
@@ -1721,7 +1721,7 @@ exports[`Menu open and close on click 2`] = `
     type="button"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hZxMRS"
+      class="StyledBox-sc-13pk1d4-0 lgRCHI"
     >
       <span
         class="StyledText-sc-1sadyjn-0 fWSbXS"
@@ -2199,18 +2199,18 @@ exports[`Menu open and close on click 4`] = `
 "
 
 @media only screen and (max-width:768px) {
-  .hZxMRS {
+  .lgRCHI {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hZxMRS {
+  .lgRCHI {
     padding: 6px;
   }
 }
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2229,61 +2229,61 @@ exports[`Menu open and close on click 4`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fsIpUF {
+  .IRSNj {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fsIpUF {
+  .IRSNj {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bQWGDI {
+  .jqGCfM {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bQWGDI {
+  .jqGCfM {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cHrFaK {
+  .cYihDV {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cHrFaK {
+  .cYihDV {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kDqOeu {
+  .iVyWoM {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kDqOeu {
+  .iVyWoM {
     padding: 6px;
   }
 }
@@ -3040,18 +3040,18 @@ exports[`Menu with dropAlign renders 3`] = `
 "
 
 @media only screen and (max-width:768px) {
-  .hZxMRS {
+  .lgRCHI {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .hZxMRS {
+  .lgRCHI {
     padding: 6px;
   }
 }
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3070,61 +3070,61 @@ exports[`Menu with dropAlign renders 3`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fsIpUF {
+  .IRSNj {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fsIpUF {
+  .IRSNj {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bQWGDI {
+  .jqGCfM {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bQWGDI {
+  .jqGCfM {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cHrFaK {
+  .cYihDV {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cHrFaK {
+  .cYihDV {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kDqOeu {
+  .iVyWoM {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kDqOeu {
+  .iVyWoM {
     padding: 6px;
   }
 }

--- a/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
+++ b/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
@@ -60,7 +60,7 @@ exports[`Meter background 1`] = `
       fill="none"
       stroke="#DDDDDD"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -111,7 +111,7 @@ exports[`Meter background 1`] = `
       r={180}
       stroke="#DDDDDD"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -163,7 +163,7 @@ exports[`Meter basic 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -215,7 +215,7 @@ exports[`Meter default 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
   </svg>
@@ -258,7 +258,7 @@ exports[`Meter many values 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -368,7 +368,7 @@ exports[`Meter round 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="round"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -394,7 +394,7 @@ exports[`Meter round 1`] = `
       r={180}
       stroke="#F6F6F6"
       strokeLinecap="round"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -455,7 +455,7 @@ exports[`Meter size 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -480,7 +480,7 @@ exports[`Meter size 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -505,7 +505,7 @@ exports[`Meter size 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -530,7 +530,7 @@ exports[`Meter size 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -555,7 +555,7 @@ exports[`Meter size 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -581,7 +581,7 @@ exports[`Meter size 1`] = `
       r={36}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -607,7 +607,7 @@ exports[`Meter size 1`] = `
       r={84}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -633,7 +633,7 @@ exports[`Meter size 1`] = `
       r={180}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -659,7 +659,7 @@ exports[`Meter size 1`] = `
       r={372}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -685,7 +685,7 @@ exports[`Meter size 1`] = `
       r={564}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -737,7 +737,7 @@ exports[`Meter thickness 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={6}
     />
     <path
@@ -762,7 +762,7 @@ exports[`Meter thickness 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={12}
     />
     <path
@@ -787,7 +787,7 @@ exports[`Meter thickness 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -812,7 +812,7 @@ exports[`Meter thickness 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={48}
     />
     <path
@@ -837,7 +837,7 @@ exports[`Meter thickness 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={96}
     />
     <path
@@ -863,7 +863,7 @@ exports[`Meter thickness 1`] = `
       r={189}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={6}
     />
     <path
@@ -889,7 +889,7 @@ exports[`Meter thickness 1`] = `
       r={186}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={12}
     />
     <path
@@ -915,7 +915,7 @@ exports[`Meter thickness 1`] = `
       r={180}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -941,7 +941,7 @@ exports[`Meter thickness 1`] = `
       r={168}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={48}
     />
     <path
@@ -967,7 +967,7 @@ exports[`Meter thickness 1`] = `
       r={144}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={96}
     />
     <path
@@ -1019,7 +1019,7 @@ exports[`Meter type 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path
@@ -1045,7 +1045,7 @@ exports[`Meter type 1`] = `
       r={180}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity={0.4}
+      strokeOpacity="0.4"
       strokeWidth={24}
     />
     <path

--- a/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
+++ b/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
@@ -60,7 +60,7 @@ exports[`Meter background 1`] = `
       fill="none"
       stroke="#DDDDDD"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -111,7 +111,7 @@ exports[`Meter background 1`] = `
       r={180}
       stroke="#DDDDDD"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -163,7 +163,7 @@ exports[`Meter basic 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -215,7 +215,7 @@ exports[`Meter default 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
   </svg>
@@ -258,7 +258,7 @@ exports[`Meter many values 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -368,7 +368,7 @@ exports[`Meter round 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="round"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -394,7 +394,7 @@ exports[`Meter round 1`] = `
       r={180}
       stroke="#F6F6F6"
       strokeLinecap="round"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -455,7 +455,7 @@ exports[`Meter size 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -480,7 +480,7 @@ exports[`Meter size 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -505,7 +505,7 @@ exports[`Meter size 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -530,7 +530,7 @@ exports[`Meter size 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -555,7 +555,7 @@ exports[`Meter size 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -581,7 +581,7 @@ exports[`Meter size 1`] = `
       r={36}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -607,7 +607,7 @@ exports[`Meter size 1`] = `
       r={84}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -633,7 +633,7 @@ exports[`Meter size 1`] = `
       r={180}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -659,7 +659,7 @@ exports[`Meter size 1`] = `
       r={372}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -685,7 +685,7 @@ exports[`Meter size 1`] = `
       r={564}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -737,7 +737,7 @@ exports[`Meter thickness 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={6}
     />
     <path
@@ -762,7 +762,7 @@ exports[`Meter thickness 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={12}
     />
     <path
@@ -787,7 +787,7 @@ exports[`Meter thickness 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -812,7 +812,7 @@ exports[`Meter thickness 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={48}
     />
     <path
@@ -837,7 +837,7 @@ exports[`Meter thickness 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={96}
     />
     <path
@@ -863,7 +863,7 @@ exports[`Meter thickness 1`] = `
       r={189}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={6}
     />
     <path
@@ -889,7 +889,7 @@ exports[`Meter thickness 1`] = `
       r={186}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={12}
     />
     <path
@@ -915,7 +915,7 @@ exports[`Meter thickness 1`] = `
       r={180}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -941,7 +941,7 @@ exports[`Meter thickness 1`] = `
       r={168}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={48}
     />
     <path
@@ -967,7 +967,7 @@ exports[`Meter thickness 1`] = `
       r={144}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={96}
     />
     <path
@@ -1019,7 +1019,7 @@ exports[`Meter type 1`] = `
       fill="none"
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path
@@ -1045,7 +1045,7 @@ exports[`Meter type 1`] = `
       r={180}
       stroke="#F6F6F6"
       strokeLinecap="square"
-      strokeOpacity="0.4"
+      strokeOpacity={0.4}
       strokeWidth={24}
     />
     <path

--- a/src/js/components/Meter/utils.js
+++ b/src/js/components/Meter/utils.js
@@ -6,10 +6,11 @@ export const strokeProps = (color, theme) => {
     if (typeof color === 'object') {
       result.stroke = normalizeColor(color.color, theme);
       if (color.opacity) {
-        result.strokeOpacity =
+        result.strokeOpacity = `${
           color.opacity === true
             ? theme.global.opacity.medium
-            : theme.global.opacity[color.opacity];
+            : theme.global.opacity[color.opacity]
+        }`;
       }
     } else {
       result.stroke = normalizeColor(color, theme);

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -539,10 +539,10 @@ exports[`Select complex options and children 2`] = `
   type="button"
 >
   <div
-    class="Select__StyledSelectBox-sc-17idtfo-1 hFvoei StyledBox-sc-13pk1d4-0 kbpcIQ"
+    class="Select__StyledSelectBox-sc-17idtfo-1 hFvoei StyledBox-sc-13pk1d4-0 erazuK"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 cAPdrr"
+      class="StyledBox-sc-13pk1d4-0 XINUX"
     >
       <div
         class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 yIdXy"
@@ -560,7 +560,7 @@ exports[`Select complex options and children 2`] = `
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 fNLzOy"
+      class="StyledBox-sc-13pk1d4-0 eLQtUu"
       style="min-width: auto;"
     >
       <svg
@@ -837,43 +837,43 @@ exports[`Select complex options and children 4`] = `
 "
 
 @media only screen and (max-width:768px) {
-  .kbpcIQ {
+  .erazuK {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kbpcIQ {
+  .erazuK {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cAPdrr {
+  .XINUX {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cAPdrr {
+  .XINUX {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fNLzOy {
+  .eLQtUu {
     margin-left: 6px;
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fNLzOy {
+  .eLQtUu {
     padding: 0px;
   }
 }
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -892,61 +892,61 @@ exports[`Select complex options and children 4`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fsIpUF {
+  .IRSNj {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fsIpUF {
+  .IRSNj {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cgzWuX {
+  .iZGdeq {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cgzWuX {
+  .iZGdeq {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bQWGDI {
+  .jqGCfM {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bQWGDI {
+  .jqGCfM {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .giyozN {
+  .eEPVhE {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .giyozN {
+  .eEPVhE {
     padding: 6px;
   }
 }
@@ -1530,10 +1530,10 @@ exports[`Select disabled 2`] = `
   type="button"
 >
   <div
-    class="Select__StyledSelectBox-sc-17idtfo-1 hFvoei StyledBox-sc-13pk1d4-0 kbpcIQ"
+    class="Select__StyledSelectBox-sc-17idtfo-1 hFvoei StyledBox-sc-13pk1d4-0 erazuK"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 cAPdrr"
+      class="StyledBox-sc-13pk1d4-0 XINUX"
     >
       <div
         class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 yIdXy"
@@ -1551,7 +1551,7 @@ exports[`Select disabled 2`] = `
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 fNLzOy"
+      class="StyledBox-sc-13pk1d4-0 eLQtUu"
       style="min-width: auto;"
     >
       <svg
@@ -2118,10 +2118,10 @@ exports[`Select multiple values 2`] = `
   type="button"
 >
   <div
-    class="Select__StyledSelectBox-sc-17idtfo-1 hFvoei StyledBox-sc-13pk1d4-0 kbpcIQ"
+    class="Select__StyledSelectBox-sc-17idtfo-1 hFvoei StyledBox-sc-13pk1d4-0 erazuK"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 cAPdrr"
+      class="StyledBox-sc-13pk1d4-0 XINUX"
     >
       <div
         class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 yIdXy"
@@ -2140,7 +2140,7 @@ exports[`Select multiple values 2`] = `
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 fNLzOy"
+      class="StyledBox-sc-13pk1d4-0 eLQtUu"
       style="min-width: auto;"
     >
       <svg
@@ -2475,43 +2475,43 @@ exports[`Select multiple values 4`] = `
 "
 
 @media only screen and (max-width:768px) {
-  .kbpcIQ {
+  .erazuK {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kbpcIQ {
+  .erazuK {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cAPdrr {
+  .XINUX {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cAPdrr {
+  .XINUX {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fNLzOy {
+  .eLQtUu {
     margin-left: 6px;
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fNLzOy {
+  .eLQtUu {
     padding: 0px;
   }
 }
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2530,73 +2530,73 @@ exports[`Select multiple values 4`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fsIpUF {
+  .IRSNj {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fsIpUF {
+  .IRSNj {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cgzWuX {
+  .iZGdeq {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cgzWuX {
+  .iZGdeq {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bQWGDI {
+  .jqGCfM {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bQWGDI {
+  .jqGCfM {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .giyozN {
+  .eEPVhE {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .giyozN {
+  .eEPVhE {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fpNKLD {
+  .keIKGj {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fpNKLD {
+  .keIKGj {
     padding: 3px;
   }
 }
@@ -2915,10 +2915,10 @@ exports[`Select opens 2`] = `
   type="button"
 >
   <div
-    class="Select__StyledSelectBox-sc-17idtfo-1 hFvoei StyledBox-sc-13pk1d4-0 kbpcIQ"
+    class="Select__StyledSelectBox-sc-17idtfo-1 hFvoei StyledBox-sc-13pk1d4-0 erazuK"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 cAPdrr"
+      class="StyledBox-sc-13pk1d4-0 XINUX"
     >
       <div
         class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 yIdXy"
@@ -2936,7 +2936,7 @@ exports[`Select opens 2`] = `
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 fNLzOy"
+      class="StyledBox-sc-13pk1d4-0 eLQtUu"
       style="min-width: auto;"
     >
       <svg
@@ -3268,43 +3268,43 @@ exports[`Select opens 4`] = `
 "
 
 @media only screen and (max-width:768px) {
-  .kbpcIQ {
+  .erazuK {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kbpcIQ {
+  .erazuK {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cAPdrr {
+  .XINUX {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cAPdrr {
+  .XINUX {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fNLzOy {
+  .eLQtUu {
     margin-left: 6px;
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fNLzOy {
+  .eLQtUu {
     padding: 0px;
   }
 }
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3323,61 +3323,61 @@ exports[`Select opens 4`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fsIpUF {
+  .IRSNj {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fsIpUF {
+  .IRSNj {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cgzWuX {
+  .iZGdeq {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cgzWuX {
+  .iZGdeq {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bQWGDI {
+  .jqGCfM {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bQWGDI {
+  .jqGCfM {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .giyozN {
+  .eEPVhE {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .giyozN {
+  .eEPVhE {
     padding: 6px;
   }
 }
@@ -3430,12 +3430,12 @@ exports[`Select opens 4`] = `
 
 exports[`Select opens 5`] = `
 <div
-  class="SelectContainer__OptionsBox-sc-1wi0ul8-1 jZWhdj StyledBox-sc-13pk1d4-0 cgzWuX"
+  class="SelectContainer__OptionsBox-sc-1wi0ul8-1 jZWhdj StyledBox-sc-13pk1d4-0 iZGdeq"
   role="menubar"
   tabindex="-1"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bQWGDI"
+    class="StyledBox-sc-13pk1d4-0 jqGCfM"
   >
     <button
       class="StyledButton-sc-323bzc-0 gFnwgj"
@@ -3443,7 +3443,7 @@ exports[`Select opens 5`] = `
       type="button"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 giyozN"
+        class="StyledBox-sc-13pk1d4-0 eEPVhE"
       >
         <span
           class="StyledText-sc-1sadyjn-0 fLjoaM"
@@ -3454,7 +3454,7 @@ exports[`Select opens 5`] = `
     </button>
   </div>
   <div
-    class="StyledBox-sc-13pk1d4-0 bQWGDI"
+    class="StyledBox-sc-13pk1d4-0 jqGCfM"
   >
     <button
       class="StyledButton-sc-323bzc-0 gFnwgj"
@@ -3462,7 +3462,7 @@ exports[`Select opens 5`] = `
       type="button"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 giyozN"
+        class="StyledBox-sc-13pk1d4-0 eEPVhE"
       >
         <span
           class="StyledText-sc-1sadyjn-0 fLjoaM"
@@ -4133,43 +4133,43 @@ exports[`Select search 3`] = `
 "
 
 @media only screen and (max-width:768px) {
-  .kbpcIQ {
+  .erazuK {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .kbpcIQ {
+  .erazuK {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cAPdrr {
+  .XINUX {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cAPdrr {
+  .XINUX {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fNLzOy {
+  .eLQtUu {
     margin-left: 6px;
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fNLzOy {
+  .eLQtUu {
     padding: 0px;
   }
 }
 
-.dhsUIZ {
+.bXSDsi {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4188,73 +4188,73 @@ exports[`Select search 3`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .dhsUIZ {
+  .bXSDsi {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fsIpUF {
+  .IRSNj {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fsIpUF {
+  .IRSNj {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cgzWuX {
+  .iZGdeq {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cgzWuX {
+  .iZGdeq {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bQWGDI {
+  .jqGCfM {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .bQWGDI {
+  .jqGCfM {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .giyozN {
+  .eEPVhE {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .giyozN {
+  .eEPVhE {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fpNKLD {
+  .keIKGj {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .fpNKLD {
+  .keIKGj {
     padding: 3px;
   }
 }

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -539,11 +539,11 @@ exports[`Tabs change to second tab 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledTabs-a4fwxl-1 jRybGp StyledBox-sc-13pk1d4-0 fsIpUF"
+    class="StyledTabs-a4fwxl-1 jRybGp StyledBox-sc-13pk1d4-0 IRSNj"
     role="tablist"
   >
     <div
-      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 hyUBDc"
+      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 hlYSr"
     >
       <button
         aria-expanded="false"
@@ -553,7 +553,7 @@ exports[`Tabs change to second tab 2`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 kQoGpx"
+          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 iaGDCb"
         >
           <span
             class="StyledText-sc-1sadyjn-0 iEgnbY"
@@ -570,7 +570,7 @@ exports[`Tabs change to second tab 2`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 SnIPS"
+          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 kvUzDk"
         >
           <span
             class="StyledText-sc-1sadyjn-0 dndifk"
@@ -1207,11 +1207,11 @@ exports[`Tabs set on hover 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledTabs-a4fwxl-1 jRybGp StyledBox-sc-13pk1d4-0 fsIpUF"
+    class="StyledTabs-a4fwxl-1 jRybGp StyledBox-sc-13pk1d4-0 IRSNj"
     role="tablist"
   >
     <div
-      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 hyUBDc"
+      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 hlYSr"
     >
       <button
         aria-expanded="true"
@@ -1221,7 +1221,7 @@ exports[`Tabs set on hover 2`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 SnIPS"
+          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 kvUzDk"
         >
           <span
             class="StyledText-sc-1sadyjn-0 dndifk"
@@ -1238,7 +1238,7 @@ exports[`Tabs set on hover 2`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 kQoGpx"
+          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 iaGDCb"
         >
           <span
             class="StyledText-sc-1sadyjn-0 iEgnbY"
@@ -1263,11 +1263,11 @@ exports[`Tabs set on hover 3`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledTabs-a4fwxl-1 jRybGp StyledBox-sc-13pk1d4-0 fsIpUF"
+    class="StyledTabs-a4fwxl-1 jRybGp StyledBox-sc-13pk1d4-0 IRSNj"
     role="tablist"
   >
     <div
-      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 hyUBDc"
+      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 hlYSr"
     >
       <button
         aria-expanded="true"
@@ -1277,7 +1277,7 @@ exports[`Tabs set on hover 3`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 SnIPS"
+          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 kvUzDk"
         >
           <span
             class="StyledText-sc-1sadyjn-0 dndifk"
@@ -1294,7 +1294,7 @@ exports[`Tabs set on hover 3`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 kQoGpx"
+          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 iaGDCb"
         >
           <span
             class="StyledText-sc-1sadyjn-0 iEgnbY"
@@ -1319,11 +1319,11 @@ exports[`Tabs set on hover 4`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledTabs-a4fwxl-1 jRybGp StyledBox-sc-13pk1d4-0 fsIpUF"
+    class="StyledTabs-a4fwxl-1 jRybGp StyledBox-sc-13pk1d4-0 IRSNj"
     role="tablist"
   >
     <div
-      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 hyUBDc"
+      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 hlYSr"
     >
       <button
         aria-expanded="true"
@@ -1333,7 +1333,7 @@ exports[`Tabs set on hover 4`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 SnIPS"
+          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 kvUzDk"
         >
           <span
             class="StyledText-sc-1sadyjn-0 dndifk"
@@ -1350,7 +1350,7 @@ exports[`Tabs set on hover 4`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 kQoGpx"
+          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 iaGDCb"
         >
           <span
             class="StyledText-sc-1sadyjn-0 iEgnbY"
@@ -1375,11 +1375,11 @@ exports[`Tabs set on hover 5`] = `
   class="StyledGrommet-sc-19lkkz7-0 gmnngJ"
 >
   <div
-    class="StyledTabs-a4fwxl-1 jRybGp StyledBox-sc-13pk1d4-0 fsIpUF"
+    class="StyledTabs-a4fwxl-1 jRybGp StyledBox-sc-13pk1d4-0 IRSNj"
     role="tablist"
   >
     <div
-      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 hyUBDc"
+      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 hlYSr"
     >
       <button
         aria-expanded="true"
@@ -1389,7 +1389,7 @@ exports[`Tabs set on hover 5`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 SnIPS"
+          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 kvUzDk"
         >
           <span
             class="StyledText-sc-1sadyjn-0 dndifk"
@@ -1406,7 +1406,7 @@ exports[`Tabs set on hover 5`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 kQoGpx"
+          class="StyledTab-sc-1nnwnsb-0 coQChF StyledBox-sc-13pk1d4-0 iaGDCb"
         >
           <span
             class="StyledText-sc-1sadyjn-0 iEgnbY"

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -337,7 +337,7 @@ exports[`TextInput close suggestion drop 2`] = `
 exports[`TextInput close suggestion drop 3`] = `
 "
 
-.dcSwUN {
+.fmlvSF {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -356,25 +356,25 @@ exports[`TextInput close suggestion drop 3`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .cHrFaK {
+  .cYihDV {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cHrFaK {
+  .cYihDV {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .giyozN {
+  .eEPVhE {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .giyozN {
+  .eEPVhE {
     padding: 6px;
   }
 }
@@ -685,7 +685,7 @@ exports[`TextInput complex suggestions 2`] = `
 exports[`TextInput complex suggestions 3`] = `
 "
 
-.dcSwUN {
+.fmlvSF {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -704,25 +704,25 @@ exports[`TextInput complex suggestions 3`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .cHrFaK {
+  .cYihDV {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cHrFaK {
+  .cYihDV {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .giyozN {
+  .eEPVhE {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .giyozN {
+  .eEPVhE {
     padding: 6px;
   }
 }
@@ -1219,7 +1219,7 @@ exports[`TextInput select suggestion 2`] = `
 exports[`TextInput select suggestion 3`] = `
 "
 
-.dcSwUN {
+.fmlvSF {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1238,25 +1238,25 @@ exports[`TextInput select suggestion 3`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .cHrFaK {
+  .cYihDV {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cHrFaK {
+  .cYihDV {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .giyozN {
+  .eEPVhE {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .giyozN {
+  .eEPVhE {
     padding: 6px;
   }
 }
@@ -1594,7 +1594,7 @@ exports[`TextInput suggestions 2`] = `
 exports[`TextInput suggestions 3`] = `
 "
 
-.dcSwUN {
+.fmlvSF {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1613,25 +1613,25 @@ exports[`TextInput suggestions 3`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .cHrFaK {
+  .cYihDV {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .cHrFaK {
+  .cYihDV {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .giyozN {
+  .eEPVhE {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .giyozN {
+  .eEPVhE {
     padding: 6px;
   }
 }

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -192,7 +192,29 @@ If specified, the entire panel header will be managed by the caller.
 \`\`\`
 node
 \`\`\`
-  ",
+  
+## Theme
+  
+**accordion.icons.collapse**
+
+The icon to use when the panel is expanded. Expects \`React.element\`.
+
+Defaults to
+
+\`\`\`
+<FormUp />
+\`\`\`
+
+**accordion.icons.expand**
+
+The icon to use when the panel is collapsed. Expects \`React.element\`.
+
+Defaults to
+
+\`\`\`
+<FormDown />
+\`\`\`
+",
   "Anchor": "## Anchor
 A text link.
 
@@ -369,66 +391,82 @@ boolean
   
 **global.focus.border.color**
 
-The color around the Anchor when in focus. Defaults to \`#FD6FFF\`.
+The color around the Anchor when in focus. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
 
 \`\`\`
-string | { dark: string, light: string }
+#FD6FFF
 \`\`\`
 
 **anchor.color**
 
-The color of the label text and icon strokes. Defaults to \`{ light: '#1D67E3', dark: '#6194EB' }\`.
+The color of the label text and icon strokes. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
 
 \`\`\`
-string | { dark: string, light: string }
+{ light: '#1D67E3', dark: '#6194EB' }
 \`\`\`
 
 **anchor.fontWeight**
 
-The font weight of the label. Defaults to \`600\`.
+The font weight of the label. Expects \`number\`.
+
+Defaults to
 
 \`\`\`
-number
+600
 \`\`\`
 
 **anchor.textDecoration**
 
-The text decoration of the label. Refer to https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration for possible values. Defaults to \`none\`.
+The text decoration of the label. Refer to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration) for possible values. Expects \`string\`.
+
+Defaults to
 
 \`\`\`
-string
+none
 \`\`\`
 
 **anchor.hover.fontWeight**
 
-The font weight of the label when hovering. Defaults to \`undefined\`.
+The font weight of the label when hovering. Expects \`number\`.
+
+Defaults to
 
 \`\`\`
-number
+undefined
 \`\`\`
 
 **anchor.hover.textDecoration**
 
-The text decoration of the label when hovering. Refer to https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration for possible values. Defaults to \`underline\`.
+The text decoration of the label when hovering. Refer to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration) for possible values. Expects \`string\`.
+
+Defaults to
 
 \`\`\`
-string
+underline
 \`\`\`
 
 **anchor.hover.extend**
 
-Any additional style for the Anchor when hovering. Defaults to \`undefined\`.
+Any additional style for the Anchor when hovering. Expects \`string | (props) => {}\`.
+
+Defaults to
 
 \`\`\`
-string | (props) => {}
+undefined
 \`\`\`
 
 **anchor.extend**
 
-Any additional style for the Anchor. Defaults to \`undefined\`.
+Any additional style for the Anchor. Expects \`string | (props) => {}\`.
+
+Defaults to
 
 \`\`\`
-string | (props) => {}
+undefined
 \`\`\`
 ",
   "Box": "## Box
@@ -971,7 +1009,192 @@ Whether children can wrap if they
 \`\`\`
 boolean
 \`\`\`
-  ",
+  
+## Theme
+  
+**global.animation**
+
+The animation configuration for the Box. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+  duration: '1s',
+  jiggle: {
+    duration: '0.1s',
+  },
+}
+\`\`\`
+
+**global.border.size**
+
+The possible border sizes in the Box. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+  xsmall: '1px',
+  small: '2px',
+  medium: '4px',
+  large: '12px',
+  xlarge: '24px,
+}
+\`\`\`
+
+**global.breakpoints**
+
+The possible breakpoints that could affect border, direction, gap, margin, pad, and round. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+  small: {
+    value: '768px',
+    borderSize: {
+      xsmall: '1px',
+      small: '2px',
+      medium: '4px',
+      large: '6px',
+      xlarge: '12px',
+    },
+    edgeSize: {
+      none: '0px',
+      hair: '1px',
+      xxsmall: '2px',
+      xsmall: '3px',
+      small: '6px',
+      medium: '12px',
+      large: '24px',
+      xlarge: '48px',
+    },
+    size: {
+      xxsmall: '24px',
+      xsmall: '48px',
+      small: '96px',
+      medium: '192px',
+      large: '384px',
+      xlarge: '768px',
+      full: '100%',
+    },
+  },
+  medium: {
+    value: '1536px',
+  },
+  large: {},
+}
+\`\`\`
+
+**global.edgeSize**
+
+The possible sizes for gap, margin, and pad. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+  edgeSize: {
+    none: '0px',
+    hair: '1px',
+    xxsmall: '3px',
+    xsmall: '6px',
+    small: '12px',
+    medium: '24px',
+    large: '48px',
+    xlarge: '96px',
+    responsiveBreakpoint: 'small',
+  },
+}
+\`\`\`
+
+**global.elevation**
+
+The possible shadows in Box elevation. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+  light: {
+    none: 'none',
+    xsmall: '0px 1px 2px rgba(100, 100, 100, 0.50)',
+    small: '0px 2px 4px rgba(100, 100, 100, 0.50)',
+    medium: '0px 3px 8px rgba(100, 100, 100, 0.50)',
+    large: '0px 6px 12px rgba(100, 100, 100, 0.50)',
+    xlarge: '0px 8px 16px rgba(100, 100, 100, 0.50)',
+  },
+  dark: {
+    none: 'none',
+    xsmall: '0px 2px 2px rgba(255, 255, 255, 0.40)',
+    small: '0px 4px 4px rgba(255, 255, 255, 0.40)',
+    medium: '0px 6px 8px rgba(255, 255, 255, 0.40)',
+    large: '0px 8px 16px rgba(255, 255, 255, 0.40)',
+    xlarge: '0px 10px 24px rgba(255, 255, 255, 0.40)',
+  },
+}
+\`\`\`
+
+**global.colors.text**
+
+The text color used inside the Box. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+{ dark: '#f8f8f8', light: '#444444' }
+\`\`\`
+
+**global.opacity.medium**
+
+The value used when background opacity is set to true. Expects \`number\`.
+
+Defaults to
+
+\`\`\`
+0.4
+\`\`\`
+
+**global.size**
+
+The possible sizes for width, height, and basis. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+  xxsmall: '48px',
+  xsmall: '96px',
+  small: '192px',
+  medium: '384px',
+  large: '768px',
+  xlarge: '1152px',
+  xxlarge: '1536px',
+  full: '100%',
+}
+\`\`\`
+
+**box.extend**
+
+Any additional style for the Box. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**box.responsiveBreakpoint**
+
+The actual breakpoint to trigger changes in the border, direction, gap, margin, pad, and round. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+small
+\`\`\`
+",
   "Button": "## Button
 A button. We have a separate component from the browser base so we can style it.
 

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -219,9 +219,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         weight: 600,
       },
       opacity: {
-        strong: '0.8',
-        medium: '0.4',
-        weak: '0.1',
+        strong: 0.8,
+        medium: 0.4,
+        weak: 0.1,
       },
       spacing: `${baseSpacing}px`,
       size: {
@@ -258,6 +258,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     },
     box: {
       responsiveBreakpoint: 'small', // when we switch rows to columns
+      // extend: undefined,
     },
     button: {
       border: {

--- a/tools/generate-readme-ts.js
+++ b/tools/generate-readme-ts.js
@@ -28,12 +28,12 @@ const toMarkdown = theme => {
     themeEntry => `
 **${themeEntry}**
 
-${theme[themeEntry].description} Defaults to \`${
-      theme[themeEntry].defaultValue
-    }\`.
+${theme[themeEntry].description} Expects \`${theme[themeEntry].type}\`.
+
+Defaults to
 
 ${code}
-${theme[themeEntry].type}
+${theme[themeEntry].defaultValue}
 ${code}
 `,
   );


### PR DESCRIPTION
* Added documentation for Accordion and Box
* Changed documentation output in markdown to account for complex default values
* Fixed box stories with gradient background
* Fix documentation for Anchor theme to use markdown syntax
* Removed unnecessary focus style in Box since focus is driven from Buttons
* Replaced opacity values in base theme to be numbers instead of strings

Backwards compatible