### PR TITLE
Layer - to allow corner options

### DIFF
--- a/src/js/components/Layer/README.md
+++ b/src/js/components/Layer/README.md
@@ -120,11 +120,15 @@ Position of the layer content. Defaults to `center`.
 
 ```
 bottom
+bottom-left
+bottom-right
 center
 hidden
 left
 right
 top
+top-left
+top-right
 ```
 
 **responsive**

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -76,7 +76,9 @@ const StyledOverlay = styled.div`
 
 const getMargin = (margin, theme, position) => {
   const axis =
-    position === 'top' || position === 'bottom' ? 'vertical' : 'horizontal';
+    position.includes('top') || position.includes('bottom')
+      ? 'vertical'
+      : 'horizontal';
   const marginValue = margin[position] || margin[axis] || margin;
   const marginApplied = theme.global.edgeSize[marginValue] || marginValue;
   const marginInTheme = !!theme.global.edgeSize[marginValue];
@@ -91,10 +93,14 @@ const MARGINS = (margin, theme, position = undefined) => {
     return getMargin(margin, theme, position);
   }
   return {
-    top: getMargin(margin, theme, 'top'),
     bottom: getMargin(margin, theme, 'bottom'),
+    'bottom-left': getMargin(margin, theme, 'bottom-left'),
+    'bottom-right': getMargin(margin, theme, 'bottom-right'),
     left: getMargin(margin, theme, 'left'),
     right: getMargin(margin, theme, 'right'),
+    top: getMargin(margin, theme, 'top'),
+    'top-right': getMargin(margin, theme, 'top-right'),
+    'top-left': getMargin(margin, theme, 'top-left'),
   };
 };
 
@@ -349,6 +355,130 @@ const POSITIONS = {
       top: 50%;
       transform: translate(0, -50%);
       animation: ${KEYFRAMES.right.false} 0.2s ease-in-out forwards;
+    `,
+  },
+
+  'top-right': {
+    vertical: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
+      right: ${margin.right};
+      transform: translateX(0);
+      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+    `,
+    horizontal: margin => css`
+      left: ${margin.left};
+      right: ${margin.right};
+      top: 0;
+      transform: translateX(0);
+      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+    `,
+    true: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
+      left: ${margin.left};
+      right: ${margin.right};
+      transform: translateX(0);
+      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+    `,
+    false: margin => css`
+      top: ${margin.top};
+      right: ${margin.right};
+      transform: translateY(0);
+      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+    `,
+  },
+
+  'top-left': {
+    vertical: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
+      left: ${margin.left};
+      transform: translateX(0);
+      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+    `,
+    horizontal: margin => css`
+      left: ${margin.left};
+      right: ${margin.right};
+      top: 0;
+      transform: translateX(0);
+      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+    `,
+    true: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
+      left: ${margin.left};
+      right: ${margin.right};
+      transform: translateX(0);
+      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+    `,
+    false: margin => css`
+      top: ${margin.top};
+      left: ${margin.left};
+      transform: translateY(0);
+      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+    `,
+  },
+
+  'bottom-right': {
+    vertical: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
+      right: ${margin.right};
+      transform: translateX(0);
+      animation: ${KEYFRAMES.bottom.true} 0.2s ease-in-out forwards;
+    `,
+    horizontal: margin => css`
+      left: ${margin.left};
+      right: ${margin.right};
+      bottom: ${margin.bottom};
+      transform: translateY(0);
+      animation: ${KEYFRAMES.bottom.horizontal} 0.2s ease-in-out forwards;
+    `,
+    true: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
+      left: ${margin.left};
+      right: ${margin.right};
+      transform: translateX(0);
+      animation: ${KEYFRAMES.bottom.true} 0.2s ease-in-out forwards;
+    `,
+    false: margin => css`
+      bottom: ${margin.bottom};
+      right: ${margin.right};
+      transform: translateY(0);
+      animation: ${KEYFRAMES.bottom.true} 0.2s ease-in-out forwards;
+    `,
+  },
+
+  'bottom-left': {
+    vertical: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
+      left: ${margin.left};
+      transform: translateX(0);
+      animation: ${KEYFRAMES.bottom.true} 0.2s ease-in-out forwards;
+    `,
+    horizontal: margin => css`
+      left: ${margin.left};
+      right: ${margin.right};
+      bottom: ${margin.bottom};
+      transform: translateY(0);
+      animation: ${KEYFRAMES.bottom.horizontal} 0.2s ease-in-out forwards;
+    `,
+    true: margin => css`
+      top: ${margin.top};
+      bottom: ${margin.bottom};
+      left: ${margin.left};
+      right: ${margin.right};
+      transform: translateX(0);
+      animation: ${KEYFRAMES.bottom.true} 0.2s ease-in-out forwards;
+    `,
+    false: margin => css`
+      bottom: ${margin.bottom};
+      left: ${margin.left};
+      transform: translateY(0);
+      animation: ${KEYFRAMES.bottom.true} 0.2s ease-in-out forwards;
     `,
   },
 };

--- a/src/js/components/Layer/doc.js
+++ b/src/js/components/Layer/doc.js
@@ -77,11 +77,15 @@ particular side of the layer`,
       .defaultValue(false),
     position: PropTypes.oneOf([
       'bottom',
+      'bottom-left',
+      'bottom-right',
       'center',
       'hidden',
       'left',
       'right',
       'top',
+      'top-left',
+      'top-right',
     ])
       .description('Position of the layer content.')
       .defaultValue('center'),

--- a/src/js/components/Layer/index.d.ts
+++ b/src/js/components/Layer/index.d.ts
@@ -7,7 +7,7 @@ export interface LayerProps {
   onClickOutside?: (...args: any[]) => any;
   onEsc?: (...args: any[]) => any;
   plain?: boolean;
-  position?: "bottom" | "center" | "hidden" | "left" | "right" | "top";
+  position?: "bottom" | "bottom-left" | "bottom-right" | "center" | "hidden" | "left" | "right" | "top" | "top-left" | "top-right";
   responsive?: boolean;
 }
 

--- a/src/js/components/Layer/layer.stories.js
+++ b/src/js/components/Layer/layer.stories.js
@@ -109,6 +109,41 @@ class CenterLayer extends Component {
   }
 }
 
+class CornerLayer extends Component {
+  state = {};
+
+  onOpen = () => this.setState({ open: true });
+
+  onClose = () => this.setState({ open: undefined });
+
+  render() {
+    const { open } = this.state;
+    return (
+      <Grommet theme={grommet} full>
+        <Box fill align="center" justify="center">
+          <Button
+            icon={<Add color="brand" />}
+            label={
+              <Text>
+                <strong>Add Corner Layer</strong>
+              </Text>
+            }
+            onClick={this.onOpen}
+            plain
+          />
+        </Box>
+        {open && (
+          <Layer position="top-right">
+            <Box height="small" overflow="auto">
+              <Box pad="xlarge">Corner top-right position</Box>
+            </Box>
+          </Layer>
+        )}
+      </Grommet>
+    );
+  }
+}
+
 class FormLayer extends Component {
   state = { open: false, select: '' };
 
@@ -415,6 +450,7 @@ const ScrollBodyLayer = () => (
 
 storiesOf('Layer', module)
   .add('Center', () => <CenterLayer />)
+  .add('CornerLayer', () => <CornerLayer />)
   .add('Form', () => <FormLayer />)
   .add('Notification', () => <NotificationLayer />)
   .add('Margin', () => <MarginLayer full />)

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -956,7 +956,6 @@ exports[`MaskedInput option via mouse 4`] = `
   <input
     autocomplete="off"
     class="StyledMaskedInput-sc-99vkfa-0 kWovZR"
-    data-g-tabindex="-1"
     data-testid="test-input"
     id="item"
     name="item"

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -956,6 +956,7 @@ exports[`MaskedInput option via mouse 4`] = `
   <input
     autocomplete="off"
     class="StyledMaskedInput-sc-99vkfa-0 kWovZR"
+    data-g-tabindex="-1"
     data-testid="test-input"
     id="item"
     name="item"

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4621,11 +4621,15 @@ Position of the layer content. Defaults to \`center\`.
 
 \`\`\`
 bottom
+bottom-left
+bottom-right
 center
 hidden
 left
 right
 top
+top-left
+top-right
 \`\`\`
 
 **responsive**

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -445,7 +445,7 @@ export interface LayerProps {
   onClickOutside?: (...args: any[]) => any;
   onEsc?: (...args: any[]) => any;
   plain?: boolean;
-  position?: \\"bottom\\" | \\"center\\" | \\"hidden\\" | \\"left\\" | \\"right\\" | \\"top\\";
+  position?: \\"bottom\\" | \\"bottom-left\\" | \\"bottom-right\\" | \\"center\\" | \\"hidden\\" | \\"left\\" | \\"right\\" | \\"top\\" | \\"top-left\\" | \\"top-right\\";
   responsive?: boolean;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Allows the user to consume a corner Layer

#### Where should the reviewer start?
doc.js

#### What testing has been done on this PR?
storybook + added story

#### How should this be manually tested?
storybook and play with the `position` and `full` values.

#### Any background context you want to provide?

#### What are the relevant issues?
#2545 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Done

#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible