### PR TITLE
WIP Box Improvements

### DIFF
--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -1,18 +1,24 @@
 import React, { Children, Component } from 'react';
 import { compose } from 'recompose';
+import { ThemeContext as IconThemeContext } from 'grommet-icons/contexts';
 import { withTheme } from 'styled-components';
 
-import { ThemeContext as IconThemeContext } from 'grommet-icons/contexts';
-
+import { withForwardRef, withDocs } from '../hocs';
 import { ThemeContext } from '../../contexts';
 import { backgroundIsDark } from '../../utils';
 import { defaultProps } from '../../default-props';
 
-import { withForwardRef } from '../hocs';
-
 import { StyledBox, StyledBoxGap } from './StyledBox';
 
-class Box extends Component {
+const wrapWithHocs = compose(
+  withTheme,
+  withForwardRef,
+  withDocs('./Box/doc'),
+);
+
+class BoxImpl extends Component {
+  static displayName = 'Box';
+
   static defaultProps = {
     direction: 'column',
     margin: 'none',
@@ -136,15 +142,6 @@ class Box extends Component {
   }
 }
 
-Object.setPrototypeOf(Box.defaultProps, defaultProps);
+Object.setPrototypeOf(BoxImpl.defaultProps, defaultProps);
 
-let BoxDoc;
-if (process.env.NODE_ENV !== 'production') {
-  BoxDoc = require('./doc').doc(Box); // eslint-disable-line global-require
-}
-const BoxWrapper = compose(
-  withTheme,
-  withForwardRef,
-)(BoxDoc || Box);
-
-export { BoxWrapper as Box };
+export const Box = wrapWithHocs(BoxImpl);

--- a/src/js/components/hocs.js
+++ b/src/js/components/hocs.js
@@ -6,6 +6,15 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 
 import { AnnounceContext } from '../contexts';
 
+let doc = () => x => x;
+
+// Do not use the documentation wrapper in production.
+if (process.env.NODE_ENV !== 'production') {
+  doc = path => require(path).doc; // eslint-disable-line
+}
+
+export const withDocs = doc;
+
 export const withFocus = WrappedComponent => {
   class FocusableComponent extends Component {
     static getDerivedStateFromProps(nextProps, prevState) {


### PR DESCRIPTION
**Phase 1: Re-organize how HOCs are applied to Box**

Currently the documentation wrapper is treated distinctly different from
an HOC, but it is an HOC so it belongs in the hocs file. Since the
documentation path is relative to the component, we pass that value in
first to let the require dynamically pick it up.