### PR TITLE
Deprecate tag property for Text and Heading component

### DIFF
--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -190,6 +190,13 @@ exports[`Accordion AccordionPanel 1`] = `
   visibility: hidden;
 }
 
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
 .c0 {
   font-size: 18px;
   line-height: 24px;
@@ -198,13 +205,6 @@ exports[`Accordion AccordionPanel 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-  max-width: 432px;
-  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {
@@ -336,7 +336,7 @@ exports[`Accordion AccordionPanel 1`] = `
             className="c5"
           >
             <h4
-              className="-h4 c6"
+              className="c6"
             >
               Panel 1
             </h4>
@@ -397,7 +397,7 @@ exports[`Accordion AccordionPanel 1`] = `
             className="c5"
           >
             <h4
-              className="-h4 c6"
+              className="c6"
             >
               Panel 2
             </h4>
@@ -608,6 +608,13 @@ exports[`Accordion change active index 1`] = `
   text-align: inherit;
 }
 
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
 .c0 {
   font-size: 18px;
   line-height: 24px;
@@ -616,13 +623,6 @@ exports[`Accordion change active index 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-  max-width: 432px;
-  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {
@@ -737,7 +737,7 @@ exports[`Accordion change active index 1`] = `
             class="c5"
           >
             <h4
-              class="-h4 c6"
+              class="c6"
             >
               Panel 1
             </h4>
@@ -785,7 +785,7 @@ exports[`Accordion change active index 1`] = `
             class="c5"
           >
             <h4
-              class="-h4 c6"
+              class="c6"
             >
               Panel 2
             </h4>
@@ -848,7 +848,7 @@ exports[`Accordion change active index 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 1
             </h4>
@@ -896,7 +896,7 @@ exports[`Accordion change active index 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 2
             </h4>
@@ -1124,6 +1124,13 @@ exports[`Accordion change to second Panel 1`] = `
   visibility: hidden;
 }
 
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
 .c0 {
   font-size: 18px;
   line-height: 24px;
@@ -1132,13 +1139,6 @@ exports[`Accordion change to second Panel 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-  max-width: 432px;
-  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {
@@ -1265,7 +1265,7 @@ exports[`Accordion change to second Panel 1`] = `
             class="c5"
           >
             <h4
-              class="-h4 c6"
+              class="c6"
             >
               Panel 1
             </h4>
@@ -1320,7 +1320,7 @@ exports[`Accordion change to second Panel 1`] = `
             class="c5"
           >
             <h4
-              class="-h4 c6"
+              class="c6"
             >
               Panel 2
             </h4>
@@ -1387,7 +1387,7 @@ exports[`Accordion change to second Panel 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 1
             </h4>
@@ -1442,7 +1442,7 @@ exports[`Accordion change to second Panel 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 2
             </h4>
@@ -1686,6 +1686,13 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   text-align: inherit;
 }
 
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
 .c0 {
   font-size: 18px;
   line-height: 24px;
@@ -1694,13 +1701,6 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-  max-width: 432px;
-  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {
@@ -1815,7 +1815,7 @@ exports[`Accordion change to second Panel without onActive 1`] = `
             class="c5"
           >
             <h4
-              class="-h4 c6"
+              class="c6"
             >
               Panel 1
             </h4>
@@ -1863,7 +1863,7 @@ exports[`Accordion change to second Panel without onActive 1`] = `
             class="c5"
           >
             <h4
-              class="-h4 c6"
+              class="c6"
             >
               Panel 2
             </h4>
@@ -1923,7 +1923,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 1
             </h4>
@@ -1971,7 +1971,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 2
             </h4>
@@ -2812,6 +2812,13 @@ exports[`Accordion multiple panels 1`] = `
   text-align: inherit;
 }
 
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
 .c0 {
   font-size: 18px;
   line-height: 24px;
@@ -2820,13 +2827,6 @@ exports[`Accordion multiple panels 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-  max-width: 432px;
-  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {
@@ -2941,7 +2941,7 @@ exports[`Accordion multiple panels 1`] = `
             class="c5"
           >
             <h4
-              class="-h4 c6"
+              class="c6"
             >
               Panel 1
             </h4>
@@ -2989,7 +2989,7 @@ exports[`Accordion multiple panels 1`] = `
             class="c5"
           >
             <h4
-              class="-h4 c6"
+              class="c6"
             >
               Panel 2
             </h4>
@@ -3049,7 +3049,7 @@ exports[`Accordion multiple panels 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 1
             </h4>
@@ -3097,7 +3097,7 @@ exports[`Accordion multiple panels 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 2
             </h4>
@@ -3192,7 +3192,7 @@ exports[`Accordion multiple panels 3`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 1
             </h4>
@@ -3275,7 +3275,7 @@ exports[`Accordion multiple panels 3`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 2
             </h4>
@@ -3338,7 +3338,7 @@ exports[`Accordion multiple panels 4`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 1
             </h4>
@@ -3389,7 +3389,7 @@ exports[`Accordion multiple panels 4`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 2
             </h4>
@@ -3481,7 +3481,7 @@ exports[`Accordion multiple panels 5`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 1
             </h4>
@@ -3561,7 +3561,7 @@ exports[`Accordion multiple panels 5`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 2
             </h4>
@@ -3837,6 +3837,13 @@ exports[`Accordion set on hover 1`] = `
   visibility: hidden;
 }
 
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
 .c0 {
   font-size: 18px;
   line-height: 24px;
@@ -3845,13 +3852,6 @@ exports[`Accordion set on hover 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-  max-width: 432px;
-  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {
@@ -3978,7 +3978,7 @@ exports[`Accordion set on hover 1`] = `
             class="c5"
           >
             <h4
-              class="-h4 c6"
+              class="c6"
             >
               Panel 1
             </h4>
@@ -4033,7 +4033,7 @@ exports[`Accordion set on hover 1`] = `
             class="c5"
           >
             <h4
-              class="-h4 c6"
+              class="c6"
             >
               Panel 2
             </h4>
@@ -4100,7 +4100,7 @@ exports[`Accordion set on hover 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 QduAt"
+              class="StyledHeading-sc-1rdh4aw-0 liBGQI"
             >
               Panel 1
             </h4>
@@ -4155,7 +4155,7 @@ exports[`Accordion set on hover 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 2
             </h4>
@@ -4222,7 +4222,7 @@ exports[`Accordion set on hover 3`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 QduAt"
+              class="StyledHeading-sc-1rdh4aw-0 liBGQI"
             >
               Panel 1
             </h4>
@@ -4277,7 +4277,7 @@ exports[`Accordion set on hover 3`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 QduAt"
+              class="StyledHeading-sc-1rdh4aw-0 liBGQI"
             >
               Panel 2
             </h4>
@@ -4344,7 +4344,7 @@ exports[`Accordion set on hover 4`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 1
             </h4>
@@ -4399,7 +4399,7 @@ exports[`Accordion set on hover 4`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 QduAt"
+              class="StyledHeading-sc-1rdh4aw-0 liBGQI"
             >
               Panel 2
             </h4>
@@ -4466,7 +4466,7 @@ exports[`Accordion set on hover 5`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 1
             </h4>
@@ -4521,7 +4521,7 @@ exports[`Accordion set on hover 5`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0-h4 lcpbRl"
+              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
             >
               Panel 2
             </h4>

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -190,6 +190,14 @@ exports[`Calendar date 1`] = `
   color: #000000;
 }
 
+.c5 {
+  margin: 0px;
+  font-size: 22px;
+  line-height: 28px;
+  max-width: 528px;
+  font-weight: 600;
+}
+
 .c1 {
   font-size: 18px;
   line-height: 1.45;
@@ -289,14 +297,6 @@ exports[`Calendar date 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c5 {
-  margin: 0px;
-  font-size: 22px;
-  line-height: 28px;
-  max-width: 528px;
-  font-weight: 600;
-}
-
 @media only screen and (max-width:768px) {
   .c2 {
     margin: 0px;
@@ -389,7 +389,7 @@ exports[`Calendar date 1`] = `
           className="c4"
         >
           <h3
-            className="-h3 c5"
+            className="c5"
             size="medium"
           >
             January 2018
@@ -1446,6 +1446,14 @@ exports[`Calendar dates 1`] = `
   color: #000000;
 }
 
+.c5 {
+  margin: 0px;
+  font-size: 22px;
+  line-height: 28px;
+  max-width: 528px;
+  font-weight: 600;
+}
+
 .c1 {
   font-size: 18px;
   line-height: 1.45;
@@ -1545,14 +1553,6 @@ exports[`Calendar dates 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c5 {
-  margin: 0px;
-  font-size: 22px;
-  line-height: 28px;
-  max-width: 528px;
-  font-weight: 600;
-}
-
 @media only screen and (max-width:768px) {
   .c2 {
     margin: 0px;
@@ -1645,7 +1645,7 @@ exports[`Calendar dates 1`] = `
           className="c4"
         >
           <h3
-            className="-h3 c5"
+            className="c5"
             size="medium"
           >
             January 2018
@@ -2702,6 +2702,14 @@ exports[`Calendar firstDayOfWeek 1`] = `
   color: #000000;
 }
 
+.c5 {
+  margin: 0px;
+  font-size: 22px;
+  line-height: 28px;
+  max-width: 528px;
+  font-weight: 600;
+}
+
 .c1 {
   font-size: 18px;
   line-height: 1.45;
@@ -2801,14 +2809,6 @@ exports[`Calendar firstDayOfWeek 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c5 {
-  margin: 0px;
-  font-size: 22px;
-  line-height: 28px;
-  max-width: 528px;
-  font-weight: 600;
-}
-
 @media only screen and (max-width:768px) {
   .c2 {
     margin: 0px;
@@ -2901,7 +2901,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
           className="c4"
         >
           <h3
-            className="-h3 c5"
+            className="c5"
             size="medium"
           >
             January 2018
@@ -3779,7 +3779,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
           className="c4"
         >
           <h3
-            className="-h3 c5"
+            className="c5"
             size="medium"
           >
             January 2018
@@ -5989,6 +5989,14 @@ exports[`Calendar reference 1`] = `
   color: #000000;
 }
 
+.c5 {
+  margin: 0px;
+  font-size: 22px;
+  line-height: 28px;
+  max-width: 528px;
+  font-weight: 600;
+}
+
 .c1 {
   font-size: 18px;
   line-height: 1.45;
@@ -6066,14 +6074,6 @@ exports[`Calendar reference 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-.c5 {
-  margin: 0px;
-  font-size: 22px;
-  line-height: 28px;
-  max-width: 528px;
-  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {
@@ -6168,7 +6168,7 @@ exports[`Calendar reference 1`] = `
           className="c4"
         >
           <h3
-            className="-h3 c5"
+            className="c5"
             size="medium"
           >
             January 2018
@@ -7333,6 +7333,30 @@ exports[`Calendar size 1`] = `
   color: #000000;
 }
 
+.c20 {
+  margin: 0px;
+  font-size: 22px;
+  line-height: 28px;
+  max-width: 528px;
+  font-weight: 600;
+}
+
+.c5 {
+  margin: 0px;
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
+.c28 {
+  margin: 0px;
+  font-size: 34px;
+  line-height: 40px;
+  max-width: 816px;
+  font-weight: 600;
+}
+
 .c18 {
   font-size: 18px;
   line-height: 1.45;
@@ -7564,30 +7588,6 @@ exports[`Calendar size 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c20 {
-  margin: 0px;
-  font-size: 22px;
-  line-height: 28px;
-  max-width: 528px;
-  font-weight: 600;
-}
-
-.c28 {
-  margin: 0px;
-  font-size: 34px;
-  line-height: 40px;
-  max-width: 816px;
-  font-weight: 600;
-}
-
-.c5 {
-  margin: 0px;
-  font-size: 18px;
-  line-height: 24px;
-  max-width: 432px;
-  font-weight: 600;
-}
-
 @media only screen and (max-width:768px) {
   .c2 {
     margin: 0px;
@@ -7690,13 +7690,13 @@ exports[`Calendar size 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c28 {
+  .c5 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c28 {
+  .c5 {
     font-size: 18px;
     line-height: 24px;
     max-width: 432px;
@@ -7704,13 +7704,13 @@ exports[`Calendar size 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c28 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c28 {
     font-size: 18px;
     line-height: 24px;
     max-width: 432px;
@@ -7734,7 +7734,7 @@ exports[`Calendar size 1`] = `
           className="c4"
         >
           <h4
-            className="-h4 c5"
+            className="c5"
             size="small"
           >
             January 2018
@@ -8610,7 +8610,7 @@ exports[`Calendar size 1`] = `
           className="c19"
         >
           <h3
-            className="-h3 c20"
+            className="c20"
             size="medium"
           >
             January 2018
@@ -9488,7 +9488,7 @@ exports[`Calendar size 1`] = `
           className="c27"
         >
           <h3
-            className="-h3 c28"
+            className="c28"
             size="large"
           >
             January 2018

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -672,7 +672,7 @@ exports[`renders label 1`] = `
       className="c2"
     >
       <label
-        className="-label c3"
+        className="c3"
       >
         test label
       </label>

--- a/src/js/components/Heading/Heading.js
+++ b/src/js/components/Heading/Heading.js
@@ -5,10 +5,6 @@ import { withTheme } from '../hocs';
 
 import { StyledHeading } from './StyledHeading';
 
-const styledComponents = {
-  div: StyledHeading,
-}; // tag -> styled component
-
 const Heading = props => {
   const {
     color, // munged to avoid styled-components putting it in the DOM
@@ -16,15 +12,15 @@ const Heading = props => {
     ...rest
   } = props;
 
-  const tag = `h${level}`;
-  let StyledComponent = styledComponents[tag];
-  if (!StyledComponent) {
-    StyledComponent = StyledHeading.withComponent(tag);
-    styledComponents[tag] = StyledComponent;
-  }
-
   // enforce level to be a number
-  return <StyledComponent colorProp={color} level={+level} {...rest} />;
+  return (
+    <StyledHeading
+      as={`h${level}`}
+      colorProp={color}
+      level={+level}
+      {...rest}
+    />
+  );
 };
 
 Heading.defaultProps = {

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -31,7 +31,7 @@ exports[`Heading color renders 1`] = `
   className="c0"
 >
   <h1
-    className="-h1 c1"
+    className="c1"
   />
 </div>
 `;
@@ -111,28 +111,28 @@ exports[`Heading level renders 1`] = `
   className="c0"
 >
   <h1
-    className="-h1 c1"
+    className="c1"
   />
   <h2
-    className="-h2 c2"
+    className="c2"
   />
   <h3
-    className="-h3 c3"
+    className="c3"
   />
   <h4
-    className="-h4 c4"
+    className="c4"
   />
   <h1
-    className="-h1 c1"
+    className="c1"
   />
   <h2
-    className="-h2 c2"
+    className="c2"
   />
   <h3
-    className="-h3 c3"
+    className="c3"
   />
   <h4
-    className="-h4 c4"
+    className="c4"
   />
 </div>
 `;
@@ -328,28 +328,28 @@ exports[`Heading margin renders 1`] = `
   className="c0"
 >
   <h1
-    className="-h1 c1"
+    className="c1"
   />
   <h1
-    className="-h1 c2"
+    className="c2"
   />
   <h1
-    className="-h1 c3"
+    className="c3"
   />
   <h1
-    className="-h1 c4"
+    className="c4"
   />
   <h1
-    className="-h1 c5"
+    className="c5"
   />
   <h1
-    className="-h1 c6"
+    className="c6"
   />
   <h1
-    className="-h1 c7"
+    className="c7"
   />
   <h1
-    className="-h1 c8"
+    className="c8"
   />
 </div>
 `;
@@ -384,7 +384,7 @@ exports[`Heading renders 1`] = `
   className="c0"
 >
   <h1
-    className="-h1 c1"
+    className="c1"
   />
 </div>
 `;
@@ -404,6 +404,27 @@ exports[`Heading size renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
+}
+
+.c6 {
+  font-size: 34px;
+  line-height: 40px;
+  max-width: 816px;
+  font-weight: 600;
+}
+
+.c8 {
+  font-size: 22px;
+  line-height: 28px;
+  max-width: 528px;
+  font-weight: 600;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
   font-weight: 600;
 }
 
@@ -428,13 +449,6 @@ exports[`Heading size renders 1`] = `
   font-weight: 600;
 }
 
-.c6 {
-  font-size: 34px;
-  line-height: 40px;
-  max-width: 816px;
-  font-weight: 600;
-}
-
 .c5 {
   font-size: 26px;
   line-height: 32px;
@@ -443,13 +457,6 @@ exports[`Heading size renders 1`] = `
 }
 
 .c7 {
-  font-size: 50px;
-  line-height: 56px;
-  max-width: 1200px;
-  font-weight: 600;
-}
-
-.c8 {
   font-size: 66px;
   line-height: 72px;
   max-width: 1584px;
@@ -457,30 +464,16 @@ exports[`Heading size renders 1`] = `
 }
 
 .c9 {
-  font-size: 22px;
-  line-height: 28px;
-  max-width: 528px;
-  font-weight: 600;
-}
-
-.c10 {
   font-size: 34px;
   line-height: 40px;
   max-width: 816px;
   font-weight: 600;
 }
 
-.c11 {
+.c10 {
   font-size: 42px;
   line-height: 48px;
   max-width: 1008px;
-  font-weight: 600;
-}
-
-.c12 {
-  font-size: 18px;
-  line-height: 24px;
-  max-width: 432px;
   font-weight: 600;
 }
 
@@ -489,6 +482,30 @@ exports[`Heading size renders 1`] = `
     font-size: 34px;
     line-height: 40px;
     max-width: 816px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 22px;
+    line-height: 28px;
+    max-width: 528px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
   }
 }
 
@@ -517,14 +534,6 @@ exports[`Heading size renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
-    font-size: 22px;
-    line-height: 28px;
-    max-width: 528px;
-  }
-}
-
-@media only screen and (max-width:768px) {
   .c5 {
     font-size: 22px;
     line-height: 28px;
@@ -534,14 +543,6 @@ exports[`Heading size renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c7 {
-    font-size: 34px;
-    line-height: 40px;
-    max-width: 816px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c8 {
     font-size: 42px;
     line-height: 48px;
     max-width: 1008px;
@@ -564,87 +565,71 @@ exports[`Heading size renders 1`] = `
   }
 }
 
-@media only screen and (max-width:768px) {
-  .c11 {
-    font-size: 18px;
-    line-height: 24px;
-    max-width: 432px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c12 {
-    font-size: 18px;
-    line-height: 24px;
-    max-width: 432px;
-  }
-}
-
 <div
   className="c0"
 >
   <h1
-    className="-h1 c1"
+    className="c1"
     size="small"
   />
   <h1
-    className="-h1 c2"
+    className="c2"
     size="medium"
   />
   <h1
-    className="-h1 c3"
+    className="c3"
     size="large"
   />
   <h1
-    className="-h1 c4"
+    className="c4"
     size="xlarge"
   />
   <h2
-    className="-h2 c5"
+    className="c5"
     size="small"
   />
   <h2
-    className="-h2 c6"
+    className="c6"
     size="medium"
   />
   <h2
-    className="-h2 c7"
+    className="c2"
     size="large"
   />
   <h2
-    className="-h2 c8"
+    className="c7"
     size="xlarge"
   />
   <h3
-    className="-h3 c9"
+    className="c8"
     size="small"
   />
   <h3
-    className="-h3 c9"
+    className="c8"
     size="medium"
   />
   <h3
-    className="-h3 c10"
+    className="c9"
     size="large"
   />
   <h3
-    className="-h3 c11"
+    className="c10"
     size="xlarge"
   />
   <h4
-    className="-h4 c12"
+    className="c11"
     size="small"
   />
   <h4
-    className="-h4 c12"
+    className="c11"
     size="medium"
   />
   <h4
-    className="-h4 c12"
+    className="c11"
     size="large"
   />
   <h4
-    className="-h4 c12"
+    className="c11"
     size="xlarge"
   />
 </div>
@@ -713,13 +698,13 @@ exports[`Heading textAlign renders 1`] = `
   className="c0"
 >
   <h1
-    className="-h1 c1"
+    className="c1"
   />
   <h1
-    className="-h1 c2"
+    className="c2"
   />
   <h1
-    className="-h1 c3"
+    className="c3"
   />
 </div>
 `;
@@ -772,12 +757,12 @@ exports[`Heading truncate renders 1`] = `
   className="c0"
 >
   <h1
-    className="-h1 c1"
+    className="c1"
   >
     a b c d e f g h i j k l m n o p q r s t u v w x y z
   </h1>
   <h1
-    className="-h1 c2"
+    className="c2"
   >
     a b c d e f g h i j k l m n o p q r s t u v w x y z
   </h1>
@@ -821,10 +806,10 @@ exports[`responsive renders 1`] = `
   className="c0"
 >
   <h1
-    className="-h1 c1"
+    className="c1"
   />
   <h1
-    className="-h1 c2"
+    className="c2"
   />
 </div>
 `;

--- a/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
+++ b/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
@@ -11,12 +11,6 @@ exports[`Markdown renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  max-width: 432px;
-}
-
 .c1 {
   font-size: 50px;
   line-height: 56px;
@@ -43,6 +37,12 @@ exports[`Markdown renders 1`] = `
   line-height: 24px;
   max-width: 432px;
   font-weight: 600;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
 }
 
 @media only screen and (max-width:768px) {
@@ -82,7 +82,7 @@ exports[`Markdown renders 1`] = `
 >
   <div>
     <h1
-      className="-h1 c1"
+      className="c1"
       id="h1"
     >
       H1
@@ -93,19 +93,19 @@ exports[`Markdown renders 1`] = `
       Paragraph
     </p>
     <h2
-      className="-h2 c3"
+      className="c3"
       id="h2"
     >
       H2
     </h2>
     <h3
-      className="-h3 c4"
+      className="c4"
       id="h3"
     >
       H3
     </h3>
     <h4
-      className="-h4 c5"
+      className="c5"
       id="h4"
     >
       H4

--- a/src/js/components/Text/README.md
+++ b/src/js/components/Text/README.md
@@ -134,6 +134,15 @@ string
 
 **tag**
 
+The DOM tag to use for the element. NOTE: This is deprecated in favor
+of indicating the DOM tag via the 'as' property.
+
+```
+string
+```
+
+**as**
+
 The DOM tag to use for the element. Defaults to `span`.
 
 ```
@@ -217,7 +226,7 @@ Defaults to
         size: '14px',
         height: '20px',
        },
-      medium: {          
+      medium: {
         size: '18px',
         height: '24px',
       },

--- a/src/js/components/Text/Text.js
+++ b/src/js/components/Text/Text.js
@@ -5,23 +5,12 @@ import { withTheme } from '../hocs';
 
 import { StyledText } from './StyledText';
 
-const styledComponents = {
-  span: StyledText,
-}; // tag -> styled component
-
-const Text = ({ color, tag, ...rest }) => {
-  let StyledComponent = styledComponents[tag];
-  if (!StyledComponent) {
-    StyledComponent = StyledText.withComponent(tag);
-    styledComponents[tag] = StyledComponent;
-  }
-
-  return <StyledComponent colorProp={color} {...rest} />;
-};
+const Text = ({ color, tag, as, ...rest }) => (
+  <StyledText as={!as && tag ? tag : as} colorProp={color} {...rest} />
+);
 
 Text.defaultProps = {
   level: 1,
-  tag: 'span',
 };
 
 let TextDoc;

--- a/src/js/components/Text/__tests__/Text-test.js
+++ b/src/js/components/Text/__tests__/Text-test.js
@@ -94,6 +94,20 @@ test('renders tag', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('proxies tag', () => {
+  const tagComponent = renderer.create(
+    <Grommet>
+      <Text tag="div" />
+    </Grommet>,
+  );
+  const asComponent = renderer.create(
+    <Grommet>
+      <Text as="div" />
+    </Grommet>,
+  );
+  expect(tagComponent.toJSON()).toEqual(asComponent.toJSON());
+});
+
 test('renders weight', () => {
   const component = renderer.create(
     <Grommet>

--- a/src/js/components/Text/__tests__/Text-test.js
+++ b/src/js/components/Text/__tests__/Text-test.js
@@ -87,7 +87,7 @@ test('renders color', () => {
 test('renders tag', () => {
   const component = renderer.create(
     <Grommet>
-      <Text tag="div" />
+      <Text as="div" />
     </Grommet>,
   );
   const tree = component.toJSON();

--- a/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
+++ b/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
@@ -277,7 +277,7 @@ exports[`renders tag 1`] = `
   className="c0"
 >
   <div
-    className="-div c1"
+    className="c1"
   />
 </div>
 `;

--- a/src/js/components/Text/doc.js
+++ b/src/js/components/Text/doc.js
@@ -32,8 +32,12 @@ be adjusted via this size property. The tag should be set for semantic
 correctness and accessibility. This size property allows for stylistic
 adjustments.`,
     ),
-    tag: PropTypes.string
-      .description('The DOM tag to use for the element.')
+    tag: PropTypes.string.description(
+      `The DOM tag to use for the element. NOTE: This is deprecated in favor
+of indicating the DOM tag via the 'as' property.`,
+    ),
+    as: PropTypes.string
+      .description(`The DOM tag to use for the element.`)
       .defaultValue('span'),
     textAlign: PropTypes.oneOf(['start', 'center', 'end'])
       .description('How to align the text inside the component.')
@@ -86,7 +90,7 @@ export const themeDoc = {
         size: '14px',
         height: '20px',
        },
-      medium: {          
+      medium: {
         size: '18px',
         height: '24px',
       },

--- a/src/js/components/Text/index.d.ts
+++ b/src/js/components/Text/index.d.ts
@@ -8,6 +8,7 @@ export interface TextProps {
   color?: string;
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
   tag?: string;
+  as?: string;
   textAlign?: "start" | "center" | "end";
   truncate?: boolean;
   weight?: "normal" | "bold" | number;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -6627,6 +6627,15 @@ string
 
 **tag**
 
+The DOM tag to use for the element. NOTE: This is deprecated in favor
+of indicating the DOM tag via the 'as' property.
+
+\`\`\`
+string
+\`\`\`
+
+**as**
+
 The DOM tag to use for the element. Defaults to \`span\`.
 
 \`\`\`
@@ -6710,7 +6719,7 @@ Defaults to
         size: '14px',
         height: '20px',
        },
-      medium: {          
+      medium: {
         size: '18px',
         height: '24px',
       },

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -755,6 +755,7 @@ export interface TextProps {
   color?: string;
   size?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | \\"xxlarge\\" | string;
   tag?: string;
+  as?: string;
   textAlign?: \\"start\\" | \\"center\\" | \\"end\\";
   truncate?: boolean;
   weight?: \\"normal\\" | \\"bold\\" | number;


### PR DESCRIPTION
Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

Contributes to: #2487 

There are a lot of css class changes going around probably due to the change of usage of styled components. Box is a bit trickier to do since it is used in other components https://github.com/grommet/grommet/blob/master/src/js/components/CheckBox/CheckBox.js#L116-L117 so i ll do in another PR

#### What testing has been done on this PR?

Should i test that tag is correctly proxied?

#### Should this PR be mentioned in the release notes?

probably

#### Is this change backwards compatible or is it a breaking change?

compatible