### PR TITLE
[Datatable] Add an onRowClick callback

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -40,6 +40,7 @@ export const Body = ({
             onClick={evt => onClick(evt, datum)}
             key={datum[primaryProperty]}
             size={size}
+            hoverIndicator={onRowClick !== undefined}
           >
             {columns.map(column => (
               <Cell

--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -14,37 +14,50 @@ export const Body = ({
   primaryProperty,
   size,
   theme,
+  onRowClick,
   ...rest
-}) => (
-  <StyledDataTableBody size={size} {...rest}>
-    <InfiniteScroll
-      items={data}
-      onMore={onMore}
-      scrollableAncestor="window"
-      renderMarker={marker => (
-        <TableRow>
-          <TableCell>{marker}</TableCell>
-        </TableRow>
-      )}
-    >
-      {datum => (
-        <StyledDataTableRow key={datum[primaryProperty]} size={size}>
-          {columns.map(column => (
-            <Cell
-              key={column.property}
-              context="body"
-              column={column}
-              datum={datum}
-              primaryProperty={primaryProperty}
-              scope={
-                column.primary || column.property === primaryProperty
-                  ? 'row'
-                  : undefined
-              }
-            />
-          ))}
-        </StyledDataTableRow>
-      )}
-    </InfiniteScroll>
-  </StyledDataTableBody>
-);
+}) => {
+  const onClick = (evt, datum) => {
+    if (onRowClick) {
+      onRowClick(evt, datum);
+    }
+  };
+
+  return (
+    <StyledDataTableBody size={size} {...rest}>
+      <InfiniteScroll
+        items={data}
+        onMore={onMore}
+        scrollableAncestor="window"
+        renderMarker={marker => (
+          <TableRow>
+            <TableCell>{marker}</TableCell>
+          </TableRow>
+        )}
+      >
+        {datum => (
+          <StyledDataTableRow
+            onClick={evt => onClick(evt, datum)}
+            key={datum[primaryProperty]}
+            size={size}
+          >
+            {columns.map(column => (
+              <Cell
+                key={column.property}
+                context="body"
+                column={column}
+                datum={datum}
+                primaryProperty={primaryProperty}
+                scope={
+                  column.primary || column.property === primaryProperty
+                    ? 'row'
+                    : undefined
+                }
+              />
+            ))}
+          </StyledDataTableRow>
+        )}
+      </InfiniteScroll>
+    </StyledDataTableBody>
+  );
+};

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -83,6 +83,7 @@ class DataTable extends Component {
       size,
       sortable,
       onSearch, // removing unknown DOM attributes
+      onRowClick,
       ...rest
     } = this.props;
     const {
@@ -135,6 +136,7 @@ class DataTable extends Component {
             onMore={onMore}
             primaryProperty={primaryProperty}
             size={size}
+            onRowClick={onRowClick}
           />
         )}
         {showFooter && (

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -197,6 +197,15 @@ When supplied, and when at least one column has 'search' enabled,
 function
 ```
 
+**onRowClick**
+
+When supplied, it will be called when a row is clicked and it will
+      provide you with the event and datum of the corresponding row.
+
+```
+function
+```
+
 **primaryKey**
 
 When supplied, indicates the property for a data object to use to

--- a/src/js/components/DataTable/StyledDataTable.js
+++ b/src/js/components/DataTable/StyledDataTable.js
@@ -1,6 +1,6 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-import { genericStyles } from '../../utils';
+import { genericStyles, backgroundStyle, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';
 
 const StyledDataTable = styled.table`
@@ -13,7 +13,16 @@ const StyledDataTable = styled.table`
 StyledDataTable.defaultProps = {};
 Object.setPrototypeOf(StyledDataTable.defaultProps, defaultProps);
 
+const hoverStyle = css`
+  &:hover {
+    ${props => backgroundStyle(props.theme.global.hover.background, props.theme)}
+    ${props => `color: ${normalizeColor(props.theme.global.hover.color, props.theme)}`};
+  }
+  cursor: pointer;
+`;
+
 const StyledDataTableRow = styled.tr`
+  ${props => props.hoverIndicator && hoverStyle}
   ${props =>
     props.size &&
     `

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -254,6 +254,7 @@ exports[`DataTable aggregate 1`] = `
     >
       <tr
         className=""
+        onClick={[Function]}
       >
         <th
           className="c6"
@@ -285,6 +286,7 @@ exports[`DataTable aggregate 1`] = `
       </tr>
       <tr
         className=""
+        onClick={[Function]}
       >
         <th
           className="c6"
@@ -540,6 +542,7 @@ exports[`DataTable basic 1`] = `
     >
       <tr
         className=""
+        onClick={[Function]}
       >
         <th
           className="c6"
@@ -571,6 +574,7 @@ exports[`DataTable basic 1`] = `
       </tr>
       <tr
         className=""
+        onClick={[Function]}
       >
         <th
           className="c6"
@@ -900,6 +904,7 @@ exports[`DataTable footer 1`] = `
     >
       <tr
         className=""
+        onClick={[Function]}
       >
         <th
           className="c6"
@@ -931,6 +936,7 @@ exports[`DataTable footer 1`] = `
       </tr>
       <tr
         className=""
+        onClick={[Function]}
       >
         <th
           className="c6"
@@ -1833,6 +1839,7 @@ exports[`DataTable primaryKey 1`] = `
     >
       <tr
         className=""
+        onClick={[Function]}
       >
         <td
           className="c6"
@@ -1864,6 +1871,7 @@ exports[`DataTable primaryKey 1`] = `
       </tr>
       <tr
         className=""
+        onClick={[Function]}
       >
         <td
           className="c6"
@@ -2181,6 +2189,7 @@ exports[`DataTable resizeable 1`] = `
     >
       <tr
         className=""
+        onClick={[Function]}
       >
         <th
           className="c9"
@@ -2212,6 +2221,7 @@ exports[`DataTable resizeable 1`] = `
       </tr>
       <tr
         className=""
+        onClick={[Function]}
       >
         <th
           className="c9"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -1478,7 +1478,7 @@ exports[`DataTable groupBy 2`] = `
       class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 bAIczD StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 bYmmUz StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezoiKY"
@@ -1540,7 +1540,7 @@ exports[`DataTable groupBy 2`] = `
       class="StyledDataTable__StyledDataTableBody-xrlyjm-2 hbZQKY"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 bYmmUz"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezoiKY"
@@ -1591,7 +1591,7 @@ exports[`DataTable groupBy 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 bYmmUz"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezoiKY"
@@ -2606,7 +2606,7 @@ exports[`DataTable sort 2`] = `
       class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 bAIczD StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 bYmmUz StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
       >
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 hNAgVv"
@@ -2802,7 +2802,7 @@ exports[`DataTable sort 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 bYmmUz"
       >
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"

--- a/src/js/components/DataTable/datatable.stories.js
+++ b/src/js/components/DataTable/datatable.stories.js
@@ -223,20 +223,34 @@ class ControlledDataTable extends Component {
     checked: [],
   };
 
-  onCheck = (event, value) => {
+  handleCheck = (value) => {
     const { checked } = this.state;
-    if (event.target.checked) {
+    if (checked.indexOf(value) !== -1) {
+      this.setState({ checked: checked.filter(item => item !== value) });
+    } else {
       checked.push(value);
       this.setState({ checked });
-    } else {
-      this.setState({ checked: checked.filter(item => item !== value) });
     }
   };
+
+  onCheck = (value) => {
+    const { rowClick } = this.props;
+    if (!rowClick) {
+      this.handleCheck(value)
+    }
+  }
 
   onCheckAll = event =>
     this.setState({
       checked: event.target.checked ? DATA.map(datum => datum.name) : [],
     });
+
+  onRowClick = (_, datum) => {
+    const { rowClick } = this.props;
+    if (rowClick) {
+      this.handleCheck(datum.name)
+    }
+  };
 
   render() {
     const { checked } = this.state;
@@ -245,6 +259,7 @@ class ControlledDataTable extends Component {
       <Grommet theme={grommet}>
         <Box align="center" pad="medium">
           <DataTable
+            onRowClick={this.onRowClick}
             columns={[
               {
                 property: 'checkbox',
@@ -252,7 +267,7 @@ class ControlledDataTable extends Component {
                   <CheckBox
                     key={datum.name}
                     checked={checked.indexOf(datum.name) !== -1}
-                    onChange={e => this.onCheck(e, datum.name)}
+                    onChange={() => this.onCheck(datum.name)}
                   />
                 ),
                 header: (
@@ -284,4 +299,5 @@ storiesOf('DataTable', module)
   .add('Tunable DataTable', () => <TunableDataTable />)
   .add('Grouped DataTable', () => <GroupedDataTable />)
   .add('Served DataTable', () => <ServedDataTable />)
-  .add('Controlled DataTable', () => <ControlledDataTable />);
+  .add('Controlled DataTable', () => <ControlledDataTable />)
+  .add('Clickable rows DataTable', () => <ControlledDataTable rowClick />);

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -72,6 +72,10 @@ export const doc = DataTable => {
       names and values which are the search text strings. This is typically
       employed so a back-end can be used to search through the data.`,
     ),
+    onRowClick: PropTypes.func.description(
+      `When supplied, it will be called when a row is clicked and it will
+      provide you with the event and datum of the corresponding row.`,
+    ),
     primaryKey: PropTypes.string.description(
       `When supplied, indicates the property for a data object to use to
       get a unique identifier. See also the 'columns.primary' description.

--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -10,6 +10,7 @@ export interface DataTableProps {
   groupBy?: string;
   onMore?: ((...args: any[]) => any);
   onSearch?: ((...args: any[]) => any);
+  onRowClick?: ((...args: any[]) => any);
   primaryKey?: string;
   resizeable?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | string;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -3125,6 +3125,15 @@ When supplied, and when at least one column has 'search' enabled,
 function
 \`\`\`
 
+**onRowClick**
+
+When supplied, it will be called when a row is clicked and it will
+      provide you with the event and datum of the corresponding row.
+
+\`\`\`
+function
+\`\`\`
+
 **primaryKey**
 
 When supplied, indicates the property for a data object to use to

--- a/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/typescript-test.js.snap
@@ -241,6 +241,7 @@ export interface DataTableProps {
   groupBy?: string;
   onMore?: ((...args: any[]) => any);
   onSearch?: ((...args: any[]) => any);
+  onRowClick?: ((...args: any[]) => any);
   primaryKey?: string;
   resizeable?: boolean;
   size?: \\"small\\" | \\"medium\\" | \\"large\\" | \\"xlarge\\" | string;


### PR DESCRIPTION
Contributes: #2527

Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

Adding here previous comments:

> *    We need to adjust the mouse pointer when over a row since it is a control surface.
> *    What happens if a cell contains an interactive element, like a link?
>  * I don't think we should expect that checkboxes would be the only way to represent whether a row is >selected. I think we should also explore supporting a both a hover indicator and selection indicator for >the whole row.

#### What does this PR do?
Adds an on row click event
#### Where should the reviewer start?

#### What testing has been done on this PR?
storybook
#### How should this be manually tested?

#### Any background context you want to provide?

This started here #2639

#### What are the relevant issues?
#2527
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
compatible