### PR TITLE
Adds theme documentation for WorldMap and Image components

### DIFF
--- a/src/js/components/Image/README.md
+++ b/src/js/components/Image/README.md
@@ -116,3 +116,14 @@ cover
 contain
 ```
   
+## Theme
+  
+**image.extend**
+
+Any additional style for the Image. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```

--- a/src/js/components/Image/doc.js
+++ b/src/js/components/Image/doc.js
@@ -2,6 +2,14 @@ import { describe, PropTypes } from 'react-desc';
 
 import { genericProps, getAvailableAtBadge } from '../../utils';
 
+export const themeDoc = {
+  'image.extend': {
+    description: 'Any additional style for the Image.',
+    type: 'string | (props) => {}',
+    defaultValue: undefined,
+  },
+};
+
 export const doc = Image => {
   const DocumentedImage = describe(Image)
     .availableAt(getAvailableAtBadge('Image'))

--- a/src/js/components/WorldMap/README.md
+++ b/src/js/components/WorldMap/README.md
@@ -165,3 +165,74 @@ Color when hovering over places while selecting.
 string
 ```
   
+## Theme
+  
+**worldMap.color**
+
+The color for each individual dot when a color is not passed as a prop Expects `string`.
+
+Defaults to
+
+```
+light-3
+```
+
+**worldMap.continent.active**
+
+The size of the visual dots belonging to a continent when the continent is being hovered. Expects `string`.
+
+Defaults to
+
+```
+8px
+```
+
+**worldMap.continent.base**
+
+The size of the visual dots belonging to a continent that is not being hovered. Expects `string`.
+
+Defaults to
+
+```
+6px
+```
+
+**worldMap.hover.color**
+
+The color for an individual dot when it is being hovered Expects `string`.
+
+Defaults to
+
+```
+light-4
+```
+
+**worldMap.place.active**
+
+The size of a visual dot for an individual place in the map when it is being hovered. Expects `string`.
+
+Defaults to
+
+```
+20px
+```
+
+**worldMap.place.base**
+
+The size of the visual dot representing an individual place in the map when it is not being hovered. Expects `string`.
+
+Defaults to
+
+```
+8px
+```
+
+**worldMap.extend**
+
+Any additional style for the WorldMap. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```

--- a/src/js/components/WorldMap/WorldMap.js
+++ b/src/js/components/WorldMap/WorldMap.js
@@ -563,7 +563,10 @@ class WorldMap extends Component {
             strokeWidth={parseMetricToNum(
               theme.worldMap.continent[active ? 'active' : 'base'],
             )}
-            stroke={normalizeColor(continentColor || color || 'light-3', theme)}
+            stroke={normalizeColor(
+              continentColor || color || theme.worldMap.color,
+              theme,
+            )}
           />
         </g>
       );
@@ -598,7 +601,10 @@ class WorldMap extends Component {
           strokeWidth={parseMetricToNum(
             theme.worldMap.place[active ? 'active' : 'base'],
           )}
-          stroke={normalizeColor(placeColor || color || 'light-3', theme)}
+          stroke={normalizeColor(
+            placeColor || color || theme.worldMap.color,
+            theme,
+          )}
           {...interactiveProps}
           {...restPlace}
           d={d}
@@ -631,7 +637,10 @@ class WorldMap extends Component {
           <path
             strokeLinecap="round"
             strokeWidth={parseMetricToNum(theme.worldMap.place.active)}
-            stroke={normalizeColor(hoverColor || color || 'light-4', theme)}
+            stroke={normalizeColor(
+              hoverColor || color || theme.worldMap.hover.color,
+              theme,
+            )}
             d={d}
           />
         </g>

--- a/src/js/components/WorldMap/doc.js
+++ b/src/js/components/WorldMap/doc.js
@@ -2,6 +2,49 @@ import { describe, PropTypes } from 'react-desc';
 
 import { genericProps, getAvailableAtBadge } from '../../utils';
 
+export const themeDoc = {
+  'worldMap.color': {
+    description:
+      'The color for each individual dot when a color is not passed as a prop',
+    type: 'string',
+    defaultValue: 'light-3',
+  },
+  'worldMap.continent.active': {
+    description:
+      'The size of the visual dots belonging to a continent when the continent is being hovered.',
+    type: 'string',
+    defaultValue: '8px',
+  },
+  'worldMap.continent.base': {
+    description:
+      'The size of the visual dots belonging to a continent that is not being hovered.',
+    type: 'string',
+    defaultValue: '6px',
+  },
+  'worldMap.hover.color': {
+    description: 'The color for an individual dot when it is being hovered',
+    type: 'string',
+    defaultValue: 'light-4',
+  },
+  'worldMap.place.active': {
+    description:
+      'The size of a visual dot for an individual place in the map when it is being hovered.',
+    type: 'string',
+    defaultValue: '20px',
+  },
+  'worldMap.place.base': {
+    description:
+      'The size of the visual dot representing an individual place in the map when it is not being hovered.',
+    type: 'string',
+    defaultValue: '8px',
+  },
+  'worldMap.extend': {
+    description: 'Any additional style for the WorldMap.',
+    type: 'string | (props) => {}',
+    defaultValue: undefined,
+  },
+};
+
 export const doc = WorldMap => {
   const DocumentedWorldMap = describe(WorldMap)
     .availableAt(getAvailableAtBadge('WorldMap'))

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -3830,7 +3830,19 @@ How the image fills its container.
 cover
 contain
 \`\`\`
-  ",
+  
+## Theme
+  
+**image.extend**
+
+Any additional style for the Image. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+",
   "InfiniteScroll": "## InfiniteScroll
 A container that lazily renders items.
 
@@ -6700,6 +6712,78 @@ Color when hovering over places while selecting.
 \`\`\`
 string
 \`\`\`
-  ",
+  
+## Theme
+  
+**worldMap.color**
+
+The color for each individual dot when a color is not passed as a prop Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+light-3
+\`\`\`
+
+**worldMap.continent.active**
+
+The size of the visual dots belonging to a continent when the continent is being hovered. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+8px
+\`\`\`
+
+**worldMap.continent.base**
+
+The size of the visual dots belonging to a continent that is not being hovered. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+6px
+\`\`\`
+
+**worldMap.hover.color**
+
+The color for an individual dot when it is being hovered Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+light-4
+\`\`\`
+
+**worldMap.place.active**
+
+The size of a visual dot for an individual place in the map when it is being hovered. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+20px
+\`\`\`
+
+**worldMap.place.base**
+
+The size of the visual dot representing an individual place in the map when it is not being hovered. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+8px
+\`\`\`
+
+**worldMap.extend**
+
+Any additional style for the WorldMap. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+",
 }
 `;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -692,9 +692,13 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // scrubber: { track: { color: undefined } },
     },
     worldMap: {
+      color: 'light-3',
       continent: {
         active: '8px',
         base: '6px',
+      },
+      hover: {
+        color: 'light-4',
       },
       place: {
         active: '20px',


### PR DESCRIPTION
#### What does this PR do?
Adds theme documentation for WorldMap and Image components
Moves hardcoded colors from the WorldMap component to theme

#### Where should the reviewer start?
src/js/components/WorldMap/doc.js
src/js/components/Image/doc.js

#### What testing has been done on this PR?
jest / storybook

#### How should this be manually tested?
storybook / changing the theme to apply colors to WorldMap

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
 backwards compatible