### PR TITLE
Changed Select to fix an issue with scrolling and keyboard navigation

### DIFF
--- a/src/js/components/Layer/layer.stories.js
+++ b/src/js/components/Layer/layer.stories.js
@@ -110,10 +110,7 @@ class CenterLayer extends Component {
 }
 
 class FormLayer extends Component {
-  state = {
-    fourthOption: 'one',
-    open: false,
-  };
+  state = { open: false, select: '' };
 
   onOpen = () => this.setState({ open: true });
 
@@ -122,7 +119,7 @@ class FormLayer extends Component {
   };
 
   render() {
-    const { open, fourthOption } = this.state;
+    const { open, select } = this.state;
     return (
       <Grommet theme={grommet} full>
         <Box fill align="center" justify="center">
@@ -154,19 +151,26 @@ class FormLayer extends Component {
                     <TextInput />
                   </FormField>
                   <FormField label="Second">
-                    <TextInput />
+                    <Select
+                      options={[
+                        'one',
+                        'two',
+                        'three',
+                        'four',
+                        'five',
+                        'six',
+                        'seven',
+                        'eight',
+                      ]}
+                      value={select}
+                      onSearch={() => {}}
+                      onChange={({ option }) =>
+                        this.setState({ select: option })
+                      }
+                    />
                   </FormField>
                   <FormField label="Third">
                     <TextArea />
-                  </FormField>
-                  <FormField label="Fourth">
-                    <Select
-                      options={['one', 'two', 'three']}
-                      value={fourthOption}
-                      onChange={({ option }) =>
-                        this.setState({ fourthOption: option })
-                      }
-                    />
                   </FormField>
                 </Box>
                 <Box flex={false} as="footer" align="start">

--- a/src/js/utils/DOM.js
+++ b/src/js/utils/DOM.js
@@ -140,8 +140,8 @@ export const findVisibleParent = element => {
 
 export const isNodeAfterScroll = (node, target = window) => {
   const { bottom } = node.getBoundingClientRect();
-  const { height } = target.getBoundingClientRect();
-  return bottom >= height;
+  const { height, top } = target.getBoundingClientRect();
+  return bottom >= top + height;
 };
 
 export const isNodeBeforeScroll = (node, target = window) => {


### PR DESCRIPTION
#### What does this PR do?

Changed Select to fix an issue with scrolling and keyboard navigation.
The issue was the isNodeAfterScroll() wasn't taking into account the top of the target element.

#### Where should the reviewer start?

DOM.js

#### What testing has been done on this PR?

storybook

#### How should this be manually tested?

storybook

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/2449

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
