### PR TITLE
Button - fix for hoverIndicator warning 

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "styled-components": ">= 4.X"
   },
   "dependencies": {
+    "acorn": "^6.0.4",
     "css": "^2.2.3",
     "markdown-to-jsx": "^6.6.6",
     "polished": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "styled-components": ">= 4.X"
   },
   "dependencies": {
-    "acorn": "^6.0.4",
     "css": "^2.2.3",
     "markdown-to-jsx": "^6.6.6",
     "polished": "^2.2.0",

--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -156,6 +156,7 @@ with plain Buttons.
 
 ```
 boolean
+string
 background
 {
   background: 

--- a/src/js/components/Button/__tests__/Button-test.js
+++ b/src/js/components/Button/__tests__/Button-test.js
@@ -126,7 +126,7 @@ test('Button href renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Button hoverIndicator renders', () => {
+test('Button hoverIndicator background renders', () => {
   const component = renderer.create(
     <Grommet>
       <Button onClick={() => {}} hoverIndicator="background">
@@ -199,6 +199,18 @@ test('Button hoverIndicator as object with invalid colorIndex renders', () => {
   const component = renderer.create(
     <Grommet>
       <Button onClick={() => {}} hoverIndicator={{ background: 'accent-100' }}>
+        hoverIndicator
+      </Button>
+    </Grommet>,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Button hoverIndicator color renders', () => {
+  const component = renderer.create(
+    <Grommet>
+      <Button onClick={() => {}} hoverIndicator="dark-5">
         hoverIndicator
       </Button>
     </Grommet>,

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -660,7 +660,7 @@ exports[`Button hoverIndicator as object with invalid colorIndex renders 1`] = `
 </div>
 `;
 
-exports[`Button hoverIndicator renders 1`] = `
+exports[`Button hoverIndicator background renders 1`] = `
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -682,6 +682,56 @@ exports[`Button hoverIndicator renders 1`] = `
 .c1:hover {
   background-color: rgba(221,221,221,0.4);
   color: #444444;
+  color: #000000;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+  className="c0"
+>
+  <button
+    className="c1"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    type="button"
+  >
+    hoverIndicator
+  </button>
+</div>
+`;
+
+exports[`Button hoverIndicator color renders 1`] = `
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c1:hover {
+  background: #777777;
+  color: #f8f8f8;
   color: #000000;
 }
 

--- a/src/js/components/Button/button.stories.js
+++ b/src/js/components/Button/button.stories.js
@@ -48,7 +48,7 @@ const AnchorButton = () => (
 
 const RouteButton = () => (
   <Grommet theme={grommet}>
-    <RoutedButton label="Go" path="/" />
+    <RoutedButton hoverIndicator="light-5" label="Go" path="/" />
   </Grommet>
 );
 
@@ -180,9 +180,9 @@ const customButtonColor = deepMerge(grommet, {
 
 const ThemeColored = () => (
   <Grommet theme={customButtonColor}>
-    <Box align='start' gap='small'>
-      <Button primary label='Submit' onClick={() => {}} />
-      <Button primary color='dark-1' label='Submit' onClick={() => {}} />
+    <Box align="start" gap="small">
+      <Button primary label="Submit" onClick={() => {}} />
+      <Button primary color="dark-1" label="Submit" onClick={() => {}} />
     </Box>
   </Grommet>
 );

--- a/src/js/components/Button/button.stories.js
+++ b/src/js/components/Button/button.stories.js
@@ -31,7 +31,7 @@ const IconLabelButton = () => (
 
 const PlainButton = props => (
   <Grommet theme={grommet}>
-    <Button hoverIndicator onClick={() => {}} {...props}>
+    <Button hoverIndicator="light-1" onClick={() => {}} {...props}>
       <Box pad="small" direction="row" align="center" gap="small">
         <Add />
         <Text>Add</Text>
@@ -48,7 +48,7 @@ const AnchorButton = () => (
 
 const RouteButton = () => (
   <Grommet theme={grommet}>
-    <RoutedButton hoverIndicator="light-5" label="Go" path="/" />
+    <RoutedButton label="Go" path="/" />
   </Grommet>
 );
 

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -34,6 +34,7 @@ export const doc = Button => {
       .defaultValue(true),
     hoverIndicator: PropTypes.oneOfType([
       PropTypes.bool,
+      PropTypes.string,
       PropTypes.oneOf(['background']),
       PropTypes.shape({
         background: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -10,7 +10,7 @@ export interface ButtonProps {
   disabled?: boolean;
   fill?: boolean;
   focusIndicator?: boolean;
-  hoverIndicator?: boolean | "background" | {background: boolean | string};
+  hoverIndicator?: boolean | string | "background" | {background: boolean | string};
   href?: string;
   icon?: JSX.Element;
   label?: React.ReactNode;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1360,6 +1360,7 @@ with plain Buttons.
 
 \`\`\`
 boolean
+string
 background
 {
   background: 

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -97,7 +97,7 @@ export interface ButtonProps {
   disabled?: boolean;
   fill?: boolean;
   focusIndicator?: boolean;
-  hoverIndicator?: boolean | \\"background\\" | {background: boolean | string};
+  hoverIndicator?: boolean | string | \\"background\\" | {background: boolean | string};
   href?: string;
   icon?: JSX.Element;
   label?: React.ReactNode;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes the warning for hoverIndicator warning.
hoverIndicator should accept input type of a string, to apply colors (e.g. "dark-5", "light-1"...)

#### Where should the reviewer start?
 src/js/components/Button/doc.js

#### What testing has been done on this PR?
storybook, see the hoverIndicator example added to Button plain. 
#### How should this be manually tested?
try to add hoverIndicator="dark-5" to any button on Button storybook and see the warning.
use the PR branch and see that the problem doesn't reproduce anymore.

#### Any background context you want to provide?
Issue was raised as a result of  the Sidebar template example https://codesandbox.io/s/lp3y7rj1k9

#### What are the relevant issues?
Not filed yet

#### Screenshots (if appropriate)
VM48 iframe.bundle.js:42559 Warning: Failed prop type: Invalid prop `hoverIndicator` supplied to `Button`.
    in Button (created by Button)
    in ThemedComponent (created by Context.Consumer)
    in FocusableComponent (created by Button)
    in RoutedButton (created by RoutedButton)
    in RoutedButton (created by RouteButton)
    in div (created by Context.Consumer)
    in StyledComponent (created by StyledGrommet)
    in Grommet (created by Grommet)
    in Grommet (created by Context.Consumer)
    in Grommet (created by RouteButton)
    in RouteButton
#### Do the grommet docs need to be updated?
looks to me like it is already documented
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backward compatible