### PR TITLE
Grid - add theme doc

### DIFF
--- a/src/js/components/Grid/README.md
+++ b/src/js/components/Grid/README.md
@@ -352,3 +352,55 @@ The DOM tag to use for the element. Defaults to `div`.
 string
 ```
   
+## Theme
+  
+**global.edgeSize**
+
+The possible sizes for the grid gap. Expects `object`.
+
+Defaults to
+
+```
+{
+      edgeSize: {
+        none: '0px',
+        hair: '1px',
+        xxsmall: '3px',
+        xsmall: '6px',
+        small: '12px',
+        medium: '24px',
+        large: '48px',
+        xlarge: '96px',
+        responsiveBreakpoint: 'small',
+      },
+    }
+```
+
+**global.size**
+
+The possible sizes for row and column. Expects `object`.
+
+Defaults to
+
+```
+{
+      xxsmall: '48px',
+      xsmall: '96px',
+      small: '192px',
+      medium: '384px',
+      large: '768px',
+      xlarge: '1152px',
+      xxlarge: '1536px',
+      full: '100%',
+    }
+```
+
+**grid.extend**
+
+Any additional style for the Grid. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -152,3 +152,42 @@ of indicating the DOM tag via the 'as' property.`,
 
   return DocumentedGrid;
 };
+
+export const themeDoc = {
+  'global.edgeSize': {
+    description: 'The possible sizes for the grid gap.',
+    type: 'object',
+    defaultValue: `{
+      edgeSize: {
+        none: '0px',
+        hair: '1px',
+        xxsmall: '3px',
+        xsmall: '6px',
+        small: '12px',
+        medium: '24px',
+        large: '48px',
+        xlarge: '96px',
+        responsiveBreakpoint: 'small',
+      },
+    }`,
+  },
+  'global.size': {
+    description: 'The possible sizes for row and column.',
+    type: 'object',
+    defaultValue: `{
+      xxsmall: '48px',
+      xsmall: '96px',
+      small: '192px',
+      medium: '384px',
+      large: '768px',
+      xlarge: '1152px',
+      xxlarge: '1536px',
+      full: '100%',
+    }`,
+  },
+  'grid.extend': {
+    description: 'Any additional style for the Grid.',
+    type: 'string | (props) => {}',
+    defaultValue: undefined,
+  },
+}

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -3975,7 +3975,60 @@ The DOM tag to use for the element. Defaults to \`div\`.
 \`\`\`
 string
 \`\`\`
-  ",
+  
+## Theme
+  
+**global.edgeSize**
+
+The possible sizes for the grid gap. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+      edgeSize: {
+        none: '0px',
+        hair: '1px',
+        xxsmall: '3px',
+        xsmall: '6px',
+        small: '12px',
+        medium: '24px',
+        large: '48px',
+        xlarge: '96px',
+        responsiveBreakpoint: 'small',
+      },
+    }
+\`\`\`
+
+**global.size**
+
+The possible sizes for row and column. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+      xxsmall: '48px',
+      xsmall: '96px',
+      small: '192px',
+      medium: '384px',
+      large: '768px',
+      xlarge: '1152px',
+      xxlarge: '1536px',
+      full: '100%',
+    }
+\`\`\`
+
+**grid.extend**
+
+Any additional style for the Grid. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+",
   "Grommet": "## Grommet
 The top level Grommet container.
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
adds doc to theme grid
#### Where should the reviewer start?
doc.js
#### What testing has been done on this PR?
verify content
#### How should this be manually tested?
go over styledGrid and compare with docs
#### Any background context you want to provide?

#### What are the relevant issues?
poor docs
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible 