### PR TITLE
Changed Drop to fix an issue with resizing it

### DIFF
--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -193,8 +193,8 @@ export class DropContainer extends Component {
       // if we can't fit it all, or we're rather close,
       // see if there's more room the other direction
       if (
-        (responsive && containerRect.height > maxHeight) ||
-        maxHeight > windowHeight / 10
+        responsive &&
+        (containerRect.height > maxHeight || maxHeight > windowHeight / 10)
       ) {
         // We need more room than we have.
         if (align.top && top > windowHeight / 2) {

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -63,11 +63,15 @@ export class DropContainer extends Component {
     window.addEventListener('resize', this.onResize);
     document.addEventListener('mousedown', this.onClickDocument);
 
-    this.place(true);
+    this.place(false);
 
     if (restrictFocus) {
       this.dropRef.current.focus();
     }
+  }
+
+  componentDidUpdate() {
+    this.place(true);
   }
 
   componentWillUnmount() {
@@ -107,10 +111,12 @@ export class DropContainer extends Component {
   onResize = () => {
     this.removeScrollListener();
     this.addScrollListener();
-    this.place(true);
+    this.place(false);
   };
 
-  place = resize => {
+  // We try to preserve the maxHeight as changing it causes any scroll position
+  // to be lost. We set the maxHeight on mount and if the window is resized.
+  place = preserveHeight => {
     const { align, dropTarget, responsive, stretch, theme } = this.props;
     const windowWidth = window.innerWidth;
     const windowHeight = window.innerHeight;
@@ -120,8 +126,9 @@ export class DropContainer extends Component {
       // clear prior styling
       container.style.left = '';
       container.style.top = '';
-      if (resize) {
-        container.style.width = '';
+      container.style.bottom = '';
+      container.style.width = '';
+      if (!preserveHeight) {
         container.style.maxHeight = '';
       }
       // get bounds
@@ -156,68 +163,66 @@ export class DropContainer extends Component {
       } else if (left < 0) {
         left = 0;
       }
-      // set top position
+      // set top or bottom position
       let top;
-      let maxHeight = resize ? undefined : containerRect.height;
+      let bottom;
+      let maxHeight = containerRect.height;
       if (align.top) {
         if (align.top === 'top') {
           ({ top } = targetRect);
         } else {
           top = targetRect.bottom;
         }
-        if (resize) {
-          maxHeight = Math.min(windowHeight - top);
-        }
+        maxHeight = windowHeight - top;
       } else if (align.bottom) {
         if (align.bottom === 'bottom') {
-          top = targetRect.bottom - containerRect.height;
-          if (resize) {
-            maxHeight = Math.min(targetRect.bottom - top, windowHeight - top);
-          }
+          // top = targetRect.bottom - containerRect.height;
+          // maxHeight = Math.min(targetRect.bottom - top, windowHeight - top);
+          ({ bottom } = targetRect);
         } else {
-          top = targetRect.top - containerRect.height;
-          if (resize) {
-            maxHeight = Math.min(targetRect.top - top, windowHeight - top);
-          }
+          // top = targetRect.top - containerRect.height;
+          // maxHeight = Math.min(targetRect.top - top, windowHeight - top);
+          bottom = targetRect.top;
         }
+        maxHeight = windowHeight - bottom;
       } else {
+        // center
         top = targetRect.top + targetRect.height / 2 - containerRect.height / 2;
-        if (resize) {
-          maxHeight = Math.min(windowHeight - top);
-        }
+        maxHeight = windowHeight - top;
       }
-      // if we can't fit it all, see if there's more room the other direction
+      // if we can't fit it all, or we're rather close,
+      // see if there's more room the other direction
       if (
-        resize &&
-        (containerRect.height > maxHeight || maxHeight > windowHeight / 10)
+        (responsive && containerRect.height > maxHeight) ||
+        maxHeight > windowHeight / 10
       ) {
         // We need more room than we have.
         if (align.top && top > windowHeight / 2) {
           // We put it below, but there's more room above, put it above
+          top = '';
           if (align.top === 'bottom') {
-            if (responsive) {
-              top = Math.max(targetRect.top - containerRect.height, 0);
-              maxHeight = targetRect.top - top;
-            }
-          } else if (responsive) {
-            top = Math.max(targetRect.bottom - containerRect.height, 0);
-            maxHeight = targetRect.bottom - top;
+            // top = Math.max(targetRect.top - containerRect.height, 0);
+            // maxHeight = targetRect.top - top;
+            bottom = targetRect.top;
+          } else {
+            // top = Math.max(targetRect.bottom - containerRect.height, 0);
+            // maxHeight = targetRect.bottom - top;
+            ({ bottom } = targetRect);
           }
+          maxHeight = windowHeight - bottom;
         } else if (align.bottom && maxHeight < windowHeight / 2) {
           // We put it above but there's more room below, put it below
+          bottom = '';
           if (align.bottom === 'bottom') {
-            if (responsive) {
-              ({ top } = targetRect);
-              maxHeight = windowHeight - top;
-            }
-          } else if (responsive) {
+            ({ top } = targetRect);
+          } else {
             top = targetRect.bottom;
-            maxHeight = windowHeight - top;
           }
+          maxHeight = windowHeight - top;
         }
       }
       container.style.left = `${left}px`;
-      if (resize && stretch) {
+      if (stretch) {
         // offset width by 0.1 to avoid a bug in ie11 that
         // unnecessarily wraps the text if width is the same
         // NOTE: turned off for now
@@ -225,9 +230,13 @@ export class DropContainer extends Component {
       }
       // the (position:absolute + scrollTop)
       // is presenting issues with desktop scroll flickering
-      container.style.top = `${top}px`;
-      if (resize) {
-        // maxHeight = windowHeight - (top || 0);
+      if (top !== '') {
+        container.style.top = `${top}px`;
+      }
+      if (bottom !== '') {
+        container.style.bottom = `${windowHeight - bottom}px`;
+      }
+      if (!preserveHeight) {
         if (theme.drop && theme.drop.maxHeight) {
           maxHeight = Math.min(
             maxHeight,

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -72,7 +72,7 @@ exports[`Drop align left random 1`] = `
 <div
   class="c0 c1"
   id="drop-node"
-  style="width: 0.1px; top: 0px; max-height: 0px;"
+  style="width: 0.1px; bottom: 768px; max-height: 768px;"
   tabindex="-1"
 >
   this is a test
@@ -788,7 +788,7 @@ exports[`Drop align right right bottom top 1`] = `
 <div
   class="c0 c1"
   id="drop-node"
-  style="left: 0px; width: 0.1px; top: 0px; max-height: 0px;"
+  style="left: 0px; width: 0.1px; bottom: 768px; max-height: 768px;"
   tabindex="-1"
 >
   this is a test
@@ -954,7 +954,7 @@ exports[`Drop align right right bottom top 3`] = `
 <div
   class="c0 c1"
   id="drop-node"
-  style="left: 0px; width: 0.1px; top: 0px; max-height: 0px;"
+  style="left: 0px; width: 0.1px; bottom: 768px; max-height: 768px;"
   tabindex="-1"
 >
   this is a test

--- a/src/js/components/Drop/drop.stories.js
+++ b/src/js/components/Drop/drop.stories.js
@@ -311,7 +311,10 @@ class LazyDrop extends Component {
               target={this.bottomTargetRef.current}
               responsive
             >
-              <Box height="xsmall" overflow="auto" pad={pad}>
+              <Box
+                height={pad === 'small' ? 'xsmall' : undefined}
+                pad={{ horizontal: 'large', vertical: pad }}
+              >
                 Drop Contents
               </Box>
             </Drop>

--- a/src/js/components/Drop/drop.stories.js
+++ b/src/js/components/Drop/drop.stories.js
@@ -236,7 +236,6 @@ class ProgressiveDrop extends Component {
           {openDrop && (
             <Drop
               target={this.boxRef.current}
-              align={{ top: 'bottom' }}
               onClickOutside={this.onCloseDrop}
               onEsc={this.onCloseDrop}
             >

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -791,7 +791,7 @@ exports[`Select complex options and children 3`] = `
 <div
   class="c0 c1"
   id="test-select__drop"
-  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
+  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
   tabindex="-1"
 >
   <div
@@ -2419,7 +2419,7 @@ exports[`Select multiple values 3`] = `
 <div
   class="c0 c1"
   id="test-select__drop"
-  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
+  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
   tabindex="-1"
 >
   <div
@@ -3214,7 +3214,7 @@ exports[`Select opens 3`] = `
 <div
   class="c0 c1"
   id="test-select__drop"
-  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
+  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
   tabindex="-1"
 >
   <div
@@ -4067,7 +4067,7 @@ exports[`Select search 2`] = `
 <div
   class="c0 c1"
   id="test-select__drop"
-  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
+  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
   tabindex="-1"
 >
   <div

--- a/src/js/components/Select/stories/select.stories.js
+++ b/src/js/components/Select/stories/select.stories.js
@@ -57,15 +57,17 @@ class SimpleSelect extends Component {
     const { theme } = this.props;
     const { options, value } = this.state;
     return (
-      <Grommet theme={theme || grommet}>
-        <Select
-          id="select"
-          name="select"
-          placeholder="Select"
-          value={value}
-          options={options}
-          onChange={({ option }) => this.setState({ value: option })}
-        />
+      <Grommet full theme={theme || grommet}>
+        <Box fill align="center" justify="center">
+          <Select
+            id="select"
+            name="select"
+            placeholder="Select"
+            value={value}
+            options={options}
+            onChange={({ option }) => this.setState({ value: option })}
+          />
+        </Box>
       </Grommet>
     );
   }
@@ -83,21 +85,23 @@ class SearchSelect extends Component {
   render() {
     const { options, value } = this.state;
     return (
-      <Grommet theme={grommet}>
-        <Select
-          size="medium"
-          placeholder="Select"
-          value={value}
-          options={options}
-          onChange={({ option }) => this.setState({ value: option })}
-          onClose={() => this.setState({ options: DEFAULT_OPTIONS })}
-          onSearch={text => {
-            const exp = new RegExp(text, 'i');
-            this.setState({
-              options: DEFAULT_OPTIONS.filter(o => exp.test(o)),
-            });
-          }}
-        />
+      <Grommet full theme={grommet}>
+        <Box fill align="center" justify="center">
+          <Select
+            size="medium"
+            placeholder="Select"
+            value={value}
+            options={options}
+            onChange={({ option }) => this.setState({ value: option })}
+            onClose={() => this.setState({ options: DEFAULT_OPTIONS })}
+            onSearch={text => {
+              const exp = new RegExp(text, 'i');
+              this.setState({
+                options: DEFAULT_OPTIONS.filter(o => exp.test(o)),
+              });
+            }}
+          />
+        </Box>
       </Grommet>
     );
   }
@@ -169,34 +173,30 @@ class SeasonsSelect extends Component {
   render() {
     const { selected } = this.state;
     return (
-      <Grommet theme={grommet}>
-        <Box direction="row">
-          <Box align="start" basis="medium" direction="row">
-            <Select
-              placeholder="Select Season"
-              closeOnChange={false}
-              multiple
-              value={
-                selected && selected.length ? (
-                  <Box wrap direction="row" style={{ width: '208px' }}>
-                    {selected.map(index =>
-                      this.renderSeason(allSeasons[index]),
-                    )}
-                  </Box>
-                ) : (
-                  undefined
-                )
-              }
-              options={allSeasons}
-              selected={selected}
-              disabled={[2, 6]}
-              onChange={({ selected: nextSelected }) => {
-                this.setState({ selected: nextSelected.sort() });
-              }}
-            >
-              {this.renderOption}
-            </Select>
-          </Box>
+      <Grommet full theme={grommet}>
+        <Box fill align="center" justify="center">
+          <Select
+            placeholder="Select Season"
+            closeOnChange={false}
+            multiple
+            value={
+              selected && selected.length ? (
+                <Box wrap direction="row" style={{ width: '208px' }}>
+                  {selected.map(index => this.renderSeason(allSeasons[index]))}
+                </Box>
+              ) : (
+                undefined
+              )
+            }
+            options={allSeasons}
+            selected={selected}
+            disabled={[2, 6]}
+            onChange={({ selected: nextSelected }) => {
+              this.setState({ selected: nextSelected.sort() });
+            }}
+          >
+            {this.renderOption}
+          </Select>
         </Box>
       </Grommet>
     );
@@ -329,8 +329,8 @@ class CustomSearchSelect extends Component {
     const { contentPartners, searching, selectedContentPartners } = this.state;
 
     return (
-      <Grommet theme={customSearchTheme}>
-        <Box align="start" width="medium" direction="row">
+      <Grommet full theme={customSearchTheme}>
+        <Box fill align="center" justify="center" width="medium">
           <SearchInputContext.Provider value={{ searching }}>
             <Select
               ref={this.selectRef}


### PR DESCRIPTION
#### What does this PR do?

Changed Drop to fix an issue with resizing it.

This brings back calling DropContainer.place() on every update. But, we now do bottom alignment to the bottom of the window, this allows us to set maxHeight relative to the windowHeight rather than from the top to the anchor point. So, when the DropContainer is above the target, it will correctly grow upwards, just like when below the target it can grow downwards. Duh.

#### Where should the reviewer start?

DropContainer.place()

#### What testing has been done on this PR?

storybook DropContainer, Select, and Menu

#### How should this be manually tested?

storybook DropContainer, Select, and Menu

#### Any background context you want to provide?

#### What are the relevant issues?

should have one, but don't

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
