### PR TITLE
Add intrinsic elements to non polymorphic components

### DIFF
--- a/src/js/components/Anchor/README.md
+++ b/src/js/components/Anchor/README.md
@@ -185,6 +185,11 @@ The DOM tag to use for the element.
 string
 ```
   
+## Intrinsic element
+
+```
+a
+```
 ## Theme
   
 **global.focus.border.color**

--- a/src/js/components/Anchor/doc.js
+++ b/src/js/components/Anchor/doc.js
@@ -13,7 +13,8 @@ or just use children.`,
     )
     .usage(
       "import { Anchor } from 'grommet';\n<Anchor href={location} label='Label' />",
-    );
+    )
+    .intrinsicElement('a');
 
   DocumentedAnchor.propTypes = {
     ...genericProps,

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -15,6 +15,6 @@ export interface AnchorProps {
   as?: string;
 }
 
-declare const Anchor: React.ComponentType<AnchorProps>;
+declare const Anchor: React.ComponentType<AnchorProps & JSX.IntrinsicElements['a']>;
 
 export { Anchor };

--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -241,6 +241,11 @@ The DOM tag to use for the element.
 string
 ```
   
+## Intrinsic element
+
+```
+button
+```
 ## Theme
   
 **global.hover.color**

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -11,7 +11,8 @@ export const doc = Button => {
     .usage(
       `import { Button } from 'grommet';
 <Button primary={true} label='Label' />`,
-    );
+    )
+    .intrinsicElement('button');
 
   DocumentedButton.propTypes = {
     ...genericProps,

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -22,6 +22,6 @@ export interface ButtonProps {
   as?: string;
 }
 
-declare const Button: React.ComponentType<ButtonProps>;
+declare const Button: React.ComponentType<ButtonProps & JSX.IntrinsicElements['button']>;
 
 export { Button };

--- a/src/js/components/Image/README.md
+++ b/src/js/components/Image/README.md
@@ -116,6 +116,11 @@ cover
 contain
 ```
   
+## Intrinsic element
+
+```
+img
+```
 ## Theme
   
 **image.extend**

--- a/src/js/components/Image/doc.js
+++ b/src/js/components/Image/doc.js
@@ -17,7 +17,8 @@ export const doc = Image => {
     .usage(
       `import { Image } from 'grommet';
 <Image/>`,
-    );
+    )
+    .intrinsicElement('img');
 
   DocumentedImage.propTypes = {
     ...genericProps,

--- a/src/js/components/Image/index.d.ts
+++ b/src/js/components/Image/index.d.ts
@@ -8,6 +8,6 @@ export interface ImageProps {
   fit?: "cover" | "contain";
 }
 
-declare const Image: React.ComponentType<ImageProps>;
+declare const Image: React.ComponentType<ImageProps & JSX.IntrinsicElements['img']>;
 
 export { Image };

--- a/src/js/components/Paragraph/README.md
+++ b/src/js/components/Paragraph/README.md
@@ -146,6 +146,11 @@ center
 end
 ```
   
+## Intrinsic element
+
+```
+p
+```
 ## Theme
   
 **global.colors.text**
@@ -191,7 +196,7 @@ Defaults to
         height: '20px',
         maxWidth: '336px',
        },
-      medium: {          
+      medium: {
         size: '18px',
         height: '24px',
         maxWidth: '432px',

--- a/src/js/components/Paragraph/doc.js
+++ b/src/js/components/Paragraph/doc.js
@@ -9,7 +9,8 @@ export const doc = Paragraph => {
     .usage(
       `import { Paragraph } from 'grommet';
 <Paragraph />`,
-    );
+    )
+    .intrinsicElement('p');
 
   DocumentedParagraph.propTypes = {
     ...genericProps,
@@ -63,7 +64,7 @@ export const themeDoc = {
         height: '20px',
         maxWidth: '336px',
        },
-      medium: {          
+      medium: {
         size: '18px',
         height: '24px',
         maxWidth: '432px',

--- a/src/js/components/Paragraph/index.d.ts
+++ b/src/js/components/Paragraph/index.d.ts
@@ -11,6 +11,6 @@ export interface ParagraphProps {
   textAlign?: "start" | "center" | "end";
 }
 
-declare const Paragraph: React.ComponentType<ParagraphProps>;
+declare const Paragraph: React.ComponentType<ParagraphProps & JSX.IntrinsicElements['p']>;
 
 export { Paragraph };

--- a/src/js/components/Table/README.md
+++ b/src/js/components/Table/README.md
@@ -115,3 +115,8 @@ One line description.
 string
 ```
   
+## Intrinsic element
+
+```
+table
+```

--- a/src/js/components/Table/doc.js
+++ b/src/js/components/Table/doc.js
@@ -9,7 +9,8 @@ export const doc = Table => {
     .usage(
       `import { Table, TableHeader, TableFooter, TableBody, TableRow } from 'grommet';
 <Table />`,
-    );
+    )
+    .intrinsicElement('table');
 
   DocumentedTable.propTypes = {
     ...genericProps,

--- a/src/js/components/Table/index.d.ts
+++ b/src/js/components/Table/index.d.ts
@@ -8,6 +8,6 @@ export interface TableProps {
   caption?: string;
 }
 
-declare const Table: React.ComponentType<TableProps>;
+declare const Table: React.ComponentType<TableProps & JSX.IntrinsicElements['table']>;
 
 export { Table };

--- a/src/js/components/TableBody/README.md
+++ b/src/js/components/TableBody/README.md
@@ -11,3 +11,8 @@ import { TableBody } from 'grommet';
 ## Properties
 
   
+## Intrinsic element
+
+```
+tbody
+```

--- a/src/js/components/TableBody/doc.js
+++ b/src/js/components/TableBody/doc.js
@@ -6,7 +6,8 @@ export const doc = TableBody => {
     .usage(
       `import { TableBody } from 'grommet';
 <TableBody />`,
-    );
+    )
+    .intrinsicElement('tbody');
 
   return DocumentedTableBody;
 };

--- a/src/js/components/TableBody/index.d.ts
+++ b/src/js/components/TableBody/index.d.ts
@@ -4,6 +4,6 @@ export interface TableBodyProps {
   
 }
 
-declare const TableBody: React.ComponentType<TableBodyProps>;
+declare const TableBody: React.ComponentType<TableBodyProps & JSX.IntrinsicElements['tbody']>;
 
 export { TableBody };

--- a/src/js/components/TableCell/README.md
+++ b/src/js/components/TableCell/README.md
@@ -60,3 +60,8 @@ middle
 bottom
 ```
   
+## Intrinsic element
+
+```
+td
+```

--- a/src/js/components/TableCell/doc.js
+++ b/src/js/components/TableCell/doc.js
@@ -6,7 +6,8 @@ export const doc = TableCell => {
     .usage(
       `import { TableCell } from 'grommet';
 <TableCell />`,
-    );
+    )
+    .intrinsicElement('td');
 
   DocumentedTableCell.propTypes = {
     plain: PropTypes.bool

--- a/src/js/components/TableCell/index.d.ts
+++ b/src/js/components/TableCell/index.d.ts
@@ -7,6 +7,6 @@ export interface TableCellProps {
   verticalAlign?: "top" | "middle" | "bottom";
 }
 
-declare const TableCell: React.ComponentType<TableCellProps>;
+declare const TableCell: React.ComponentType<TableCellProps & JSX.IntrinsicElements['td']>;
 
 export { TableCell };

--- a/src/js/components/TableFooter/README.md
+++ b/src/js/components/TableFooter/README.md
@@ -11,3 +11,8 @@ import { TableFooter } from 'grommet';
 ## Properties
 
   
+## Intrinsic element
+
+```
+tfoot
+```

--- a/src/js/components/TableFooter/doc.js
+++ b/src/js/components/TableFooter/doc.js
@@ -6,7 +6,8 @@ export const doc = TableFooter => {
     .usage(
       `import { TableFooter } from 'grommet';
 <TableFooter />`,
-    );
+    )
+    .intrinsicElement('tfoot');
 
   return DocumentedTableFooter;
 };

--- a/src/js/components/TableFooter/index.d.ts
+++ b/src/js/components/TableFooter/index.d.ts
@@ -4,6 +4,6 @@ export interface TableFooterProps {
   
 }
 
-declare const TableFooter: React.ComponentType<TableFooterProps>;
+declare const TableFooter: React.ComponentType<TableFooterProps & JSX.IntrinsicElements['tfoot']>;
 
 export { TableFooter };

--- a/src/js/components/TableHeader/README.md
+++ b/src/js/components/TableHeader/README.md
@@ -11,3 +11,8 @@ import { TableHeader } from 'grommet';
 ## Properties
 
   
+## Intrinsic element
+
+```
+thead
+```

--- a/src/js/components/TableHeader/doc.js
+++ b/src/js/components/TableHeader/doc.js
@@ -6,7 +6,8 @@ export const doc = TableHeader => {
     .usage(
       `import { TableHeader } from 'grommet';
 <TableHeader />`,
-    );
+    )
+    .intrinsicElement('thead');
 
   return DocumentedTableHeader;
 };

--- a/src/js/components/TableHeader/index.d.ts
+++ b/src/js/components/TableHeader/index.d.ts
@@ -4,6 +4,6 @@ export interface TableHeaderProps {
   
 }
 
-declare const TableHeader: React.ComponentType<TableHeaderProps>;
+declare const TableHeader: React.ComponentType<TableHeaderProps & JSX.IntrinsicElements['thead']>;
 
 export { TableHeader };

--- a/src/js/components/TableRow/README.md
+++ b/src/js/components/TableRow/README.md
@@ -11,3 +11,8 @@ import { TableRow } from 'grommet';
 ## Properties
 
   
+## Intrinsic element
+
+```
+tr
+```

--- a/src/js/components/TableRow/doc.js
+++ b/src/js/components/TableRow/doc.js
@@ -6,7 +6,8 @@ export const doc = TableRow => {
     .usage(
       `import { TableRow } from 'grommet';
 <TableRow />`,
-    );
+    )
+    .intrinsicElement('tr');
 
   return DocumentedTableRow;
 };

--- a/src/js/components/TableRow/index.d.ts
+++ b/src/js/components/TableRow/index.d.ts
@@ -4,6 +4,6 @@ export interface TableRowProps {
   
 }
 
-declare const TableRow: React.ComponentType<TableRowProps>;
+declare const TableRow: React.ComponentType<TableRowProps & JSX.IntrinsicElements['tr']>;
 
 export { TableRow };

--- a/src/js/components/Text/README.md
+++ b/src/js/components/Text/README.md
@@ -178,6 +178,11 @@ bold
 number
 ```
   
+## Intrinsic element
+
+```
+span
+```
 ## Theme
   
 **color**

--- a/src/js/components/Text/doc.js
+++ b/src/js/components/Text/doc.js
@@ -9,7 +9,8 @@ export const doc = Text => {
     .usage(
       `import { Text } from 'grommet';
 <Text />`,
-    );
+    )
+    .intrinsicElement('span');
 
   DocumentedText.propTypes = {
     ...genericProps,

--- a/src/js/components/Text/index.d.ts
+++ b/src/js/components/Text/index.d.ts
@@ -14,6 +14,6 @@ export interface TextProps {
   weight?: "normal" | "bold" | number;
 }
 
-declare const Text: React.ComponentType<TextProps>;
+declare const Text: React.ComponentType<TextProps & JSX.IntrinsicElements['span']>;
 
 export { Text };

--- a/src/js/components/TextArea/README.md
+++ b/src/js/components/TextArea/README.md
@@ -76,6 +76,11 @@ What text to put in the textarea.
 string
 ```
   
+## Intrinsic element
+
+```
+textarea
+```
 ## Theme
   
 **global.colors.placeholder**

--- a/src/js/components/TextArea/doc.js
+++ b/src/js/components/TextArea/doc.js
@@ -9,7 +9,8 @@ export const doc = TextArea => {
     .usage(
       `import { TextArea } from 'grommet';
 <TextArea id='item' name='item' />`,
-    );
+    )
+    .intrinsicElement('textarea');
 
   DocumentedTextArea.propTypes = {
     id: PropTypes.string.description('The id attribute of the textarea.'),

--- a/src/js/components/TextArea/index.d.ts
+++ b/src/js/components/TextArea/index.d.ts
@@ -11,6 +11,6 @@ export interface TextAreaProps {
   value?: string;
 }
 
-declare const TextArea: React.ComponentType<TextAreaProps>;
+declare const TextArea: React.ComponentType<TextAreaProps & JSX.IntrinsicElements['textarea']>;
 
 export { TextArea };

--- a/src/js/components/TextInput/README.md
+++ b/src/js/components/TextInput/README.md
@@ -173,6 +173,11 @@ What text to put in the input.
 string
 ```
   
+## Intrinsic element
+
+```
+input
+```
 ## Theme
   
 **global.colors.placeholder**
@@ -241,7 +246,7 @@ Defaults to
         size: '14px',
         height: '20px',
        },
-      medium: {          
+      medium: {
         size: '18px',
         height: '24px',
       },

--- a/src/js/components/TextInput/doc.js
+++ b/src/js/components/TextInput/doc.js
@@ -9,7 +9,8 @@ export const doc = TextInput => {
     .usage(
       `import { TextInput } from 'grommet';
 <TextInput id='item' name='item' />`,
-    );
+    )
+    .intrinsicElement('input');
 
   DocumentedTextInput.propTypes = {
     dropAlign: PropTypes.shape({
@@ -131,7 +132,7 @@ export const themeDoc = {
         size: '14px',
         height: '20px',
        },
-      medium: {          
+      medium: {
         size: '18px',
         height: '24px',
       },

--- a/src/js/components/TextInput/index.d.ts
+++ b/src/js/components/TextInput/index.d.ts
@@ -18,6 +18,6 @@ export interface TextInputProps {
   value?: string;
 }
 
-declare const TextInput: React.ComponentType<TextInputProps>;
+declare const TextInput: React.ComponentType<TextInputProps & JSX.IntrinsicElements['input']>;
 
 export { TextInput };

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -402,6 +402,11 @@ The DOM tag to use for the element.
 string
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+a
+\`\`\`
 ## Theme
   
 **global.focus.border.color**
@@ -1460,6 +1465,11 @@ The DOM tag to use for the element.
 string
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+button
+\`\`\`
 ## Theme
   
 **global.hover.color**
@@ -4253,6 +4263,11 @@ cover
 contain
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+img
+\`\`\`
 ## Theme
   
 **image.extend**
@@ -5190,6 +5205,11 @@ center
 end
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+p
+\`\`\`
 ## Theme
   
 **global.colors.text**
@@ -5235,7 +5255,7 @@ Defaults to
         height: '20px',
         maxWidth: '336px',
        },
-      medium: {          
+      medium: {
         size: '18px',
         height: '24px',
         maxWidth: '432px',
@@ -6372,7 +6392,12 @@ One line description.
 \`\`\`
 string
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+table
+\`\`\`",
   "TableBody": "## TableBody
 The body of a table.
 
@@ -6385,7 +6410,12 @@ import { TableBody } from 'grommet';
 
 ## Properties
 
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+tbody
+\`\`\`",
   "TableCell": "## TableCell
 A cell of data in a table.
 
@@ -6447,7 +6477,12 @@ top
 middle
 bottom
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+td
+\`\`\`",
   "TableFooter": "## TableFooter
 The footer of a table.
 
@@ -6460,7 +6495,12 @@ import { TableFooter } from 'grommet';
 
 ## Properties
 
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+tfoot
+\`\`\`",
   "TableHeader": "## TableHeader
 The header of a table.
 
@@ -6473,7 +6513,12 @@ import { TableHeader } from 'grommet';
 
 ## Properties
 
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+thead
+\`\`\`",
   "TableRow": "## TableRow
 A row of cells in a table.
 
@@ -6486,7 +6531,12 @@ import { TableRow } from 'grommet';
 
 ## Properties
 
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+tr
+\`\`\`",
   "Tabs": "## Tabs
 A tabular view component.
 
@@ -6838,6 +6888,11 @@ bold
 number
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+span
+\`\`\`
 ## Theme
   
 **color**
@@ -6993,6 +7048,11 @@ What text to put in the textarea.
 string
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+textarea
+\`\`\`
 ## Theme
   
 **global.colors.placeholder**
@@ -7230,6 +7290,11 @@ What text to put in the input.
 string
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+input
+\`\`\`
 ## Theme
   
 **global.colors.placeholder**
@@ -7298,7 +7363,7 @@ Defaults to
         size: '14px',
         height: '20px',
        },
-      medium: {          
+      medium: {
         size: '18px',
         height: '24px',
       },

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -37,6 +37,7 @@ node",
     "details": "We have a separate component from the browser
 base so we can style it. You can either set the icon and/or label properties
 or just use children.",
+    "intrinsicElement": "a",
     "name": "Anchor",
     "properties": Array [
       Object {
@@ -681,6 +682,7 @@ string",
       },
     ],
     "description": "A button. We have a separate component from the browser base so we can style it.",
+    "intrinsicElement": "button",
     "name": "Button",
     "properties": Array [
       Object {
@@ -1825,6 +1827,7 @@ node",
       },
     ],
     "description": "An image.",
+    "intrinsicElement": "img",
     "name": "Image",
     "properties": Array [
       Object {
@@ -2681,6 +2684,7 @@ node",
   "TableBody": [Function],
   "TableCell": Object {
     "description": "A cell of data in a table.",
+    "intrinsicElement": "td",
     "name": "TableCell",
     "properties": Array [
       Object {
@@ -2895,6 +2899,7 @@ currently active tab changes.",
       },
     ],
     "description": "A textarea.",
+    "intrinsicElement": "textarea",
     "name": "TextArea",
     "properties": Array [
       Object {
@@ -2957,6 +2962,7 @@ Only use this when the containing context provides sufficient affordance.",
       },
     ],
     "description": "A text input field with optional suggestions.",
+    "intrinsicElement": "input",
     "name": "TextInput",
     "properties": Array [
       Object {

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -49,7 +49,7 @@ export interface AnchorProps {
   as?: string;
 }
 
-declare const Anchor: React.ComponentType<AnchorProps>;
+declare const Anchor: React.ComponentType<AnchorProps & JSX.IntrinsicElements['a']>;
 
 export { Anchor };
 ",
@@ -111,7 +111,7 @@ export interface ButtonProps {
   as?: string;
 }
 
-declare const Button: React.ComponentType<ButtonProps>;
+declare const Button: React.ComponentType<ButtonProps & JSX.IntrinsicElements['button']>;
 
 export { Button };
 ",
@@ -394,7 +394,7 @@ export interface ImageProps {
   fit?: \\"cover\\" | \\"contain\\";
 }
 
-declare const Image: React.ComponentType<ImageProps>;
+declare const Image: React.ComponentType<ImageProps & JSX.IntrinsicElements['img']>;
 
 export { Image };
 ",
@@ -517,7 +517,7 @@ export interface ParagraphProps {
   textAlign?: \\"start\\" | \\"center\\" | \\"end\\";
 }
 
-declare const Paragraph: React.ComponentType<ParagraphProps>;
+declare const Paragraph: React.ComponentType<ParagraphProps & JSX.IntrinsicElements['p']>;
 
 export { Paragraph };
 ",
@@ -679,7 +679,7 @@ export interface TableProps {
   caption?: string;
 }
 
-declare const Table: React.ComponentType<TableProps>;
+declare const Table: React.ComponentType<TableProps & JSX.IntrinsicElements['table']>;
 
 export { Table };
 ",
@@ -689,7 +689,7 @@ export interface TableBodyProps {
   
 }
 
-declare const TableBody: React.ComponentType<TableBodyProps>;
+declare const TableBody: React.ComponentType<TableBodyProps & JSX.IntrinsicElements['tbody']>;
 
 export { TableBody };
 ",
@@ -702,7 +702,7 @@ export interface TableCellProps {
   verticalAlign?: \\"top\\" | \\"middle\\" | \\"bottom\\";
 }
 
-declare const TableCell: React.ComponentType<TableCellProps>;
+declare const TableCell: React.ComponentType<TableCellProps & JSX.IntrinsicElements['td']>;
 
 export { TableCell };
 ",
@@ -712,7 +712,7 @@ export interface TableFooterProps {
   
 }
 
-declare const TableFooter: React.ComponentType<TableFooterProps>;
+declare const TableFooter: React.ComponentType<TableFooterProps & JSX.IntrinsicElements['tfoot']>;
 
 export { TableFooter };
 ",
@@ -722,7 +722,7 @@ export interface TableHeaderProps {
   
 }
 
-declare const TableHeader: React.ComponentType<TableHeaderProps>;
+declare const TableHeader: React.ComponentType<TableHeaderProps & JSX.IntrinsicElements['thead']>;
 
 export { TableHeader };
 ",
@@ -732,7 +732,7 @@ export interface TableRowProps {
   
 }
 
-declare const TableRow: React.ComponentType<TableRowProps>;
+declare const TableRow: React.ComponentType<TableRowProps & JSX.IntrinsicElements['tr']>;
 
 export { TableRow };
 ",
@@ -771,7 +771,7 @@ export interface TextProps {
   weight?: \\"normal\\" | \\"bold\\" | number;
 }
 
-declare const Text: React.ComponentType<TextProps>;
+declare const Text: React.ComponentType<TextProps & JSX.IntrinsicElements['span']>;
 
 export { Text };
 ",
@@ -788,7 +788,7 @@ export interface TextAreaProps {
   value?: string;
 }
 
-declare const TextArea: React.ComponentType<TextAreaProps>;
+declare const TextArea: React.ComponentType<TextAreaProps & JSX.IntrinsicElements['textarea']>;
 
 export { TextArea };
 ",
@@ -812,7 +812,7 @@ export interface TextInputProps {
   value?: string;
 }
 
-declare const TextInput: React.ComponentType<TextInputProps>;
+declare const TextInput: React.ComponentType<TextInputProps & JSX.IntrinsicElements['input']>;
 
 export { TextInput };
 ",

--- a/tools/generate-readme-ts.js
+++ b/tools/generate-readme-ts.js
@@ -8,7 +8,7 @@ const replaceHoc = content => content.replace(/(With.*\()(.*)(\))/g, '$2');
 
 const getTypescriptDefinitionFile = (
   component,
-  { properties },
+  { properties, intrinsicElement },
 ) => `import * as React from "react";
 
 export interface ${component}Props {
@@ -20,7 +20,9 @@ export interface ${component}Props {
     .join('\n  ')}
 }
 
-declare const ${component}: React.ComponentType<${component}Props>;
+declare const ${component}: React.ComponentType<${component}Props${
+  intrinsicElement ? ` & JSX.IntrinsicElements['${intrinsicElement}']` : ''
+}>;
 
 export { ${component} };
 `;


### PR DESCRIPTION
Contributes: #2325

Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

#### What does this PR do?

Continuing on the react-desc update i added intrinsic elements to the following components

* Anchor
* Button
* Image
* Paragraph
* Table
* TableBody
* TableCell
* TableFooter
* TableHeader
* TableRow
* Text
* TextArea
* TextInput

I did not add these to RoutedAnchor, RoutedButton etc since they are using the
base components. But i could do it if you think it would be clearer for the documentation.

For the moment i haven't added intrinsic elements to components that have the `as` property
and are hence polymorphic. (But if you want i can add the default one, like div for Box). And i have no idea how to do this just yet. This also includes the Heading component since it can be h1 h2 h3 etc. Unless i missed it there is no generic h tag to rely upon.

I hope i haven't missed any other base elements!

#### Where should the reviewer start?

the generate ts script i guess.

#### What testing has been done on this PR?

actually none, i have no ts ready project to test this upon, but i feel changes are correct. i am creating a ts project soon though to help more on ts.

#### How should this be manually tested?

with a ts project

#### Any background context you want to provide?

#### What are the relevant issues?

#2325

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

i think yes since ts support is improved

#### Is this change backwards compatible or is it a breaking change?

backwards compatible