### PR TITLE
Text - doc fix to include line-height impact

### DIFF
--- a/src/js/components/Text/README.md
+++ b/src/js/components/Text/README.md
@@ -117,7 +117,7 @@ string
 
 **size**
 
-The font size is primarily driven by the chosen tag. But, it can
+The font size and line height are primarily driven by the chosen tag. But, it can
 be adjusted via this size property. The tag should be set for semantic
 correctness and accessibility. This size property allows for stylistic
 adjustments.

--- a/src/js/components/Text/doc.js
+++ b/src/js/components/Text/doc.js
@@ -27,7 +27,7 @@ export const doc = Text => {
       ]),
       PropTypes.string,
     ]).description(
-      `The font size is primarily driven by the chosen tag. But, it can
+      `The font size and line height are primarily driven by the chosen tag. But, it can
 be adjusted via this size property. The tag should be set for semantic
 correctness and accessibility. This size property allows for stylistic
 adjustments.`,

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -6610,7 +6610,7 @@ string
 
 **size**
 
-The font size is primarily driven by the chosen tag. But, it can
+The font size and line height are primarily driven by the chosen tag. But, it can
 be adjusted via this size property. The tag should be set for semantic
 correctness and accessibility. This size property allows for stylistic
 adjustments.


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
adding missing line-height property to docs
#### Where should the reviewer start?
doc.js
#### What testing has been done on this PR?
verifying behavior in code
#### How should this be manually tested?
verify in StyledText.js
#### Any background context you want to provide?
https://github.com/grommet/grommet/pull/2474
#### What are the relevant issues?
none
#### Screenshots (if appropriate)
none
#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backward compatible