### PR TITLE
extend Text theme docs

### DIFF
--- a/src/js/components/Text/README.md
+++ b/src/js/components/Text/README.md
@@ -235,3 +235,13 @@ Defaults to
       },
     }
 ```
+
+**text.extend**
+
+Any additional style for Text. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```

--- a/src/js/components/Text/doc.js
+++ b/src/js/components/Text/doc.js
@@ -104,4 +104,9 @@ export const themeDoc = {
       },
     }`,
   },
+  'text.extend': {
+    description: 'Any additional style for Text.',
+    type: 'string | (props) => {}',
+    defaultValue: undefined,
+  },
 };

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -6657,6 +6657,16 @@ Defaults to
       },
     }
 \`\`\`
+
+**text.extend**
+
+Any additional style for Text. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
 ",
   "TextArea": "## TextArea
 A textarea.


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
adding extend theme docs to Text
#### Where should the reviewer start?
doc.js
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
storybook
#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backward compatible