### PR TITLE
Fix DropButtonProps with missing ButtonProps

### DIFF
--- a/src/js/components/DropButton/index.d.ts
+++ b/src/js/components/DropButton/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { ButtonProps } from "../Button";
 
 export interface DropButtonProps {
   a11yTitle?: string;
@@ -14,6 +15,6 @@ export interface DropButtonProps {
   open?: boolean;
 }
 
-declare const DropButton: React.ComponentType<DropButtonProps & JSX.IntrinsicElements['button']>;
+declare const DropButton: React.ComponentType<DropButtonProps & ButtonProps>;
 
 export { DropButton };


### PR DESCRIPTION
This PR fixes the `DropButtonProps` interface, adding the missing `ButtonProps`, wich are passed to `Button />` by the `<DropButton />`'s render method.


