### PR TITLE
Changed Select to fix an issue with rendering option state

### DIFF
--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -411,6 +411,7 @@ class SelectContainer extends Component {
                       }}
                       disabled={isDisabled || undefined}
                       active={isActive}
+                      selected={isSelected}
                       option={option}
                       onMouseOver={
                         !isDisabled ? this.onActiveOption(index) : undefined

--- a/src/js/components/Select/SelectOption.js
+++ b/src/js/components/Select/SelectOption.js
@@ -6,14 +6,16 @@ import { withForwardRef } from '../hocs';
 
 class SelectOption extends Component {
   shouldComponentUpdate(nextProps) {
-    const { active, disabled, option } = this.props;
+    const { active, disabled, option, selected } = this.props;
     const {
       active: nextActive,
       disabled: nextDisabled,
       option: nextOption,
+      selected: nextSelected,
     } = nextProps;
     return (
       active !== nextActive ||
+      selected !== nextSelected ||
       disabled !== nextDisabled ||
       option !== nextOption
     );

--- a/src/js/components/Select/stories/select.stories.js
+++ b/src/js/components/Select/stories/select.stories.js
@@ -164,6 +164,7 @@ class ObjectMultiSelect extends Component {
             size="medium"
             placeholder="Select"
             multiple
+            closeOnChange={false}
             disabledKey="dis"
             labelKey="lab"
             valueKey="val"


### PR DESCRIPTION
#### What does this PR do?

Changed Select to fix an issue with rendering option state.
Previously, SelectOption wasn't looking for changes in selected state when deciding whether to update. This caused the internal child of SelectOption to not re-render.

#### Where should the reviewer start?

SelectOption.js

#### What testing has been done on this PR?

storybook

#### How should this be manually tested?

storybook

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
