### PR TITLE
Enables px value for size in Box's round prop

### DIFF
--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -222,11 +222,13 @@ const roundStyle = (data, responsive, theme) => {
   const styles = [];
   if (typeof data === 'object') {
     const size =
-      ROUND_MAP[data.size] || theme.global.edgeSize[data.size || 'medium'];
+      ROUND_MAP[data.size] ||
+      theme.global.edgeSize[data.size || 'medium'] ||
+      data.size;
     const responsiveSize =
       breakpoint &&
       breakpoint.edgeSize[data.size] &&
-      breakpoint.edgeSize[data.size];
+      (breakpoint.edgeSize[data.size] || data.size);
     if (data.corner === 'top') {
       styles.push(css`
         border-top-left-radius: ${size};

--- a/src/js/components/Box/box.stories.js
+++ b/src/js/components/Box/box.stories.js
@@ -150,6 +150,13 @@ const RoundBox = () => (
             {corner}
           </Box>
         ))}
+        <Box
+          background="brand"
+          pad="small"
+          round={{ corner: 'left', size: '15px' }}
+        >
+          left rounded corner px value
+        </Box>
       </Grid>
     </Box>
   </Grommet>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR allows Box to accept a px value for size in the round prop.

#### Where should the reviewer start?

StyledBox

#### What testing has been done on this PR?

Manual

#### How should this be manually tested?

Open Box > "Round" story in Storybook

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #2602 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Yes

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible
