### PR TITLE
Deprecate tag to the rest of the components

### DIFF
--- a/src/js/components/Accordion/accordion.stories.js
+++ b/src/js/components/Accordion/accordion.stories.js
@@ -144,7 +144,7 @@ class RichAccordion extends Component {
               flex={false}
               border="bottom"
               background="light-2"
-              tag="header"
+              as="header"
               pad={{ horizontal: 'small' }}
             >
               <Heading level={3}>

--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -63,7 +63,7 @@ class Anchor extends Component {
       >
         {first && second ? (
           <Box
-            tag="span"
+            as="span"
             direction="row"
             align="center"
             gap="small"

--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -14,7 +14,6 @@ class Box extends Component {
     margin: 'none',
     pad: 'none',
     responsive: true,
-    tag: 'div',
   };
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -62,6 +61,7 @@ class Box extends Component {
       overflow, // munged to avoid styled-components putting it in the DOM
       responsive,
       tag,
+      as,
       theme: propsTheme,
       wrap, // munged to avoid styled-components putting it in the DOM,
       width, // munged to avoid styled-components putting it in the DOM
@@ -97,7 +97,7 @@ class Box extends Component {
 
     let content = (
       <StyledBox
-        as={tag}
+        as={!as && tag ? tag : as}
         aria-label={a11yTitle}
         ref={forwardRef}
         directionProp={direction}

--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -511,6 +511,15 @@ string
 
 **tag**
 
+The DOM tag to use for the element. NOTE: This is deprecated in favor
+of indicating the DOM tag via the 'as' property.
+
+```
+string
+```
+
+**as**
+
 The DOM tag to use for the element. Defaults to `div`.
 
 ```

--- a/src/js/components/Box/__tests__/Box-test.js
+++ b/src/js/components/Box/__tests__/Box-test.js
@@ -339,14 +339,28 @@ describe('Box', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  test('tag', () => {
+  test('as', () => {
     const component = renderer.create(
       <Grommet>
-        <Box tag="header" />
+        <Box as="header" />
       </Grommet>,
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  test('tag proxied', () => {
+    const tagComponent = renderer.create(
+      <Grommet>
+        <Box tag="header" />
+      </Grommet>,
+    );
+    const asComponent = renderer.create(
+      <Grommet>
+        <Box as="header" />
+      </Grommet>,
+    );
+    expect(tagComponent.toJSON()).toEqual(asComponent.toJSON());
   });
 
   test('animation', () => {

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -1075,6 +1075,55 @@ exports[`Box animation 1`] = `
 </div>
 `;
 
+exports[`Box as 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding: 0px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <header
+    className="c1"
+  />
+</div>
+`;
+
 exports[`Box background 1`] = `
 .c0 {
   font-size: 18px;
@@ -5141,55 +5190,6 @@ exports[`Box round 1`] = `
   />
   <div
     className="c18"
-  />
-</div>
-`;
-
-exports[`Box tag 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  margin: 0px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding: 0px;
-}
-
-@media only screen and (max-width:768px) {
-  .c1 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c1 {
-    padding: 0px;
-  }
-}
-
-<div
-  className="c0"
->
-  <header
-    className="c1"
   />
 </div>
 `;

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -233,7 +233,11 @@ export const doc = Box => {
     ])
       .description('How much to round the corners.')
       .defaultValue(false),
-    tag: PropTypes.string
+    tag: PropTypes.string.description(
+      `The DOM tag to use for the element. NOTE: This is deprecated in favor
+of indicating the DOM tag via the 'as' property.`,
+    ),
+    as: PropTypes.string
       .description('The DOM tag to use for the element.')
       .defaultValue('div'),
     width: PropTypes.oneOfType([

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -23,6 +23,7 @@ export interface BoxProps {
   responsive?: boolean;
   round?: boolean | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | string | {corner: "top" | "left" | "bottom" | "right" | "top-left" | "top-right" | "bottom-left" | "bottom-right",size: "xsmall" | "small" | "medium" | "large" | "xlarge" | string};
   tag?: string;
+  as?: string;
   width?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   wrap?: boolean;
 }

--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -113,8 +113,7 @@ class CheckBox extends Component {
       <StyledCheckBoxContainer
         direction="row"
         align="center"
-        tag="label"
-        as={Box}
+        as={props => <Box as="label" {...props} />}
         reverse={reverse}
         {...removeUndefined({ htmlFor: id, disabled })}
         theme={theme}

--- a/src/js/components/Collapsible/collapsible.stories.js
+++ b/src/js/components/Collapsible/collapsible.stories.js
@@ -157,7 +157,7 @@ class HorizontalCollapsible extends Component {
       <Grommet full theme={grommet}>
         <Box fill>
           <Box
-            tag="header"
+            as="header"
             direction="row"
             align="center"
             pad={{ vertical: 'small', horizontal: 'medium' }}

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -95,7 +95,7 @@ class FormField extends Component {
             gap="xsmall"
           >
             {label ? (
-              <Text tag="label" htmlFor={htmlFor} {...formField.label}>
+              <Text as="label" htmlFor={htmlFor} {...formField.label}>
                 {label}
               </Text>
             ) : (

--- a/src/js/components/Grid/Grid.js
+++ b/src/js/components/Grid/Grid.js
@@ -5,29 +5,23 @@ import { withTheme } from '../hocs';
 
 import { StyledGrid } from './StyledGrid';
 
-const styledComponents = {
-  div: StyledGrid,
-}; // tag -> styled component
-
 const Grid = props => {
   const {
     fill, // munged to avoid styled-components putting it in the DOM
     rows, // munged to avoid styled-components putting it in the DOM
     tag,
+    as,
     ...rest
   } = props;
 
-  let StyledComponent = styledComponents[tag];
-  if (!StyledComponent) {
-    StyledComponent = StyledGrid.withComponent(tag);
-    styledComponents[tag] = StyledComponent;
-  }
-
-  return <StyledComponent fillContainer={fill} rowsProp={rows} {...rest} />;
-};
-
-Grid.defaultProps = {
-  tag: 'div',
+  return (
+    <StyledGrid
+      as={!as && tag ? tag : as}
+      fillContainer={fill}
+      rowsProp={rows}
+      {...rest}
+    />
+  );
 };
 
 let GridDoc;

--- a/src/js/components/Grid/README.md
+++ b/src/js/components/Grid/README.md
@@ -338,6 +338,15 @@ string
 
 **tag**
 
+The DOM tag to use for the element. NOTE: This is deprecated in favor
+of indicating the DOM tag via the 'as' property.
+
+```
+string
+```
+
+**as**
+
 The DOM tag to use for the element. Defaults to `div`.
 
 ```

--- a/src/js/components/Grid/__tests__/Grid-test.js
+++ b/src/js/components/Grid/__tests__/Grid-test.js
@@ -147,12 +147,26 @@ test('Grid fill renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Grid tag renders', () => {
+test('Grid as renders', () => {
   const component = renderer.create(
     <Grommet>
-      <Grid tag="article" />
+      <Grid as="article" />
     </Grommet>,
   );
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
+});
+
+test('Grid proxies tag', () => {
+  const tagComponent = renderer.create(
+    <Grommet>
+      <Grid tag="article" />
+    </Grommet>,
+  );
+  const asComponent = renderer.create(
+    <Grommet>
+      <Grid as="article" />
+    </Grommet>,
+  );
+  expect(tagComponent.toJSON()).toEqual(asComponent.toJSON());
 });

--- a/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
+++ b/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
@@ -176,6 +176,31 @@ exports[`Grid areas renders 1`] = `
 </div>
 `;
 
+exports[`Grid as renders 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+}
+
+<div
+  className="c0"
+>
+  <article
+    className="c1"
+  />
+</div>
+`;
+
 exports[`Grid columns renders 1`] = `
 .c0 {
   font-size: 18px;
@@ -597,31 +622,6 @@ exports[`Grid rows renders 1`] = `
   />
   <div
     className="c2"
-  />
-</div>
-`;
-
-exports[`Grid tag renders 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: grid;
-  box-sizing: border-box;
-}
-
-<div
-  className="c0"
->
-  <article
-    className="-article c1"
   />
 </div>
 `;

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -138,7 +138,11 @@ space in the row axis.`,
       Specifying a single string will cause automatically added rows to be
       the specified size.`,
     ),
-    tag: PropTypes.string
+    tag: PropTypes.string.description(
+      `The DOM tag to use for the element. NOTE: This is deprecated in favor
+of indicating the DOM tag via the 'as' property.`,
+    ),
+    as: PropTypes.string
       .description('The DOM tag to use for the element.')
       .defaultValue('div'),
   };

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -15,6 +15,7 @@ export interface GridProps {
   justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
   rows?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto"[] | string[] | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   tag?: string;
+  as?: string;
 }
 
 declare const Grid: React.ComponentType<GridProps>;

--- a/src/js/components/Layer/layer.stories.js
+++ b/src/js/components/Layer/layer.stories.js
@@ -57,7 +57,7 @@ class CenterLayer extends Component {
               </Heading>
               <Text>Are you sure you want to delete?</Text>
               <Box
-                tag="footer"
+                as="footer"
                 gap="small"
                 direction="row"
                 align="center"
@@ -92,7 +92,7 @@ class CenterLayer extends Component {
               </Heading>
               <Select options={['one', 'two', 'three']} />
               <Box
-                tag="footer"
+                as="footer"
                 gap="small"
                 direction="row"
                 align="center"
@@ -136,7 +136,7 @@ class FormLayer extends Component {
               onEsc={this.onClose}
             >
               <Box
-                tag="form"
+                as="form"
                 fill="vertical"
                 overflow="auto"
                 width="medium"
@@ -169,7 +169,7 @@ class FormLayer extends Component {
                     />
                   </FormField>
                 </Box>
-                <Box flex={false} tag="footer" align="start">
+                <Box flex={false} as="footer" align="start">
                   <Button
                     type="submit"
                     label="Submit"
@@ -317,7 +317,7 @@ const ScrollBodyLayer = () => (
         <Box
           direction="row"
           align="center"
-          tag="header"
+          as="header"
           elevation="small"
           justify="between"
         >
@@ -390,7 +390,7 @@ const ScrollBodyLayer = () => (
           <span>body</span>
         </Box>
         <Box
-          tag="footer"
+          as="footer"
           border={{ side: 'top' }}
           pad="small"
           justify="end"

--- a/src/js/components/RadioButton/RadioButton.js
+++ b/src/js/components/RadioButton/RadioButton.js
@@ -41,8 +41,7 @@ class RadioButton extends Component {
 
     return (
       <StyledRadioButtonContainer
-        as={Box}
-        tag="label"
+        as={props => <Box as="label" {...props} />}
         direction="row"
         align="center"
         {...removeUndefined({ htmlFor: id, disabled })}

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -997,6 +997,15 @@ string
 
 **tag**
 
+The DOM tag to use for the element. NOTE: This is deprecated in favor
+of indicating the DOM tag via the 'as' property.
+
+\`\`\`
+string
+\`\`\`
+
+**as**
+
 The DOM tag to use for the element. Defaults to \`div\`.
 
 \`\`\`
@@ -3851,6 +3860,15 @@ string
 \`\`\`
 
 **tag**
+
+The DOM tag to use for the element. NOTE: This is deprecated in favor
+of indicating the DOM tag via the 'as' property.
+
+\`\`\`
+string
+\`\`\`
+
+**as**
 
 The DOM tag to use for the element. Defaults to \`div\`.
 

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -78,6 +78,7 @@ export interface BoxProps {
   responsive?: boolean;
   round?: boolean | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | \\"full\\" | string | {corner: \\"top\\" | \\"left\\" | \\"bottom\\" | \\"right\\" | \\"top-left\\" | \\"top-right\\" | \\"bottom-left\\" | \\"bottom-right\\",size: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string};
   tag?: string;
+  as?: string;
   width?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string;
   wrap?: boolean;
 }
@@ -341,6 +342,7 @@ export interface GridProps {
   justifyContent?: \\"start\\" | \\"center\\" | \\"end\\" | \\"between\\" | \\"around\\" | \\"stretch\\";
   rows?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | \\"full\\" | \\"1/2\\" | \\"1/3\\" | \\"2/3\\" | \\"1/4\\" | \\"2/4\\" | \\"3/4\\" | \\"flex\\" | \\"auto\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | \\"full\\" | \\"1/2\\" | \\"1/3\\" | \\"2/3\\" | \\"1/4\\" | \\"2/4\\" | \\"3/4\\" | \\"flex\\" | \\"auto\\"[] | string[] | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string;
   tag?: string;
+  as?: string;
 }
 
 declare const Grid: React.ComponentType<GridProps>;


### PR DESCRIPTION
Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

This is a follow up on #2488 and #2487 

#### What does this PR do?

Deprecated the usage of the `tag` property for the rest of the components

#### What testing has been done on this PR?

* added proxy tests for the components that were using the tag property

#### Do the grommet docs need to be updated?

i hope i didn't forget any

#### Should this PR be mentioned in the release notes?

maybe

#### Is this change backwards compatible or is it a breaking change?
backwards compatible