### PR TITLE
Accordion - removing children requirement

### DIFF
--- a/src/js/components/Accordion/README.md
+++ b/src/js/components/Accordion/README.md
@@ -131,7 +131,7 @@ boolean
 
 **children**
 
-Required. Array of AccordionPanels.
+Array of AccordionPanels.
 
 ```
 node

--- a/src/js/components/Accordion/doc.js
+++ b/src/js/components/Accordion/doc.js
@@ -29,8 +29,7 @@ accordingly.`,
     animate: PropTypes.bool
       .description('Transition content in & out with a slide down animation.')
       .defaultValue(true),
-    children: PropTypes.node.description('Array of AccordionPanels.')
-      .isRequired,
+    children: PropTypes.node.description('Array of AccordionPanels.'),
     onActive: PropTypes.func.description(
       `Function that will be called when the active index changes.
 It will always send an array with currently active panel indexes.`,

--- a/src/js/components/Accordion/index.d.ts
+++ b/src/js/components/Accordion/index.d.ts
@@ -7,7 +7,7 @@ export interface AccordionProps {
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   activeIndex?: number | number[];
   animate?: boolean;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   onActive?: (...args: any[]) => any;
   multiple?: boolean;
   messages?: {tabContents: string};

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -135,7 +135,7 @@ boolean
 
 **children**
 
-Required. Array of AccordionPanels.
+Array of AccordionPanels.
 
 \`\`\`
 node

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -11,7 +11,7 @@ export interface AccordionProps {
   margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   activeIndex?: number | number[];
   animate?: boolean;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   onActive?: (...args: any[]) => any;
   multiple?: boolean;
   messages?: {tabContents: string};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
removing children requirement from the Accordion component, and hence eliminating repeated warnings.
#### Where should the reviewer start?
doc.js
#### What testing has been done on this PR?
`yarn test-update` to make sure no tests are failing, and the Accordion's related warning was removed 
#### How should this be manually tested?
run Accordion test or general `yarn test`
#### Any background context you want to provide?
I'm trying to gradually clean up warnings from our tests run. each case by its own, after discussion with Eric on this scenario we came to understanding there should not be a requirement for children in the Accordion component. This fix will remove the warning from Accordion tests that don't have accordion's children.
#### What are the relevant issues?
Warnings. too many of them.

#### Screenshots (if appropriate)
![screen shot 2018-11-29 at 11 43 51 pm](https://user-images.githubusercontent.com/6320236/49272995-b6f64300-f430-11e8-8e9f-e9a2f8fda89f.png)

#### Do the grommet docs need to be updated?
yes. done.
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible