### PR TITLE
Add empty option to select

### DIFF
--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -378,6 +378,14 @@ When the options array contains objects, this property indicates how
 string
 function
 ```
+
+**emptySearchMessage**
+
+Empty option message to display when no matching results were found Defaults to `No matches found`.
+
+```
+string
+```
   
 ## Theme
   

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -39,6 +39,7 @@ class SelectContainer extends Component {
   static defaultProps = {
     children: null,
     disabled: undefined,
+    emptySearchMessage: 'No matches found',
     id: undefined,
     multiple: false,
     name: undefined,

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -311,6 +311,7 @@ class SelectContainer extends Component {
     const {
       children,
       dropHeight,
+      emptySearchMessage,
       id,
       onKeyDown,
       onSearch,
@@ -354,42 +355,54 @@ class SelectContainer extends Component {
             ref={this.selectRef}
             overflow="auto"
           >
-            <InfiniteScroll items={options} step={theme.select.step} replace>
-              {(option, index) => {
-                const isDisabled = this.isDisabled(index);
-                const isSelected = this.isSelected(index);
-                const isActive = isSelected || activeIndex === index;
-                return (
-                  <SelectOption
-                    key={`option_${index}`}
-                    ref={ref => {
-                      this.optionsRef[index] = ref;
-                    }}
-                    disabled={isDisabled || undefined}
-                    active={isActive}
-                    selected={isSelected}
-                    option={option}
-                    onClick={
-                      !isDisabled
-                        ? () => this.selectOption(option, index)
-                        : undefined
-                    }
-                  >
-                    {children ? (
-                      children(option, index, options, {
-                        active: isActive,
-                        disabled: isDisabled,
-                        selected: isSelected,
-                      })
-                    ) : (
-                      <Box align="start" pad="small">
-                        <Text margin="none">{this.optionLabel(index)}</Text>
-                      </Box>
-                    )}
-                  </SelectOption>
-                );
-              }}
-            </InfiniteScroll>
+            {options.length > 0 ? (
+              <InfiniteScroll items={options} step={theme.select.step} replace>
+                {(option, index) => {
+                  const isDisabled = this.isDisabled(index);
+                  const isSelected = this.isSelected(index);
+                  const isActive = isSelected || activeIndex === index;
+                  return (
+                    <SelectOption
+                      key={`option_${index}`}
+                      ref={ref => {
+                        this.optionsRef[index] = ref;
+                      }}
+                      disabled={isDisabled || undefined}
+                      active={isActive}
+                      selected={isSelected}
+                      option={option}
+                      onClick={
+                        !isDisabled
+                          ? () => this.selectOption(option, index)
+                          : undefined
+                      }
+                    >
+                      {children ? (
+                        children(option, index, options, {
+                          active: isActive,
+                          disabled: isDisabled,
+                          selected: isSelected,
+                        })
+                      ) : (
+                        <Box align="start" pad="small">
+                          <Text margin="none">{this.optionLabel(index)}</Text>
+                        </Box>
+                      )}
+                    </SelectOption>
+                  );
+                }}
+              </InfiniteScroll>
+            ) : (
+              <SelectOption
+                key="search_empty"
+                disabled
+                option={emptySearchMessage}
+              >
+                <Box align="start" pad="small">
+                  <Text margin="none">{emptySearchMessage}</Text>
+                </Box>
+              </SelectOption>
+            )}
           </OptionsBox>
         </ContainerBox>
       </Keyboard>

--- a/src/js/components/Select/__tests__/Select-test.js
+++ b/src/js/components/Select/__tests__/Select-test.js
@@ -326,4 +326,21 @@ describe('Select', () => {
       expect(document.activeElement).toMatchSnapshot();
     });
   });
+
+  test('empty results search', () => {
+    const { getByPlaceholderText } = render(
+      <Select
+        id="test-select"
+        placeholder="test select"
+        options={[]}
+        onSearch={() => {}}
+        emptySearchMessage="no results"
+      />,
+    );
+    fireEvent.click(getByPlaceholderText('test select'));
+    document.activeElement.value = 'a';
+    fireEvent.input(document.activeElement);
+
+    expect(document.activeElement).toMatchSnapshot();
+  });
 });

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -1621,6 +1621,379 @@ exports[`Select disabled 2`] = `
 </button>
 `;
 
+exports[`Select empty results search 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+  box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+  padding: 0px;
+  overflow: auto;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding: 0px;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 12px;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding: 6px;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  border-radius: 0px;
+  position: fixed;
+  z-index: 20;
+  outline: none;
+  overflow: auto;
+  background: #ffffff;
+  color: #444444;
+  opacity: 0;
+  -webkit-transform-origin: top left;
+  -ms-transform-origin: top left;
+  transform-origin: top left;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
+  -webkit-animation-delay: 0.01s;
+  animation-delay: 0.01s;
+}
+
+.c6 {
+  box-sizing: border-box;
+  font-size: inherit;
+  border: none;
+  -webkit-appearance: none;
+  padding: 11px;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  width: 100%;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c6::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c6::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c6:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c5 {
+  position: relative;
+  width: 100%;
+}
+
+.c12 {
+  margin: 0px;
+  font-size: 18px;
+  line-height: 24px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.c2 {
+  max-height: inherit;
+}
+
+.c7 {
+  -webkit-scroll-behavior: smooth;
+  -moz-scroll-behavior: smooth;
+  -ms-scroll-behavior: smooth;
+  scroll-behavior: smooth;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    padding: 3px;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c2 {
+    width: 100%;
+  }
+}
+
+<div
+  class="c0 c1"
+  id="test-select__drop"
+  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  tabindex="-1"
+>
+  <div
+    class="c2 c3"
+    id="test-select__select-drop"
+  >
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        <input
+          autocomplete="off"
+          class="c6"
+          type="search"
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      class="c7 c8"
+      role="menubar"
+      tabindex="-1"
+    >
+      <div
+        class="c9"
+      >
+        <button
+          class="c10"
+          disabled=""
+          role="menuitem"
+          type="button"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              no results
+            </span>
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Select large drop container height 1`] = `
 .c1 {
   display: -webkit-box;

--- a/src/js/components/Select/doc.js
+++ b/src/js/components/Select/doc.js
@@ -161,6 +161,11 @@ export const doc = Select => {
       If a function is provided, it is called with the option and the
       return value indicates the value.`,
     ),
+    emptySearchMessage: PropTypes.string
+      .description(
+        `Empty option message to display when no matching results were found`,
+      )
+      .defaultValue('No matches found'),
   };
 
   return DocumentedSelect;

--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -29,6 +29,7 @@ export interface SelectProps {
   value?: string | JSX.Element | object | string | object[];
   valueLabel?: React.ReactNode;
   valueKey?: string | (...args: any[]) => any;
+  emptySearchMessage?: string;
 }
 
 declare const Select: React.ComponentType<SelectProps>;

--- a/src/js/components/Select/stories/select.stories.js
+++ b/src/js/components/Select/stories/select.stories.js
@@ -419,6 +419,7 @@ class CustomSearchSelect extends Component {
               closeOnChange={false}
               placeholder="Select Content Partners"
               searchPlaceholder="Search Content Partners"
+              emptySearchMessage="No partners found"
               multiple
               value={
                 selectedContentPartners.length

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -6033,6 +6033,14 @@ When the options array contains objects, this property indicates how
 string
 function
 \`\`\`
+
+**emptySearchMessage**
+
+Empty option message to display when no matching results were found Defaults to \`No matches found\`.
+
+\`\`\`
+string
+\`\`\`
   
 ## Theme
   

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2679,6 +2679,12 @@ object
 function",
         "name": "valueKey",
       },
+      Object {
+        "defaultValue": "No matches found",
+        "description": "Empty option message to display when no matching results were found",
+        "format": "string",
+        "name": "emptySearchMessage",
+      },
     ],
     "usage": "import { Select } from 'grommet';
 <Select />",

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -626,6 +626,7 @@ export interface SelectProps {
   value?: string | JSX.Element | object | string | object[];
   valueLabel?: React.ReactNode;
   valueKey?: string | (...args: any[]) => any;
+  emptySearchMessage?: string;
 }
 
 declare const Select: React.ComponentType<SelectProps>;


### PR DESCRIPTION
Closes: #2427
Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds an empty option message when there are no options (i.e after empty search)

#### Where should the reviewer start?

select-container that has the logic

#### What testing has been done on this PR?

added a unit-test to verify we can change message

#### How should this be manually tested?

in the storybook

#### Any background context you want to provide?

#### What are the relevant issues?
#2427
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
did it
#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
compatible