### PR TITLE
allowing Layer a custom  animation

### DIFF
--- a/src/js/components/Layer/README.md
+++ b/src/js/components/Layer/README.md
@@ -14,7 +14,7 @@ import { Layer } from 'grommet';
 
 **animate**
 
-Transition content in & out with a slide down animation. Defaults to `true`.
+Animation transition of the Layer content when it opens. Defaults to `true`.
 
 ```
 boolean

--- a/src/js/components/Layer/README.md
+++ b/src/js/components/Layer/README.md
@@ -18,7 +18,6 @@ Animation transition of the Layer content when it opens. Defaults to `true`.
 
 ```
 boolean
-string
 ```
 
 **full**

--- a/src/js/components/Layer/README.md
+++ b/src/js/components/Layer/README.md
@@ -12,6 +12,15 @@ import { Layer } from 'grommet';
 
 ## Properties
 
+**animate**
+
+Transition content in & out with a slide down animation. Defaults to `true`.
+
+```
+boolean
+string
+```
+
 **full**
 
 Whether the width and/or height should fill the current viewport size.

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -198,13 +198,12 @@ const KEYFRAMES = {
 };
 
 const getKeyframes = (animate, position, full) => {
-  if (animate === "true") {
-    return css`${KEYFRAMES[position][full]} 0.2s ease-in-out forwards` ;
-  }
-  if (animate === "false") {
+  if (!animate) {
     return 'none';
   }
-  return css`${KEYFRAMES[position][full]} ${animate}`;
+  return animate === true ?
+    css`${KEYFRAMES[position][full]} 0.2s ease-in-out forwards` :
+    css`${KEYFRAMES[position][full]} ${animate}`;
 } 
 
 // POSITIONS combines 'position', 'full', and 'margin' properties, since

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -197,19 +197,11 @@ const KEYFRAMES = {
   },
 };
 
-const getAnimationStyle = (animate, position, full) => {
-  if (animate === false) {
-    return '';
-  }
+const getAnimationStyle = (animate = true, position, full) => {
+  const defaultAnimation = css`animation: ${KEYFRAMES[position][full]} 0.2s ease-in-out forwards`;
 
-  return animate === true || animate === undefined
-    ? css`
-        animation: ${KEYFRAMES[position][full]} 0.2s ease-in-out forwards;
-      `
-    : css`
-        animation: ${KEYFRAMES[position][full]} ${animate};
-      `;
-};
+  return animate ? defaultAnimation : '';
+}
 
 // POSITIONS combines 'position', 'full', and 'margin' properties, since
 // they are all interdependent.

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -197,14 +197,19 @@ const KEYFRAMES = {
   },
 };
 
-const getKeyframes = (animate, position, full) => {
-  if (!animate) {
-    return 'none';
+const getAnimationStyle = (animate, position, full) => {
+  if (animate === false) {
+    return '';
   }
-  return animate === true ?
-    css`${KEYFRAMES[position][full]} 0.2s ease-in-out forwards` :
-    css`${KEYFRAMES[position][full]} ${animate}`;
-} 
+
+  return animate === true || animate === undefined
+    ? css`
+        animation: ${KEYFRAMES[position][full]} 0.2s ease-in-out forwards;
+      `
+    : css`
+        animation: ${KEYFRAMES[position][full]} ${animate};
+      `;
+};
 
 // POSITIONS combines 'position', 'full', and 'margin' properties, since
 // they are all interdependent.
@@ -219,27 +224,27 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       left: 50%;
       transform: translateX(-50%);
-      animation: ${props => getKeyframes(props.animate, "center", "vertical")}
+      ${props => getAnimationStyle(props.animate, 'center', 'vertical')}
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.right};
       top: 50%;
       transform: translateY(-50%);
-      animation: ${props => getKeyframes(props.animate, "center", "horizontal")}
+      ${props => getAnimationStyle(props.animate, 'center', 'horizontal')}
     `,
     true: margin => css`
       top: ${margin.top};
       bottom: ${margin.bottom};
       left: ${margin.left};
       right: ${margin.right};
-      animation: ${props => getKeyframes(props.animate, "center", "true")}
+      ${props => getAnimationStyle(props.animate, 'center', 'true')}
     `,
     false: () => css`
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
-      animation: ${props => getKeyframes(props.animate, "center", "false")}
+      ${props => getAnimationStyle(props.animate, 'center', 'false')}
     `,
   },
 
@@ -249,14 +254,14 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       left: 50%;
       transform: translate(-50%, 0%);
-      animation: ${props => getKeyframes(props.animate, "top", "vertical")}
+      ${props => getAnimationStyle(props.animate, 'top', 'vertical')}
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.right};
       top: ${margin.top};
       transform: translateY(0);
-      animation: ${props => getKeyframes(props.animate, "top", "horizontal")}
+      ${props => getAnimationStyle(props.animate, 'top', 'horizontal')}
     `,
     true: margin => css`
       top: ${margin.top};
@@ -264,13 +269,13 @@ const POSITIONS = {
       left: ${margin.left};
       right: ${margin.right};
       transform: translateY(0);
-      animation: ${props => getKeyframes(props.animate, "top", "true")}
+      ${props => getAnimationStyle(props.animate, 'top', 'true')}
     `,
     false: margin => css`
       top: ${margin.top};
       left: 50%;
       transform: translate(-50%, 0);
-      animation: ${props => getKeyframes(props.animate, "top", "false")}
+      ${props => getAnimationStyle(props.animate, 'top', 'false')}
     `,
   },
 
@@ -280,14 +285,14 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       left: 50%;
       transform: translate(-50%, 0);
-      animation: ${props => getKeyframes(props.animate, "bottom", "vertical")}
+      ${props => getAnimationStyle(props.animate, 'bottom', 'vertical')}
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.top};
       bottom: ${margin.bottom};
       transform: translateY(0);
-      animation: ${props => getKeyframes(props.animate, "bottom", "horizontal")}
+      ${props => getAnimationStyle(props.animate, 'bottom', 'horizontal')}
     `,
     true: margin => css`
       top: ${margin.top};
@@ -295,13 +300,13 @@ const POSITIONS = {
       left: ${margin.left};
       right: ${margin.right};
       transform: translateY(0);
-      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
+      ${props => getAnimationStyle(props.animate, 'bottom', 'true')}
     `,
     false: margin => css`
       bottom: ${margin.bottom};
       left: 50%;
       transform: translate(-50%, 0);
-      animation: ${props => getKeyframes(props.animate, "bottom", "false")}
+      ${props => getAnimationStyle(props.animate, 'bottom', 'false')}
     `,
   },
 
@@ -311,14 +316,14 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       left: ${margin.left};
       transform: translateX(0);
-      animation: ${props => getKeyframes(props.animate, "left", "vertical")}
+      ${props => getAnimationStyle(props.animate, 'left', 'vertical')}
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.right};
       top: 50%;
       transform: translate(0, -50%);
-      animation: ${props => getKeyframes(props.animate, "left", "horizontal")}
+      ${props => getAnimationStyle(props.animate, 'left', 'horizontal')}
     `,
     true: margin => css`
       top: ${margin.top};
@@ -326,13 +331,13 @@ const POSITIONS = {
       left: ${margin.left};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${props => getKeyframes(props.animate, "left", "true")}
+      ${props => getAnimationStyle(props.animate, 'left', 'true')}
     `,
     false: margin => css`
       left: ${margin.left};
       top: 50%;
       transform: translate(0, -50%);
-      animation: ${props => getKeyframes(props.animate, "left", "false")}
+      ${props => getAnimationStyle(props.animate, 'left', 'false')}
     `,
   },
 
@@ -342,14 +347,14 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${props => getKeyframes(props.animate, "right", "vertical")}
+      ${props => getAnimationStyle(props.animate, 'right', 'vertical')}
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.right};
       top: 50%;
       transform: translate(0, -50%);
-      animation: ${props => getKeyframes(props.animate, "right", "horizontal")}
+      ${props => getAnimationStyle(props.animate, 'right', 'horizontal')}
     `,
     true: margin => css`
       top: ${margin.top};
@@ -357,13 +362,13 @@ const POSITIONS = {
       left: ${margin.left};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${props => getKeyframes(props.animate, "right", "true")}
+      ${props => getAnimationStyle(props.animate, 'right', 'true')}
     `,
     false: margin => css`
       right: ${margin.right};
       top: 50%;
       transform: translate(0, -50%);
-      animation: ${props => getKeyframes(props.animate, "right", "false")}
+      ${props => getAnimationStyle(props.animate, 'right', 'false')}
     `,
   },
 
@@ -373,14 +378,14 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${props => getKeyframes(props.animate, "top", "true")};
+      ${props => getAnimationStyle(props.animate, 'top', 'true')};
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.right};
       top: 0;
       transform: translateX(0);
-      animation: ${props => getKeyframes(props.animate, "top", "true")};
+      ${props => getAnimationStyle(props.animate, 'top', 'true')};
     `,
     true: margin => css`
       top: ${margin.top};
@@ -388,13 +393,13 @@ const POSITIONS = {
       left: ${margin.left};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${props => getKeyframes(props.animate, "top", "true")};
+      ${props => getAnimationStyle(props.animate, 'top', 'true')};
     `,
     false: margin => css`
       top: ${margin.top};
       right: ${margin.right};
       transform: translateY(0);
-      animation: ${props => getKeyframes(props.animate, "top", "true")};
+      ${props => getAnimationStyle(props.animate, 'top', 'true')};
     `,
   },
 
@@ -404,14 +409,14 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       left: ${margin.left};
       transform: translateX(0);
-      animation: ${props => getKeyframes(props.animate, "top", "true")}
+      ${props => getAnimationStyle(props.animate, 'top', 'true')}
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.right};
       top: 0;
       transform: translateX(0);
-      animation: ${props => getKeyframes(props.animate, "top", "true")}
+      ${props => getAnimationStyle(props.animate, 'top', 'true')}
     `,
     true: margin => css`
       top: ${margin.top};
@@ -419,13 +424,13 @@ const POSITIONS = {
       left: ${margin.left};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${props => getKeyframes(props.animate, "top", "true")}
+      ${props => getAnimationStyle(props.animate, 'top', 'true')}
     `,
     false: margin => css`
       top: ${margin.top};
       left: ${margin.left};
       transform: translateY(0);
-      animation: ${props => getKeyframes(props.animate, "top", "true")}
+      ${props => getAnimationStyle(props.animate, 'top', 'true')}
     `,
   },
 
@@ -435,14 +440,14 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
+      ${props => getAnimationStyle(props.animate, 'bottom', 'true')}
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.right};
       bottom: ${margin.bottom};
       transform: translateY(0);
-      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
+      ${props => getAnimationStyle(props.animate, 'bottom', 'true')}
     `,
     true: margin => css`
       top: ${margin.top};
@@ -450,13 +455,13 @@ const POSITIONS = {
       left: ${margin.left};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
+      ${props => getAnimationStyle(props.animate, 'bottom', 'true')}
     `,
     false: margin => css`
       bottom: ${margin.bottom};
       right: ${margin.right};
       transform: translateY(0);
-      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
+      ${props => getAnimationStyle(props.animate, 'bottom', 'true')}
     `,
   },
 
@@ -466,14 +471,14 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       left: ${margin.left};
       transform: translateX(0);
-      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
+      ${props => getAnimationStyle(props.animate, 'bottom', 'true')}
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.right};
       bottom: ${margin.bottom};
       transform: translateY(0);
-      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
+      ${props => getAnimationStyle(props.animate, 'bottom', 'true')}
     `,
     true: margin => css`
       top: ${margin.top};
@@ -481,13 +486,13 @@ const POSITIONS = {
       left: ${margin.left};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
+      ${props => getAnimationStyle(props.animate, 'bottom', 'true')}
     `,
     false: margin => css`
       bottom: ${margin.bottom};
       left: ${margin.left};
       transform: translateY(0);
-      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
+      ${props => getAnimationStyle(props.animate, 'bottom', 'true')}
     `,
   },
 };

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -197,6 +197,16 @@ const KEYFRAMES = {
   },
 };
 
+const getKeyframes = (animate, position, full) => {
+  if (animate === "true") {
+    return css`${KEYFRAMES[position][full]} 0.2s ease-in-out forwards` ;
+  }
+  if (animate === "false") {
+    return 'none';
+  }
+  return css`${KEYFRAMES[position][full]} ${animate}`;
+} 
+
 // POSITIONS combines 'position', 'full', and 'margin' properties, since
 // they are all interdependent.
 // Basically, non-full axes combine 50% position with -50% translation.
@@ -210,27 +220,27 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       left: 50%;
       transform: translateX(-50%);
-      animation: ${KEYFRAMES.center.vertical} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "center", "vertical")}
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.right};
       top: 50%;
       transform: translateY(-50%);
-      animation: ${KEYFRAMES.center.horizontal} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "center", "horizontal")}
     `,
     true: margin => css`
       top: ${margin.top};
       bottom: ${margin.bottom};
       left: ${margin.left};
       right: ${margin.right};
-      animation: ${KEYFRAMES.center.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "center", "true")}
     `,
     false: () => css`
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
-      animation: ${KEYFRAMES.center.false} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "center", "false")}
     `,
   },
 
@@ -240,14 +250,14 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       left: 50%;
       transform: translate(-50%, 0%);
-      animation: ${KEYFRAMES.top.vertical} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "top", "vertical")}
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.right};
       top: ${margin.top};
       transform: translateY(0);
-      animation: ${KEYFRAMES.top.horizontal} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "top", "horizontal")}
     `,
     true: margin => css`
       top: ${margin.top};
@@ -255,13 +265,13 @@ const POSITIONS = {
       left: ${margin.left};
       right: ${margin.right};
       transform: translateY(0);
-      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "top", "true")}
     `,
     false: margin => css`
       top: ${margin.top};
       left: 50%;
       transform: translate(-50%, 0);
-      animation: ${KEYFRAMES.top.false} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "top", "false")}
     `,
   },
 
@@ -271,14 +281,14 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       left: 50%;
       transform: translate(-50%, 0);
-      animation: ${KEYFRAMES.bottom.vertical} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "bottom", "vertical")}
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.top};
       bottom: ${margin.bottom};
       transform: translateY(0);
-      animation: ${KEYFRAMES.bottom.horizontal} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "bottom", "horizontal")}
     `,
     true: margin => css`
       top: ${margin.top};
@@ -286,13 +296,13 @@ const POSITIONS = {
       left: ${margin.left};
       right: ${margin.right};
       transform: translateY(0);
-      animation: ${KEYFRAMES.bottom.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
     `,
     false: margin => css`
       bottom: ${margin.bottom};
       left: 50%;
       transform: translate(-50%, 0);
-      animation: ${KEYFRAMES.bottom.false} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "bottom", "false")}
     `,
   },
 
@@ -302,14 +312,14 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       left: ${margin.left};
       transform: translateX(0);
-      animation: ${KEYFRAMES.left.vertical} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "left", "vertical")}
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.right};
       top: 50%;
       transform: translate(0, -50%);
-      animation: ${KEYFRAMES.left.horizontal} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "left", "horizontal")}
     `,
     true: margin => css`
       top: ${margin.top};
@@ -317,13 +327,13 @@ const POSITIONS = {
       left: ${margin.left};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${KEYFRAMES.left.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "left", "true")}
     `,
     false: margin => css`
       left: ${margin.left};
       top: 50%;
       transform: translate(0, -50%);
-      animation: ${KEYFRAMES.left.false} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "left", "false")}
     `,
   },
 
@@ -333,14 +343,14 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${KEYFRAMES.right.vertical} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "right", "vertical")}
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.right};
       top: 50%;
       transform: translate(0, -50%);
-      animation: ${KEYFRAMES.right.horizontal} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "right", "horizontal")}
     `,
     true: margin => css`
       top: ${margin.top};
@@ -348,13 +358,13 @@ const POSITIONS = {
       left: ${margin.left};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${KEYFRAMES.right.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "right", "true")}
     `,
     false: margin => css`
       right: ${margin.right};
       top: 50%;
       transform: translate(0, -50%);
-      animation: ${KEYFRAMES.right.false} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "right", "false")}
     `,
   },
 
@@ -364,14 +374,14 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "top", "true")};
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.right};
       top: 0;
       transform: translateX(0);
-      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "top", "true")};
     `,
     true: margin => css`
       top: ${margin.top};
@@ -379,13 +389,13 @@ const POSITIONS = {
       left: ${margin.left};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "top", "true")};
     `,
     false: margin => css`
       top: ${margin.top};
       right: ${margin.right};
       transform: translateY(0);
-      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "top", "true")};
     `,
   },
 
@@ -395,14 +405,14 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       left: ${margin.left};
       transform: translateX(0);
-      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "top", "true")}
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.right};
       top: 0;
       transform: translateX(0);
-      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "top", "true")}
     `,
     true: margin => css`
       top: ${margin.top};
@@ -410,13 +420,13 @@ const POSITIONS = {
       left: ${margin.left};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "top", "true")}
     `,
     false: margin => css`
       top: ${margin.top};
       left: ${margin.left};
       transform: translateY(0);
-      animation: ${KEYFRAMES.top.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "top", "true")}
     `,
   },
 
@@ -426,14 +436,14 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${KEYFRAMES.bottom.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.right};
       bottom: ${margin.bottom};
       transform: translateY(0);
-      animation: ${KEYFRAMES.bottom.horizontal} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
     `,
     true: margin => css`
       top: ${margin.top};
@@ -441,13 +451,13 @@ const POSITIONS = {
       left: ${margin.left};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${KEYFRAMES.bottom.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
     `,
     false: margin => css`
       bottom: ${margin.bottom};
       right: ${margin.right};
       transform: translateY(0);
-      animation: ${KEYFRAMES.bottom.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
     `,
   },
 
@@ -457,14 +467,14 @@ const POSITIONS = {
       bottom: ${margin.bottom};
       left: ${margin.left};
       transform: translateX(0);
-      animation: ${KEYFRAMES.bottom.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
     `,
     horizontal: margin => css`
       left: ${margin.left};
       right: ${margin.right};
       bottom: ${margin.bottom};
       transform: translateY(0);
-      animation: ${KEYFRAMES.bottom.horizontal} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
     `,
     true: margin => css`
       top: ${margin.top};
@@ -472,13 +482,13 @@ const POSITIONS = {
       left: ${margin.left};
       right: ${margin.right};
       transform: translateX(0);
-      animation: ${KEYFRAMES.bottom.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
     `,
     false: margin => css`
       bottom: ${margin.bottom};
       left: ${margin.left};
       transform: translateY(0);
-      animation: ${KEYFRAMES.bottom.true} 0.2s ease-in-out forwards;
+      animation: ${props => getKeyframes(props.animate, "bottom", "true")}
     `,
   },
 };

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -885,7 +885,7 @@ exports[`Layer hidden 3`] = `
     class="StyledLayer__StyledOverlay-rmtehz-1 gVTfaV"
   />
   <div
-    class="StyledLayer__StyledContainer-rmtehz-2 bwhceh"
+    class="StyledLayer__StyledContainer-rmtehz-2 OHbxU"
     id="hidden-test"
   >
     <a

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -64,8 +64,8 @@ exports[`Layer custom margin 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm;
-  animation: bBMZdm;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c3 {
@@ -165,8 +165,8 @@ exports[`Layer dark context 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm;
-  animation: bBMZdm;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c1 {
@@ -287,8 +287,8 @@ exports[`Layer full false 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm;
-  animation: bBMZdm;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c3 {
@@ -422,8 +422,8 @@ exports[`Layer full horizontal 1`] = `
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  -webkit-animation: dcHpVA;
-  animation: dcHpVA;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c3 {
@@ -555,8 +555,8 @@ exports[`Layer full true 1`] = `
   bottom: 0px;
   left: 0px;
   right: 0px;
-  -webkit-animation: aUlIN;
-  animation: aUlIN;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c3 {
@@ -690,8 +690,8 @@ exports[`Layer full vertical 1`] = `
   -webkit-transform: translateX(-50%);
   -ms-transform: translateX(-50%);
   transform: translateX(-50%);
-  -webkit-animation: XCWMt;
-  animation: XCWMt;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c3 {
@@ -885,7 +885,7 @@ exports[`Layer hidden 3`] = `
     class="StyledLayer__StyledOverlay-rmtehz-1 gVTfaV"
   />
   <div
-    class="StyledLayer__StyledContainer-rmtehz-2 hsQxOj"
+    class="StyledLayer__StyledContainer-rmtehz-2 gvgFWT"
     id="hidden-test"
   >
     <a
@@ -995,8 +995,8 @@ exports[`Layer margin large 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm;
-  animation: bBMZdm;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c3 {
@@ -1129,8 +1129,8 @@ exports[`Layer margin medium 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm;
-  animation: bBMZdm;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c3 {
@@ -1263,8 +1263,8 @@ exports[`Layer margin none 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm;
-  animation: bBMZdm;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c3 {
@@ -1397,8 +1397,8 @@ exports[`Layer margin small 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm;
-  animation: bBMZdm;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c3 {
@@ -1531,8 +1531,8 @@ exports[`Layer margin xsmall 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm;
-  animation: bBMZdm;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c3 {
@@ -1632,8 +1632,8 @@ exports[`Layer non-modal 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm;
-  animation: bBMZdm;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c1 {
@@ -1738,8 +1738,8 @@ exports[`Layer plain 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm;
-  animation: bBMZdm;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c3 {
@@ -1872,8 +1872,8 @@ exports[`Layer position bottom 1`] = `
   -webkit-transform: translate(-50%,0);
   -ms-transform: translate(-50%,0);
   transform: translate(-50%,0);
-  -webkit-animation: jsmUBO;
-  animation: jsmUBO;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c3 {
@@ -2006,8 +2006,8 @@ exports[`Layer position center 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm;
-  animation: bBMZdm;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c3 {
@@ -2140,8 +2140,8 @@ exports[`Layer position left 1`] = `
   -webkit-transform: translate(0,-50%);
   -ms-transform: translate(0,-50%);
   transform: translate(0,-50%);
-  -webkit-animation: fNWKbM;
-  animation: fNWKbM;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c3 {
@@ -2274,8 +2274,8 @@ exports[`Layer position right 1`] = `
   -webkit-transform: translate(0,-50%);
   -ms-transform: translate(0,-50%);
   transform: translate(0,-50%);
-  -webkit-animation: lhngOP;
-  animation: lhngOP;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c3 {
@@ -2408,8 +2408,8 @@ exports[`Layer position top 1`] = `
   -webkit-transform: translate(-50%,0);
   -ms-transform: translate(-50%,0);
   transform: translate(-50%,0);
-  -webkit-animation: bAkQbM;
-  animation: bAkQbM;
+  -webkit-animation: none;
+  animation: none;
 }
 
 .c3 {

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -885,7 +885,7 @@ exports[`Layer hidden 3`] = `
     class="StyledLayer__StyledOverlay-rmtehz-1 gVTfaV"
   />
   <div
-    class="StyledLayer__StyledContainer-rmtehz-2 OHbxU"
+    class="StyledLayer__StyledContainer-rmtehz-2 bwhceh"
     id="hidden-test"
   >
     <a

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -64,8 +64,8 @@ exports[`Layer custom margin 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
+  animation: bBMZdm 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -165,8 +165,8 @@ exports[`Layer dark context 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
+  animation: bBMZdm 0.2s ease-in-out forwards;
 }
 
 .c1 {
@@ -287,8 +287,8 @@ exports[`Layer full false 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
+  animation: bBMZdm 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -422,8 +422,8 @@ exports[`Layer full horizontal 1`] = `
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: dcHpVA 0.2s ease-in-out forwards;
+  animation: dcHpVA 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -555,8 +555,8 @@ exports[`Layer full true 1`] = `
   bottom: 0px;
   left: 0px;
   right: 0px;
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: aUlIN 0.2s ease-in-out forwards;
+  animation: aUlIN 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -690,8 +690,8 @@ exports[`Layer full vertical 1`] = `
   -webkit-transform: translateX(-50%);
   -ms-transform: translateX(-50%);
   transform: translateX(-50%);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: XCWMt 0.2s ease-in-out forwards;
+  animation: XCWMt 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -885,7 +885,7 @@ exports[`Layer hidden 3`] = `
     class="StyledLayer__StyledOverlay-rmtehz-1 gVTfaV"
   />
   <div
-    class="StyledLayer__StyledContainer-rmtehz-2 gvgFWT"
+    class="StyledLayer__StyledContainer-rmtehz-2 OHbxU"
     id="hidden-test"
   >
     <a
@@ -995,8 +995,8 @@ exports[`Layer margin large 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
+  animation: bBMZdm 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -1129,8 +1129,8 @@ exports[`Layer margin medium 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
+  animation: bBMZdm 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -1263,8 +1263,8 @@ exports[`Layer margin none 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
+  animation: bBMZdm 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -1397,8 +1397,8 @@ exports[`Layer margin small 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
+  animation: bBMZdm 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -1531,8 +1531,8 @@ exports[`Layer margin xsmall 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
+  animation: bBMZdm 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -1632,8 +1632,8 @@ exports[`Layer non-modal 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
+  animation: bBMZdm 0.2s ease-in-out forwards;
 }
 
 .c1 {
@@ -1738,8 +1738,8 @@ exports[`Layer plain 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
+  animation: bBMZdm 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -1872,8 +1872,8 @@ exports[`Layer position bottom 1`] = `
   -webkit-transform: translate(-50%,0);
   -ms-transform: translate(-50%,0);
   transform: translate(-50%,0);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: jsmUBO 0.2s ease-in-out forwards;
+  animation: jsmUBO 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -2006,8 +2006,8 @@ exports[`Layer position center 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
+  animation: bBMZdm 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -2140,8 +2140,8 @@ exports[`Layer position left 1`] = `
   -webkit-transform: translate(0,-50%);
   -ms-transform: translate(0,-50%);
   transform: translate(0,-50%);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: fNWKbM 0.2s ease-in-out forwards;
+  animation: fNWKbM 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -2274,8 +2274,8 @@ exports[`Layer position right 1`] = `
   -webkit-transform: translate(0,-50%);
   -ms-transform: translate(0,-50%);
   transform: translate(0,-50%);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: lhngOP 0.2s ease-in-out forwards;
+  animation: lhngOP 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -2408,8 +2408,8 @@ exports[`Layer position top 1`] = `
   -webkit-transform: translate(-50%,0);
   -ms-transform: translate(-50%,0);
   transform: translate(-50%,0);
-  -webkit-animation: none;
-  animation: none;
+  -webkit-animation: bAkQbM 0.2s ease-in-out forwards;
+  animation: bAkQbM 0.2s ease-in-out forwards;
 }
 
 .c3 {

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -64,8 +64,8 @@ exports[`Layer custom margin 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
-  animation: bBMZdm 0.2s ease-in-out forwards;
+  -webkit-animation: bBMZdm;
+  animation: bBMZdm;
 }
 
 .c3 {
@@ -165,8 +165,8 @@ exports[`Layer dark context 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
-  animation: bBMZdm 0.2s ease-in-out forwards;
+  -webkit-animation: bBMZdm;
+  animation: bBMZdm;
 }
 
 .c1 {
@@ -287,8 +287,8 @@ exports[`Layer full false 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
-  animation: bBMZdm 0.2s ease-in-out forwards;
+  -webkit-animation: bBMZdm;
+  animation: bBMZdm;
 }
 
 .c3 {
@@ -422,8 +422,8 @@ exports[`Layer full horizontal 1`] = `
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  -webkit-animation: dcHpVA 0.2s ease-in-out forwards;
-  animation: dcHpVA 0.2s ease-in-out forwards;
+  -webkit-animation: dcHpVA;
+  animation: dcHpVA;
 }
 
 .c3 {
@@ -555,8 +555,8 @@ exports[`Layer full true 1`] = `
   bottom: 0px;
   left: 0px;
   right: 0px;
-  -webkit-animation: aUlIN 0.2s ease-in-out forwards;
-  animation: aUlIN 0.2s ease-in-out forwards;
+  -webkit-animation: aUlIN;
+  animation: aUlIN;
 }
 
 .c3 {
@@ -690,8 +690,8 @@ exports[`Layer full vertical 1`] = `
   -webkit-transform: translateX(-50%);
   -ms-transform: translateX(-50%);
   transform: translateX(-50%);
-  -webkit-animation: XCWMt 0.2s ease-in-out forwards;
-  animation: XCWMt 0.2s ease-in-out forwards;
+  -webkit-animation: XCWMt;
+  animation: XCWMt;
 }
 
 .c3 {
@@ -885,7 +885,7 @@ exports[`Layer hidden 3`] = `
     class="StyledLayer__StyledOverlay-rmtehz-1 gVTfaV"
   />
   <div
-    class="StyledLayer__StyledContainer-rmtehz-2 bwhceh"
+    class="StyledLayer__StyledContainer-rmtehz-2 hsQxOj"
     id="hidden-test"
   >
     <a
@@ -995,8 +995,8 @@ exports[`Layer margin large 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
-  animation: bBMZdm 0.2s ease-in-out forwards;
+  -webkit-animation: bBMZdm;
+  animation: bBMZdm;
 }
 
 .c3 {
@@ -1129,8 +1129,8 @@ exports[`Layer margin medium 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
-  animation: bBMZdm 0.2s ease-in-out forwards;
+  -webkit-animation: bBMZdm;
+  animation: bBMZdm;
 }
 
 .c3 {
@@ -1263,8 +1263,8 @@ exports[`Layer margin none 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
-  animation: bBMZdm 0.2s ease-in-out forwards;
+  -webkit-animation: bBMZdm;
+  animation: bBMZdm;
 }
 
 .c3 {
@@ -1397,8 +1397,8 @@ exports[`Layer margin small 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
-  animation: bBMZdm 0.2s ease-in-out forwards;
+  -webkit-animation: bBMZdm;
+  animation: bBMZdm;
 }
 
 .c3 {
@@ -1531,8 +1531,8 @@ exports[`Layer margin xsmall 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
-  animation: bBMZdm 0.2s ease-in-out forwards;
+  -webkit-animation: bBMZdm;
+  animation: bBMZdm;
 }
 
 .c3 {
@@ -1632,8 +1632,8 @@ exports[`Layer non-modal 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
-  animation: bBMZdm 0.2s ease-in-out forwards;
+  -webkit-animation: bBMZdm;
+  animation: bBMZdm;
 }
 
 .c1 {
@@ -1738,8 +1738,8 @@ exports[`Layer plain 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
-  animation: bBMZdm 0.2s ease-in-out forwards;
+  -webkit-animation: bBMZdm;
+  animation: bBMZdm;
 }
 
 .c3 {
@@ -1872,8 +1872,8 @@ exports[`Layer position bottom 1`] = `
   -webkit-transform: translate(-50%,0);
   -ms-transform: translate(-50%,0);
   transform: translate(-50%,0);
-  -webkit-animation: jsmUBO 0.2s ease-in-out forwards;
-  animation: jsmUBO 0.2s ease-in-out forwards;
+  -webkit-animation: jsmUBO;
+  animation: jsmUBO;
 }
 
 .c3 {
@@ -2006,8 +2006,8 @@ exports[`Layer position center 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
-  animation: bBMZdm 0.2s ease-in-out forwards;
+  -webkit-animation: bBMZdm;
+  animation: bBMZdm;
 }
 
 .c3 {
@@ -2140,8 +2140,8 @@ exports[`Layer position left 1`] = `
   -webkit-transform: translate(0,-50%);
   -ms-transform: translate(0,-50%);
   transform: translate(0,-50%);
-  -webkit-animation: fNWKbM 0.2s ease-in-out forwards;
-  animation: fNWKbM 0.2s ease-in-out forwards;
+  -webkit-animation: fNWKbM;
+  animation: fNWKbM;
 }
 
 .c3 {
@@ -2274,8 +2274,8 @@ exports[`Layer position right 1`] = `
   -webkit-transform: translate(0,-50%);
   -ms-transform: translate(0,-50%);
   transform: translate(0,-50%);
-  -webkit-animation: lhngOP 0.2s ease-in-out forwards;
-  animation: lhngOP 0.2s ease-in-out forwards;
+  -webkit-animation: lhngOP;
+  animation: lhngOP;
 }
 
 .c3 {
@@ -2408,8 +2408,8 @@ exports[`Layer position top 1`] = `
   -webkit-transform: translate(-50%,0);
   -ms-transform: translate(-50%,0);
   transform: translate(-50%,0);
-  -webkit-animation: bAkQbM 0.2s ease-in-out forwards;
-  animation: bAkQbM 0.2s ease-in-out forwards;
+  -webkit-animation: bAkQbM;
+  animation: bAkQbM;
 }
 
 .c3 {

--- a/src/js/components/Layer/doc.js
+++ b/src/js/components/Layer/doc.js
@@ -17,6 +17,12 @@ export const doc = Layer => {
     );
 
   DocumentedLayer.propTypes = {
+    animate: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
+    ])
+      .description('Transition content in & out with a slide down animation.')
+      .defaultValue(true),
     full: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.oneOf(['vertical', 'horizontal']),

--- a/src/js/components/Layer/doc.js
+++ b/src/js/components/Layer/doc.js
@@ -17,7 +17,7 @@ export const doc = Layer => {
     );
 
   DocumentedLayer.propTypes = {
-    animate: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+    animate: PropTypes.bool
       .description('Animation transition of the Layer content when it opens.')
       .defaultValue(true),
     full: PropTypes.oneOfType([

--- a/src/js/components/Layer/doc.js
+++ b/src/js/components/Layer/doc.js
@@ -17,11 +17,8 @@ export const doc = Layer => {
     );
 
   DocumentedLayer.propTypes = {
-    animate: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.string,
-    ])
-      .description('Transition content in & out with a slide down animation.')
+    animate: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+      .description('Animation transition of the Layer content when it opens.')
       .defaultValue(true),
     full: PropTypes.oneOfType([
       PropTypes.bool,

--- a/src/js/components/Layer/index.d.ts
+++ b/src/js/components/Layer/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 export interface LayerProps {
+  animate?: boolean | string;
   full?: boolean | "vertical" | "horizontal";
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string} | string;
   modal?: boolean;

--- a/src/js/components/Layer/index.d.ts
+++ b/src/js/components/Layer/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 export interface LayerProps {
-  animate?: boolean | string;
+  animate?: boolean;
   full?: boolean | "vertical" | "horizontal";
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string} | string;
   modal?: boolean;

--- a/src/js/components/Layer/layer.stories.js
+++ b/src/js/components/Layer/layer.stories.js
@@ -133,7 +133,7 @@ class CornerLayer extends Component {
           />
         </Box>
         {open && (
-          <Layer position="top-right">
+          <Layer position="top-right" animate="0.6s ease-in-out forwards">
             <Box height="small" overflow="auto">
               <Box pad="xlarge">Corner top-right position</Box>
             </Box>

--- a/src/js/components/Layer/layer.stories.js
+++ b/src/js/components/Layer/layer.stories.js
@@ -133,7 +133,7 @@ class CornerLayer extends Component {
           />
         </Box>
         {open && (
-          <Layer position="top-right" animate="0.6s ease-in-out forwards">
+          <Layer position="top-right">
             <Box height="small" overflow="auto">
               <Box pad="xlarge">Corner top-right position</Box>
             </Box>

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4515,7 +4515,7 @@ import { Layer } from 'grommet';
 
 **animate**
 
-Transition content in & out with a slide down animation. Defaults to \`true\`.
+Animation transition of the Layer content when it opens. Defaults to \`true\`.
 
 \`\`\`
 boolean

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4519,7 +4519,6 @@ Animation transition of the Layer content when it opens. Defaults to \`true\`.
 
 \`\`\`
 boolean
-string
 \`\`\`
 
 **full**

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4513,6 +4513,15 @@ import { Layer } from 'grommet';
 
 ## Properties
 
+**animate**
+
+Transition content in & out with a slide down animation. Defaults to \`true\`.
+
+\`\`\`
+boolean
+string
+\`\`\`
+
 **full**
 
 Whether the width and/or height should fill the current viewport size.

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -439,7 +439,7 @@ export { Keyboard };
   "Layer": "import * as React from \\"react\\";
 
 export interface LayerProps {
-  animate?: boolean | string;
+  animate?: boolean;
   full?: boolean | \\"vertical\\" | \\"horizontal\\";
   margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | {bottom?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | string,horizontal?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | string,left?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | string,right?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | string,top?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | string,vertical?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | string} | string;
   modal?: boolean;

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -439,6 +439,7 @@ export { Keyboard };
   "Layer": "import * as React from \\"react\\";
 
 export interface LayerProps {
+  animate?: boolean | string;
   full?: boolean | \\"vertical\\" | \\"horizontal\\";
   margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | {bottom?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | string,horizontal?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | string,left?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | string,right?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | string,top?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | string,vertical?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | string} | string;
   modal?: boolean;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Allowing animation to be customized on Layer
`true`- allows animation
`false` - disables
`string` - customized animation
#### Where should the reviewer start?
doc.js and StyledLayer.js
#### What testing has been done on this PR?
storybook (use cornerLayer)
#### How should this be manually tested?
storybook (you can use the existing prop on use cornerLayer)
#### Any background context you want to provide?
nop
#### What are the relevant issues?
#2578 
#### Screenshots (if appropriate)
n/a
#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible