### PR TITLE
[Box] add grow and shrink factor to flex property

### DIFF
--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -329,12 +329,16 @@ string
 
 **flex**
 
-Whether flex-grow and/or flex-shrink is true.
+Whether flex-grow and/or flex-shrink is true and at a desired factor.
 
 ```
 grow
 shrink
 boolean
+{
+  grow: number,
+  shrink: number
+}
 ```
 
 **fill**

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -99,9 +99,17 @@ const FLEX_MAP = {
   shrink: '0 1',
 };
 
+const flexGrowShrinkProp = flex => {
+  if (typeof flex === 'boolean' || typeof flex === 'string') {
+    return FLEX_MAP[flex];
+  }
+
+  return `${flex.grow ? flex.grow : 0} ${flex.shrink ? flex.shrink : 0}`;
+};
+
 const flexStyle = css`
   flex: ${props =>
-    `${FLEX_MAP[props.flex]}${
+    `${flexGrowShrinkProp(props.flex)}${
       props.flex !== true && !props.basis ? ' auto' : ''
     }`};
 `;

--- a/src/js/components/Box/__tests__/Box-test.js
+++ b/src/js/components/Box/__tests__/Box-test.js
@@ -188,6 +188,9 @@ describe('Box', () => {
           <Box flex={false} />
           <Box flex="grow" />
           <Box flex="shrink" />
+          <Box flex={{ grow: 2 }} />
+          <Box flex={{ shrink: 2 }} />
+          <Box flex={{ grow: 2, shrink: 2 }} />
         </Box>
       </Grommet>,
     );

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -3341,6 +3341,66 @@ exports[`Box flex 1`] = `
   padding: 0px;
 }
 
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 2 0 auto;
+  -ms-flex: 2 0 auto;
+  flex: 2 0 auto;
+  padding: 0px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 2 auto;
+  -ms-flex: 0 2 auto;
+  flex: 0 2 auto;
+  padding: 0px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 2 2 auto;
+  -ms-flex: 2 2 auto;
+  flex: 2 2 auto;
+  padding: 0px;
+}
+
 @media only screen and (max-width:768px) {
   .c1 {
     margin: 0px;
@@ -3397,6 +3457,42 @@ exports[`Box flex 1`] = `
 
 @media only screen and (max-width:768px) {
   .c5 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
     padding: 0px;
   }
 }
@@ -3418,6 +3514,15 @@ exports[`Box flex 1`] = `
     />
     <div
       className="c5"
+    />
+    <div
+      className="c6"
+    />
+    <div
+      className="c7"
+    />
+    <div
+      className="c8"
     />
   </div>
 </div>

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -157,7 +157,13 @@ export const doc = Box => {
     flex: PropTypes.oneOfType([
       PropTypes.oneOf(['grow', 'shrink']),
       PropTypes.bool,
-    ]).description('Whether flex-grow and/or flex-shrink is true.'),
+      PropTypes.shape({
+        grow: PropTypes.number,
+        shrink: PropTypes.number,
+      }),
+    ]).description(
+      'Whether flex-grow and/or flex-shrink is true and at a desired factor.',
+    ),
     fill: PropTypes.oneOfType([
       PropTypes.oneOf(['horizontal', 'vertical']),
       PropTypes.bool,

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -13,7 +13,7 @@ export interface BoxProps {
   border?: boolean | "top" | "left" | "bottom" | "right" | "horizontal" | "vertical" | "all" | {color?: string | {dark?: string,light?: string},side?: "top" | "left" | "bottom" | "right" | "horizontal" | "vertical" | "all",size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string,style?: "solid" | "dashed" | "dotted" | "double" | "groove" | "ridge" | "inset" | "outset" | "hidden"};
   direction?: "row" | "column" | "row-responsive";
   elevation?: "none" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
-  flex?: "grow" | "shrink" | boolean;
+  flex?: "grow" | "shrink" | boolean | {grow?: number,shrink?: number};
   fill?: "horizontal" | "vertical" | boolean;
   gap?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   height?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -824,12 +824,16 @@ string
 
 **flex**
 
-Whether flex-grow and/or flex-shrink is true.
+Whether flex-grow and/or flex-shrink is true and at a desired factor.
 
 \`\`\`
 grow
 shrink
 boolean
+{
+  grow: number,
+  shrink: number
+}
 \`\`\`
 
 **fill**

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -484,10 +484,14 @@ string",
         "name": "elevation",
       },
       Object {
-        "description": "Whether flex-grow and/or flex-shrink is true.",
+        "description": "Whether flex-grow and/or flex-shrink is true and at a desired factor.",
         "format": "grow
 shrink
-boolean",
+boolean
+{
+  grow: number,
+  shrink: number
+}",
         "name": "flex",
       },
       Object {

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -68,7 +68,7 @@ export interface BoxProps {
   border?: boolean | \\"top\\" | \\"left\\" | \\"bottom\\" | \\"right\\" | \\"horizontal\\" | \\"vertical\\" | \\"all\\" | {color?: string | {dark?: string,light?: string},side?: \\"top\\" | \\"left\\" | \\"bottom\\" | \\"right\\" | \\"horizontal\\" | \\"vertical\\" | \\"all\\",size?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,style?: \\"solid\\" | \\"dashed\\" | \\"dotted\\" | \\"double\\" | \\"groove\\" | \\"ridge\\" | \\"inset\\" | \\"outset\\" | \\"hidden\\"};
   direction?: \\"row\\" | \\"column\\" | \\"row-responsive\\";
   elevation?: \\"none\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string;
-  flex?: \\"grow\\" | \\"shrink\\" | boolean;
+  flex?: \\"grow\\" | \\"shrink\\" | boolean | {grow?: number,shrink?: number};
   fill?: \\"horizontal\\" | \\"vertical\\" | boolean;
   gap?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string;
   height?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string;


### PR DESCRIPTION
Closes: #2565

Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Add grow and shrink factor to flex property of Box component
I have one question though. i added shape to proptypes taking grow and shrink as optional parameters. Is there a way to force user to add at least one of the two? both being required seems not good to me but couldn't come up (fast) with an idea to force at least one of those.

#### Where should the reviewer start?
styled box
#### What testing has been done on this PR?
unit test
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
#2565

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
did it.

#### Should this PR be mentioned in the release notes?
maybe
#### Is this change backwards compatible or is it a breaking change?
compatible.