### PR TITLE
Added intrinsic typings

### DIFF
--- a/src/js/components/Accordion/README.md
+++ b/src/js/components/Accordion/README.md
@@ -166,3 +166,8 @@ Custom messages for Tabs. Used for accessibility by screen readers. Defaults to 
 }
 ```
   
+## Intrinsic element
+
+```
+div
+```

--- a/src/js/components/Accordion/doc.js
+++ b/src/js/components/Accordion/doc.js
@@ -12,7 +12,8 @@ export const doc = Accordion => {
   <AccordionPanel label='Panel 1'>...</AccordionPanel>
   <AccordionPanel label='Panek 2'>...</AccordionPanel>
 </Accordion>`,
-    );
+    )
+    .intrinsicElement('div');
 
   DocumentedAccordion.propTypes = {
     ...genericProps,

--- a/src/js/components/Accordion/index.d.ts
+++ b/src/js/components/Accordion/index.d.ts
@@ -13,6 +13,6 @@ export interface AccordionProps {
   messages?: {tabContents?: string};
 }
 
-declare const Accordion: React.ComponentType<AccordionProps>;
+declare const Accordion: React.ComponentType<AccordionProps & JSX.IntrinsicElements['div']>;
 
 export { Accordion };

--- a/src/js/components/AccordionPanel/README.md
+++ b/src/js/components/AccordionPanel/README.md
@@ -21,6 +21,11 @@ If specified, the entire panel header will be managed by the caller.
 node
 ```
   
+## Intrinsic element
+
+```
+div
+```
 ## Theme
   
 **accordion.icons.collapse**

--- a/src/js/components/AccordionPanel/doc.js
+++ b/src/js/components/AccordionPanel/doc.js
@@ -1,9 +1,9 @@
 import { describe, PropTypes } from 'react-desc';
 
 export function doc(Panel) {
-  const DocumentedAccordionPanel = describe(Panel).description(
-    'An Accordion panel.',
-  );
+  const DocumentedAccordionPanel = describe(Panel)
+    .description('An Accordion panel.')
+    .intrinsicElement('div');
   DocumentedAccordionPanel.propTypes = {
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).description(
       'The panel label.',

--- a/src/js/components/AccordionPanel/index.d.ts
+++ b/src/js/components/AccordionPanel/index.d.ts
@@ -5,6 +5,6 @@ export interface AccordionPanelProps {
   header?: React.ReactNode;
 }
 
-declare const AccordionPanel: React.ComponentType<AccordionPanelProps>;
+declare const AccordionPanel: React.ComponentType<AccordionPanelProps & JSX.IntrinsicElements['div']>;
 
 export { AccordionPanel };

--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -562,6 +562,11 @@ Whether children can wrap if they
 boolean
 ```
   
+## Intrinsic element
+
+```
+div
+```
 ## Theme
   
 **global.animation**

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -32,7 +32,8 @@ export const doc = Box => {
       provides CSS flexbox capabilities for layout, as well as general
       styling of things like background color, border, and animation.`,
     )
-    .usage("import { Box } from 'grommet';\n<Box />");
+    .usage("import { Box } from 'grommet';\n<Box />")
+    .intrinsicElement('div');
   DocumentedBox.propTypes = {
     ...genericProps,
     align: PropTypes.oneOf([

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -28,6 +28,6 @@ export interface BoxProps {
   wrap?: boolean;
 }
 
-declare const Box: React.ComponentType<BoxProps>;
+declare const Box: React.ComponentType<BoxProps & JSX.IntrinsicElements['div']>;
 
 export { Box };

--- a/src/js/components/Calendar/README.md
+++ b/src/js/components/Calendar/README.md
@@ -258,6 +258,11 @@ large
 string
 ```
   
+## Intrinsic element
+
+```
+div
+```
 ## Theme
   
 **global.size.small**

--- a/src/js/components/Calendar/doc.js
+++ b/src/js/components/Calendar/doc.js
@@ -13,7 +13,8 @@ export const doc = Calendar => {
     .usage(
       `import { Calendar } from 'grommet';
 <Calendar />`,
-    );
+    )
+    .intrinsicElement('div');
 
   DocumentedCalendar.propTypes = {
     ...genericProps,

--- a/src/js/components/Calendar/index.d.ts
+++ b/src/js/components/Calendar/index.d.ts
@@ -21,6 +21,6 @@ export interface CalendarProps {
   size?: "small" | "medium" | "large" | string;
 }
 
-declare const Calendar: React.ComponentType<CalendarProps>;
+declare const Calendar: React.ComponentType<CalendarProps & JSX.IntrinsicElements['div']>;
 
 export { Calendar };

--- a/src/js/components/Carousel/README.md
+++ b/src/js/components/Carousel/README.md
@@ -128,3 +128,8 @@ If specified, the number of
 number
 ```
   
+## Intrinsic element
+
+```
+div
+```

--- a/src/js/components/Carousel/doc.js
+++ b/src/js/components/Carousel/doc.js
@@ -13,7 +13,8 @@ export const doc = Carousel => {
     .usage(
       `import { Carousel } from 'grommet';
 <Carousel />`,
-    );
+    )
+    .intrinsicElement('div');
 
   DocumentedCarousel.propTypes = {
     ...genericProps,

--- a/src/js/components/Carousel/index.d.ts
+++ b/src/js/components/Carousel/index.d.ts
@@ -9,6 +9,6 @@ export interface CarouselProps {
   play?: number;
 }
 
-declare const Carousel: React.ComponentType<CarouselProps>;
+declare const Carousel: React.ComponentType<CarouselProps & JSX.IntrinsicElements['div']>;
 
 export { Carousel };

--- a/src/js/components/Chart/README.md
+++ b/src/js/components/Chart/README.md
@@ -257,3 +257,8 @@ Required. Array of value objects describing the data.
 ]
 ```
   
+## Intrinsic element
+
+```
+svg
+```

--- a/src/js/components/Chart/doc.js
+++ b/src/js/components/Chart/doc.js
@@ -6,7 +6,8 @@ export const doc = Chart => {
   const DocumentedChart = describe(Chart)
     .availableAt(getAvailableAtBadge('Chart'))
     .description('A graphical chart.')
-    .usage("import { Chart } from 'grommet';\n<Chart />");
+    .usage("import { Chart } from 'grommet';\n<Chart />")
+    .intrinsicElement('svg');
 
   DocumentedChart.propTypes = {
     ...genericProps,

--- a/src/js/components/Chart/index.d.ts
+++ b/src/js/components/Chart/index.d.ts
@@ -17,6 +17,6 @@ export interface ChartProps {
   values: (number | number[] | {label?: string,onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any),value: number | number[]})[];
 }
 
-declare const Chart: React.ComponentType<ChartProps & JSX.IntrinsicElements['div']>;
+declare const Chart: React.ComponentType<ChartProps & JSX.IntrinsicElements['svg']>;
 
 export { Chart };

--- a/src/js/components/Chart/index.d.ts
+++ b/src/js/components/Chart/index.d.ts
@@ -17,6 +17,6 @@ export interface ChartProps {
   values: (number | number[] | {label?: string,onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any),value: number | number[]})[];
 }
 
-declare const Chart: React.ComponentType<ChartProps>;
+declare const Chart: React.ComponentType<ChartProps & JSX.IntrinsicElements['div']>;
 
 export { Chart };

--- a/src/js/components/CheckBox/README.md
+++ b/src/js/components/CheckBox/README.md
@@ -87,3 +87,8 @@ NOTE: This can only be used with non-toggle components
 boolean
 ```
   
+## Intrinsic element
+
+```
+input
+```

--- a/src/js/components/CheckBox/doc.js
+++ b/src/js/components/CheckBox/doc.js
@@ -9,7 +9,8 @@ export const doc = CheckBox => {
     .usage(
       `import { CheckBox } from 'grommet';
 <CheckBox />`,
-    );
+    )
+    .intrinsicElement('input');
 
   DocumentedCheckBox.propTypes = {
     checked: PropTypes.bool

--- a/src/js/components/CheckBox/index.d.ts
+++ b/src/js/components/CheckBox/index.d.ts
@@ -12,6 +12,6 @@ export interface CheckBoxProps {
   indeterminate?: boolean;
 }
 
-declare const CheckBox: React.ComponentType<CheckBoxProps>;
+declare const CheckBox: React.ComponentType<CheckBoxProps & JSX.IntrinsicElements['input']>;
 
 export { CheckBox };

--- a/src/js/components/Clock/README.md
+++ b/src/js/components/Clock/README.md
@@ -180,3 +180,8 @@ analog
 digital
 ```
   
+## Intrinsic element
+
+```
+div,svg
+```

--- a/src/js/components/Clock/doc.js
+++ b/src/js/components/Clock/doc.js
@@ -9,7 +9,8 @@ export const doc = Clock => {
     .usage(
       `import { Clock } from 'grommet';
 <Clock />`,
-    );
+    )
+    .intrinsicElement(['div', 'svg']);
 
   DocumentedClock.propTypes = {
     ...genericProps,

--- a/src/js/components/Clock/index.d.ts
+++ b/src/js/components/Clock/index.d.ts
@@ -14,6 +14,6 @@ export interface ClockProps {
   type?: "analog" | "digital";
 }
 
-declare const Clock: React.ComponentType<ClockProps>;
+declare const Clock: React.ComponentType<ClockProps & JSX.IntrinsicElements['div']>;
 
 export { Clock };

--- a/src/js/components/Clock/index.d.ts
+++ b/src/js/components/Clock/index.d.ts
@@ -14,6 +14,6 @@ export interface ClockProps {
   type?: "analog" | "digital";
 }
 
-declare const Clock: React.ComponentType<ClockProps & JSX.IntrinsicElements['div']>;
+declare const Clock: React.ComponentType<ClockProps & (JSX.IntrinsicElements['div'] | JSX.IntrinsicElements['svg'])>;
 
 export { Clock };

--- a/src/js/components/Collapsible/README.md
+++ b/src/js/components/Collapsible/README.md
@@ -27,6 +27,11 @@ horizontal
 vertical
 ```
   
+## Intrinsic element
+
+```
+div
+```
 ## Theme
   
 **collapsible.minSpeed**

--- a/src/js/components/Collapsible/doc.js
+++ b/src/js/components/Collapsible/doc.js
@@ -6,7 +6,8 @@ export const doc = Collapsible => {
     .usage(
       `import { Collapsible } from 'grommet';
 <Collapsible open={true}>test</Collapsible>`,
-    );
+    )
+    .intrinsicElement('div');
 
   DocumentedCollapsible.propTypes = {
     open: PropTypes.bool.description(
@@ -27,7 +28,8 @@ export const themeDoc = {
     defaultValue: 200,
   },
   'collapsible.baseline': {
-    description: 'Default height to be used to calculate the optimal collapsible speed.',
+    description:
+      'Default height to be used to calculate the optimal collapsible speed.',
     type: 'number',
     defaultValue: 500,
   },
@@ -36,4 +38,4 @@ export const themeDoc = {
     type: 'string | (props) => {}',
     defaultValue: undefined,
   },
-}
+};

--- a/src/js/components/Collapsible/index.d.ts
+++ b/src/js/components/Collapsible/index.d.ts
@@ -5,6 +5,6 @@ export interface CollapsibleProps {
   direction?: "horizontal" | "vertical";
 }
 
-declare const Collapsible: React.ComponentType<CollapsibleProps>;
+declare const Collapsible: React.ComponentType<CollapsibleProps & JSX.IntrinsicElements['div']>;
 
 export { Collapsible };

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -238,3 +238,8 @@ Whether to allow the user to sort columns.
 boolean
 ```
   
+## Intrinsic element
+
+```
+table
+```

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -9,7 +9,8 @@ export const doc = DataTable => {
     .usage(
       `import { DataTable } from 'grommet';
 <DataTable />`,
-    );
+    )
+    .intrinsicElement('table');
 
   DocumentedDataTable.propTypes = {
     ...genericProps,

--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -16,6 +16,6 @@ export interface DataTableProps {
   sortable?: boolean;
 }
 
-declare const DataTable: React.ComponentType<DataTableProps>;
+declare const DataTable: React.ComponentType<DataTableProps & JSX.IntrinsicElements['div']>;
 
 export { DataTable };

--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -16,6 +16,6 @@ export interface DataTableProps {
   sortable?: boolean;
 }
 
-declare const DataTable: React.ComponentType<DataTableProps & JSX.IntrinsicElements['div']>;
+declare const DataTable: React.ComponentType<DataTableProps & JSX.IntrinsicElements['table']>;
 
 export { DataTable };

--- a/src/js/components/Diagram/README.md
+++ b/src/js/components/Diagram/README.md
@@ -61,3 +61,8 @@ Required. Array of objects describing the connections.
 }]
 ```
   
+## Intrinsic element
+
+```
+svg
+```

--- a/src/js/components/Diagram/doc.js
+++ b/src/js/components/Diagram/doc.js
@@ -10,7 +10,8 @@ export const doc = Diagram => {
       Boxes can be used in the \`guidingChild\` layer of Stack and then
       Diagram can be used to draw lines connecting the Boxes.`,
     )
-    .usage("import { Diagram } from 'grommet';\n<Diagram />");
+    .usage("import { Diagram } from 'grommet';\n<Diagram />")
+    .intrinsicElement('svg');
 
   DocumentedDiagram.propTypes = {
     connections: PropTypes.arrayOf(

--- a/src/js/components/Diagram/index.d.ts
+++ b/src/js/components/Diagram/index.d.ts
@@ -4,6 +4,6 @@ export interface DiagramProps {
   connections: {anchor?: "center" | "vertical" | "horizontal",color?: string | {dark?: string,light?: string},fromTarget: string | object,label?: string,offset?: "xsmall" | "small" | "medium" | "large" | string,thickness?: "hair" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,toTarget: string | object,type?: "direct" | "curved" | "rectilinear"}[];
 }
 
-declare const Diagram: React.ComponentType<DiagramProps>;
+declare const Diagram: React.ComponentType<DiagramProps & JSX.IntrinsicElements['div']>;
 
 export { Diagram };

--- a/src/js/components/Diagram/index.d.ts
+++ b/src/js/components/Diagram/index.d.ts
@@ -4,6 +4,6 @@ export interface DiagramProps {
   connections: {anchor?: "center" | "vertical" | "horizontal",color?: string | {dark?: string,light?: string},fromTarget: string | object,label?: string,offset?: "xsmall" | "small" | "medium" | "large" | string,thickness?: "hair" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,toTarget: string | object,type?: "direct" | "curved" | "rectilinear"}[];
 }
 
-declare const Diagram: React.ComponentType<DiagramProps & JSX.IntrinsicElements['div']>;
+declare const Diagram: React.ComponentType<DiagramProps & JSX.IntrinsicElements['svg']>;
 
 export { Diagram };

--- a/src/js/components/Distribution/README.md
+++ b/src/js/components/Distribution/README.md
@@ -158,3 +158,8 @@ Required. Array of objects containing a value. The array should already be
 }]
 ```
   
+## Intrinsic element
+
+```
+div
+```

--- a/src/js/components/Distribution/doc.js
+++ b/src/js/components/Distribution/doc.js
@@ -12,7 +12,8 @@ export const doc = Distribution => {
       manner that makes them more visually easy to scan. For example,
       two values of 48 and 52 will actually each get 50% of the area.`,
     )
-    .usage("import { Distribution } from 'grommet';\n<Distribution />");
+    .usage("import { Distribution } from 'grommet';\n<Distribution />")
+    .intrinsicElement('div');
 
   DocumentedDistribution.propTypes = {
     ...genericProps,

--- a/src/js/components/Distribution/index.d.ts
+++ b/src/js/components/Distribution/index.d.ts
@@ -11,6 +11,6 @@ export interface DistributionProps {
   values: {value: number}[];
 }
 
-declare const Distribution: React.ComponentType<DistributionProps>;
+declare const Distribution: React.ComponentType<DistributionProps & JSX.IntrinsicElements['div']>;
 
 export { Distribution };

--- a/src/js/components/Drop/README.md
+++ b/src/js/components/Drop/README.md
@@ -109,3 +109,8 @@ Whether the drop element should have no background nor shadow
 boolean
 ```
   
+## Intrinsic element
+
+```
+div
+```

--- a/src/js/components/Drop/doc.js
+++ b/src/js/components/Drop/doc.js
@@ -8,7 +8,8 @@ export const doc = Drop => {
     .description('A container that is overlaid next to a target.')
     .usage(
       "import { Drop } from 'grommet';\n<Drop target={reference}>...</Drop>",
-    );
+    )
+    .intrinsicElement('div');
 
   DocumentedDrop.propTypes = {
     align: PropTypes.shape({

--- a/src/js/components/Drop/index.d.ts
+++ b/src/js/components/Drop/index.d.ts
@@ -12,6 +12,6 @@ export interface DropProps {
   plain?: boolean;
 }
 
-declare const Drop: React.ComponentType<DropProps>;
+declare const Drop: React.ComponentType<DropProps & JSX.IntrinsicElements['div']>;
 
 export { Drop };

--- a/src/js/components/DropButton/README.md
+++ b/src/js/components/DropButton/README.md
@@ -186,3 +186,8 @@ Whether the drop should be open or not. Setting this property does not
 boolean
 ```
   
+## Intrinsic element
+
+```
+button
+```

--- a/src/js/components/DropButton/doc.js
+++ b/src/js/components/DropButton/doc.js
@@ -15,7 +15,8 @@ export const doc = DropButton => {
     .usage(
       `import { DropButton } from 'grommet';
 <DropButton dropContent={...} />`,
-    );
+    )
+    .intrinsicElement('button');
 
   DocumentedDropButton.propTypes = {
     ...genericProps,

--- a/src/js/components/DropButton/index.d.ts
+++ b/src/js/components/DropButton/index.d.ts
@@ -14,6 +14,6 @@ export interface DropButtonProps {
   open?: boolean;
 }
 
-declare const DropButton: React.ComponentType<DropButtonProps>;
+declare const DropButton: React.ComponentType<DropButtonProps & JSX.IntrinsicElements['button']>;
 
 export { DropButton };

--- a/src/js/components/Form/README.md
+++ b/src/js/components/Form/README.md
@@ -64,3 +64,8 @@ An object representing all of the data in the form. Defaults to `{}`.
 }
 ```
   
+## Intrinsic element
+
+```
+form
+```

--- a/src/js/components/Form/doc.js
+++ b/src/js/components/Form/doc.js
@@ -9,7 +9,8 @@ export const doc = Form => {
     .usage(
       `import { Form } from 'grommet';
 <Form />`,
-    );
+    )
+    .intrinsicElement('form');
 
   DocumentedForm.propTypes = {
     errors: PropTypes.shape({})

--- a/src/js/components/Form/index.d.ts
+++ b/src/js/components/Form/index.d.ts
@@ -8,6 +8,6 @@ export interface FormProps {
   value?: {};
 }
 
-declare const Form: React.ComponentType<FormProps>;
+declare const Form: React.ComponentType<FormProps & JSX.IntrinsicElements['form']>;
 
 export { Form };

--- a/src/js/components/FormField/README.md
+++ b/src/js/components/FormField/README.md
@@ -89,3 +89,8 @@ Validation rule. Provide a regular expression or a function. If a
 function
 ```
   
+## Intrinsic element
+
+```
+div
+```

--- a/src/js/components/FormField/doc.js
+++ b/src/js/components/FormField/doc.js
@@ -13,7 +13,8 @@ export const doc = FormField => {
     .usage(
       `import { FormField } from 'grommet';
 <FormField />`,
-    );
+    )
+    .intrinsicElement('div');
 
   DocumentedFormField.propTypes = {
     error: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).description(

--- a/src/js/components/FormField/index.d.ts
+++ b/src/js/components/FormField/index.d.ts
@@ -11,6 +11,6 @@ export interface FormFieldProps {
   validate?: {regexp?: object,message?: string} | ((...args: any[]) => any);
 }
 
-declare const FormField: React.ComponentType<FormFieldProps>;
+declare const FormField: React.ComponentType<FormFieldProps & JSX.IntrinsicElements['div']>;
 
 export { FormField };

--- a/src/js/components/Grid/README.md
+++ b/src/js/components/Grid/README.md
@@ -352,6 +352,11 @@ The DOM tag to use for the element. Defaults to `div`.
 string
 ```
   
+## Intrinsic element
+
+```
+div
+```
 ## Theme
   
 **global.edgeSize**

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -35,7 +35,8 @@ to create fallback rendering for older browsers, like ie11.`,
     .usage(
       `import { Grid } from 'grommet';
 <Grid />`,
-    );
+    )
+    .intrinsicElement('div');
 
   DocumentedGrid.propTypes = {
     ...genericProps,
@@ -190,4 +191,4 @@ export const themeDoc = {
     type: 'string | (props) => {}',
     defaultValue: undefined,
   },
-}
+};

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -18,6 +18,6 @@ export interface GridProps {
   as?: string;
 }
 
-declare const Grid: React.ComponentType<GridProps>;
+declare const Grid: React.ComponentType<GridProps & JSX.IntrinsicElements['div']>;
 
 export { Grid };

--- a/src/js/components/Grommet/README.md
+++ b/src/js/components/Grommet/README.md
@@ -43,3 +43,8 @@ User agent used to detect the device width for setting the initial breakpoint.
 string
 ```
   
+## Intrinsic element
+
+```
+div
+```

--- a/src/js/components/Grommet/doc.js
+++ b/src/js/components/Grommet/doc.js
@@ -9,7 +9,8 @@ export const doc = Grommet => {
     .usage(
       `import { Grommet } from 'grommet';
 <Grommet>...</Grommet>`,
-    );
+    )
+    .intrinsicElement('div');
 
   DocumentedGrommet.propTypes = {
     full: PropTypes.bool

--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -7,6 +7,6 @@ export interface GrommetProps {
   userAgent?: string;
 }
 
-declare const Grommet: React.ComponentType<GrommetProps>;
+declare const Grommet: React.ComponentType<GrommetProps & JSX.IntrinsicElements['div']>;
 
 export { Grommet };

--- a/src/js/components/Heading/README.md
+++ b/src/js/components/Heading/README.md
@@ -183,3 +183,8 @@ is too long to all fit.
 boolean
 ```
   
+## Intrinsic element
+
+```
+h1,h2,h3,h4
+```

--- a/src/js/components/Heading/doc.js
+++ b/src/js/components/Heading/doc.js
@@ -9,7 +9,8 @@ export const doc = Heading => {
     .usage(
       `import { Heading } from 'grommet';
 <Heading />`,
-    );
+    )
+    .intrinsicElement(['h1', 'h2', 'h3', 'h4']);
 
   DocumentedHeading.propTypes = {
     ...genericProps,

--- a/src/js/components/Heading/index.d.ts
+++ b/src/js/components/Heading/index.d.ts
@@ -13,6 +13,6 @@ export interface HeadingProps {
   truncate?: boolean;
 }
 
-declare const Heading: React.ComponentType<HeadingProps>;
+declare const Heading: React.ComponentType<HeadingProps & JSX.IntrinsicElements['div']>;
 
 export { Heading };

--- a/src/js/components/Heading/index.d.ts
+++ b/src/js/components/Heading/index.d.ts
@@ -13,6 +13,6 @@ export interface HeadingProps {
   truncate?: boolean;
 }
 
-declare const Heading: React.ComponentType<HeadingProps & JSX.IntrinsicElements['div']>;
+declare const Heading: React.ComponentType<HeadingProps & (JSX.IntrinsicElements['h1'] | JSX.IntrinsicElements['h2'] | JSX.IntrinsicElements['h3'] | JSX.IntrinsicElements['h4'])>;
 
 export { Heading };

--- a/src/js/components/InfiniteScroll/index.d.ts
+++ b/src/js/components/InfiniteScroll/index.d.ts
@@ -11,6 +11,6 @@ export interface InfiniteScrollProps {
   step?: number;
 }
 
-declare const InfiniteScroll: React.ComponentType<InfiniteScrollProps & JSX.IntrinsicElements['div']>;
+declare const InfiniteScroll: React.ComponentType<InfiniteScrollProps>;
 
 export { InfiniteScroll };

--- a/src/js/components/InfiniteScroll/index.d.ts
+++ b/src/js/components/InfiniteScroll/index.d.ts
@@ -11,6 +11,6 @@ export interface InfiniteScrollProps {
   step?: number;
 }
 
-declare const InfiniteScroll: React.ComponentType<InfiniteScrollProps>;
+declare const InfiniteScroll: React.ComponentType<InfiniteScrollProps & JSX.IntrinsicElements['div']>;
 
 export { InfiniteScroll };

--- a/src/js/components/Keyboard/README.md
+++ b/src/js/components/Keyboard/README.md
@@ -59,6 +59,14 @@ Function that will be called when the user presses the esc key.
 function
 ```
 
+**onKeyDown**
+
+Function that will be called when the user presses any key.
+
+```
+function
+```
+
 **onLeft**
 
 Function that will be called when the user presses the left key.

--- a/src/js/components/Keyboard/doc.js
+++ b/src/js/components/Keyboard/doc.js
@@ -27,6 +27,9 @@ export const doc = Keyboard => {
     onEsc: PropTypes.func.description(
       'Function that will be called when the user presses the esc key.',
     ),
+    onKeyDown: PropTypes.func.description(
+      'Function that will be called when the user presses any key.',
+    ),
     onLeft: PropTypes.func.description(
       'Function that will be called when the user presses the left key.',
     ),

--- a/src/js/components/Keyboard/index.d.ts
+++ b/src/js/components/Keyboard/index.d.ts
@@ -7,6 +7,7 @@ export interface KeyboardProps {
   onDown?: ((...args: any[]) => any);
   onEnter?: ((...args: any[]) => any);
   onEsc?: ((...args: any[]) => any);
+  onKeyDown?: ((...args: any[]) => any);
   onLeft?: ((...args: any[]) => any);
   onRight?: ((...args: any[]) => any);
   onShift?: ((...args: any[]) => any);
@@ -15,6 +16,6 @@ export interface KeyboardProps {
   onUp?: ((...args: any[]) => any);
 }
 
-declare const Keyboard: React.ComponentType<KeyboardProps & JSX.IntrinsicElements['div']>;
+declare const Keyboard: React.ComponentType<KeyboardProps>;
 
 export { Keyboard };

--- a/src/js/components/Keyboard/index.d.ts
+++ b/src/js/components/Keyboard/index.d.ts
@@ -15,6 +15,6 @@ export interface KeyboardProps {
   onUp?: ((...args: any[]) => any);
 }
 
-declare const Keyboard: React.ComponentType<KeyboardProps>;
+declare const Keyboard: React.ComponentType<KeyboardProps & JSX.IntrinsicElements['div']>;
 
 export { Keyboard };

--- a/src/js/components/Layer/README.md
+++ b/src/js/components/Layer/README.md
@@ -148,6 +148,11 @@ Whether the layer should take full width and height on mobile Defaults to `true`
 boolean
 ```
   
+## Intrinsic element
+
+```
+div
+```
 ## Theme
   
 **global.breakpoints**

--- a/src/js/components/Layer/doc.js
+++ b/src/js/components/Layer/doc.js
@@ -15,7 +15,8 @@ export const doc = Layer => {
     .usage(
       `import { Layer } from 'grommet';
 <Layer />`,
-    );
+    )
+    .intrinsicElement('div');
 
   DocumentedLayer.propTypes = {
     animate: PropTypes.bool

--- a/src/js/components/Layer/index.d.ts
+++ b/src/js/components/Layer/index.d.ts
@@ -12,6 +12,6 @@ export interface LayerProps {
   responsive?: boolean;
 }
 
-declare const Layer: React.ComponentType<LayerProps>;
+declare const Layer: React.ComponentType<LayerProps & JSX.IntrinsicElements['div']>;
 
 export { Layer };

--- a/src/js/components/Markdown/README.md
+++ b/src/js/components/Markdown/README.md
@@ -18,6 +18,13 @@ Custom components and props to override html elements such as 'img'
       with grommet components
 
 ```
-{ test: shape, ... }
+{
+
+}
 ```
   
+## Intrinsic element
+
+```
+div
+```

--- a/src/js/components/Markdown/README.md
+++ b/src/js/components/Markdown/README.md
@@ -13,10 +13,11 @@ import { Markdown } from 'grommet';
 
 **components**
 
-Custom components to override default html tags such as 'img' or 'pre'.
-By default only 'p' and 'a' are overrided with the Paragraph and Anchor components
+Custom components and props to override html elements such as 'img'
+      or 'pre'. By default 'a', 'p', 'img', and table elements are overriden
+      with grommet components
 
 ```
-{ test: element, ... }
+{ test: shape, ... }
 ```
   

--- a/src/js/components/Markdown/doc.js
+++ b/src/js/components/Markdown/doc.js
@@ -9,15 +9,11 @@ export const doc = Markdown => {
     .usage(
       `import { Markdown } from 'grommet';
       <Markdown>{content}</Markdown>`,
-    );
+    )
+    .intrinsicElement('div');
 
   DocumentedMarkdown.propTypes = {
-    components: PropTypes.objectOf(
-      PropTypes.shape({
-        component: PropTypes.element,
-        props: PropTypes.shape({}),
-      }),
-    ).description(
+    components: PropTypes.shape({}).description(
       `Custom components and props to override html elements such as 'img'
       or 'pre'. By default 'a', 'p', 'img', and table elements are overriden
       with grommet components`,

--- a/src/js/components/Markdown/doc.js
+++ b/src/js/components/Markdown/doc.js
@@ -12,9 +12,15 @@ export const doc = Markdown => {
     );
 
   DocumentedMarkdown.propTypes = {
-    components: PropTypes.objectOf(PropTypes.element).description(
-      `Custom components to override default html tags such as 'img' or 'pre'.
-By default only 'p' and 'a' are overrided with the Paragraph and Anchor components`,
+    components: PropTypes.objectOf(
+      PropTypes.shape({
+        component: PropTypes.element,
+        props: PropTypes.shape({}),
+      }),
+    ).description(
+      `Custom components and props to override html elements such as 'img'
+      or 'pre'. By default 'a', 'p', 'img', and table elements are overriden
+      with grommet components`,
     ),
   };
 

--- a/src/js/components/Markdown/index.d.ts
+++ b/src/js/components/Markdown/index.d.ts
@@ -4,6 +4,6 @@ export interface MarkdownProps {
   components?: { [key: string]: JSX.Element };
 }
 
-declare const Markdown: React.ComponentType<MarkdownProps>;
+declare const Markdown: React.ComponentType<MarkdownProps & JSX.IntrinsicElements['div']>;
 
 export { Markdown };

--- a/src/js/components/Markdown/index.d.ts
+++ b/src/js/components/Markdown/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 export interface MarkdownProps {
-  components?: { [key: string]: JSX.Element };
+  components?: { [key: string]: {component?: JSX.Element,props?: {}} };
 }
 
 declare const Markdown: React.ComponentType<MarkdownProps & JSX.IntrinsicElements['div']>;

--- a/src/js/components/Markdown/index.d.ts
+++ b/src/js/components/Markdown/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 export interface MarkdownProps {
-  components?: { [key: string]: {component?: JSX.Element,props?: {}} };
+  components?: {};
 }
 
 declare const Markdown: React.ComponentType<MarkdownProps & JSX.IntrinsicElements['div']>;

--- a/src/js/components/MaskedInput/README.md
+++ b/src/js/components/MaskedInput/README.md
@@ -76,3 +76,8 @@ What text to put in the input. The caller should ensure that it
 string
 ```
   
+## Intrinsic element
+
+```
+input
+```

--- a/src/js/components/MaskedInput/doc.js
+++ b/src/js/components/MaskedInput/doc.js
@@ -9,7 +9,8 @@ export const doc = MaskedInput => {
     .usage(
       `import { MaskedInput } from 'grommet';
 <MaskedInput id='item' name='item' />`,
-    );
+    )
+    .intrinsicElement('input');
 
   DocumentedMaskedInput.propTypes = {
     id: PropTypes.string.description('The id attribute of the input.'),

--- a/src/js/components/MaskedInput/index.d.ts
+++ b/src/js/components/MaskedInput/index.d.ts
@@ -9,6 +9,6 @@ export interface MaskedInputProps {
   value?: string;
 }
 
-declare const MaskedInput: React.ComponentType<MaskedInputProps>;
+declare const MaskedInput: React.ComponentType<MaskedInputProps & JSX.IntrinsicElements['input']>;
 
 export { MaskedInput };

--- a/src/js/components/Menu/README.md
+++ b/src/js/components/Menu/README.md
@@ -224,6 +224,11 @@ xlarge
 string
 ```
   
+## Intrinsic element
+
+```
+button
+```
 ## Theme
   
 **global.colors.control**

--- a/src/js/components/Menu/doc.js
+++ b/src/js/components/Menu/doc.js
@@ -16,7 +16,8 @@ export const doc = Menu => {
     .usage(
       `import { Menu } from 'grommet';
 <Menu />`,
-    );
+    )
+    .intrinsicElement('button');
 
   DocumentedMenu.propTypes = {
     ...genericProps,

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -16,6 +16,6 @@ export interface MenuProps {
   size?: "small" | "medium" | "large" | "xlarge" | string;
 }
 
-declare const Menu: React.ComponentType<MenuProps>;
+declare const Menu: React.ComponentType<MenuProps & JSX.IntrinsicElements['button']>;
 
 export { Menu };

--- a/src/js/components/Meter/README.md
+++ b/src/js/components/Meter/README.md
@@ -193,3 +193,8 @@ Array of value objects describing the data.
 }]
 ```
   
+## Intrinsic element
+
+```
+svg
+```

--- a/src/js/components/Meter/doc.js
+++ b/src/js/components/Meter/doc.js
@@ -13,7 +13,8 @@ export const doc = Meter => {
     .usage(
       `import { Meter } from 'grommet';
 <Meter />`,
-    );
+    )
+    .intrinsicElement('svg');
 
   DocumentedMeter.propTypes = {
     ...genericProps,

--- a/src/js/components/Meter/index.d.ts
+++ b/src/js/components/Meter/index.d.ts
@@ -13,6 +13,6 @@ export interface MeterProps {
   values?: {color?: string,highlight?: boolean,label: string,onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any),value: number}[];
 }
 
-declare const Meter: React.ComponentType<MeterProps>;
+declare const Meter: React.ComponentType<MeterProps & JSX.IntrinsicElements['div']>;
 
 export { Meter };

--- a/src/js/components/Meter/index.d.ts
+++ b/src/js/components/Meter/index.d.ts
@@ -13,6 +13,6 @@ export interface MeterProps {
   values?: {color?: string,highlight?: boolean,label: string,onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any),value: number}[];
 }
 
-declare const Meter: React.ComponentType<MeterProps & JSX.IntrinsicElements['div']>;
+declare const Meter: React.ComponentType<MeterProps & JSX.IntrinsicElements['svg']>;
 
 export { Meter };

--- a/src/js/components/RadioButton/README.md
+++ b/src/js/components/RadioButton/README.md
@@ -62,3 +62,8 @@ Function that will be called when the user clicks the radio button. It
 function
 ```
   
+## Intrinsic element
+
+```
+input
+```

--- a/src/js/components/RadioButton/doc.js
+++ b/src/js/components/RadioButton/doc.js
@@ -9,7 +9,8 @@ export const doc = RadioButton => {
     .usage(
       `import { RadioButton } from 'grommet';
 <RadioButton />`,
-    );
+    )
+    .intrinsicElement('input');
 
   DocumentedRadioButton.propTypes = {
     checked: PropTypes.bool.description('Same as React <input checked={} />'),

--- a/src/js/components/RadioButton/index.d.ts
+++ b/src/js/components/RadioButton/index.d.ts
@@ -9,6 +9,6 @@ export interface RadioButtonProps {
   onChange?: ((...args: any[]) => any);
 }
 
-declare const RadioButton: React.ComponentType<RadioButtonProps>;
+declare const RadioButton: React.ComponentType<RadioButtonProps & JSX.IntrinsicElements['div']>;
 
 export { RadioButton };

--- a/src/js/components/RadioButton/index.d.ts
+++ b/src/js/components/RadioButton/index.d.ts
@@ -9,6 +9,6 @@ export interface RadioButtonProps {
   onChange?: ((...args: any[]) => any);
 }
 
-declare const RadioButton: React.ComponentType<RadioButtonProps & JSX.IntrinsicElements['div']>;
+declare const RadioButton: React.ComponentType<RadioButtonProps & JSX.IntrinsicElements['input']>;
 
 export { RadioButton };

--- a/src/js/components/RangeInput/README.md
+++ b/src/js/components/RangeInput/README.md
@@ -72,3 +72,8 @@ number
 string
 ```
   
+## Intrinsic element
+
+```
+input
+```

--- a/src/js/components/RangeInput/doc.js
+++ b/src/js/components/RangeInput/doc.js
@@ -9,7 +9,8 @@ export const doc = RangeInput => {
     .usage(
       `import { RangeInput } from 'grommet';
 <RangeInput />`,
-    );
+    )
+    .intrinsicElement('input');
 
   DocumentedRangeInput.propTypes = {
     id: PropTypes.string.description('The id attribute of the range input.'),

--- a/src/js/components/RangeInput/index.d.ts
+++ b/src/js/components/RangeInput/index.d.ts
@@ -10,6 +10,6 @@ export interface RangeInputProps {
   value?: number | string;
 }
 
-declare const RangeInput: React.ComponentType<RangeInputProps>;
+declare const RangeInput: React.ComponentType<RangeInputProps & JSX.IntrinsicElements['input']>;
 
 export { RangeInput };

--- a/src/js/components/RangeSelector/README.md
+++ b/src/js/components/RangeSelector/README.md
@@ -134,3 +134,8 @@ Required. The current values. Defaults to `[]`.
 [number]
 ```
   
+## Intrinsic element
+
+```
+div
+```

--- a/src/js/components/RangeSelector/doc.js
+++ b/src/js/components/RangeSelector/doc.js
@@ -9,7 +9,8 @@ export const doc = RangeSelector => {
     .usage(
       `import { RangeSelector } from 'grommet';
 <RangeSelector />`,
-    );
+    )
+    .intrinsicElement('div');
 
   DocumentedRangeSelector.propTypes = {
     color: colorPropType.description(

--- a/src/js/components/RangeSelector/index.d.ts
+++ b/src/js/components/RangeSelector/index.d.ts
@@ -15,6 +15,6 @@ export interface RangeSelectorProps {
   values: number[];
 }
 
-declare const RangeSelector: React.ComponentType<RangeSelectorProps>;
+declare const RangeSelector: React.ComponentType<RangeSelectorProps & JSX.IntrinsicElements['div']>;
 
 export { RangeSelector };

--- a/src/js/components/RoutedAnchor/README.md
+++ b/src/js/components/RoutedAnchor/README.md
@@ -28,3 +28,8 @@ push
 replace
 ```
   
+## Intrinsic element
+
+```
+a
+```

--- a/src/js/components/RoutedAnchor/doc.js
+++ b/src/js/components/RoutedAnchor/doc.js
@@ -8,7 +8,8 @@ export const doc = RoutedAnchor => {
     .description('An Anchor with support for React Router.')
     .usage(
       "import { RoutedAnchor } from 'grommet';\n<RoutedAnchor primary={true} path='/documentation' />",
-    );
+    )
+    .intrinsicElement('a');
   DocumentedRoutedAnchor.propTypes = { ...ROUTER_PROPS };
   return DocumentedRoutedAnchor;
 };

--- a/src/js/components/RoutedAnchor/index.d.ts
+++ b/src/js/components/RoutedAnchor/index.d.ts
@@ -5,6 +5,6 @@ export interface RoutedAnchorProps {
   method?: "push" | "replace";
 }
 
-declare const RoutedAnchor: React.ComponentType<RoutedAnchorProps>;
+declare const RoutedAnchor: React.ComponentType<RoutedAnchorProps & JSX.IntrinsicElements['a']>;
 
 export { RoutedAnchor };

--- a/src/js/components/RoutedButton/README.md
+++ b/src/js/components/RoutedButton/README.md
@@ -28,3 +28,8 @@ push
 replace
 ```
   
+## Intrinsic element
+
+```
+button
+```

--- a/src/js/components/RoutedButton/doc.js
+++ b/src/js/components/RoutedButton/doc.js
@@ -9,7 +9,8 @@ export const doc = RoutedButton => {
     .usage(
       `import { RoutedButton } from 'grommet';
 <RoutedButton primary={true} path='/documentation' />`,
-    );
+    )
+    .intrinsicElement('button');
   DocumentedRoutedButton.propTypes = { ...ROUTER_PROPS };
   return DocumentedRoutedButton;
 };

--- a/src/js/components/RoutedButton/index.d.ts
+++ b/src/js/components/RoutedButton/index.d.ts
@@ -5,6 +5,6 @@ export interface RoutedButtonProps {
   method?: "push" | "replace";
 }
 
-declare const RoutedButton: React.ComponentType<RoutedButtonProps>;
+declare const RoutedButton: React.ComponentType<RoutedButtonProps & JSX.IntrinsicElements['button']>;
 
 export { RoutedButton };

--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -387,6 +387,11 @@ Empty option message to display when no matching results were found Defaults to 
 string
 ```
   
+## Intrinsic element
+
+```
+select
+```
 ## Theme
   
 **select.background**

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -16,7 +16,8 @@ import { SelectContainer } from './SelectContainer';
 const SelectTextInput = styled(TextInput)`
   cursor: pointer;
 `;
-const StyledSelectBox = styled(Box)`
+
+const StyledSelectDropButton = styled(DropButton)`
   ${props => !props.plain && controlBorderStyle};
   ${props =>
     props.theme.select &&
@@ -24,8 +25,19 @@ const StyledSelectBox = styled(Box)`
     props.theme.select.control.extend};
 `;
 
-StyledSelectBox.defaultProps = {};
-Object.setPrototypeOf(StyledSelectBox.defaultProps, defaultProps);
+StyledSelectDropButton.defaultProps = {};
+Object.setPrototypeOf(StyledSelectDropButton.defaultProps, defaultProps);
+
+// const StyledSelectBox = styled(Box)`
+//   ${props => !props.plain && controlBorderStyle};
+//   ${props =>
+//     props.theme.select &&
+//     props.theme.select.control &&
+//     props.theme.select.control.extend};
+// `;
+
+// StyledSelectBox.defaultProps = {};
+// Object.setPrototypeOf(StyledSelectBox.defaultProps, defaultProps);
 
 class Select extends Component {
   static defaultProps = {
@@ -153,7 +165,7 @@ class Select extends Component {
 
     return (
       <Keyboard onDown={this.onOpen} onUp={this.onOpen}>
-        <DropButton
+        <StyledSelectDropButton
           ref={forwardRef}
           id={id}
           disabled={disabled === true || undefined}
@@ -169,7 +181,7 @@ class Select extends Component {
             <SelectContainer {...this.props} onChange={onSelectChange} />
           }
         >
-          <StyledSelectBox
+          <Box
             align="center"
             direction="row"
             justify="between"
@@ -206,8 +218,8 @@ class Select extends Component {
             >
               <SelectIcon color={iconColor} size={size} />
             </Box>
-          </StyledSelectBox>
-        </DropButton>
+          </Box>
+        </StyledSelectDropButton>
       </Keyboard>
     );
   }

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -28,17 +28,6 @@ const StyledSelectDropButton = styled(DropButton)`
 StyledSelectDropButton.defaultProps = {};
 Object.setPrototypeOf(StyledSelectDropButton.defaultProps, defaultProps);
 
-// const StyledSelectBox = styled(Box)`
-//   ${props => !props.plain && controlBorderStyle};
-//   ${props =>
-//     props.theme.select &&
-//     props.theme.select.control &&
-//     props.theme.select.control.extend};
-// `;
-
-// StyledSelectBox.defaultProps = {};
-// Object.setPrototypeOf(StyledSelectBox.defaultProps, defaultProps);
-
 class Select extends Component {
   static defaultProps = {
     closeOnChange: true,

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -103,7 +103,7 @@ exports[`Select basic 1`] = `
   padding: 0px;
 }
 
-.c0 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -168,7 +168,7 @@ exports[`Select basic 1`] = `
   cursor: pointer;
 }
 
-.c1 {
+.c0 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -212,7 +212,7 @@ exports[`Select basic 1`] = `
 
 <button
   aria-label="Open Drop"
-  className="c0"
+  className="c0 c1"
   id="test-select"
   onBlur={[Function]}
   onClick={[Function]}
@@ -221,7 +221,7 @@ exports[`Select basic 1`] = `
   type="button"
 >
   <div
-    className="c1 c2"
+    className="c2"
   >
     <div
       className="c3"
@@ -372,7 +372,7 @@ exports[`Select complex options and children 1`] = `
   padding: 0px;
 }
 
-.c0 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -437,7 +437,7 @@ exports[`Select complex options and children 1`] = `
   cursor: pointer;
 }
 
-.c1 {
+.c0 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -481,12 +481,12 @@ exports[`Select complex options and children 1`] = `
 
 <button
   aria-label="Open Drop"
-  class="c0"
+  class="c0 c1"
   id="test-select"
   type="button"
 >
   <div
-    class="c1 c2"
+    class="c2"
   >
     <div
       class="c3"
@@ -530,12 +530,12 @@ exports[`Select complex options and children 1`] = `
 exports[`Select complex options and children 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 fRAxrl"
+  class="Select__StyledSelectDropButton-sc-17idtfo-1 dloaWS StyledButton-sc-323bzc-0 fRAxrl"
   id="test-select"
   type="button"
 >
   <div
-    class="Select__StyledSelectBox-sc-17idtfo-1 hFvoei StyledBox-sc-13pk1d4-0 erazuK"
+    class="StyledBox-sc-13pk1d4-0 erazuK"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 XINUX"
@@ -1135,7 +1135,7 @@ exports[`Select deselect an option 1`] = `
   padding: 0px;
 }
 
-.c0 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1200,7 +1200,7 @@ exports[`Select deselect an option 1`] = `
   cursor: pointer;
 }
 
-.c1 {
+.c0 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -1244,12 +1244,12 @@ exports[`Select deselect an option 1`] = `
 
 <button
   aria-label="Open Drop"
-  class="c0"
+  class="c0 c1"
   id="test-select"
   type="button"
 >
   <div
-    class="c1 c2"
+    class="c2"
   >
     <div
       class="c3"
@@ -1394,7 +1394,7 @@ exports[`Select disabled 1`] = `
   padding: 0px;
 }
 
-.c0 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1461,7 +1461,7 @@ exports[`Select disabled 1`] = `
   cursor: pointer;
 }
 
-.c1 {
+.c0 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -1505,13 +1505,13 @@ exports[`Select disabled 1`] = `
 
 <button
   aria-label="Open Drop"
-  class="c0"
+  class="c0 c1"
   disabled=""
   id="test-select"
   type="button"
 >
   <div
-    class="c1 c2"
+    class="c2"
   >
     <div
       class="c3"
@@ -1555,13 +1555,13 @@ exports[`Select disabled 1`] = `
 exports[`Select disabled 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 giLeBY"
+  class="Select__StyledSelectDropButton-sc-17idtfo-1 dloaWS StyledButton-sc-323bzc-0 giLeBY"
   disabled=""
   id="test-select"
   type="button"
 >
   <div
-    class="Select__StyledSelectBox-sc-17idtfo-1 hFvoei StyledBox-sc-13pk1d4-0 erazuK"
+    class="StyledBox-sc-13pk1d4-0 erazuK"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 XINUX"
@@ -2756,7 +2756,7 @@ exports[`Select multiple 1`] = `
   padding: 0px;
 }
 
-.c0 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2821,7 +2821,7 @@ exports[`Select multiple 1`] = `
   cursor: pointer;
 }
 
-.c1 {
+.c0 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -2865,7 +2865,7 @@ exports[`Select multiple 1`] = `
 
 <button
   aria-label="Open Drop"
-  className="c0"
+  className="c0 c1"
   id="test-select"
   onBlur={[Function]}
   onClick={[Function]}
@@ -2874,7 +2874,7 @@ exports[`Select multiple 1`] = `
   type="button"
 >
   <div
-    className="c1 c2"
+    className="c2"
   >
     <div
       className="c3"
@@ -3027,7 +3027,7 @@ exports[`Select multiple values 1`] = `
   padding: 0px;
 }
 
-.c0 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3092,7 +3092,7 @@ exports[`Select multiple values 1`] = `
   cursor: pointer;
 }
 
-.c1 {
+.c0 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -3136,12 +3136,12 @@ exports[`Select multiple values 1`] = `
 
 <button
   aria-label="Open Drop"
-  class="c0"
+  class="c0 c1"
   id="test-select"
   type="button"
 >
   <div
-    class="c1 c2"
+    class="c2"
   >
     <div
       class="c3"
@@ -3186,12 +3186,12 @@ exports[`Select multiple values 1`] = `
 exports[`Select multiple values 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 fRAxrl"
+  class="Select__StyledSelectDropButton-sc-17idtfo-1 dloaWS StyledButton-sc-323bzc-0 fRAxrl"
   id="test-select"
   type="button"
 >
   <div
-    class="Select__StyledSelectBox-sc-17idtfo-1 hFvoei StyledBox-sc-13pk1d4-0 erazuK"
+    class="StyledBox-sc-13pk1d4-0 erazuK"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 XINUX"
@@ -3865,7 +3865,7 @@ exports[`Select opens 1`] = `
   padding: 0px;
 }
 
-.c0 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3930,7 +3930,7 @@ exports[`Select opens 1`] = `
   cursor: pointer;
 }
 
-.c1 {
+.c0 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -3974,12 +3974,12 @@ exports[`Select opens 1`] = `
 
 <button
   aria-label="Open Drop"
-  class="c0"
+  class="c0 c1"
   id="test-select"
   type="button"
 >
   <div
-    class="c1 c2"
+    class="c2"
   >
     <div
       class="c3"
@@ -4023,12 +4023,12 @@ exports[`Select opens 1`] = `
 exports[`Select opens 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 fRAxrl"
+  class="Select__StyledSelectDropButton-sc-17idtfo-1 dloaWS StyledButton-sc-323bzc-0 fRAxrl"
   id="test-select"
   type="button"
 >
   <div
-    class="Select__StyledSelectBox-sc-17idtfo-1 hFvoei StyledBox-sc-13pk1d4-0 erazuK"
+    class="StyledBox-sc-13pk1d4-0 erazuK"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 XINUX"
@@ -4735,7 +4735,7 @@ exports[`Select search 1`] = `
   padding: 0px;
 }
 
-.c0 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -4800,7 +4800,7 @@ exports[`Select search 1`] = `
   cursor: pointer;
 }
 
-.c1 {
+.c0 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -4844,12 +4844,12 @@ exports[`Select search 1`] = `
 
 <button
   aria-label="Open Drop"
-  class="c0"
+  class="c0 c1"
   id="test-select"
   type="button"
 >
   <div
-    class="c1 c2"
+    class="c2"
   >
     <div
       class="c3"
@@ -5606,7 +5606,7 @@ exports[`Select select an option 1`] = `
   padding: 0px;
 }
 
-.c0 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5671,7 +5671,7 @@ exports[`Select select an option 1`] = `
   cursor: pointer;
 }
 
-.c1 {
+.c0 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -5715,12 +5715,12 @@ exports[`Select select an option 1`] = `
 
 <button
   aria-label="Open Drop"
-  class="c0"
+  class="c0 c1"
   id="test-select"
   type="button"
 >
   <div
-    class="c1 c2"
+    class="c2"
   >
     <div
       class="c3"
@@ -5762,7 +5762,7 @@ exports[`Select select an option 1`] = `
 `;
 
 exports[`Select select an option with complex options 1`] = `
-.c4 {
+.c5 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -5773,30 +5773,30 @@ exports[`Select select an option with complex options 1`] = `
   stroke: #7D4CDB;
 }
 
-.c4 g {
+.c5 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c4 *:not([stroke])[fill="none"] {
+.c5 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c4 *[stroke*="#"],
-.c4 *[STROKE*="#"] {
+.c5 *[stroke*="#"],
+.c5 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c4 *[fill-rule],
-.c4 *[FILL-RULE],
-.c4 *[fill*="#"],
-.c4 *[FILL*="#"] {
+.c5 *[fill-rule],
+.c5 *[FILL-RULE],
+.c5 *[fill*="#"],
+.c5 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
 
-.c1 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5821,7 +5821,7 @@ exports[`Select select an option with complex options 1`] = `
   padding: 0px;
 }
 
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5843,7 +5843,7 @@ exports[`Select select an option with complex options 1`] = `
   padding: 0px;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5864,7 +5864,7 @@ exports[`Select select an option with complex options 1`] = `
   padding: 0px;
 }
 
-.c0 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5882,16 +5882,9 @@ exports[`Select select an option with complex options 1`] = `
   text-align: inherit;
 }
 
-@media only screen and (max-width:768px) {
-  .c1 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c1 {
-    padding: 0px;
-  }
+.c0 {
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
 }
 
 @media only screen and (max-width:768px) {
@@ -5908,40 +5901,52 @@ exports[`Select select an option with complex options 1`] = `
 
 @media only screen and (max-width:768px) {
   .c3 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
     margin-left: 6px;
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c4 {
     padding: 0px;
   }
 }
 
 <button
   aria-label="Open Drop"
-  class="c0"
+  class="c0 c1"
   id="test-select"
   type="button"
 >
   <div
-    class="c1"
+    class="c2"
   >
     <div
-      class="c2"
+      class="c3"
     >
       <span>
         one
       </span>
     </div>
     <div
-      class="c3"
+      class="c4"
       style="min-width: auto;"
     >
       <svg
         aria-label="FormDown"
-        class="c4"
+        class="c5"
         viewBox="0 0 24 24"
       >
         <polyline
@@ -6059,7 +6064,7 @@ exports[`Select select an option with enter 1`] = `
   padding: 0px;
 }
 
-.c0 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6124,7 +6129,7 @@ exports[`Select select an option with enter 1`] = `
   cursor: pointer;
 }
 
-.c1 {
+.c0 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -6168,12 +6173,12 @@ exports[`Select select an option with enter 1`] = `
 
 <button
   aria-label="Open Drop"
-  class="c0"
+  class="c0 c1"
   id="test-select"
   type="button"
 >
   <div
-    class="c1 c2"
+    class="c2"
   >
     <div
       class="c3"
@@ -6317,7 +6322,7 @@ exports[`Select select another option 1`] = `
   padding: 0px;
 }
 
-.c0 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6382,7 +6387,7 @@ exports[`Select select another option 1`] = `
   cursor: pointer;
 }
 
-.c1 {
+.c0 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -6426,12 +6431,12 @@ exports[`Select select another option 1`] = `
 
 <button
   aria-label="Open Drop"
-  class="c0"
+  class="c0 c1"
   id="test-select"
   type="button"
 >
   <div
-    class="c1 c2"
+    class="c2"
   >
     <div
       class="c3"
@@ -6576,7 +6581,7 @@ exports[`Select size 1`] = `
   padding: 0px;
 }
 
-.c0 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6643,7 +6648,7 @@ exports[`Select size 1`] = `
   cursor: pointer;
 }
 
-.c1 {
+.c0 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -6687,7 +6692,7 @@ exports[`Select size 1`] = `
 
 <button
   aria-label="Open Drop"
-  className="c0"
+  className="c0 c1"
   id="test-select"
   onBlur={[Function]}
   onClick={[Function]}
@@ -6696,7 +6701,7 @@ exports[`Select size 1`] = `
   type="button"
 >
   <div
-    className="c1 c2"
+    className="c2"
   >
     <div
       className="c3"

--- a/src/js/components/Select/doc.js
+++ b/src/js/components/Select/doc.js
@@ -9,7 +9,8 @@ export const doc = Select => {
     .usage(
       `import { Select } from 'grommet';
 <Select />`,
-    );
+    )
+    .intrinsicElement('select');
 
   DocumentedSelect.propTypes = {
     ...genericProps,

--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -32,6 +32,6 @@ export interface SelectProps {
   emptySearchMessage?: string;
 }
 
-declare const Select: React.ComponentType<SelectProps>;
+declare const Select: React.ComponentType<SelectProps & JSX.IntrinsicElements['select']>;
 
 export { Select };

--- a/src/js/components/SkipLinks/index.d.ts
+++ b/src/js/components/SkipLinks/index.d.ts
@@ -5,6 +5,6 @@ export interface SkipLinksProps {
   messages?: {skipTo?: string};
 }
 
-declare const SkipLinks: React.ComponentType<SkipLinksProps & JSX.IntrinsicElements['div']>;
+declare const SkipLinks: React.ComponentType<SkipLinksProps>;
 
 export { SkipLinks };

--- a/src/js/components/SkipLinks/index.d.ts
+++ b/src/js/components/SkipLinks/index.d.ts
@@ -5,6 +5,6 @@ export interface SkipLinksProps {
   messages?: {skipTo?: string};
 }
 
-declare const SkipLinks: React.ComponentType<SkipLinksProps>;
+declare const SkipLinks: React.ComponentType<SkipLinksProps & JSX.IntrinsicElements['div']>;
 
 export { SkipLinks };

--- a/src/js/components/Stack/README.md
+++ b/src/js/components/Stack/README.md
@@ -148,6 +148,11 @@ first
 last
 ```
   
+## Intrinsic element
+
+```
+div
+```
 ## Theme
   
 **stack.extend**

--- a/src/js/components/Stack/doc.js
+++ b/src/js/components/Stack/doc.js
@@ -15,7 +15,8 @@ export const doc = Stack => {
     .usage(
       `import { Stack } from 'grommet';
 <Stack />`,
-    );
+    )
+    .intrinsicElement('div');
 
   DocumentedStack.propTypes = {
     ...genericProps,

--- a/src/js/components/Stack/index.d.ts
+++ b/src/js/components/Stack/index.d.ts
@@ -10,6 +10,6 @@ export interface StackProps {
   guidingChild?: number | "first" | "last";
 }
 
-declare const Stack: React.ComponentType<StackProps>;
+declare const Stack: React.ComponentType<StackProps & JSX.IntrinsicElements['div']>;
 
 export { Stack };

--- a/src/js/components/Tab/README.md
+++ b/src/js/components/Tab/README.md
@@ -27,3 +27,8 @@ string
 node
 ```
   
+## Intrinsic element
+
+```
+button
+```

--- a/src/js/components/Tab/doc.js
+++ b/src/js/components/Tab/doc.js
@@ -6,7 +6,8 @@ export const doc = Tab => {
     .usage(
       `import { Tab } from 'grommet';
 <Tab />`,
-    );
+    )
+    .intrinsicElement('button');
 
   DocumentedTab.propTypes = {
     plain: PropTypes.bool

--- a/src/js/components/Tab/index.d.ts
+++ b/src/js/components/Tab/index.d.ts
@@ -5,6 +5,6 @@ export interface TabProps {
   title?: string | React.ReactNode;
 }
 
-declare const Tab: React.ComponentType<TabProps>;
+declare const Tab: React.ComponentType<TabProps & JSX.IntrinsicElements['div']>;
 
 export { Tab };

--- a/src/js/components/Tab/index.d.ts
+++ b/src/js/components/Tab/index.d.ts
@@ -5,6 +5,6 @@ export interface TabProps {
   title?: string | React.ReactNode;
 }
 
-declare const Tab: React.ComponentType<TabProps & JSX.IntrinsicElements['div']>;
+declare const Tab: React.ComponentType<TabProps & JSX.IntrinsicElements['button']>;
 
 export { Tab };

--- a/src/js/components/Tabs/README.md
+++ b/src/js/components/Tabs/README.md
@@ -169,3 +169,8 @@ currently active tab changes.
 function
 ```
   
+## Intrinsic element
+
+```
+div
+```

--- a/src/js/components/Tabs/doc.js
+++ b/src/js/components/Tabs/doc.js
@@ -12,7 +12,8 @@ export const doc = Tabs => {
   <Tab title='Tab 1'>...</Tab>
   <Tab title='Tab 2'>...</Tab>
 </Tabs>`,
-    );
+    )
+    .intrinsicElement('div');
 
   DocumentedTabs.propTypes = {
     ...genericProps,

--- a/src/js/components/Tabs/index.d.ts
+++ b/src/js/components/Tabs/index.d.ts
@@ -13,6 +13,6 @@ export interface TabsProps {
   onActive?: ((...args: any[]) => any);
 }
 
-declare const Tabs: React.ComponentType<TabsProps>;
+declare const Tabs: React.ComponentType<TabsProps & JSX.IntrinsicElements['div']>;
 
 export { Tabs };

--- a/src/js/components/Video/README.md
+++ b/src/js/components/Video/README.md
@@ -150,3 +150,8 @@ Enables video muting. This option is best used with the autoPlay flag.
 boolean
 ```
   
+## Intrinsic element
+
+```
+video
+```

--- a/src/js/components/Video/doc.js
+++ b/src/js/components/Video/doc.js
@@ -9,7 +9,8 @@ export const doc = Video => {
     .usage(
       `import { Video } from 'grommet';
 <Video />`,
-    );
+    )
+    .intrinsicElement('video');
 
   DocumentedVideo.propTypes = {
     ...genericProps,

--- a/src/js/components/Video/index.d.ts
+++ b/src/js/components/Video/index.d.ts
@@ -12,6 +12,6 @@ export interface VideoProps {
   mute?: boolean;
 }
 
-declare const Video: React.ComponentType<VideoProps>;
+declare const Video: React.ComponentType<VideoProps & JSX.IntrinsicElements['video']>;
 
 export { Video };

--- a/src/js/components/WorldMap/README.md
+++ b/src/js/components/WorldMap/README.md
@@ -183,6 +183,11 @@ string
 }
 ```
   
+## Intrinsic element
+
+```
+svg
+```
 ## Theme
   
 **worldMap.color**

--- a/src/js/components/WorldMap/doc.js
+++ b/src/js/components/WorldMap/doc.js
@@ -49,7 +49,8 @@ export const doc = WorldMap => {
   const DocumentedWorldMap = describe(WorldMap)
     .availableAt(getAvailableAtBadge('WorldMap'))
     .description('A map of the world, or a continent.')
-    .usage("import { WorldMap } from 'grommet';\n<WorldMap />");
+    .usage("import { WorldMap } from 'grommet';\n<WorldMap />")
+    .intrinsicElement('svg');
 
   DocumentedWorldMap.propTypes = {
     ...genericProps,

--- a/src/js/components/WorldMap/index.d.ts
+++ b/src/js/components/WorldMap/index.d.ts
@@ -12,6 +12,6 @@ export interface WorldMapProps {
   hoverColor?: string | {dark?: string,light?: string};
 }
 
-declare const WorldMap: React.ComponentType<WorldMapProps & JSX.IntrinsicElements['div']>;
+declare const WorldMap: React.ComponentType<WorldMapProps & JSX.IntrinsicElements['svg']>;
 
 export { WorldMap };

--- a/src/js/components/WorldMap/index.d.ts
+++ b/src/js/components/WorldMap/index.d.ts
@@ -12,6 +12,6 @@ export interface WorldMapProps {
   hoverColor?: string | {dark?: string,light?: string};
 }
 
-declare const WorldMap: React.ComponentType<WorldMapProps>;
+declare const WorldMap: React.ComponentType<WorldMapProps & JSX.IntrinsicElements['div']>;
 
 export { WorldMap };

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -2595,7 +2595,12 @@ NOTE: This can only be used with non-toggle components
 \`\`\`
 boolean
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+input
+\`\`\`",
   "Clock": "## Clock
 A clock with timezone awareness.
 
@@ -3600,7 +3605,12 @@ Whether the drop should be open or not. Setting this property does not
 \`\`\`
 boolean
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+button
+\`\`\`",
   "Form": "## Form
 A form that manages state for its fields.
 
@@ -3666,7 +3676,12 @@ An object representing all of the data in the form. Defaults to \`{}\`.
 
 }
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+form
+\`\`\`",
   "FormField": "## FormField
 A single field in a form. FormField wraps an input component with
       a label, help, and/or error messaging. It typically contains an input
@@ -5101,7 +5116,12 @@ What text to put in the input. The caller should ensure that it
 \`\`\`
 string
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+input
+\`\`\`",
   "Menu": "## Menu
 A control that opens a Drop containing plain Buttons. The labels
       and behavior of the contained Buttons are described via the \`items\`
@@ -5328,6 +5348,11 @@ xlarge
 string
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+button
+\`\`\`
 ## Theme
   
 **global.colors.control**
@@ -5947,7 +5972,12 @@ The current value.
 number
 string
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+input
+\`\`\`",
   "RangeSelector": "## RangeSelector
 A control to input a range of values.
 
@@ -6113,7 +6143,12 @@ Indicates whether the browser history should be appended to or replaced. Default
 push
 replace
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+a
+\`\`\`",
   "RoutedButton": "## RoutedButton
 A button with support for React Router.
 
@@ -6143,7 +6178,12 @@ Indicates whether the browser history should be appended to or replaced. Default
 push
 replace
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+button
+\`\`\`",
   "Select": "## Select
 A control to select a value, with optional search.
 
@@ -6533,6 +6573,11 @@ Empty option message to display when no matching results were found Defaults to 
 string
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+select
+\`\`\`
 ## Theme
   
 **select.background**
@@ -8123,7 +8168,12 @@ Enables video muting. This option is best used with the autoPlay flag.
 \`\`\`
 boolean
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+video
+\`\`\`",
   "WorldMap": "## WorldMap
 A map of the world, or a continent.
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5032,11 +5032,12 @@ import { Markdown } from 'grommet';
 
 **components**
 
-Custom components to override default html tags such as 'img' or 'pre'.
-By default only 'p' and 'a' are overrided with the Paragraph and Anchor components
+Custom components and props to override html elements such as 'img'
+      or 'pre'. By default 'a', 'p', 'img', and table elements are overriden
+      with grommet components
 
 \`\`\`
-{ test: element, ... }
+{ test: shape, ... }
 \`\`\`
   ",
   "MaskedInput": "## MaskedInput

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -169,7 +169,12 @@ Custom messages for Tabs. Used for accessibility by screen readers. Defaults to 
   tabContents: string
 }
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`",
   "AccordionPanel": "## AccordionPanel
 An Accordion panel.
 
@@ -193,6 +198,11 @@ If specified, the entire panel header will be managed by the caller.
 node
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`
 ## Theme
   
 **accordion.icons.collapse**
@@ -1057,6 +1067,11 @@ Whether children can wrap if they
 boolean
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`
 ## Theme
   
 **global.animation**
@@ -1906,6 +1921,11 @@ large
 string
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`
 ## Theme
   
 **global.size.small**
@@ -2247,7 +2267,12 @@ If specified, the number of
 \`\`\`
 number
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`",
   "Chart": "## Chart
 A graphical chart.
 
@@ -2506,7 +2531,12 @@ Required. Array of value objects describing the data.
   }
 ]
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+svg
+\`\`\`",
   "CheckBox": "## CheckBox
 A checkbox toggle control.
 
@@ -2782,7 +2812,12 @@ What type of visualization to show. Defaults to \`analog\`.
 analog
 digital
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+div,svg
+\`\`\`",
   "Collapsible": "## Collapsible
 Expand or collapse animation.
 
@@ -2812,6 +2847,11 @@ horizontal
 vertical
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`
 ## Theme
   
 **collapsible.minSpeed**
@@ -3083,7 +3123,12 @@ Whether to allow the user to sort columns.
 \`\`\`
 boolean
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+table
+\`\`\`",
   "Diagram": "## Diagram
 Graphical connection lines. Diagram is meant to be used with Stack.
       Boxes can be used in the \`guidingChild\` layer of Stack and then
@@ -3146,7 +3191,12 @@ Required. Array of objects describing the connections.
     rectilinear
 }]
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+svg
+\`\`\`",
   "Distribution": "## Distribution
 Proportionally sized grid of boxes. The proportions are approximate. The
       area given to each box isn't mathematically precise according to the
@@ -3306,7 +3356,12 @@ Required. Array of objects containing a value. The array should already be
   value: number
 }]
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`",
   "Drop": "## Drop
 A container that is overlaid next to a target.
 
@@ -3417,7 +3472,12 @@ Whether the drop element should have no background nor shadow
 \`\`\`
 boolean
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`",
   "DropButton": "## DropButton
 A Button that controls a Drop. When opened, the Drop will contain
       whatever is specified via \`dropContent\`. The Drop will control the focus
@@ -3772,7 +3832,12 @@ Validation rule. Provide a regular expression or a function. If a
 }
 function
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`",
   "Grid": "## Grid
 A grid system for laying out content. To use, define the
 rows and columns, create area names for adjacent cells, and then
@@ -4127,6 +4192,11 @@ The DOM tag to use for the element. Defaults to \`div\`.
 string
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`
 ## Theme
   
 **global.edgeSize**
@@ -4224,7 +4294,12 @@ User agent used to detect the device width for setting the initial breakpoint.
 \`\`\`
 string
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`",
   "Heading": "## Heading
 Heading text structed in levels.
 
@@ -4409,7 +4484,12 @@ is too long to all fit.
 \`\`\`
 boolean
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+h1,h2,h3,h4
+\`\`\`",
   "Image": "## Image
 An image.
 
@@ -4703,6 +4783,14 @@ Function that will be called when the user presses the esc key.
 function
 \`\`\`
 
+**onKeyDown**
+
+Function that will be called when the user presses any key.
+
+\`\`\`
+function
+\`\`\`
+
 **onLeft**
 
 Function that will be called when the user presses the left key.
@@ -4901,6 +4989,11 @@ Whether the layer should take full width and height on mobile Defaults to \`true
 boolean
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`
 ## Theme
   
 **global.breakpoints**
@@ -5037,9 +5130,16 @@ Custom components and props to override html elements such as 'img'
       with grommet components
 
 \`\`\`
-{ test: shape, ... }
+{
+
+}
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`",
   "MaskedInput": "## MaskedInput
 An input field with formalized syntax.
 
@@ -5590,7 +5690,12 @@ Array of value objects describing the data.
   value: number
 }]
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+svg
+\`\`\`",
   "Paragraph": "## Paragraph
 A paragraph of text.
 
@@ -5899,7 +6004,12 @@ Function that will be called when the user clicks the radio button. It
 \`\`\`
 function
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+input
+\`\`\`",
   "RangeInput": "## RangeInput
 A slider control to input a value within a fixed range.
 
@@ -6114,7 +6224,12 @@ Required. The current values. Defaults to \`[]\`.
 \`\`\`
 [number]
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`",
   "RoutedAnchor": "## RoutedAnchor
 An Anchor with support for React Router.
 
@@ -6834,6 +6949,11 @@ first
 last
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`
 ## Theme
   
 **stack.extend**
@@ -6874,7 +6994,12 @@ The title of the tab.
 string
 node
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+button
+\`\`\`",
   "Table": "## Table
 A table of data organized in cells.
 
@@ -7306,7 +7431,12 @@ currently active tab changes.
 \`\`\`
 function
 \`\`\`
-  ",
+  
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`",
   "Text": "## Text
 Arbitrary text.
 
@@ -8360,6 +8490,11 @@ string
 }
 \`\`\`
   
+## Intrinsic element
+
+\`\`\`
+svg
+\`\`\`
 ## Theme
   
 **worldMap.color**

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1478,6 +1478,7 @@ area",
       },
     ],
     "description": "A checkbox toggle control.",
+    "intrinsicElement": "input",
     "name": "CheckBox",
     "properties": Array [
       Object {
@@ -1649,6 +1650,7 @@ vertical",
       so that the contents behind it are not focusable. All properties of
       Button can be passed through.
       ",
+    "intrinsicElement": "button",
     "name": "DropButton",
     "properties": Array [
       Object {
@@ -2023,6 +2025,7 @@ contain",
       },
     ],
     "description": "An input field with formalized syntax.",
+    "intrinsicElement": "input",
     "name": "MaskedInput",
     "properties": Array [
       Object {
@@ -2093,6 +2096,7 @@ string",
     "description": "A control that opens a Drop containing plain Buttons. The labels
       and behavior of the contained Buttons are described via the \`items\`
       property.",
+    "intrinsicElement": "button",
     "name": "Menu",
     "properties": Array [
       Object {
@@ -2347,6 +2351,7 @@ with the same name so form submissions work.",
       },
     ],
     "description": "A slider control to input a value within a fixed range.",
+    "intrinsicElement": "input",
     "name": "RangeInput",
     "properties": Array [
       Object {
@@ -2525,6 +2530,7 @@ string",
       },
     ],
     "description": "A control to select a value, with optional search.",
+    "intrinsicElement": "select",
     "name": "Select",
     "properties": Array [
       Object {
@@ -3290,6 +3296,7 @@ suggestions and instead rely on the user to type more.",
       },
     ],
     "description": "A video player.",
+    "intrinsicElement": "video",
     "name": "Video",
     "properties": Array [
       Object {

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -5,6 +5,7 @@ Object {
   "Accordion": [Function],
   "AccordionPanel": Object {
     "description": "An Accordion panel.",
+    "intrinsicElement": "div",
     "name": "AccordionPanel",
     "properties": Array [
       Object {
@@ -199,6 +200,7 @@ string",
     "description": "A container that lays out its contents in one direction. Box
       provides CSS flexbox capabilities for layout, as well as general
       styling of things like background color, border, and animation.",
+    "intrinsicElement": "div",
     "name": "Box",
     "properties": Array [
       Object {
@@ -911,6 +913,7 @@ submit",
     "description": "A calendar of days displayed by month.
       It can be used to select a single date, a range of dates, or multiple
       individual dates.",
+    "intrinsicElement": "div",
     "name": "Calendar",
     "properties": Array [
       Object {
@@ -1130,6 +1133,7 @@ string",
     "description": "A carousel that cycles through children. Child components
       would typically be Images. It is the caller's responsibility to ensure
       that all children are the same size.",
+    "intrinsicElement": "div",
     "name": "Carousel",
     "properties": Array [
       Object {
@@ -1247,6 +1251,7 @@ string",
       },
     ],
     "description": "A graphical chart.",
+    "intrinsicElement": "svg",
     "name": "Chart",
     "properties": Array [
       Object {
@@ -1542,6 +1547,7 @@ NOTE: This can only be used with non-toggle components",
   "Clock": [Function],
   "Collapsible": Object {
     "description": "Expand or collapse animation.",
+    "intrinsicElement": "div",
     "name": "Collapsible",
     "properties": Array [
       Object {
@@ -1577,6 +1583,7 @@ vertical",
     "description": "Graphical connection lines. Diagram is meant to be used with Stack.
       Boxes can be used in the \`guidingChild\` layer of Stack and then
       Diagram can be used to draw lines connecting the Boxes.",
+    "intrinsicElement": "svg",
     "name": "Diagram",
     "properties": Array [
       Object {
@@ -1835,6 +1842,7 @@ string",
     "description": "A single field in a form. FormField wraps an input component with
       a label, help, and/or error messaging. It typically contains an input
       control like TextInput, TextArea, Select, etc.",
+    "intrinsicElement": "div",
     "name": "FormField",
     "properties": Array [
       Object {
@@ -2297,6 +2305,7 @@ string",
       },
     ],
     "description": "A radio button control.",
+    "intrinsicElement": "input",
     "name": "RadioButton",
     "properties": Array [
       Object {
@@ -2412,6 +2421,7 @@ string",
       },
     ],
     "description": "A control to input a range of values.",
+    "intrinsicElement": "div",
     "name": "RangeSelector",
     "properties": Array [
       Object {
@@ -2838,6 +2848,7 @@ function",
   "Stack": [Function],
   "Tab": Object {
     "description": "One tab within Tabs.",
+    "intrinsicElement": "button",
     "name": "Tab",
     "properties": Array [
       Object {
@@ -2923,6 +2934,7 @@ bottom",
       },
     ],
     "description": "A container with controls to show one Tab at a time.",
+    "intrinsicElement": "div",
     "name": "Tabs",
     "properties": Array [
       Object {
@@ -3430,6 +3442,7 @@ contain",
       },
     ],
     "description": "A map of the world, or a continent.",
+    "intrinsicElement": "svg",
     "name": "WorldMap",
     "properties": Array [
       Object {

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -476,7 +476,7 @@ export { Layer };
   "Markdown": "import * as React from \\"react\\";
 
 export interface MarkdownProps {
-  components?: { [key: string]: JSX.Element };
+  components?: { [key: string]: {component?: JSX.Element,props?: {}} };
 }
 
 declare const Markdown: React.ComponentType<MarkdownProps & JSX.IntrinsicElements['div']>;

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -176,7 +176,7 @@ export interface ChartProps {
   values: (number | number[] | {label?: string,onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any),value: number | number[]})[];
 }
 
-declare const Chart: React.ComponentType<ChartProps & JSX.IntrinsicElements['div']>;
+declare const Chart: React.ComponentType<ChartProps & JSX.IntrinsicElements['svg']>;
 
 export { Chart };
 ",
@@ -214,7 +214,7 @@ export interface ClockProps {
   type?: \\"analog\\" | \\"digital\\";
 }
 
-declare const Clock: React.ComponentType<ClockProps & JSX.IntrinsicElements['div']>;
+declare const Clock: React.ComponentType<ClockProps & (JSX.IntrinsicElements['div'] | JSX.IntrinsicElements['svg'])>;
 
 export { Clock };
 ",
@@ -247,7 +247,7 @@ export interface DataTableProps {
   sortable?: boolean;
 }
 
-declare const DataTable: React.ComponentType<DataTableProps & JSX.IntrinsicElements['div']>;
+declare const DataTable: React.ComponentType<DataTableProps & JSX.IntrinsicElements['table']>;
 
 export { DataTable };
 ",
@@ -257,7 +257,7 @@ export interface DiagramProps {
   connections: {anchor?: \\"center\\" | \\"vertical\\" | \\"horizontal\\",color?: string | {dark?: string,light?: string},fromTarget: string | object,label?: string,offset?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | string,thickness?: \\"hair\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | string,toTarget: string | object,type?: \\"direct\\" | \\"curved\\" | \\"rectilinear\\"}[];
 }
 
-declare const Diagram: React.ComponentType<DiagramProps & JSX.IntrinsicElements['div']>;
+declare const Diagram: React.ComponentType<DiagramProps & JSX.IntrinsicElements['svg']>;
 
 export { Diagram };
 ",
@@ -399,7 +399,7 @@ export interface HeadingProps {
   truncate?: boolean;
 }
 
-declare const Heading: React.ComponentType<HeadingProps & JSX.IntrinsicElements['div']>;
+declare const Heading: React.ComponentType<HeadingProps & (JSX.IntrinsicElements['h1'] | JSX.IntrinsicElements['h2'] | JSX.IntrinsicElements['h3'] | JSX.IntrinsicElements['h4'])>;
 
 export { Heading };
 ",
@@ -430,7 +430,7 @@ export interface InfiniteScrollProps {
   step?: number;
 }
 
-declare const InfiniteScroll: React.ComponentType<InfiniteScrollProps & JSX.IntrinsicElements['div']>;
+declare const InfiniteScroll: React.ComponentType<InfiniteScrollProps>;
 
 export { InfiniteScroll };
 ",
@@ -443,6 +443,7 @@ export interface KeyboardProps {
   onDown?: ((...args: any[]) => any);
   onEnter?: ((...args: any[]) => any);
   onEsc?: ((...args: any[]) => any);
+  onKeyDown?: ((...args: any[]) => any);
   onLeft?: ((...args: any[]) => any);
   onRight?: ((...args: any[]) => any);
   onShift?: ((...args: any[]) => any);
@@ -451,7 +452,7 @@ export interface KeyboardProps {
   onUp?: ((...args: any[]) => any);
 }
 
-declare const Keyboard: React.ComponentType<KeyboardProps & JSX.IntrinsicElements['div']>;
+declare const Keyboard: React.ComponentType<KeyboardProps>;
 
 export { Keyboard };
 ",
@@ -476,7 +477,7 @@ export { Layer };
   "Markdown": "import * as React from \\"react\\";
 
 export interface MarkdownProps {
-  components?: { [key: string]: {component?: JSX.Element,props?: {}} };
+  components?: {};
 }
 
 declare const Markdown: React.ComponentType<MarkdownProps & JSX.IntrinsicElements['div']>;
@@ -535,7 +536,7 @@ export interface MeterProps {
   values?: {color?: string,highlight?: boolean,label: string,onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any),value: number}[];
 }
 
-declare const Meter: React.ComponentType<MeterProps & JSX.IntrinsicElements['div']>;
+declare const Meter: React.ComponentType<MeterProps & JSX.IntrinsicElements['svg']>;
 
 export { Meter };
 ",
@@ -567,7 +568,7 @@ export interface RadioButtonProps {
   onChange?: ((...args: any[]) => any);
 }
 
-declare const RadioButton: React.ComponentType<RadioButtonProps & JSX.IntrinsicElements['div']>;
+declare const RadioButton: React.ComponentType<RadioButtonProps & JSX.IntrinsicElements['input']>;
 
 export { RadioButton };
 ",
@@ -675,7 +676,7 @@ export interface SkipLinksProps {
   messages?: {skipTo?: string};
 }
 
-declare const SkipLinks: React.ComponentType<SkipLinksProps & JSX.IntrinsicElements['div']>;
+declare const SkipLinks: React.ComponentType<SkipLinksProps>;
 
 export { SkipLinks };
 ",
@@ -702,7 +703,7 @@ export interface TabProps {
   title?: string | React.ReactNode;
 }
 
-declare const Tab: React.ComponentType<TabProps & JSX.IntrinsicElements['div']>;
+declare const Tab: React.ComponentType<TabProps & JSX.IntrinsicElements['button']>;
 
 export { Tab };
 ",
@@ -887,7 +888,7 @@ export interface WorldMapProps {
   hoverColor?: string | {dark?: string,light?: string};
 }
 
-declare const WorldMap: React.ComponentType<WorldMapProps & JSX.IntrinsicElements['div']>;
+declare const WorldMap: React.ComponentType<WorldMapProps & JSX.IntrinsicElements['svg']>;
 
 export { WorldMap };
 ",

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -17,7 +17,7 @@ export interface AccordionProps {
   messages?: {tabContents?: string};
 }
 
-declare const Accordion: React.ComponentType<AccordionProps>;
+declare const Accordion: React.ComponentType<AccordionProps & JSX.IntrinsicElements['div']>;
 
 export { Accordion };
 ",
@@ -28,7 +28,7 @@ export interface AccordionPanelProps {
   header?: React.ReactNode;
 }
 
-declare const AccordionPanel: React.ComponentType<AccordionPanelProps>;
+declare const AccordionPanel: React.ComponentType<AccordionPanelProps & JSX.IntrinsicElements['div']>;
 
 export { AccordionPanel };
 ",
@@ -83,7 +83,7 @@ export interface BoxProps {
   wrap?: boolean;
 }
 
-declare const Box: React.ComponentType<BoxProps>;
+declare const Box: React.ComponentType<BoxProps & JSX.IntrinsicElements['div']>;
 
 export { Box };
 ",
@@ -138,7 +138,7 @@ export interface CalendarProps {
   size?: \\"small\\" | \\"medium\\" | \\"large\\" | string;
 }
 
-declare const Calendar: React.ComponentType<CalendarProps>;
+declare const Calendar: React.ComponentType<CalendarProps & JSX.IntrinsicElements['div']>;
 
 export { Calendar };
 ",
@@ -153,7 +153,7 @@ export interface CarouselProps {
   play?: number;
 }
 
-declare const Carousel: React.ComponentType<CarouselProps>;
+declare const Carousel: React.ComponentType<CarouselProps & JSX.IntrinsicElements['div']>;
 
 export { Carousel };
 ",
@@ -176,7 +176,7 @@ export interface ChartProps {
   values: (number | number[] | {label?: string,onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any),value: number | number[]})[];
 }
 
-declare const Chart: React.ComponentType<ChartProps>;
+declare const Chart: React.ComponentType<ChartProps & JSX.IntrinsicElements['div']>;
 
 export { Chart };
 ",
@@ -194,7 +194,7 @@ export interface CheckBoxProps {
   indeterminate?: boolean;
 }
 
-declare const CheckBox: React.ComponentType<CheckBoxProps>;
+declare const CheckBox: React.ComponentType<CheckBoxProps & JSX.IntrinsicElements['input']>;
 
 export { CheckBox };
 ",
@@ -214,7 +214,7 @@ export interface ClockProps {
   type?: \\"analog\\" | \\"digital\\";
 }
 
-declare const Clock: React.ComponentType<ClockProps>;
+declare const Clock: React.ComponentType<ClockProps & JSX.IntrinsicElements['div']>;
 
 export { Clock };
 ",
@@ -225,7 +225,7 @@ export interface CollapsibleProps {
   direction?: \\"horizontal\\" | \\"vertical\\";
 }
 
-declare const Collapsible: React.ComponentType<CollapsibleProps>;
+declare const Collapsible: React.ComponentType<CollapsibleProps & JSX.IntrinsicElements['div']>;
 
 export { Collapsible };
 ",
@@ -247,7 +247,7 @@ export interface DataTableProps {
   sortable?: boolean;
 }
 
-declare const DataTable: React.ComponentType<DataTableProps>;
+declare const DataTable: React.ComponentType<DataTableProps & JSX.IntrinsicElements['div']>;
 
 export { DataTable };
 ",
@@ -257,7 +257,7 @@ export interface DiagramProps {
   connections: {anchor?: \\"center\\" | \\"vertical\\" | \\"horizontal\\",color?: string | {dark?: string,light?: string},fromTarget: string | object,label?: string,offset?: \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | string,thickness?: \\"hair\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | string,toTarget: string | object,type?: \\"direct\\" | \\"curved\\" | \\"rectilinear\\"}[];
 }
 
-declare const Diagram: React.ComponentType<DiagramProps>;
+declare const Diagram: React.ComponentType<DiagramProps & JSX.IntrinsicElements['div']>;
 
 export { Diagram };
 ",
@@ -274,7 +274,7 @@ export interface DistributionProps {
   values: {value: number}[];
 }
 
-declare const Distribution: React.ComponentType<DistributionProps>;
+declare const Distribution: React.ComponentType<DistributionProps & JSX.IntrinsicElements['div']>;
 
 export { Distribution };
 ",
@@ -292,7 +292,7 @@ export interface DropProps {
   plain?: boolean;
 }
 
-declare const Drop: React.ComponentType<DropProps>;
+declare const Drop: React.ComponentType<DropProps & JSX.IntrinsicElements['div']>;
 
 export { Drop };
 ",
@@ -312,7 +312,7 @@ export interface DropButtonProps {
   open?: boolean;
 }
 
-declare const DropButton: React.ComponentType<DropButtonProps>;
+declare const DropButton: React.ComponentType<DropButtonProps & JSX.IntrinsicElements['button']>;
 
 export { DropButton };
 ",
@@ -326,7 +326,7 @@ export interface FormProps {
   value?: {};
 }
 
-declare const Form: React.ComponentType<FormProps>;
+declare const Form: React.ComponentType<FormProps & JSX.IntrinsicElements['form']>;
 
 export { Form };
 ",
@@ -343,7 +343,7 @@ export interface FormFieldProps {
   validate?: {regexp?: object,message?: string} | ((...args: any[]) => any);
 }
 
-declare const FormField: React.ComponentType<FormFieldProps>;
+declare const FormField: React.ComponentType<FormFieldProps & JSX.IntrinsicElements['div']>;
 
 export { FormField };
 ",
@@ -367,7 +367,7 @@ export interface GridProps {
   as?: string;
 }
 
-declare const Grid: React.ComponentType<GridProps>;
+declare const Grid: React.ComponentType<GridProps & JSX.IntrinsicElements['div']>;
 
 export { Grid };
 ",
@@ -380,7 +380,7 @@ export interface GrommetProps {
   userAgent?: string;
 }
 
-declare const Grommet: React.ComponentType<GrommetProps>;
+declare const Grommet: React.ComponentType<GrommetProps & JSX.IntrinsicElements['div']>;
 
 export { Grommet };
 ",
@@ -399,7 +399,7 @@ export interface HeadingProps {
   truncate?: boolean;
 }
 
-declare const Heading: React.ComponentType<HeadingProps>;
+declare const Heading: React.ComponentType<HeadingProps & JSX.IntrinsicElements['div']>;
 
 export { Heading };
 ",
@@ -430,7 +430,7 @@ export interface InfiniteScrollProps {
   step?: number;
 }
 
-declare const InfiniteScroll: React.ComponentType<InfiniteScrollProps>;
+declare const InfiniteScroll: React.ComponentType<InfiniteScrollProps & JSX.IntrinsicElements['div']>;
 
 export { InfiniteScroll };
 ",
@@ -451,7 +451,7 @@ export interface KeyboardProps {
   onUp?: ((...args: any[]) => any);
 }
 
-declare const Keyboard: React.ComponentType<KeyboardProps>;
+declare const Keyboard: React.ComponentType<KeyboardProps & JSX.IntrinsicElements['div']>;
 
 export { Keyboard };
 ",
@@ -469,7 +469,7 @@ export interface LayerProps {
   responsive?: boolean;
 }
 
-declare const Layer: React.ComponentType<LayerProps>;
+declare const Layer: React.ComponentType<LayerProps & JSX.IntrinsicElements['div']>;
 
 export { Layer };
 ",
@@ -479,7 +479,7 @@ export interface MarkdownProps {
   components?: { [key: string]: JSX.Element };
 }
 
-declare const Markdown: React.ComponentType<MarkdownProps>;
+declare const Markdown: React.ComponentType<MarkdownProps & JSX.IntrinsicElements['div']>;
 
 export { Markdown };
 ",
@@ -494,7 +494,7 @@ export interface MaskedInputProps {
   value?: string;
 }
 
-declare const MaskedInput: React.ComponentType<MaskedInputProps>;
+declare const MaskedInput: React.ComponentType<MaskedInputProps & JSX.IntrinsicElements['input']>;
 
 export { MaskedInput };
 ",
@@ -516,7 +516,7 @@ export interface MenuProps {
   size?: \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string;
 }
 
-declare const Menu: React.ComponentType<MenuProps>;
+declare const Menu: React.ComponentType<MenuProps & JSX.IntrinsicElements['button']>;
 
 export { Menu };
 ",
@@ -535,7 +535,7 @@ export interface MeterProps {
   values?: {color?: string,highlight?: boolean,label: string,onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any),value: number}[];
 }
 
-declare const Meter: React.ComponentType<MeterProps>;
+declare const Meter: React.ComponentType<MeterProps & JSX.IntrinsicElements['div']>;
 
 export { Meter };
 ",
@@ -567,7 +567,7 @@ export interface RadioButtonProps {
   onChange?: ((...args: any[]) => any);
 }
 
-declare const RadioButton: React.ComponentType<RadioButtonProps>;
+declare const RadioButton: React.ComponentType<RadioButtonProps & JSX.IntrinsicElements['div']>;
 
 export { RadioButton };
 ",
@@ -583,7 +583,7 @@ export interface RangeInputProps {
   value?: number | string;
 }
 
-declare const RangeInput: React.ComponentType<RangeInputProps>;
+declare const RangeInput: React.ComponentType<RangeInputProps & JSX.IntrinsicElements['input']>;
 
 export { RangeInput };
 ",
@@ -604,7 +604,7 @@ export interface RangeSelectorProps {
   values: number[];
 }
 
-declare const RangeSelector: React.ComponentType<RangeSelectorProps>;
+declare const RangeSelector: React.ComponentType<RangeSelectorProps & JSX.IntrinsicElements['div']>;
 
 export { RangeSelector };
 ",
@@ -615,7 +615,7 @@ export interface RoutedAnchorProps {
   method?: \\"push\\" | \\"replace\\";
 }
 
-declare const RoutedAnchor: React.ComponentType<RoutedAnchorProps>;
+declare const RoutedAnchor: React.ComponentType<RoutedAnchorProps & JSX.IntrinsicElements['a']>;
 
 export { RoutedAnchor };
 ",
@@ -626,7 +626,7 @@ export interface RoutedButtonProps {
   method?: \\"push\\" | \\"replace\\";
 }
 
-declare const RoutedButton: React.ComponentType<RoutedButtonProps>;
+declare const RoutedButton: React.ComponentType<RoutedButtonProps & JSX.IntrinsicElements['button']>;
 
 export { RoutedButton };
 ",
@@ -664,7 +664,7 @@ export interface SelectProps {
   emptySearchMessage?: string;
 }
 
-declare const Select: React.ComponentType<SelectProps>;
+declare const Select: React.ComponentType<SelectProps & JSX.IntrinsicElements['select']>;
 
 export { Select };
 ",
@@ -675,7 +675,7 @@ export interface SkipLinksProps {
   messages?: {skipTo?: string};
 }
 
-declare const SkipLinks: React.ComponentType<SkipLinksProps>;
+declare const SkipLinks: React.ComponentType<SkipLinksProps & JSX.IntrinsicElements['div']>;
 
 export { SkipLinks };
 ",
@@ -691,7 +691,7 @@ export interface StackProps {
   guidingChild?: number | \\"first\\" | \\"last\\";
 }
 
-declare const Stack: React.ComponentType<StackProps>;
+declare const Stack: React.ComponentType<StackProps & JSX.IntrinsicElements['div']>;
 
 export { Stack };
 ",
@@ -702,7 +702,7 @@ export interface TabProps {
   title?: string | React.ReactNode;
 }
 
-declare const Tab: React.ComponentType<TabProps>;
+declare const Tab: React.ComponentType<TabProps & JSX.IntrinsicElements['div']>;
 
 export { Tab };
 ",
@@ -788,7 +788,7 @@ export interface TabsProps {
   onActive?: ((...args: any[]) => any);
 }
 
-declare const Tabs: React.ComponentType<TabsProps>;
+declare const Tabs: React.ComponentType<TabsProps & JSX.IntrinsicElements['div']>;
 
 export { Tabs };
 ",
@@ -869,7 +869,7 @@ export interface VideoProps {
   mute?: boolean;
 }
 
-declare const Video: React.ComponentType<VideoProps>;
+declare const Video: React.ComponentType<VideoProps & JSX.IntrinsicElements['video']>;
 
 export { Video };
 ",
@@ -887,7 +887,7 @@ export interface WorldMapProps {
   hoverColor?: string | {dark?: string,light?: string};
 }
 
-declare const WorldMap: React.ComponentType<WorldMapProps>;
+declare const WorldMap: React.ComponentType<WorldMapProps & JSX.IntrinsicElements['div']>;
 
 export { WorldMap };
 ",

--- a/tools/generate-readme-ts.js
+++ b/tools/generate-readme-ts.js
@@ -20,8 +20,17 @@ export interface ${component}Props {
     .join('\n  ')}
 }
 
-declare const ${component}: React.ComponentType<${component}Props & ${`JSX.IntrinsicElements['${intrinsicElement ||
-  'div'}']`}>;
+declare const ${component}: React.ComponentType<${component}Props${
+  intrinsicElement
+    ? ` & ${
+        Array.isArray(intrinsicElement)
+          ? `(${intrinsicElement
+              .map(e => `JSX.IntrinsicElements['${e}']`)
+              .join(' | ')})`
+          : `JSX.IntrinsicElements['${intrinsicElement}']`
+      }`
+    : ''
+}>;
 
 export { ${component} };
 `;

--- a/tools/generate-readme-ts.js
+++ b/tools/generate-readme-ts.js
@@ -20,9 +20,8 @@ export interface ${component}Props {
     .join('\n  ')}
 }
 
-declare const ${component}: React.ComponentType<${component}Props${
-  intrinsicElement ? ` & JSX.IntrinsicElements['${intrinsicElement}']` : ''
-}>;
+declare const ${component}: React.ComponentType<${component}Props & ${`JSX.IntrinsicElements['${intrinsicElement ||
+  'div'}']`}>;
 
 export { ${component} };
 `;


### PR DESCRIPTION
#### What does this PR do?

Added intrinsic typings so HTML properties can be used in typescript.
Also changed Select to put styling on outer DropButton instead of the first Box inside it.

#### Where should the reviewer start?

tools/generate-readme-ts.js

#### What testing has been done on this PR?

used with a create-react-app using typescript

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/2608
https://github.com/grommet/grommet/issues/2413

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
