### PR TITLE
Flexible zIndex for Drop and Layer.

### DIFF
--- a/src/js/components/Drop/StyledDrop.js
+++ b/src/js/components/Drop/StyledDrop.js
@@ -30,7 +30,7 @@ export const StyledDrop = styled.div`
 
   border-radius: ${props => props.theme.global.drop.border.radius};
   position: fixed;
-  z-index: 20;
+  z-index: ${props => props.theme.global.drop.zIndex};
   outline: none;
   overflow: auto; //since we set max-height
 

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -29,7 +29,7 @@ const responsiveLayerStyle = `
 export const StyledLayer = styled.div`
   ${baseStyle} background: unset;
   position: relative;
-  z-index: 10;
+  z-index: ${props => props.theme.layer.zIndex};
   pointer-events: none;
   outline: none;
 
@@ -379,7 +379,7 @@ export const StyledContainer = styled.div`
     props.theme.layer.background &&
     backgroundStyle(props.theme.layer.background, props.theme)} outline: none;
   pointer-events: all;
-  z-index: 15;
+  z-index: ${props => props.theme.layer.container.zIndex};
 
   ${desktopContainerStyle} ${props => {
     if (props.responsive && props.theme.layer.responsiveBreakpoint) {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -164,6 +164,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           radius: '0px',
         },
         shadowSize: 'small',
+        zIndex: '20',
       },
       edgeSize: {
         none: '0px',
@@ -525,10 +526,14 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       border: {
         radius: '4px',
       },
+      container: {
+        zIndex: '15',
+      },
       overlay: {
         background: 'rgba(0, 0, 0, 0.5)',
       },
       responsiveBreakpoint: 'small', // when Layer takes over the full screen
+      zIndex: '10',
     },
     menu: {
       // background: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changes Layer and Drop to allow for a custom zIndex
#### Where should the reviewer start?
Layer and Drop
#### What testing has been done on this PR?
manual
#### How should this be manually tested?
open storybook examples for Layer and Drop
#### Any background context you want to provide?

#### What are the relevant issues?
closes #2462 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
I wish my answer would be yes, but we don't have theme documentation for Layer and Drop yet 😢 
#### Should this PR be mentioned in the release notes?
yeahhhh
#### Is this change backwards compatible or is it a breaking change?
backwards