### PR TITLE
Fix responsive context typings

### DIFF
--- a/src/js/contexts/ResponsiveContext/index.d.ts
+++ b/src/js/contexts/ResponsiveContext/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export type ResponsiveValue = 'small' | 'medium' | 'large';
+export type ResponsiveValue = string;
 
 declare const ResponsiveContext: React.Context<ResponsiveValue>;
 

--- a/src/js/contexts/ResponsiveContext/index.d.ts
+++ b/src/js/contexts/ResponsiveContext/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export type ResponsiveValue = 'wide' | 'narrow';
+export type ResponsiveValue = 'small' | 'medium' | 'large';
 
 declare const ResponsiveContext: React.Context<ResponsiveValue>;
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixing ResponsiveValue typing

It is that simple that does not need any explanation.
It may be something old from v1 or something, but at this moment it makes impossible to use ResponsiveContext without `@ts-ignore` so I fixed it.

When creating that I thought the breakpoints are defined in the library, but I found it is not the case.

We would need to decide whether we want to make it open or specify an array of allowable breakpoints which then can be typed and provide intellisense when creating themes