### PR TITLE
Add tag property into Button to let user pick a DOM tag

### DIFF
--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -57,7 +57,7 @@ class Button extends Component {
       reverse,
       theme,
       type,
-      tag,
+      as,
       ...rest
     } = this.props;
 
@@ -72,7 +72,7 @@ class Button extends Component {
       });
     }
 
-    const domTag = !tag && href ? 'a' : tag;
+    const domTag = !as && href ? 'a' : as;
     const first = reverse ? label : buttonIcon;
     const second = reverse ? buttonIcon : label;
 

--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -57,6 +57,7 @@ class Button extends Component {
       reverse,
       theme,
       type,
+      tag,
       ...rest
     } = this.props;
 
@@ -70,13 +71,20 @@ class Button extends Component {
           ],
       });
     }
+
+    let domTag = tag;
+    // Only set domTag to a if user did not provide a tag and provided an href
+    if (!domTag && href) {
+      domTag = 'a';
+    }
+
     const first = reverse ? label : buttonIcon;
     const second = reverse ? buttonIcon : label;
 
     return (
       <StyledButton
         {...rest}
-        as={href ? 'a' : undefined}
+        as={domTag}
         ref={forwardRef}
         aria-label={a11yTitle}
         colorValue={color}

--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -72,12 +72,7 @@ class Button extends Component {
       });
     }
 
-    let domTag = tag;
-    // Only set domTag to a if user did not provide a tag and provided an href
-    if (!domTag && href) {
-      domTag = 'a';
-    }
-
+    const domTag = !tag && href ? 'a' : tag;
     const first = reverse ? label : buttonIcon;
     const second = reverse ? buttonIcon : label;
 

--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -232,7 +232,7 @@ reset
 submit
 ```
 
-**tag**
+**as**
 
 The DOM tag to use for the element.
 

--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -231,6 +231,14 @@ button
 reset
 submit
 ```
+
+**tag**
+
+The DOM tag to use for the element.
+
+```
+string
+```
   
 ## Theme
   

--- a/src/js/components/Button/__tests__/Button-test.js
+++ b/src/js/components/Button/__tests__/Button-test.js
@@ -220,3 +220,13 @@ test('Button is clickable', () => {
   button[0].props.onClick();
   expect(onClick).toBeCalled();
 });
+
+test('renders tag', () => {
+  const component = renderer.create(
+    <Grommet>
+      <Button tag="span" />
+    </Grommet>,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/js/components/Button/__tests__/Button-test.js
+++ b/src/js/components/Button/__tests__/Button-test.js
@@ -224,7 +224,7 @@ test('Button is clickable', () => {
 test('renders tag', () => {
   const component = renderer.create(
     <Grommet>
-      <Button tag="span" />
+      <Button as="span" />
     </Grommet>,
   );
   const tree = component.toJSON();

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -1326,3 +1326,52 @@ exports[`Button warns about invalid label render 1`] = `
   </button>
 </div>
 `;
+
+exports[`renders tag 1`] = `
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  -webkit-transition: 0.1s ease-in-out;
+  transition: 0.1s ease-in-out;
+}
+
+.c1:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+  className="c0"
+>
+  <span
+    className="c1"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    type="button"
+  />
+</div>
+`;

--- a/src/js/components/Button/button.stories.js
+++ b/src/js/components/Button/button.stories.js
@@ -54,7 +54,7 @@ const RouteButton = () => (
 
 const CustomTagButton = () => (
   <Grommet theme={grommet}>
-    <Button tag="span" label="Go" path="/" />
+    <Button as="span" label="Go" path="/" />
   </Grommet>
 );
 

--- a/src/js/components/Button/button.stories.js
+++ b/src/js/components/Button/button.stories.js
@@ -52,6 +52,12 @@ const RouteButton = () => (
   </Grommet>
 );
 
+const CustomTagButton = () => (
+  <Grommet theme={grommet}>
+    <Button tag="span" label="Go" path="/" />
+  </Grommet>
+);
+
 const customTheme = {
   global: {
     font: {
@@ -180,9 +186,9 @@ const customButtonColor = deepMerge(grommet, {
 
 const ThemeColored = () => (
   <Grommet theme={customButtonColor}>
-    <Box align='start' gap='small'>
-      <Button primary label='Submit' onClick={() => {}} />
-      <Button primary color='dark-1' label='Submit' onClick={() => {}} />
+    <Box align="start" gap="small">
+      <Button primary label="Submit" onClick={() => {}} />
+      <Button primary color="dark-1" label="Submit" onClick={() => {}} />
     </Box>
   </Grommet>
 );
@@ -200,4 +206,5 @@ storiesOf('Button', module)
   .add('Custom theme', () => <CustomThemeButton />)
   .add('Multiple Same Line', () => <MultipleButton />)
   .add('Colored', () => <ColoredButton />)
-  .add('Theme Colored', () => <ThemeColored />);
+  .add('Theme Colored', () => <ThemeColored />)
+  .add('Custom tag Button', () => <CustomTagButton />);

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -74,6 +74,7 @@ end of the anchor.`,
         'The type of button. Set the type to submit for the default button on forms.',
       )
       .defaultValue('button'),
+    tag: PropTypes.string.description(`The DOM tag to use for the element.`),
   };
 
   return DocumentedButton;

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -74,7 +74,7 @@ end of the anchor.`,
         'The type of button. Set the type to submit for the default button on forms.',
       )
       .defaultValue('button'),
-    tag: PropTypes.string.description(`The DOM tag to use for the element.`),
+    as: PropTypes.string.description(`The DOM tag to use for the element.`),
   };
 
   return DocumentedButton;

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -19,7 +19,7 @@ export interface ButtonProps {
   primary?: boolean;
   reverse?: boolean;
   type?: "button" | "reset" | "submit";
-  tag?: string;
+  as?: string;
 }
 
 declare const Button: React.ComponentType<ButtonProps>;

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -19,6 +19,7 @@ export interface ButtonProps {
   primary?: boolean;
   reverse?: boolean;
   type?: "button" | "reset" | "submit";
+  tag?: string;
 }
 
 declare const Button: React.ComponentType<ButtonProps>;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1436,7 +1436,7 @@ reset
 submit
 \`\`\`
 
-**tag**
+**as**
 
 The DOM tag to use for the element.
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1435,6 +1435,14 @@ button
 reset
 submit
 \`\`\`
+
+**tag**
+
+The DOM tag to use for the element.
+
+\`\`\`
+string
+\`\`\`
   
 ## Theme
   

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -106,6 +106,7 @@ export interface ButtonProps {
   primary?: boolean;
   reverse?: boolean;
   type?: \\"button\\" | \\"reset\\" | \\"submit\\";
+  tag?: string;
 }
 
 declare const Button: React.ComponentType<ButtonProps>;

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -106,7 +106,7 @@ export interface ButtonProps {
   primary?: boolean;
   reverse?: boolean;
   type?: \\"button\\" | \\"reset\\" | \\"submit\\";
-  tag?: string;
+  as?: string;
 }
 
 declare const Button: React.ComponentType<ButtonProps>;


### PR DESCRIPTION
Closes: #2463
Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Let user pick a tag for the Anchor component

#### What testing has been done on this PR?

I added a unit test changing the tag to `span`

#### What are the relevant issues?

#2463 

#### Do the grommet docs need to be updated?

I update the readme and doc file.

#### Is this change backwards compatible or is it a breaking change?

I kept current compatibility with Anchor when use does not supply a tag
