### PR TITLE
Add resize prop to textarea

### DIFF
--- a/src/js/components/TextArea/README.md
+++ b/src/js/components/TextArea/README.md
@@ -75,6 +75,16 @@ What text to put in the textarea.
 ```
 string
 ```
+
+**resize**
+
+Whether user is allowed to resize the textarea. Defaults to `true`.
+
+```
+vertical
+horizontal
+boolean
+```
   
 ## Intrinsic element
 

--- a/src/js/components/TextArea/StyledTextArea.js
+++ b/src/js/components/TextArea/StyledTextArea.js
@@ -9,11 +9,25 @@ const plainStyle = css`
   -webkit-appearance: none;
 `;
 
+const resizeStyle = resize => {
+  if (resize === 'horizontal') {
+    return 'resize: horizontal;';
+  }
+  if (resize === 'vertical') {
+    return 'resize: vertical;';
+  }
+  if (resize) {
+    return 'resize: both;';
+  }
+  return 'resize: none;';
+};
+
 const StyledTextArea = styled.textarea`
   ${inputStyle} width: 100%;
+  ${props => props.resize !== undefined && resizeStyle(props.resize)}
 
-  ${props => props.fillArg && 'height: 100%;'} ${props =>
-  props.plain && plainStyle}
+  ${props => props.fillArg && 'height: 100%;'}
+  ${props => props.plain && plainStyle}
 
   ${placeholderStyle}
 

--- a/src/js/components/TextArea/__tests__/TextArea-test.js
+++ b/src/js/components/TextArea/__tests__/TextArea-test.js
@@ -57,4 +57,16 @@ describe('TextArea', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  [true, false, 'horizontal', 'vertical'].forEach(resize => {
+    test(`resize ${resize}`, () => {
+      const component = renderer.create(
+        <Grommet>
+          <TextArea id="item" name="item" resize={resize} />
+        </Grommet>,
+      );
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
 });

--- a/src/js/components/TextArea/__tests__/__snapshots__/TextArea-test.js.snap
+++ b/src/js/components/TextArea/__tests__/__snapshots__/TextArea-test.js.snap
@@ -314,3 +314,255 @@ exports[`TextArea plain 1`] = `
   />
 </div>
 `;
+
+exports[`TextArea resize false 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  box-sizing: border-box;
+  font-size: inherit;
+  border: none;
+  -webkit-appearance: none;
+  padding: 11px;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  width: 100%;
+  resize: none;
+}
+
+.c1::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c1::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c1:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+<div
+  className="c0"
+>
+  <textarea
+    className="c1"
+    id="item"
+    name="item"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+  />
+</div>
+`;
+
+exports[`TextArea resize horizontal 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  box-sizing: border-box;
+  font-size: inherit;
+  border: none;
+  -webkit-appearance: none;
+  padding: 11px;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  width: 100%;
+  resize: horizontal;
+}
+
+.c1::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c1::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c1:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+<div
+  className="c0"
+>
+  <textarea
+    className="c1"
+    id="item"
+    name="item"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+  />
+</div>
+`;
+
+exports[`TextArea resize true 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  box-sizing: border-box;
+  font-size: inherit;
+  border: none;
+  -webkit-appearance: none;
+  padding: 11px;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  width: 100%;
+  resize: both;
+}
+
+.c1::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c1::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c1:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+<div
+  className="c0"
+>
+  <textarea
+    className="c1"
+    id="item"
+    name="item"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+  />
+</div>
+`;
+
+exports[`TextArea resize vertical 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  box-sizing: border-box;
+  font-size: inherit;
+  border: none;
+  -webkit-appearance: none;
+  padding: 11px;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  width: 100%;
+  resize: vertical;
+}
+
+.c1::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c1::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c1:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+<div
+  className="c0"
+>
+  <textarea
+    className="c1"
+    id="item"
+    name="item"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+  />
+</div>
+`;

--- a/src/js/components/TextArea/doc.js
+++ b/src/js/components/TextArea/doc.js
@@ -32,6 +32,12 @@ export const doc = TextArea => {
 Only use this when the containing context provides sufficient affordance.`,
     ),
     value: PropTypes.string.description('What text to put in the textarea.'),
+    resize: PropTypes.oneOfType([
+      PropTypes.oneOf(['vertical', 'horizontal']),
+      PropTypes.bool,
+    ])
+      .description('Whether user is allowed to resize the textarea.')
+      .defaultValue(true),
   };
 
   return DocumentedTextArea;

--- a/src/js/components/TextArea/index.d.ts
+++ b/src/js/components/TextArea/index.d.ts
@@ -9,6 +9,7 @@ export interface TextAreaProps {
   placeholder?: string;
   plain?: boolean;
   value?: string;
+  resize?: "vertical" | "horizontal" | boolean;
 }
 
 declare const TextArea: React.ComponentType<TextAreaProps & JSX.IntrinsicElements['textarea']>;

--- a/src/js/components/TextArea/textarea.stories.js
+++ b/src/js/components/TextArea/textarea.stories.js
@@ -43,5 +43,6 @@ class FillTextArea extends Component {
 }
 
 storiesOf('TextArea', module)
-  .add('Simple', () => <SimpleTextArea />)
-  .add('Fill', () => <FillTextArea />);
+  .add('Simple', () => <SimpleTextArea resize />)
+  .add('Fill', () => <FillTextArea />)
+  .add('Non resizable', () => <SimpleTextArea resize={false} />);

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -7522,6 +7522,16 @@ What text to put in the textarea.
 \`\`\`
 string
 \`\`\`
+
+**resize**
+
+Whether user is allowed to resize the textarea. Defaults to \`true\`.
+
+\`\`\`
+vertical
+horizontal
+boolean
+\`\`\`
   
 ## Intrinsic element
 

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -3110,6 +3110,14 @@ Only use this when the containing context provides sufficient affordance.",
         "format": "string",
         "name": "value",
       },
+      Object {
+        "defaultValue": true,
+        "description": "Whether user is allowed to resize the textarea.",
+        "format": "vertical
+horizontal
+boolean",
+        "name": "resize",
+      },
     ],
     "usage": "import { TextArea } from 'grommet';
 <TextArea id='item' name='item' />",

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -822,6 +822,7 @@ export interface TextAreaProps {
   placeholder?: string;
   plain?: boolean;
   value?: string;
+  resize?: \\"vertical\\" | \\"horizontal\\" | boolean;
 }
 
 declare const TextArea: React.ComponentType<TextAreaProps & JSX.IntrinsicElements['textarea']>;


### PR DESCRIPTION
Closes: #2445

Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

#### Where should the reviewer start?
Add resize prop to textarea to disable resize or enable only vertically|horizontally
#### What testing has been done on this PR?
storybook and unittest
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
#2445
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
compatible