### PR TITLE
Add ability to configure font-weight by heading level in the theme

### DIFF
--- a/src/js/components/Heading/StyledHeading.js
+++ b/src/js/components/Heading/StyledHeading.js
@@ -15,7 +15,7 @@ const sizeStyle = props => {
         font-size: ${data.size};
         line-height: ${data.height};
         max-width: ${data.maxWidth};
-        font-weight: ${headingTheme.weight};
+        font-weight: ${levelStyle.font.weight || headingTheme.weight};
       `,
     ];
     if (props.responsive && headingTheme.responsiveBreakpoint) {

--- a/src/js/components/Heading/__tests__/Heading-test.js
+++ b/src/js/components/Heading/__tests__/Heading-test.js
@@ -156,3 +156,38 @@ test('Theme based font family renders', () => {
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test('Theme based font weight renders', () => {
+  const customTheme = {
+    heading: {
+      weight: 600,
+      level: {
+        1: {
+          font: {
+            weight: '700',
+          },
+        },
+        2: {
+          font: {
+            weight: '400',
+          },
+        },
+        3: {
+          font: {
+            weight: '200',
+          },
+        },
+      },
+    },
+  };
+  const component = renderer.create(
+    <Grommet theme={customTheme}>
+      <Heading level={1} />
+      <Heading level={2} />
+      <Heading level={3} />
+      <Heading level={4} />
+    </Grommet>,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -862,6 +862,95 @@ exports[`Theme based font family renders 1`] = `
 </div>
 `;
 
+exports[`Theme based font weight renders 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
+.c1 {
+  font-size: 50px;
+  line-height: 56px;
+  max-width: 1200px;
+  font-weight: 700;
+}
+
+.c2 {
+  font-size: 34px;
+  line-height: 40px;
+  max-width: 816px;
+  font-weight: 400;
+}
+
+.c3 {
+  font-size: 22px;
+  line-height: 28px;
+  max-width: 528px;
+  font-weight: 200;
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    font-size: 34px;
+    line-height: 40px;
+    max-width: 816px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    font-size: 22px;
+    line-height: 28px;
+    max-width: 528px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <h1
+    className="c1"
+  />
+  <h2
+    className="c2"
+  />
+  <h3
+    className="c3"
+  />
+  <h4
+    className="c4"
+  />
+</div>
+`;
+
 exports[`responsive renders 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -499,6 +499,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         1: {
           font: {
             // family: undefined,
+            // weight: undefined,
           },
           small: { ...fontSizing(4) },
           medium: { ...fontSizing(8) },
@@ -508,6 +509,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         2: {
           font: {
             // family: undefined,
+            // weight: undefined,
           },
           small: { ...fontSizing(2) },
           medium: { ...fontSizing(4) },
@@ -517,6 +519,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         3: {
           font: {
             // family: undefined,
+            // weight: undefined,
           },
           small: { ...fontSizing(1) },
           medium: { ...fontSizing(1) },
@@ -526,6 +529,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         4: {
           font: {
             // family: undefined,
+            // weight: undefined,
           },
           small: { ...fontSizing(0) },
           medium: { ...fontSizing(0) },


### PR DESCRIPTION
Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds a font-weight per heading functionnality in the theme
#### Where should the reviewer start?

#### What testing has been done on this PR?
add a unit test
#### How should this be manually tested?

#### Any background context you want to provide?
#2606
#### What are the relevant issues?
#2606
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
well the font-family is not documented so not sure where to document this either :/
#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
compatible