### PR TITLE
grommet-styles and grommet-icons removed as peerDependency

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,5 @@
 {
-  "presets": [
-    "./tools/grommet-babel-preset-es2015",
-    "@babel/preset-react"
-  ],
+  "presets": ["./tools/grommet-babel-preset-es2015", "@babel/preset-react"],
   "plugins": [
     ["styled-components", { "useDisplayName": false }],
     "@babel/plugin-proposal-class-properties"
@@ -10,18 +7,21 @@
   "env": {
     "es6": {
       "plugins": [
-        ["transform-imports", {
-          "grommet-icons$": {
-             "transform": "grommet-icons/es6/icons/${member}",
-             "preventFullImport": true,
-             "skipDefaultConversion": true
-          },
-          "grommet-icons/contexts": {
-            "transform": "grommet-icons/es6/contexts/${member}",
-            "preventFullImport": true,
-            "skipDefaultConversion": true
-         }
-        }]
+        [
+          "transform-imports",
+          {
+            "grommet-icons$": {
+              "transform": "grommet-icons/es6/icons/${member}",
+              "preventFullImport": true,
+              "skipDefaultConversion": true
+            },
+            "grommet-icons/themes": {
+              "transform": "grommet-icons/es6/themes/${member}",
+              "preventFullImport": true,
+              "skipDefaultConversion": true
+            }
+          }
+        ]
       ]
     }
   }

--- a/README.md
+++ b/README.md
@@ -14,31 +14,33 @@ Before opening an issue or pull request, please read the [Contributing](https://
 
 ### Install
 
-  You can install Grommet using either of the methods below.
+You can install Grommet using either of the methods below.
 
-  For NPM users:
-  ```
-    $ npm install grommet grommet-icons@3.x styled-components --save
-  ```
+For NPM users:
 
-  Detailed instructions are on the [Get Started](https://v2.grommet.io/use) page.
+```
+  $ npm install grommet styled-components --save
+```
+
+Detailed instructions are on the [Get Started](https://v2.grommet.io/use) page.
 
 ### Explore
 
-  We have a few examples on Storybook, you can see them by running:
+We have a few examples on Storybook, you can see them by running:
 
-  ```
-    $ npm run storybook
-  ```
-  
-  or you can navigate our [Storybook site](https://storybook.grommet.io)
+```
+  $ npm run storybook
+```
+
+or you can navigate our [Storybook site](https://storybook.grommet.io)
 
 ### Release History
 
-  See the [Change Log](https://github.com/grommet/grommet/wiki/Change-Log).
+See the [Change Log](https://github.com/grommet/grommet/wiki/Change-Log).
 
 ### Tools Behind Grommet
 
- Grommet is produced using these great tools
- * [Travis CI](https://travis-ci.org/grommet/grommet) for continuous integration
- * [Waffle.io](https://waffle.io/grommet/grommet) for backlog tracking
+Grommet is produced using these great tools
+
+- [Travis CI](https://travis-ci.org/grommet/grommet) for continuous integration
+- [Waffle.io](https://waffle.io/grommet/grommet) for backlog tracking

--- a/package.json
+++ b/package.json
@@ -39,8 +39,6 @@
     "prettier": "pretty-quick --staged"
   },
   "peerDependencies": {
-    "grommet-icons": ">= 4.0.0",
-    "grommet-styles": ">= 0.2.0",
     "react": ">= 16.4.1",
     "react-dom": ">= 16.4.1",
     "styled-components": ">= 4.X"
@@ -48,6 +46,8 @@
   "dependencies": {
     "css": "^2.2.3",
     "hoist-non-react-statics": "^3.2.0",
+    "grommet-icons": "^4.0.0",
+    "grommet-styles": "^0.2.0",
     "markdown-to-jsx": "^6.6.6",
     "mobile-detect": "^1.4.3",
     "polished": "^2.2.0",
@@ -93,8 +93,6 @@
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.9.1",
     "fs-extra": "^7.0.0",
-    "grommet-icons": "^4.0.0",
-    "grommet-styles": "^0.2.0",
     "grommet-theme-aruba": "^0.1.0",
     "grommet-theme-dxc": "^0.1.0",
     "grommet-theme-hp": "^0.1.0",

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -2,7 +2,6 @@ import { rgba } from 'polished';
 import { css } from 'styled-components';
 
 import {
-  base as iconBase,
   Actions,
   ClosedCaption,
   Expand,
@@ -18,6 +17,7 @@ import {
   Volume,
   VolumeLow,
 } from 'grommet-icons';
+import { base as iconBase } from 'grommet-icons/themes';
 
 import { deepMerge, deepFreeze, normalizeColor } from '../utils';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2171,7 +2171,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.x.x, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@^6.5.0:
+babel-runtime@6.x.x, babel-runtime@^6.11.6, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@^6.5.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -4645,9 +4645,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 grommet-icons@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.0.0.tgz#41d2def68d96617ef8c6a4391dd94329b862bcd5"
-  integrity sha512-AMmBcedzfjGQu7KV3YU3F0dxq1Kr7L16j/3xO/q8rBqrtczjgDCBgWrYM6MqwXaoDuLf3dl/8YAcqrBTYkgIjQ==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.0.1.tgz#20dea0759607f959cb3ab2a90339ab5de71b87ea"
+  integrity sha512-gw1S2lmgb0bmq7Pb9Or4HtvzSFBOUjjtXl8eaCT8hW52ib39b5fKVib6q84PHnInIxs3ka3VQj24Lm2ytRawfw==
+  dependencies:
+    grommet-styles "^0.2.0"
 
 grommet-styles@^0.2.0:
   version "0.2.0"
@@ -6536,9 +6538,9 @@ minipass@^2.2.1, minipass@^2.3.4:
     yallist "^3.0.0"
 
 minizlib@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.0.tgz#59517387478fd98d8017ed0299c6cb16cbd12da3"
-  integrity sha512-vQhkoouK/oKRVuFJynustmW3wrqZEXOrfbVVirvOVeglH4TNvIkcqiyojlIbbZYYDJZSbEKEXmDudg+tyRkm6g==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
+  integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
   dependencies:
     minipass "^2.2.1"
 
@@ -7866,11 +7868,11 @@ react-style-proptype@^3.0.0:
     prop-types "^15.5.4"
 
 react-syntax-highlighter@^10.0.0:
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-10.1.1.tgz#1bf7ad4f2f16d2978b04594407b670671b4d3316"
-  integrity sha512-2EzDjKuU51BuL9CZ5qfGJ9+6m9BKGm+IJODyeR7ANC3g3wQY1LPxEzo6vDPsdV1EzDbYUAAai3AYtSBaKVusuw==
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-10.1.2.tgz#645ad5e3d8667fd7a2b73fc1059f871055d23f82"
+  integrity sha512-p/xy9rb13Cr+SaErdOvJWTYH8moDrlszv4LPDd314pk5PmT6OTWQYFy66tBZFWhM2xk6bh4BttTU9SYje5c75g==
   dependencies:
-    babel-runtime "^6.18.0"
+    "@babel/runtime" "^7.1.2"
     highlight.js "~9.12.0"
     lowlight "~1.9.1"
     prismjs "^1.8.4"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
changes package.json to move grommet styles and grommet icons to peer dependency.
#### Where should the reviewer start?
package.json
#### What testing has been done on this PR?
manual
#### How should this be manually tested?
run yarn install and npm run build and make sure everything passes.
also take a look on storybook and tests
#### Any background context you want to provide?

#### What are the relevant issues?
no issues
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards