### PR TITLE
[Datatable] Add sortable property on columns

### DIFF
--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -59,11 +59,10 @@ const Header = ({
           />
         )}
 
-        {columns.map(({ property, header, align, search }) => {
+        {columns.map(({ property, header, align, search, sortable }) => {
           let content =
             typeof header === 'string' ? <Text>{header}</Text> : header;
-
-          if (onSort) {
+          if (onSort && sortable !== false) {
             content = (
               <Sorter
                 align={align}

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -103,7 +103,7 @@ const Header = ({
                 />
               </Box>
             );
-          } else if (!onSort) {
+          } else if (!onSort || sortable === false) {
             content = (
               <Box
                 {...dataTableContextTheme}

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -149,7 +149,8 @@ A description of the data. The order controls the column order.
   primary: boolean,
   property: string,
   render: function,
-  search: boolean
+  search: boolean,
+  sortable: boolean
 }]
 ```
 

--- a/src/js/components/DataTable/datatable.stories.js
+++ b/src/js/components/DataTable/datatable.stories.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
 
-import { Grommet, Box, DataTable, Meter, Text } from 'grommet';
+import { Grommet, Box, DataTable, Meter, Text, CheckBox } from 'grommet';
 import { grommet } from 'grommet/themes';
 
 const amountFormatter = new Intl.NumberFormat('en-US', {
@@ -211,9 +211,73 @@ class ServedDataTable extends Component {
   }
 }
 
+class ControlledDataTable extends Component {
+  state = {
+    checked: [],
+  };
+
+  onCheck = (event, value) => {
+    const { checked } = this.state;
+    if (event.target.checked) {
+      checked.push(value);
+      this.setState({ checked });
+    } else {
+      this.setState({ checked: checked.filter(item => item !== value) });
+    }
+  };
+
+  onCheckAll = event =>
+    this.setState({
+      checked: event.target.checked ? DATA.map(datum => datum.name) : [],
+    });
+
+  render() {
+    const { checked } = this.state;
+    return (
+      <Grommet theme={grommet}>
+        <Box align="center" pad="medium">
+          <DataTable
+            columns={[
+              {
+                property: 'checkbox',
+                header: (
+                  <Box margin={{ left: 'small' }} pad={{ bottom: 'small' }}>
+                    <CheckBox
+                      checked={checked.length === DATA.length}
+                      indeterminate={
+                        checked.length > 0 && checked.length < DATA.length
+                      }
+                      onChange={this.onCheckAll}
+                    />
+                  </Box>
+                ),
+                sortable: false,
+              },
+              ...columns,
+            ].map(col => ({ ...col }))}
+            data={DATA.map(datum => ({
+              checkbox: (
+                <CheckBox
+                  key={datum.name}
+                  checked={checked.indexOf(datum.name) !== -1}
+                  onChange={e => this.onCheck(e, datum.name)}
+                />
+              ),
+              ...datum,
+            }))}
+            sortable
+            size="medium"
+          />
+        </Box>
+      </Grommet>
+    );
+  }
+}
+
 storiesOf('DataTable', module)
   .add('Simple DataTable', () => <SimpleDataTable />)
   .add('Sized DataTable', () => <SizedDataTable />)
   .add('Tunable DataTable', () => <TunableDataTable />)
   .add('Grouped DataTable', () => <GroupedDataTable />)
-  .add('Served DataTable', () => <ServedDataTable />);
+  .add('Served DataTable', () => <ServedDataTable />)
+  .add('Controlled DataTable', () => <ControlledDataTable />);

--- a/src/js/components/DataTable/datatable.stories.js
+++ b/src/js/components/DataTable/datatable.stories.js
@@ -211,6 +211,13 @@ class ServedDataTable extends Component {
   }
 }
 
+const controlledColumns = [...columns];
+const name = controlledColumns[0];
+const totals = controlledColumns[4];
+delete name.footer;
+delete totals.footer;
+delete totals.aggregate;
+
 class ControlledDataTable extends Component {
   state = {
     checked: [],
@@ -233,6 +240,7 @@ class ControlledDataTable extends Component {
 
   render() {
     const { checked } = this.state;
+
     return (
       <Grommet theme={grommet}>
         <Box align="center" pad="medium">
@@ -240,31 +248,26 @@ class ControlledDataTable extends Component {
             columns={[
               {
                 property: 'checkbox',
+                render: datum => (
+                  <CheckBox
+                    key={datum.name}
+                    checked={checked.indexOf(datum.name) !== -1}
+                    onChange={e => this.onCheck(e, datum.name)}
+                  />
+                ),
                 header: (
-                  <Box margin={{ left: 'small' }} pad={{ bottom: 'small' }}>
-                    <CheckBox
-                      checked={checked.length === DATA.length}
-                      indeterminate={
-                        checked.length > 0 && checked.length < DATA.length
-                      }
-                      onChange={this.onCheckAll}
-                    />
-                  </Box>
+                  <CheckBox
+                    indeterminate={
+                      checked.length > 0 && checked.length < DATA.length
+                    }
+                    onChange={this.onCheckAll}
+                  />
                 ),
                 sortable: false,
               },
-              ...columns,
+              ...controlledColumns,
             ].map(col => ({ ...col }))}
-            data={DATA.map(datum => ({
-              checkbox: (
-                <CheckBox
-                  key={datum.name}
-                  checked={checked.indexOf(datum.name) !== -1}
-                  onChange={e => this.onCheck(e, datum.name)}
-                />
-              ),
-              ...datum,
-            }))}
+            data={DATA}
             sortable
             size="medium"
           />

--- a/src/js/components/DataTable/datatable.stories.js
+++ b/src/js/components/DataTable/datatable.stories.js
@@ -257,6 +257,7 @@ class ControlledDataTable extends Component {
                 ),
                 header: (
                   <CheckBox
+                    checked={checked.length === DATA.length}
                     indeterminate={
                       checked.length > 0 && checked.length < DATA.length
                     }

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -34,6 +34,7 @@ export const doc = DataTable => {
         property: PropTypes.string.isRequired,
         render: PropTypes.func,
         search: PropTypes.bool,
+        sortable: PropTypes.bool,
       }),
     ).description(
       `A description of the data. The order controls the column order.

--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -5,7 +5,7 @@ export interface DataTableProps {
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
-  columns?: {align?: "center" | "start" | "end",aggregate?: "avg" | "max" | "min" | "sum",footer?: React.ReactNode | {aggregate?: boolean},header?: string | React.ReactNode | {aggregate?: boolean},primary?: boolean,property: string,render?: ((...args: any[]) => any),search?: boolean}[];
+  columns?: {align?: "center" | "start" | "end",aggregate?: "avg" | "max" | "min" | "sum",footer?: React.ReactNode | {aggregate?: boolean},header?: string | React.ReactNode | {aggregate?: boolean},primary?: boolean,property: string,render?: ((...args: any[]) => any),search?: boolean,sortable?: boolean}[];
   data?: {}[];
   groupBy?: string;
   onMore?: ((...args: any[]) => any);

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -3032,7 +3032,8 @@ A description of the data. The order controls the column order.
   primary: boolean,
   property: string,
   render: function,
-  search: boolean
+  search: boolean,
+  sortable: boolean
 }]
 \`\`\`
 

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -236,7 +236,7 @@ export interface DataTableProps {
   alignSelf?: \\"start\\" | \\"center\\" | \\"end\\" | \\"stretch\\";
   gridArea?: string;
   margin?: \\"none\\" | \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | {bottom?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,horizontal?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,left?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,right?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,top?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string,vertical?: \\"xxsmall\\" | \\"xsmall\\" | \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string} | string;
-  columns?: {align?: \\"center\\" | \\"start\\" | \\"end\\",aggregate?: \\"avg\\" | \\"max\\" | \\"min\\" | \\"sum\\",footer?: React.ReactNode | {aggregate?: boolean},header?: string | React.ReactNode | {aggregate?: boolean},primary?: boolean,property: string,render?: ((...args: any[]) => any),search?: boolean}[];
+  columns?: {align?: \\"center\\" | \\"start\\" | \\"end\\",aggregate?: \\"avg\\" | \\"max\\" | \\"min\\" | \\"sum\\",footer?: React.ReactNode | {aggregate?: boolean},header?: string | React.ReactNode | {aggregate?: boolean},primary?: boolean,property: string,render?: ((...args: any[]) => any),search?: boolean,sortable?: boolean}[];
   data?: {}[];
   groupBy?: string;
   onMore?: ((...args: any[]) => any);


### PR DESCRIPTION
Closes: #2634
Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
* Enable user to turn off sortable property on selective columns
#### Where should the reviewer start?

#### What testing has been done on this PR?
storybook.
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
#2634
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
compatible