### PR TITLE
Improved checkbox theme extend 

### DIFF
--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -97,6 +97,8 @@ class CheckBox extends Component {
         round={theme.checkBox.check.radius}
         focus={focus}
         checked={checked}
+        disabled={disabled}
+        toggle={toggle}
       >
         {!indeterminate &&
           checked &&

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -447,6 +447,7 @@ exports[`CheckBox disabled renders 1`] = `
       />
       <div
         className="c6"
+        disabled={true}
       />
     </div>
   </label>
@@ -470,6 +471,7 @@ exports[`CheckBox disabled renders 1`] = `
       <div
         checked={true}
         className="c7"
+        disabled={true}
       >
         <svg
           className="c8"

--- a/src/js/components/CheckBox/checkbox.stories.js
+++ b/src/js/components/CheckBox/checkbox.stories.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
+import { css } from 'styled-components';
 
 import { Box, Button, Grommet, CheckBox, Text } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -86,15 +87,26 @@ class ThemedCheckBox extends Component {
   }
 }
 
+const checkboxCheckStyle = css`
+  background-color: #2196f3;
+  border-color: #2196f3;
+`;
+
 const customToggleTheme = {
+  global: {
+    colors: {
+      'toggle-bg': '#757575',
+      'toggle-knob': 'white',
+    },
+  },
   checkBox: {
     border: {
       color: {
-        light: 'light-2',
+        light: 'toggle-bg',
       },
     },
     color: {
-      light: 'neutral-1',
+      light: 'toggle-knob',
     },
     check: {
       radius: '2px',
@@ -105,11 +117,21 @@ const customToggleTheme = {
       },
     },
     toggle: {
-      background: 'light-2',
+      background: 'toggle-bg',
       color: {
-        light: 'light-4',
+        light: 'toggle-knob',
       },
       size: '36px',
+      knob: {
+        extend: `
+          top: -4px;
+          box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.12), 0px 2px 2px 0px rgba(0,0,0,0.24);
+        `,
+      },
+      extend: ({ checked }) => `
+        height: 14px;
+        ${checked && checkboxCheckStyle}
+      `,
     },
     gap: 'xsmall',
     size: '18px',


### PR DESCRIPTION


<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Allows checkbox check entry to inspect toggle and disabled. This would allow different styling between checkbox and toggle

#### Where should the reviewer start?
styledcheckbox
#### What testing has been done on this PR?
manual
#### How should this be manually tested?
open themetoggle example in storybook
#### Any background context you want to provide?

#### What are the relevant issues?
no so far
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards