### PR TITLE
Fix custom margin on Layer component and refactor margin calculation

### DIFF
--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -70,17 +70,13 @@ export const StyledOverlay = styled.div`
 `;
 
 const getMargin = (margin, theme, position) => {
-  const axe =
+  const axis =
     position === 'top' || position === 'bottom' ? 'vertical' : 'horizontal';
-  const marginApplied =
-    theme.global.edgeSize[margin[position] || margin[axe] || margin] ||
-    margin[position] ||
-    margin[axe] ||
-    margin;
+  const marginValue = margin[position] || margin[axis] || margin;
+  const marginApplied = theme.global.edgeSize[marginValue] || marginValue;
+  const marginInTheme = !!theme.global.edgeSize[marginValue];
 
-  return marginApplied &&
-    typeof marginApplied === 'object' &&
-    marginApplied.constructor === Object
+  return !marginInTheme && typeof marginValue !== 'string'
     ? '0px'
     : marginApplied;
 };

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -69,15 +69,32 @@ export const StyledOverlay = styled.div`
     )} pointer-events: all;
 `;
 
-const MARGINS = {
-  top: (margin, theme) =>
-    theme.global.edgeSize[margin.top || margin.vertical || margin] || '0px',
-  bottom: (margin, theme) =>
-    theme.global.edgeSize[margin.bottom || margin.vertical || margin] || '0px',
-  left: (margin, theme) =>
-    theme.global.edgeSize[margin.left || margin.horizontal || margin] || '0px',
-  right: (margin, theme) =>
-    theme.global.edgeSize[margin.right || margin.horizontal || margin] || '0px',
+const getMargin = (margin, theme, position) => {
+  const axe =
+    position === 'top' || position === 'bottom' ? 'vertical' : 'horizontal';
+  const marginApplied =
+    theme.global.edgeSize[margin[position] || margin[axe] || margin] ||
+    margin[position] ||
+    margin[axe] ||
+    margin;
+
+  return marginApplied &&
+    typeof marginApplied === 'object' &&
+    marginApplied.constructor === Object
+    ? '0px'
+    : marginApplied;
+};
+
+const MARGINS = (margin, theme, position = undefined) => {
+  if (position) {
+    return getMargin(margin, theme, position);
+  }
+  return {
+    top: getMargin(margin, theme, 'top'),
+    bottom: getMargin(margin, theme, 'bottom'),
+    left: getMargin(margin, theme, 'left'),
+    right: getMargin(margin, theme, 'right'),
+  };
 };
 
 const KEYFRAMES = {
@@ -181,25 +198,25 @@ const KEYFRAMES = {
 // as well so they must take into account the non-animated positioning.
 const POSITIONS = {
   center: {
-    vertical: (margin, theme) => css`
-      top: ${MARGINS.top(margin, theme)};
-      bottom: ${MARGINS.bottom(margin, theme)};
+    vertical: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
       left: 50%;
       transform: translateX(-50%);
       animation: ${KEYFRAMES.center.vertical} 0.2s ease-in-out forwards;
     `,
-    horizontal: (margin, theme) => css`
-      left: ${MARGINS.left(margin, theme)};
-      right: ${MARGINS.right(margin, theme)};
+    horizontal: margin => css`
+      left: ${margin.left};
+      right: ${margin.right};
       top: 50%;
       transform: translateY(-50%);
       animation: ${KEYFRAMES.center.horizontal} 0.2s ease-in-out forwards;
     `,
-    true: (margin, theme) => css`
-      top: ${MARGINS.top(margin, theme)};
-      bottom: ${MARGINS.bottom(margin, theme)};
-      left: ${MARGINS.left(margin, theme)};
-      right: ${MARGINS.right(margin, theme)};
+    true: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
+      left: ${margin.left};
+      right: ${margin.right};
       animation: ${KEYFRAMES.center.true} 0.2s ease-in-out forwards;
     `,
     false: () => css`
@@ -211,61 +228,61 @@ const POSITIONS = {
   },
 
   top: {
-    vertical: (margin, theme) => css`
-      top: ${MARGINS.top(margin, theme)};
-      bottom: ${MARGINS.bottom(margin, theme)};
+    vertical: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
       left: 50%;
       transform: translate(-50%, 0%);
       animation: ${KEYFRAMES.top.vertical} 0.2s ease-in-out forwards;
     `,
-    horizontal: (margin, theme) => css`
-      left: ${MARGINS.left(margin, theme)};
-      right: ${MARGINS.right(margin, theme)};
-      top: ${MARGINS.top(margin, theme)};
+    horizontal: margin => css`
+      left: ${margin.left};
+      right: ${margin.right};
+      top: ${margin.top};
       transform: translateY(0);
       animation: ${KEYFRAMES.top.horizontal} 0.2s ease-in-out forwards;
     `,
-    true: (margin, theme) => css`
-      top: ${MARGINS.top(margin, theme)};
-      bottom: ${MARGINS.bottom(margin, theme)};
-      left: ${MARGINS.left(margin, theme)};
-      right: ${MARGINS.right(margin, theme)};
+    true: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
+      left: ${margin.left};
+      right: ${margin.right};
       transform: translateY(0);
       animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
     `,
-    false: (margin, theme) => css`
-      top: ${MARGINS.top(margin, theme)};
-      left: 50%;
-      transform: translate(-50%, 0);
-      animation: ${KEYFRAMES.top.false} 0.2s ease-in-out forwards;
+    false: margin => css`
+      top: calc(50% + ${margin.top});
+      left: calc(50% + ${margin.left});
+      transform: translate(-50%, -50%);
+      animation: ${KEYFRAMES.center.false} 0.2s ease-in-out forwards;
     `,
   },
 
   bottom: {
-    vertical: (margin, theme) => css`
-      top: ${MARGINS.top(margin, theme)};
-      bottom: ${MARGINS.bottom(margin, theme)};
+    vertical: margin => css`
+      top: ${margin.top}
+      bottom: ${margin.bottom};
       left: 50%;
       transform: translate(-50%, 0);
       animation: ${KEYFRAMES.bottom.vertical} 0.2s ease-in-out forwards;
     `,
-    horizontal: (margin, theme) => css`
-      left: ${MARGINS.left(margin, theme)};
-      right: ${MARGINS.right(margin, theme)};
-      bottom: ${MARGINS.bottom(margin, theme)};
+    horizontal: margin => css`
+      left: ${margin.left};
+      right: ${margin.top};
+      bottom: ${margin.bottom};
       transform: translateY(0);
       animation: ${KEYFRAMES.bottom.horizontal} 0.2s ease-in-out forwards;
     `,
-    true: (margin, theme) => css`
-      top: ${MARGINS.top(margin, theme)};
-      bottom: ${MARGINS.bottom(margin, theme)};
-      left: ${MARGINS.left(margin, theme)};
-      right: ${MARGINS.right(margin, theme)};
+    true: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
+      left: ${margin.left};
+      right: ${margin.right};
       transform: translateY(0);
       animation: ${KEYFRAMES.bottom.true} 0.2s ease-in-out forwards;
     `,
-    false: (margin, theme) => css`
-      bottom: ${MARGINS.bottom(margin, theme)};
+    false: margin => css`
+      bottom: ${margin.top};
       left: 50%;
       transform: translate(-50%, 0);
       animation: ${KEYFRAMES.bottom.false} 0.2s ease-in-out forwards;
@@ -273,30 +290,30 @@ const POSITIONS = {
   },
 
   left: {
-    vertical: (margin, theme) => css`
-      top: ${MARGINS.top(margin, theme)};
-      bottom: ${MARGINS.bottom(margin, theme)};
-      left: ${MARGINS.left(margin, theme)};
+    vertical: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
+      left: ${margin.left};
       transform: translateX(0);
       animation: ${KEYFRAMES.left.vertical} 0.2s ease-in-out forwards;
     `,
-    horizontal: (margin, theme) => css`
-      left: ${MARGINS.left(margin, theme)};
-      right: ${MARGINS.right(margin, theme)};
+    horizontal: margin => css`
+      left: ${margin.left};
+      right: ${margin.right};
       top: 50%;
       transform: translate(0, -50%);
       animation: ${KEYFRAMES.left.horizontal} 0.2s ease-in-out forwards;
     `,
-    true: (margin, theme) => css`
-      top: ${MARGINS.top(margin, theme)};
-      bottom: ${MARGINS.bottom(margin, theme)};
-      left: ${MARGINS.left(margin, theme)};
-      right: ${MARGINS.right(margin, theme)};
+    true: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
+      left: ${margin.left};
+      right: ${margin.right};
       transform: translateX(0);
       animation: ${KEYFRAMES.left.true} 0.2s ease-in-out forwards;
     `,
-    false: (margin, theme) => css`
-      left: ${MARGINS.left(margin, theme)};
+    false: margin => css`
+      left: ${margin.top};
       top: 50%;
       transform: translate(0, -50%);
       animation: ${KEYFRAMES.left.false} 0.2s ease-in-out forwards;
@@ -304,30 +321,30 @@ const POSITIONS = {
   },
 
   right: {
-    vertical: (margin, theme) => css`
-      top: ${MARGINS.top(margin, theme)};
-      bottom: ${MARGINS.bottom(margin, theme)};
-      right: ${MARGINS.right(margin, theme)};
+    vertical: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
+      right: ${margin.right};
       transform: translateX(0);
       animation: ${KEYFRAMES.right.vertical} 0.2s ease-in-out forwards;
     `,
-    horizontal: (margin, theme) => css`
-      left: ${MARGINS.left(margin, theme)};
-      right: ${MARGINS.right(margin, theme)};
+    horizontal: margin => css`
+      left: ${margin.left};
+      right: ${margin.right};
       top: 50%;
       transform: translate(0, -50%);
       animation: ${KEYFRAMES.right.horizontal} 0.2s ease-in-out forwards;
     `,
-    true: (margin, theme) => css`
-      top: ${MARGINS.top(margin, theme)};
-      bottom: ${MARGINS.bottom(margin, theme)};
-      left: ${MARGINS.left(margin, theme)};
-      right: ${MARGINS.right(margin, theme)};
+    true: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
+      left: ${margin.left};
+      right: ${margin.right};
       transform: translateX(0);
       animation: ${KEYFRAMES.right.true} 0.2s ease-in-out forwards;
     `,
-    false: (margin, theme) => css`
-      right: ${MARGINS.right(margin, theme)};
+    false: margin => css`
+      right: ${margin.right};
       top: 50%;
       transform: translate(0, -50%);
       animation: ${KEYFRAMES.right.false} 0.2s ease-in-out forwards;
@@ -338,20 +355,24 @@ const POSITIONS = {
 const desktopContainerStyle = css`
   position: ${props => (props.modal ? 'absolute' : 'fixed')};
   max-height: ${props =>
-    `calc(100% - ${MARGINS.top(props.margin, props.theme)} - ${MARGINS.bottom(
+    `calc(100% - ${MARGINS(props.margin, props.theme, 'top')} - ${MARGINS(
       props.margin,
       props.theme,
+      'bottom',
     )})`};
   max-width: ${props =>
-    `calc(100% - ${MARGINS.left(props.margin, props.theme)} - ${MARGINS.right(
+    `calc(100% - ${MARGINS(props.margin, props.theme, 'left')} - ${MARGINS(
       props.margin,
       props.theme,
+      'right',
     )})`};
   border-radius: ${props =>
     props.plain ? 0 : props.theme.layer.border.radius};
   ${props =>
     (props.position !== 'hidden' &&
-      POSITIONS[props.position][props.full](props.margin, props.theme)) ||
+      POSITIONS[props.position][props.full](
+        MARGINS(props.margin, props.theme),
+      )) ||
     ''};
 `;
 

--- a/src/js/components/Layer/__tests__/Layer-test.js
+++ b/src/js/components/Layer/__tests__/Layer-test.js
@@ -86,6 +86,20 @@ describe('Layer', () => {
     }),
   );
 
+  test(`custom margin`, () => {
+    render(
+      <Grommet>
+        <Layer
+          id="margin-test"
+          margin={{ top: '50px', bottom: '40px', left: '30px', right: '20px' }}
+        >
+          This is a layer
+        </Layer>
+      </Grommet>,
+    );
+    expectPortal('margin-test').toMatchSnapshot();
+  });
+
   test('hidden', () => {
     const { rerender } = render(
       <Grommet>

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -1,5 +1,139 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Layer custom margin 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  background: unset;
+  position: relative;
+  z-index: 10;
+  pointer-events: none;
+  outline: none;
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  width: 100vw;
+  height: 100vh;
+}
+
+.c1 {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  background: rgba(0,0,0,0.5);
+  color: #f8f8f8;
+  pointer-events: all;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-height: 48px;
+  background: #FFFFFF;
+  color: #444444;
+  outline: none;
+  pointer-events: all;
+  z-index: 15;
+  position: fixed;
+  max-height: calc(100% - 50px - 40px);
+  max-width: calc(100% - 30px - 20px);
+  border-radius: 4px;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
+  animation: bBMZdm 0.2s ease-in-out forwards;
+}
+
+.c3 {
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+@media only screen and (max-width:768px) {
+  .c0 {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    min-height: 100vh;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    position: relative;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    position: relative;
+    max-height: none;
+    max-width: none;
+    border-radius: 0;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    -webkit-transform: none;
+    -ms-transform: none;
+    transform: none;
+    -webkit-animation: none;
+    animation: none;
+    height: 100vh;
+    width: 100vw;
+  }
+}
+
+<div
+  class="c0"
+  id="margin-test"
+  tabindex="-1"
+>
+  <div
+    class="c1"
+  />
+  <div
+    class="c2"
+    id="margin-test"
+  >
+    <a
+      aria-hidden="true"
+      class="c3"
+      tabindex="-1"
+    />
+    This is a layer
+  </div>
+</div>
+`;
+
+exports[`Layer custom margin 2`] = `""`;
+
 exports[`Layer dark context 1`] = `
 .c0 {
   font-size: 18px;
@@ -2269,13 +2403,13 @@ exports[`Layer position top 1`] = `
   max-height: calc(100% - 0px - 0px);
   max-width: calc(100% - 0px - 0px);
   border-radius: 4px;
-  top: 0px;
-  left: 50%;
-  -webkit-transform: translate(-50%,0);
-  -ms-transform: translate(-50%,0);
-  transform: translate(-50%,0);
-  -webkit-animation: bAkQbM 0.2s ease-in-out forwards;
-  animation: bAkQbM 0.2s ease-in-out forwards;
+  top: calc(50% + 0px);
+  left: calc(50% + 0px);
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
+  animation: bBMZdm 0.2s ease-in-out forwards;
 }
 
 .c3 {


### PR DESCRIPTION
Closes: #2456

Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

It all started from trying to fix the issue and then lead to a small refactoring

#### Where should the reviewer start?

Unit tests are passing, the one modifying was a part of the fix to the bug. I think i improved the `MARGINS` sugar. i am open to suggestions to further improve. It still seems to me a bit code-repeating but i prefer incremental improvements here.

#### What testing has been done on this PR?

Added a test for the custom margin

#### How should this be manually tested?

i was playing around in the storybook for this. Maybe this could help

```
const CustomLayer = () => (
<Grommet theme={grommet}>
  <Box background="dark-3">
    <Heading>body</Heading>
    <Layer background="dark-1" margin={{ top: '50px' }}>
      <Box pad="xlarge">text</Box>
      <Box pad="xlarge">text</Box>
      <Box pad="xlarge">text</Box>
    </Layer>
  </Box>
</Grommet>
);

```


#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
nope
#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
compatible