### PR TITLE
Add plain property for Drop component

### DIFF
--- a/src/js/components/Drop/Drop.js
+++ b/src/js/components/Drop/Drop.js
@@ -13,6 +13,7 @@ class Drop extends Component {
       top: 'top',
       left: 'left',
     },
+    plain: false,
   };
 
   originalFocusedElement = document.activeElement;

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -282,7 +282,7 @@ export class DropContainer extends Component {
         as={Box}
         plain={plain}
         elevation={
-          plain ? 'none' : elevation || theme.global.drop.shadowSize || 'small'
+          !plain && (elevation || theme.global.drop.shadowSize || 'small')
         }
         tabIndex="-1"
         ref={this.dropRef}

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -271,6 +271,7 @@ export class DropContainer extends Component {
       onKeyDown,
       theme: propsTheme,
       elevation,
+      plain,
       ...rest
     } = this.props;
     const { theme: stateTheme } = this.state;
@@ -279,7 +280,10 @@ export class DropContainer extends Component {
     let content = (
       <StyledDrop
         as={Box}
-        elevation={elevation || theme.global.drop.shadowSize || 'small'}
+        plain={plain}
+        elevation={
+          plain ? 'none' : elevation || theme.global.drop.shadowSize || 'small'
+        }
         tabIndex="-1"
         ref={this.dropRef}
         alignProp={alignProp}

--- a/src/js/components/Drop/README.md
+++ b/src/js/components/Drop/README.md
@@ -100,4 +100,12 @@ large
 xlarge
 string
 ```
+
+**plain**
+
+Whether the drop element should have no background nor shadow
+
+```
+boolean
+```
   

--- a/src/js/components/Drop/StyledDrop.js
+++ b/src/js/components/Drop/StyledDrop.js
@@ -34,7 +34,9 @@ export const StyledDrop = styled.div`
   outline: none;
   overflow: auto; //since we set max-height
 
-  ${props => backgroundStyle(props.theme.global.drop.background, props.theme)}
+  ${props =>
+    !props.plain &&
+    backgroundStyle(props.theme.global.drop.background, props.theme)}
 
   opacity: 0;
   transform-origin: ${props => getTransformOriginStyle(props.alignProp)};

--- a/src/js/components/Drop/__tests__/Drop-test.js
+++ b/src/js/components/Drop/__tests__/Drop-test.js
@@ -155,4 +155,9 @@ describe('Drop', () => {
     render(<TestInput theme={customTheme} elevation="medium" />);
     expectPortal('drop-node').toMatchSnapshot();
   });
+
+  test('plain renders', () => {
+    render(<TestInput plain />);
+    expectPortal('drop-node').toMatchSnapshot();
+  });
 });

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -2139,6 +2139,239 @@ exports[`Drop no stretch 2`] = `
 }"
 `;
 
+exports[`Drop plain renders 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+  box-shadow: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  border-radius: 0px;
+  position: fixed;
+  z-index: 20;
+  outline: none;
+  overflow: auto;
+  opacity: 0;
+  -webkit-transform-origin: top left;
+  -ms-transform-origin: top left;
+  transform-origin: top left;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
+  -webkit-animation-delay: 0.01s;
+  animation-delay: 0.01s;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding: 0px;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+<div
+  class="c0 c1"
+  id="drop-node"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
+  tabindex="-1"
+>
+  this is a test
+</div>
+`;
+
+exports[`Drop plain renders 2`] = `
+"@media only screen and (max-width:768px) {
+  .iVWgBr {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .iVWgBr {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .kQBqZa {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .kQBqZa {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .kCYoUl {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .kCYoUl {
+    padding: 0px;
+  }
+}
+
+.iKFnrI {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+  box-shadow: none;
+}
+
+@media only screen and (max-width:768px) {
+  .iKFnrI {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .iKFnrI {
+    padding: 0px;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .tNmko {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .gwSJCj {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .gTPiGk {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .dFReaY {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+.hjDDoT {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  border-radius: 0px;
+  position: fixed;
+  z-index: 20;
+  outline: none;
+  overflow: auto;
+  opacity: 0;
+  -webkit-transform-origin: top left;
+  -ms-transform-origin: top left;
+  transform-origin: top left;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
+  -webkit-animation-delay: 0.01s;
+  animation-delay: 0.01s;
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .hjDDoT {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}"
+`;
+
 exports[`Drop props elevation renders 1`] = `
 .c1 {
   display: -webkit-box;

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -2155,7 +2155,6 @@ exports[`Drop plain renders 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 0px;
-  box-shadow: none;
 }
 
 .c0 {
@@ -2253,7 +2252,7 @@ exports[`Drop plain renders 2`] = `
   }
 }
 
-.iKFnrI {
+.IRSNj {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2268,17 +2267,16 @@ exports[`Drop plain renders 2`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 0px;
-  box-shadow: none;
 }
 
 @media only screen and (max-width:768px) {
-  .iKFnrI {
+  .IRSNj {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .iKFnrI {
+  .IRSNj {
     padding: 0px;
   }
 }

--- a/src/js/components/Drop/doc.js
+++ b/src/js/components/Drop/doc.js
@@ -54,6 +54,11 @@ export const doc = Drop => {
     ]).description(
       `Elevated height of the target, indicated via a drop shadow.`,
     ),
+    plain: PropTypes.bool
+      .description(
+        `Whether the drop element should have no background nor shadow`,
+      )
+      .defaultValue(false),
   };
 
   return DocumentedDrop;

--- a/src/js/components/Drop/drop.stories.js
+++ b/src/js/components/Drop/drop.stories.js
@@ -388,8 +388,44 @@ class LazyDrop extends Component {
   }
 }
 
+class PlainDrop extends Component {
+  targetRef = createRef();
+
+  componentDidMount() {
+    this.forceUpdate();
+  }
+
+  render() {
+    return (
+      <Grommet theme={grommet} full>
+        <Box background="brand" fill align="center" justify="center">
+          <Box
+            background="dark-4"
+            pad="medium"
+            align="center"
+            justify="start"
+            ref={this.targetRef}
+          >
+            Target
+          </Box>
+          {this.targetRef.current && (
+            <Drop
+              plain
+              align={{ top: 'bottom', left: 'left' }}
+              target={this.targetRef.current}
+            >
+              <Box pad="large">No background no shadow</Box>
+            </Drop>
+          )}
+        </Box>
+      </Grommet>
+    );
+  }
+}
+
 storiesOf('Drop', module)
   .add('Simple', () => <SimpleDrop />)
   .add('All not stretch', () => <AllDrops />)
   .add('Progressive', () => <ProgressiveDrop />)
-  .add('Lazy', () => <LazyDrop />);
+  .add('Lazy', () => <LazyDrop />)
+  .add('Plain', () => <PlainDrop />);

--- a/src/js/components/Drop/index.d.ts
+++ b/src/js/components/Drop/index.d.ts
@@ -9,6 +9,7 @@ export interface DropProps {
   stretch?: boolean;
   target: object;
   elevation?: "none" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
+  plain?: boolean;
 }
 
 declare const Drop: React.ComponentType<DropProps>;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -3308,6 +3308,14 @@ large
 xlarge
 string
 \`\`\`
+
+**plain**
+
+Whether the drop element should have no background nor shadow
+
+\`\`\`
+boolean
+\`\`\`
   ",
   "DropButton": "## DropButton
 A Button that when clicked will a Drop with the specified 'dropContent'.

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -288,6 +288,7 @@ export interface DropProps {
   stretch?: boolean;
   target: object;
   elevation?: \\"none\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string;
+  plain?: boolean;
 }
 
 declare const Drop: React.ComponentType<DropProps>;


### PR DESCRIPTION
Closes: #2410

Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds a plain property for drop that removes background and shadow from target

#### Where should the reviewer start?

i am not sure the case for this, imho it seems to render weird. i am wondering if there should be at least a border or something.

#### What testing has been done on this PR?

added a unit test that verifies that there is no background and shadow none

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

covered

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
compatible