### PR TITLE
[Meter] fix bug not allowing to set custom thickness size

### DIFF
--- a/src/js/components/Meter/Bar.js
+++ b/src/js/components/Meter/Bar.js
@@ -22,7 +22,9 @@ const Bar = props => {
   } = props;
   const width =
     size === 'full' ? 288 : parseMetricToNum(theme.global.size[size]);
-  const height = parseMetricToNum(theme.global.edgeSize[thickness]);
+  const height = parseMetricToNum(
+    theme.global.edgeSize[thickness] || thickness,
+  );
   // account for the round cap, if any
   const capOffset = round ? height / 2 : 0;
   const mid = height / 2;

--- a/src/js/components/Meter/Circle.js
+++ b/src/js/components/Meter/Circle.js
@@ -22,7 +22,9 @@ const Circle = props => {
   } = props;
   const width =
     size === 'full' ? 288 : parseMetricToNum(theme.global.size[size]);
-  const height = parseMetricToNum(theme.global.edgeSize[thickness]);
+  const height = parseMetricToNum(
+    theme.global.edgeSize[thickness] || thickness,
+  );
   const mid = width / 2;
   const radius = width / 2 - height / 2;
   const anglePer = 360 / max;

--- a/src/js/components/Meter/__tests__/Meter-test.js
+++ b/src/js/components/Meter/__tests__/Meter-test.js
@@ -87,11 +87,13 @@ describe('Meter', () => {
         <Meter thickness="medium" values={VALUES} />
         <Meter thickness="large" values={VALUES} />
         <Meter thickness="xlarge" values={VALUES} />
+        <Meter thickness="55px" values={VALUES} />
         <Meter type="circle" thickness="xsmall" values={VALUES} />
         <Meter type="circle" thickness="small" values={VALUES} />
         <Meter type="circle" thickness="medium" values={VALUES} />
         <Meter type="circle" thickness="large" values={VALUES} />
         <Meter type="circle" thickness="xlarge" values={VALUES} />
+        <Meter type="circle" thickness="55px" values={VALUES} />
       </Grommet>,
     );
     const tree = component.toJSON();

--- a/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
+++ b/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
@@ -852,6 +852,31 @@ exports[`Meter thickness 1`] = `
   </svg>
   <svg
     className="c1"
+    height={55}
+    preserveAspectRatio="none"
+    viewBox="0 0 384 55"
+    width={384}
+  >
+    <path
+      d="M 0,27.5 L 384,27.5"
+      fill="none"
+      stroke="#F2F2F2"
+      strokeLinecap="square"
+      strokeOpacity="0.4"
+      strokeWidth={55}
+    />
+    <path
+      d="M 0,27.5 L 76.8,27.5"
+      fill="none"
+      onMouseLeave={[Function]}
+      onMouseOver={[Function]}
+      stroke="#6FFFB0"
+      strokeLinecap="butt"
+      strokeWidth={55}
+    />
+  </svg>
+  <svg
+    className="c1"
     height={384}
     viewBox="0 0 384 384"
     width={384}
@@ -978,6 +1003,32 @@ exports[`Meter thickness 1`] = `
       stroke="#6FFFB0"
       strokeLinecap="butt"
       strokeWidth={96}
+    />
+  </svg>
+  <svg
+    className="c1"
+    height={384}
+    viewBox="0 0 384 384"
+    width={384}
+  >
+    <circle
+      cx={192}
+      cy={192}
+      fill="none"
+      r={164.5}
+      stroke="#F2F2F2"
+      strokeLinecap="square"
+      strokeOpacity="0.4"
+      strokeWidth={55}
+    />
+    <path
+      d="M 348.4487969306 141.1667044253 A 164.5000000000 164.5000000000 0 0 0 192.0000000000 27.5000000000"
+      fill="none"
+      onMouseLeave={[Function]}
+      onMouseOver={[Function]}
+      stroke="#6FFFB0"
+      strokeLinecap="butt"
+      strokeWidth={55}
     />
   </svg>
 </div>


### PR DESCRIPTION
Closes: #2585

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes a bug when setting thickness value
#### Where should the reviewer start?
Any of Bar or Circle. fix is identical
#### What testing has been done on this PR?
added unit-test. i also tested manually on storybook but didnt add a story (should I?) 
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
#2585
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
nope
#### Should this PR be mentioned in the release notes?
maybe
#### Is this change backwards compatible or is it a breaking change?
compatible