### PR TITLE
Improve typescript support for some Components having true or false values in props

### DIFF
--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -322,8 +322,7 @@ Whether flex-grow and/or flex-shrink is true.
 ```
 grow
 shrink
-true
-false
+boolean
 ```
 
 **fill**
@@ -333,8 +332,7 @@ Whether the width and/or height should fill the container.
 ```
 horizontal
 vertical
-true
-false
+boolean
 ```
 
 **gap**

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -141,10 +141,14 @@ export const doc = Box => {
         via a drop shadow.`,
       )
       .defaultValue('none'),
-    flex: PropTypes.oneOf(['grow', 'shrink', true, false]).description(
-      'Whether flex-grow and/or flex-shrink is true.',
-    ),
-    fill: PropTypes.oneOf(['horizontal', 'vertical', true, false]).description(
+    flex: PropTypes.oneOfType([
+      PropTypes.oneOf(['grow', 'shrink']),
+      PropTypes.bool,
+    ]).description('Whether flex-grow and/or flex-shrink is true.'),
+    fill: PropTypes.oneOfType([
+      PropTypes.oneOf(['horizontal', 'vertical']),
+      PropTypes.bool,
+    ]).description(
       'Whether the width and/or height should fill the container.',
     ),
     gap: PropTypes.oneOfType([

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -13,8 +13,8 @@ export interface BoxProps {
   border?: boolean | "top" | "left" | "bottom" | "right" | "horizontal" | "vertical" | "all" | {color: string | {dark: string,light: string},side: "top" | "left" | "bottom" | "right" | "horizontal" | "vertical" | "all",size: "xsmall" | "small" | "medium" | "large" | "xlarge" | string};
   direction?: "row" | "column" | "row-responsive";
   elevation?: "none" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
-  flex?: "grow" | "shrink" | "true" | "false";
-  fill?: "horizontal" | "vertical" | "true" | "false";
+  flex?: "grow" | "shrink" | boolean;
+  fill?: "horizontal" | "vertical" | boolean;
   gap?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   height?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   justify?: "start" | "center" | "between" | "end";

--- a/src/js/components/Grid/README.md
+++ b/src/js/components/Grid/README.md
@@ -233,8 +233,7 @@ Whether the width and/or height should fill the container.
 ```
 horizontal
 vertical
-true
-false
+boolean
 ```
 
 **gap**

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -90,7 +90,10 @@ space in the column axis.`,
       Specifying an object allows indicating how the columns
       stretch to fit the available space.`,
     ),
-    fill: PropTypes.oneOf(['horizontal', 'vertical', true, false]).description(
+    fill: PropTypes.oneOfType([
+      PropTypes.oneOf(['horizontal', 'vertical']),
+      PropTypes.bool,
+    ]).description(
       'Whether the width and/or height should fill the container.',
     ),
     gap: PropTypes.oneOfType([

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -9,7 +9,7 @@ export interface GridProps {
   alignContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
   areas?: {name: string,start: number[],end: number[]}[];
   columns?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto"[] | string[] | "xsmall" | "small" | "medium" | "large" | "xlarge" | {count: "fit" | "fill" | number,size: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto"[] | string} | string;
-  fill?: "horizontal" | "vertical" | "true" | "false";
+  fill?: "horizontal" | "vertical" | boolean;
   gap?: "small" | "medium" | "large" | "none" | {row: "small" | "medium" | "large" | "none" | string,column: "small" | "medium" | "large" | "none" | string} | string;
   justify?: "start" | "center" | "end" | "stretch";
   justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch";

--- a/src/js/components/Tabs/README.md
+++ b/src/js/components/Tabs/README.md
@@ -135,8 +135,7 @@ Whether flex-grow and/or flex-shrink is true.
 ```
 grow
 shrink
-true
-false
+boolean
 ```
 
 **justify**

--- a/src/js/components/Tabs/doc.js
+++ b/src/js/components/Tabs/doc.js
@@ -22,9 +22,10 @@ This means that future tab changes will not work unless you subscribe to
 onActive function and update activeIndex accordingly.`,
     ),
     children: PropTypes.node.description('Array of Tab.').isRequired,
-    flex: PropTypes.oneOf(['grow', 'shrink', true, false]).description(
-      'Whether flex-grow and/or flex-shrink is true.',
-    ),
+    flex: PropTypes.oneOfType([
+      PropTypes.oneOf(['grow', 'shrink']),
+      PropTypes.bool,
+    ]).description('Whether flex-grow and/or flex-shrink is true.'),
     justify: PropTypes.oneOf(['start', 'center', 'end'])
       .description('How to align the tabs along the main axis.')
       .defaultValue('center'),

--- a/src/js/components/Tabs/index.d.ts
+++ b/src/js/components/Tabs/index.d.ts
@@ -7,7 +7,7 @@ export interface TabsProps {
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   activeIndex?: number;
   children: React.ReactNode;
-  flex?: "grow" | "shrink" | "true" | "false";
+  flex?: "grow" | "shrink" | boolean;
   justify?: "start" | "center" | "end";
   messages?: {tabContents: string};
   onActive?: (...args: any[]) => any;

--- a/src/js/components/TextArea/README.md
+++ b/src/js/components/TextArea/README.md
@@ -24,8 +24,7 @@ string
 Whether the width and height should fill the container.
 
 ```
-true
-false
+boolean
 ```
 
 **focusIndicator**

--- a/src/js/components/TextArea/doc.js
+++ b/src/js/components/TextArea/doc.js
@@ -13,7 +13,7 @@ export const doc = TextArea => {
 
   DocumentedTextArea.propTypes = {
     id: PropTypes.string.description('The id attribute of the textarea.'),
-    fill: PropTypes.oneOf([true, false])
+    fill: PropTypes.bool
       .description('Whether the width and height should fill the container.')
       .defaultValue(false),
     focusIndicator: PropTypes.bool.description(

--- a/src/js/components/TextArea/index.d.ts
+++ b/src/js/components/TextArea/index.d.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 
 export interface TextAreaProps {
   id?: string;
-  fill?: "true" | "false";
+  fill?: boolean;
   focusIndicator?: boolean;
   name?: string;
   onChange?: (...args: any[]) => any;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -808,8 +808,7 @@ Whether flex-grow and/or flex-shrink is true.
 \`\`\`
 grow
 shrink
-true
-false
+boolean
 \`\`\`
 
 **fill**
@@ -819,8 +818,7 @@ Whether the width and/or height should fill the container.
 \`\`\`
 horizontal
 vertical
-true
-false
+boolean
 \`\`\`
 
 **gap**
@@ -3787,8 +3785,7 @@ Whether the width and/or height should fill the container.
 \`\`\`
 horizontal
 vertical
-true
-false
+boolean
 \`\`\`
 
 **gap**
@@ -6537,8 +6534,7 @@ Whether flex-grow and/or flex-shrink is true.
 \`\`\`
 grow
 shrink
-true
-false
+boolean
 \`\`\`
 
 **justify**
@@ -6855,8 +6851,7 @@ string
 Whether the width and height should fill the container.
 
 \`\`\`
-true
-false
+boolean
 \`\`\`
 
 **focusIndicator**

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -68,8 +68,8 @@ export interface BoxProps {
   border?: boolean | \\"top\\" | \\"left\\" | \\"bottom\\" | \\"right\\" | \\"horizontal\\" | \\"vertical\\" | \\"all\\" | {color: string | {dark: string,light: string},side: \\"top\\" | \\"left\\" | \\"bottom\\" | \\"right\\" | \\"horizontal\\" | \\"vertical\\" | \\"all\\",size: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string};
   direction?: \\"row\\" | \\"column\\" | \\"row-responsive\\";
   elevation?: \\"none\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string;
-  flex?: \\"grow\\" | \\"shrink\\" | \\"true\\" | \\"false\\";
-  fill?: \\"horizontal\\" | \\"vertical\\" | \\"true\\" | \\"false\\";
+  flex?: \\"grow\\" | \\"shrink\\" | boolean;
+  fill?: \\"horizontal\\" | \\"vertical\\" | boolean;
   gap?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string;
   height?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string;
   justify?: \\"start\\" | \\"center\\" | \\"between\\" | \\"end\\";
@@ -339,7 +339,7 @@ export interface GridProps {
   alignContent?: \\"start\\" | \\"center\\" | \\"end\\" | \\"between\\" | \\"around\\" | \\"stretch\\";
   areas?: {name: string,start: number[],end: number[]}[];
   columns?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | \\"full\\" | \\"1/2\\" | \\"1/3\\" | \\"2/3\\" | \\"1/4\\" | \\"2/4\\" | \\"3/4\\" | \\"flex\\" | \\"auto\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | \\"full\\" | \\"1/2\\" | \\"1/3\\" | \\"2/3\\" | \\"1/4\\" | \\"2/4\\" | \\"3/4\\" | \\"flex\\" | \\"auto\\"[] | string[] | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {count: \\"fit\\" | \\"fill\\" | number,size: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | \\"full\\" | \\"1/2\\" | \\"1/3\\" | \\"2/3\\" | \\"1/4\\" | \\"2/4\\" | \\"3/4\\" | \\"flex\\" | \\"auto\\"[] | string} | string;
-  fill?: \\"horizontal\\" | \\"vertical\\" | \\"true\\" | \\"false\\";
+  fill?: \\"horizontal\\" | \\"vertical\\" | boolean;
   gap?: \\"small\\" | \\"medium\\" | \\"large\\" | \\"none\\" | {row: \\"small\\" | \\"medium\\" | \\"large\\" | \\"none\\" | string,column: \\"small\\" | \\"medium\\" | \\"large\\" | \\"none\\" | string} | string;
   justify?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
   justifyContent?: \\"start\\" | \\"center\\" | \\"end\\" | \\"between\\" | \\"around\\" | \\"stretch\\";
@@ -744,7 +744,7 @@ export interface TabsProps {
   margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
   activeIndex?: number;
   children: React.ReactNode;
-  flex?: \\"grow\\" | \\"shrink\\" | \\"true\\" | \\"false\\";
+  flex?: \\"grow\\" | \\"shrink\\" | boolean;
   justify?: \\"start\\" | \\"center\\" | \\"end\\";
   messages?: {tabContents: string};
   onActive?: (...args: any[]) => any;
@@ -778,7 +778,7 @@ export { Text };
 
 export interface TextAreaProps {
   id?: string;
-  fill?: \\"true\\" | \\"false\\";
+  fill?: boolean;
   focusIndicator?: boolean;
   name?: string;
   onChange?: (...args: any[]) => any;


### PR DESCRIPTION
Contributes: #2464

Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Some of the components were misusing, i think, the react-desc and instead of using oneOfType(bool, string) they were inserting true or false values directly in the props hence provoking issues in the typescript index.d.ts file as the values where then considered as strings

#### Where should the reviewer start?

I hope i didn't modify something else acctidentaly

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

last comment there #2464 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backwards compatible.