### PR TITLE
Removed Firefox outline from focused elements.

### DIFF
--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
@@ -79,6 +79,10 @@ exports[`Anchor focus renders 1`] = `
   outline: #FD6FFF solid 2px;
 }
 
+.c1::-moz-focus-inner {
+  border: 0;
+}
+
 <div
   className="c0"
 >

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -327,6 +327,10 @@ exports[`Button focus renders 1`] = `
   outline: #FD6FFF solid 2px;
 }
 
+.c1::-moz-focus-inner {
+  border: 0;
+}
+
 .c0 {
   font-size: 18px;
   line-height: 24px;

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -157,6 +157,10 @@ export const focusStyle = css`
   box-shadow: 0 0 2px 2px
     ${props =>
       normalizeColor(props.theme.global.focus.border.color, props.theme)};
+
+  ::-moz-focus-inner {
+    border: 0;
+  }
 `;
 
 export const inputStyle = css`


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changes `focusStyle` to fix an issue where firefox adds an unexpected outline around the text.
#### Where should the reviewer start?
focusStyle
#### What testing has been done on this PR?
manual
#### How should this be manually tested?
storybook
#### Any background context you want to provide?

#### What are the relevant issues?
no issue created
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards