### PR TITLE
Makes Select.options an array

### DIFF
--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -20,7 +20,7 @@ export interface SelectProps {
   onClose?: ((...args: any[]) => any);
   onOpen?: ((...args: any[]) => any);
   onSearch?: ((...args: any[]) => any);
-  options: string | JSX.Element | object[];
+  options: string[] | JSX.Element[] | object[];
   placeholder?: string | React.ReactNode;
   plain?: boolean;
   searchPlaceholder?: string;


### PR DESCRIPTION
#### What does this PR do?
Corrects an incorrect typescript field description.

#### Where should the reviewer start?
There is only one file to review

#### What testing has been done on this PR?
In my own local repo, works as expected.

#### How should this be manually tested?
Try to create a select component in a fresh typescript repo with and without this patch.

#### Any background context you want to provide?
Nope, should be straightforward...

#### What are the relevant issues?
Can't find any

#### Screenshots (if appropriate)
![options](https://user-images.githubusercontent.com/525350/50582007-a9850c00-0e67-11e9-865b-d0f05674f16c.png)

#### Do the grommet docs need to be updated?
Yes, the docs are misleading a bit as it is not clear that "options" is an array.

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible