### PR TITLE
Added findDOMNode back for infinite scroll.

### DIFF
--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2398,30 +2398,87 @@ exports[`DataTable sort 2`] = `
     <tbody
       class="StyledDataTable__StyledDataTableBody-xrlyjm-2 hbZQKY"
     >
-      <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws"
+      .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+<tr
+        class=""
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
+          class="c0"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eAAZJM"
+            class="c1"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 fWSbXS"
+              class="c2"
             >
               one
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
+          class="c0"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eAAZJM"
+            class="c1"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 fWSbXS"
+              class="c2"
             >
               1
             </span>
@@ -2458,30 +2515,87 @@ exports[`DataTable sort 2`] = `
           </div>
         </td>
       </tr>
-      <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws"
+      .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+<tr
+        class=""
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
+          class="c0"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eAAZJM"
+            class="c1"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 fWSbXS"
+              class="c2"
             >
               zero
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
+          class="c0"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eAAZJM"
+            class="c1"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 fWSbXS"
+              class="c2"
             >
               0
             </span>

--- a/src/js/components/InfiniteScroll/InfiniteScroll.js
+++ b/src/js/components/InfiniteScroll/InfiniteScroll.js
@@ -1,4 +1,5 @@
 import React, { createRef, PureComponent } from 'react';
+import { findDOMNode } from 'react-dom';
 import { findScrollParents } from '../../utils';
 import { Box } from '../Box';
 
@@ -87,8 +88,12 @@ class InfiniteScroll extends PureComponent {
   setPageHeight = () => {
     const { pageHeight } = this.state;
     if (this.firstPageItemRef && this.lastPageItemRef && !pageHeight) {
-      const beginRect = this.firstPageItemRef.getBoundingClientRect();
-      const endRect = this.lastPageItemRef.getBoundingClientRect();
+      /* eslint-disable react/no-find-dom-node */
+      const beginRect = findDOMNode(
+        this.firstPageItemRef,
+      ).getBoundingClientRect();
+      const endRect = findDOMNode(this.lastPageItemRef).getBoundingClientRect();
+      /* eslint-enable react/no-find-dom-node */
       const nextPageHeight = endRect.y + endRect.height - beginRect.y;
       // In case the pageHeight is smaller than the visible area,
       // we call onScroll to set the page boundaries appropriately.

--- a/src/js/components/InfiniteScroll/infinitescroll.stories.js
+++ b/src/js/components/InfiniteScroll/infinitescroll.stories.js
@@ -27,6 +27,29 @@ const SimpleInfiniteScroll = props => (
   </Grommet>
 );
 
+/* eslint-disable react/prefer-stateless-function */
+class MyItem extends Component {
+  render() {
+    const { item } = this.props;
+    return (
+      <Box pad="medium" border={{ side: 'bottom' }} align="center">
+        <Text>{item}</Text>
+      </Box>
+    );
+  }
+}
+/* eslint-enable react/prefer-stateless-function */
+
+const ClassChildrenInfiniteScroll = props => (
+  <Grommet theme={grommet}>
+    <Box>
+      <InfiniteScroll items={allItems} {...props}>
+        {item => <MyItem key={item} item={item} />}
+      </InfiniteScroll>
+    </Box>
+  </Grommet>
+);
+
 class LazyInfiniteScroll extends Component {
   state = { items: allItems.slice(0, 200) };
 
@@ -73,4 +96,5 @@ storiesOf('InfiniteScroll', module)
     />
   ))
   .add('Replace', () => <SimpleInfiniteScroll replace />)
-  .add('onMore', () => <LazyInfiniteScroll />);
+  .add('onMore', () => <LazyInfiniteScroll />)
+  .add('Class Children', () => <ClassChildrenInfiniteScroll />);

--- a/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
+++ b/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
@@ -50,7 +50,7 @@ describe('MaskedInput', () => {
       expect(onChange).not.toBeCalled();
       expect(onFocus).toBeCalled();
       done();
-    }, 100);
+    }, 300);
   });
 
   test('option via mouse', done => {
@@ -87,7 +87,7 @@ describe('MaskedInput', () => {
         expect.objectContaining({ target: { value: 'aa!' } }),
       );
       done();
-    }, 100);
+    }, 300);
   });
 
   test('option via keyboard', done => {
@@ -125,7 +125,7 @@ describe('MaskedInput', () => {
         expect.objectContaining({ target: { value: 'aa!' } }),
       );
       done();
-    }, 100);
+    }, 300);
   });
 
   test('next and previous without options', done => {
@@ -159,6 +159,6 @@ describe('MaskedInput', () => {
       expect(onChange).not.toBeCalled();
       expect(container.firstChild).toMatchSnapshot();
       done();
-    }, 100);
+    }, 300);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Brings back findDOMNode for InifiniteScroll to avoid a regression issue.
#### Where should the reviewer start?
inifinitescroll.js
#### What testing has been done on this PR?
manual

#### How should this be manually tested?
run `Class Children` example in storybook
#### Any background context you want to provide?

#### What are the relevant issues?
Closes #2600 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards