### PR TITLE
Document as property for Anchor component

### DIFF
--- a/src/js/components/Anchor/README.md
+++ b/src/js/components/Anchor/README.md
@@ -145,7 +145,7 @@ node
 
 **onClick**
 
-Click handler. It can be used, for example, 
+Click handler. It can be used, for example,
         to add analytics and track who clicked in the anchor.
 
 ```
@@ -174,6 +174,15 @@ medium
 large
 xlarge
 xxlarge
+string
+```
+
+**as**
+
+The DOM tag to use for the element. This the polymorphic as property of
+      Styled Components.
+
+```
 string
 ```
   

--- a/src/js/components/Anchor/README.md
+++ b/src/js/components/Anchor/README.md
@@ -179,8 +179,7 @@ string
 
 **as**
 
-The DOM tag to use for the element. This the polymorphic as property of
-      Styled Components.
+The DOM tag to use for the element.
 
 ```
 string

--- a/src/js/components/Anchor/__tests__/Anchor-test.js
+++ b/src/js/components/Anchor/__tests__/Anchor-test.js
@@ -128,3 +128,13 @@ test('Anchor is clickable', () => {
   anchor[0].props.onClick();
   expect(onClick).toBeCalled();
 });
+
+test('renders tag', () => {
+  const component = renderer.create(
+    <Grommet>
+      <Anchor href="#" label="Test" as="span" />
+    </Grommet>,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
@@ -500,3 +500,45 @@ exports[`Anchor warns about invalid label render 1`] = `
   </a>
 </div>
 `;
+
+exports[`renders tag 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  box-sizing: border-box;
+  font-size: inherit;
+  line-height: inherit;
+  color: #1D67E3;
+  font-weight: 600;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  outline: none;
+}
+
+.c1:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+<div
+  className="c0"
+>
+  <span
+    className="c1"
+    href="#"
+    onBlur={[Function]}
+    onFocus={[Function]}
+  >
+    Test
+  </span>
+</div>
+`;

--- a/src/js/components/Anchor/doc.js
+++ b/src/js/components/Anchor/doc.js
@@ -29,7 +29,7 @@ or just use children.`,
     icon: PropTypes.element.description('Icon element to place in the anchor.'),
     label: PropTypes.node.description('Label text to place in the anchor.'),
     onClick: PropTypes.func.description(
-      `Click handler. It can be used, for example, 
+      `Click handler. It can be used, for example,
         to add analytics and track who clicked in the anchor.`,
     ),
     reverse: PropTypes.bool
@@ -52,6 +52,10 @@ or just use children.`,
       `The font size is typically driven by the components containing
 this component. But, it can be adjusted directly via this size property, typically
 when it is not contained in a 'Heading', 'Paragraph', or 'Text'.`,
+    ),
+    as: PropTypes.string.description(
+      `The DOM tag to use for the element. This the polymorphic as property of
+      Styled Components.`,
     ),
   };
 

--- a/src/js/components/Anchor/doc.js
+++ b/src/js/components/Anchor/doc.js
@@ -53,10 +53,7 @@ or just use children.`,
 this component. But, it can be adjusted directly via this size property, typically
 when it is not contained in a 'Heading', 'Paragraph', or 'Text'.`,
     ),
-    as: PropTypes.string.description(
-      `The DOM tag to use for the element. This the polymorphic as property of
-      Styled Components.`,
-    ),
+    as: PropTypes.string.description(`The DOM tag to use for the element.`),
   };
 
   return DocumentedAnchor;

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -12,6 +12,7 @@ export interface AnchorProps {
   onClick?: (...args: any[]) => any;
   reverse?: boolean;
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
+  as?: string;
 }
 
 declare const Anchor: React.ComponentType<AnchorProps>;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -396,8 +396,7 @@ string
 
 **as**
 
-The DOM tag to use for the element. This the polymorphic as property of
-      Styled Components.
+The DOM tag to use for the element.
 
 \`\`\`
 string

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -362,7 +362,7 @@ node
 
 **onClick**
 
-Click handler. It can be used, for example, 
+Click handler. It can be used, for example,
         to add analytics and track who clicked in the anchor.
 
 \`\`\`
@@ -391,6 +391,15 @@ medium
 large
 xlarge
 xxlarge
+string
+\`\`\`
+
+**as**
+
+The DOM tag to use for the element. This the polymorphic as property of
+      Styled Components.
+
+\`\`\`
 string
 \`\`\`
   

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -46,6 +46,7 @@ export interface AnchorProps {
   onClick?: (...args: any[]) => any;
   reverse?: boolean;
   size?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | \\"xxlarge\\" | string;
+  as?: string;
 }
 
 declare const Anchor: React.ComponentType<AnchorProps>;


### PR DESCRIPTION
Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Documents the `as` property for the Anchor component.

My editor fixed up some trailing spaces issues on the files i opened. If you feel this is not needed i can modify.

#### What testing has been done on this PR?

Added a unit-test for verifying the `as` property works as intended

#### Any background context you want to provide?

#2463 

#### Do the grommet docs need to be updated?

The PR does that

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible