### PR TITLE
Can style the day button on Calendar component

### DIFF
--- a/src/js/components/Calendar/README.md
+++ b/src/js/components/Calendar/README.md
@@ -459,3 +459,13 @@ Defaults to
 ```
 undefined
 ```
+
+**calendar.day.extend**
+
+Any additional style for the day of Calendar. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```

--- a/src/js/components/Calendar/StyledCalendar.js
+++ b/src/js/components/Calendar/StyledCalendar.js
@@ -98,6 +98,7 @@ const StyledDay = styled.div`
       backgroundStyle({ color: 'control', opacity: 'weak' }, props.theme))}
   ${props => props.otherMonth && 'opacity: 0.5;'}
   ${props => props.isSelected && 'font-weight: bold;'}
+  ${props => props.theme.calendar && props.theme.calendar.day && props.theme.calendar.day.extend}
 `;
 
 StyledDay.defaultProps = {};

--- a/src/js/components/Calendar/doc.js
+++ b/src/js/components/Calendar/doc.js
@@ -203,4 +203,8 @@ export const themeDoc = {
     description: 'Any additional style for the Calendar.',
     type: 'string | (props) => {}',
   },
+  'calendar.day.extend': {
+    description: 'Any additional style for the day of Calendar.',
+    type: 'string | (props) => {}',
+  },
 };

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -2103,6 +2103,16 @@ Defaults to
 \`\`\`
 undefined
 \`\`\`
+
+**calendar.day.extend**
+
+Any additional style for the day of Calendar. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
 ",
   "Carousel": "## Carousel
 A carousel that cycles through children. Child components


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Add `calendar.day.extend` into theme

#### What testing has been done on this PR?
Can style the day button on calendar component
