### PR TITLE
Added extend capabilities to select container

### DIFF
--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -25,6 +25,9 @@ const ContainerBox = styled(Box)`
   @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
     width: 100%;
   }
+
+  ${props =>
+    props.theme.select.container && props.theme.select.container.extend};
 `;
 
 const OptionsBox = styled(Box)`

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -993,7 +993,7 @@ exports[`Select complex options and children 4`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .hLVQfB {
+  .kZuSOe {
     width: 100%;
   }
 }"
@@ -2645,7 +2645,7 @@ exports[`Select multiple values 4`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .hLVQfB {
+  .kZuSOe {
     width: 100%;
   }
 }"
@@ -3428,7 +3428,7 @@ exports[`Select opens 4`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .hLVQfB {
+  .kZuSOe {
     width: 100%;
   }
 }"
@@ -4307,7 +4307,7 @@ exports[`Select search 3`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .hLVQfB {
+  .kZuSOe {
     width: 100%;
   }
 }"

--- a/src/js/components/Select/stories/theme.js
+++ b/src/js/components/Select/stories/theme.js
@@ -74,6 +74,9 @@ export const theme = {
       down: ArrowDown,
     },
     searchInput: SearchInput,
+    container: {
+      extend: 'max-height: 250px;',
+    },
   },
   textInput: {
     extend: props => `

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -581,6 +581,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
       // searchInput: undefined,
       step: 20,
+      container: {
+        // extend: undefined,
+      },
       control: {
         // extend: undefined,
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changes SelectContainer to accept an extend on the ContainerBox
#### Where should the reviewer start?
SelectContainer
#### What testing has been done on this PR?
manual
#### How should this be manually tested?
open custom search Select example in storybook
#### Any background context you want to provide?

#### What are the relevant issues?
no issue :(
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes (when we add the Select theme documentation)
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards