### PR TITLE
Updating size docs on Text to include line height

### DIFF
--- a/src/js/components/Text/README.md
+++ b/src/js/components/Text/README.md
@@ -117,7 +117,7 @@ string
 
 **size**
 
-The font size is primarily driven by the chosen tag. But, it can
+The font size and line height are primarily driven by the chosen tag. But, it can
 be adjusted via this size property. The tag should be set for semantic
 correctness and accessibility. This size property allows for stylistic
 adjustments.


### PR DESCRIPTION
Suggestion to include line-height part of the `size` documentation.

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
fix docs

#### Where should the reviewer start?
readme
#### What testing has been done on this PR?
verifying behavior in code
#### How should this be manually tested?
verify in StyledText.js
#### Any background context you want to provide?
noticed it while writing theme for Text
#### What are the relevant issues?
none
#### Screenshots (if appropriate)
none
#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backward compatible