### PR TITLE
Added temporary withTheme proxy.

### DIFF
--- a/src/js/components/hocs.js
+++ b/src/js/components/hocs.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import getDisplayName from 'recompose/getDisplayName';
 import hoistNonReactStatics from 'hoist-non-react-statics';
+import { withTheme } from 'styled-components';
 import { AnnounceContext } from '../contexts';
 
 let doc = () => x => x;
@@ -158,3 +159,5 @@ export const withAnnounce = WrappedComponent => {
 
   return ForwardRef;
 };
+
+export { withTheme };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds `withTheme` proxy to styled-components so that libraries using `import { withTheme } from 'grommet/components/hocs';` don't break.

#### Where should the reviewer start?
hocs.
#### What testing has been done on this PR?
manual
#### How should this be manually tested?
storybook
#### Any background context you want to provide?

github.com/atanasster/grommet-controls/issues/3
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards