### PR TITLE
Only Use Table* components on DataTable

### DIFF
--- a/src/js/components/DataTable/Footer.js
+++ b/src/js/components/DataTable/Footer.js
@@ -7,7 +7,6 @@ import { defaultProps } from '../../default-props';
 
 import { Box } from '../Box';
 import { TableRow } from '../TableRow';
-import { TableFooter } from '../TableFooter';
 import { TableCell } from '../TableCell';
 
 import { Cell } from './Cell';
@@ -21,7 +20,7 @@ const Footer = ({
   theme,
   ...rest
 }) => (
-  <StyledDataTableFooter as={TableFooter} {...rest}>
+  <StyledDataTableFooter {...rest}>
     <TableRow>
       {groups && (
         <TableCell size="xxsmall" plain verticalAlign="top">

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -6,8 +6,6 @@ import { withTheme } from 'styled-components';
 import { defaultProps } from '../../default-props';
 
 import { Box } from '../Box';
-import { TableHeader } from '../TableHeader';
-import { TableRow } from '../TableRow';
 import { TableCell } from '../TableCell';
 import { Text } from '../Text';
 
@@ -46,8 +44,8 @@ const Header = ({
   }))(dataTableContextTheme);
   const { border, background, ...innerThemeProps } = dataTableContextTheme;
   return (
-    <StyledDataTableHeader as={TableHeader} {...rest}>
-      <StyledDataTableRow as={TableRow}>
+    <StyledDataTableHeader {...rest}>
+      <StyledDataTableRow>
         {groups && (
           <ExpanderCell
             context="header"

--- a/src/js/components/DataTable/StyledDataTable.js
+++ b/src/js/components/DataTable/StyledDataTable.js
@@ -2,8 +2,13 @@ import styled from 'styled-components';
 
 import { genericStyles } from '../../utils';
 import { defaultProps } from '../../default-props';
+import { TableRow } from '../TableRow';
+import { Table } from '../Table';
+import { TableBody } from '../TableBody';
+import { TableHeader } from '../TableHeader';
+import { TableFooter } from '../TableFooter';
 
-const StyledDataTable = styled.table`
+const StyledDataTable = styled(Table)`
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
@@ -13,7 +18,7 @@ const StyledDataTable = styled.table`
 StyledDataTable.defaultProps = {};
 Object.setPrototypeOf(StyledDataTable.defaultProps, defaultProps);
 
-const StyledDataTableRow = styled.tr`
+const StyledDataTableRow = styled(TableRow)`
   ${props =>
     props.size &&
     `
@@ -26,7 +31,7 @@ const StyledDataTableRow = styled.tr`
 StyledDataTableRow.defaultProps = {};
 Object.setPrototypeOf(StyledDataTableRow.defaultProps, defaultProps);
 
-const StyledDataTableBody = styled.tbody`
+const StyledDataTableBody = styled(TableBody)`
   ${props =>
     props.size &&
     `
@@ -40,7 +45,7 @@ const StyledDataTableBody = styled.tbody`
 StyledDataTableBody.defaultProps = {};
 Object.setPrototypeOf(StyledDataTableBody.defaultProps, defaultProps);
 
-const StyledDataTableHeader = styled.thead`
+const StyledDataTableHeader = styled(TableHeader)`
   ${props =>
     props.size &&
     `
@@ -53,7 +58,7 @@ const StyledDataTableHeader = styled.thead`
 StyledDataTableHeader.defaultProps = {};
 Object.setPrototypeOf(StyledDataTableHeader.defaultProps, defaultProps);
 
-const StyledDataTableFooter = styled.tfoot`
+const StyledDataTableFooter = styled(TableFooter)`
   ${props =>
     props.size &&
     `

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -11,7 +11,7 @@ exports[`DataTable aggregate 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -38,7 +38,7 @@ exports[`DataTable aggregate 1`] = `
   padding-bottom: 6px;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -62,7 +62,7 @@ exports[`DataTable aggregate 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -88,7 +88,7 @@ exports[`DataTable aggregate 1`] = `
   padding-bottom: 6px;
 }
 
-.c3 {
+.c4 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -97,7 +97,7 @@ exports[`DataTable aggregate 1`] = `
   vertical-align: bottom;
 }
 
-.c6 {
+.c7 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -105,7 +105,7 @@ exports[`DataTable aggregate 1`] = `
   height: 100%;
 }
 
-.c9 {
+.c10 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -114,16 +114,21 @@ exports[`DataTable aggregate 1`] = `
   vertical-align: top;
 }
 
-.c2 {
+.c3 {
   height: 100%;
 }
 
-.c5 {
+.c2 {
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+.c6 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c8 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -136,72 +141,72 @@ exports[`DataTable aggregate 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c11 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c11 {
     border-top: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c11 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c11 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
@@ -211,37 +216,37 @@ exports[`DataTable aggregate 1`] = `
   className="c0"
 >
   <table
-    className="c1"
+    className="c1 c2"
   >
     <thead
       className=""
     >
       <tr
-        className="c2"
+        className="c3"
       >
         <th
-          className="c3"
+          className="c4"
           scope="col"
         >
           <div
-            className="c4"
+            className="c5"
           >
             <span
-              className="c5"
+              className="c6"
             >
               A
             </span>
           </div>
         </th>
         <th
-          className="c3"
+          className="c4"
           scope="col"
         >
           <div
-            className="c4"
+            className="c5"
           >
             <span
-              className="c5"
+              className="c6"
             >
               B
             </span>
@@ -253,30 +258,30 @@ exports[`DataTable aggregate 1`] = `
       className=""
     >
       <tr
-        className=""
+        className="c3"
       >
         <th
-          className="c6"
+          className="c7"
           scope="row"
         >
           <div
-            className="c7"
+            className="c8"
           >
             <span
-              className="c8"
+              className="c9"
             >
               one
             </span>
           </div>
         </th>
         <td
-          className="c6"
+          className="c7"
         >
           <div
-            className="c7"
+            className="c8"
           >
             <span
-              className="c5"
+              className="c6"
             >
               1
             </span>
@@ -284,30 +289,30 @@ exports[`DataTable aggregate 1`] = `
         </td>
       </tr>
       <tr
-        className=""
+        className="c3"
       >
         <th
-          className="c6"
+          className="c7"
           scope="row"
         >
           <div
-            className="c7"
+            className="c8"
           >
             <span
-              className="c8"
+              className="c9"
             >
               two
             </span>
           </div>
         </th>
         <td
-          className="c6"
+          className="c7"
         >
           <div
-            className="c7"
+            className="c8"
           >
             <span
-              className="c5"
+              className="c6"
             >
               2
             </span>
@@ -319,23 +324,23 @@ exports[`DataTable aggregate 1`] = `
       className=""
     >
       <tr
-        className="c2"
+        className="c3"
       >
         <td
-          className="c9"
+          className="c10"
         >
           <div
-            className="c10"
+            className="c11"
           />
         </td>
         <td
-          className="c9"
+          className="c10"
         >
           <div
-            className="c10"
+            className="c11"
           >
             <span
-              className="c5"
+              className="c6"
             >
               3
             </span>
@@ -358,7 +363,7 @@ exports[`DataTable basic 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -385,7 +390,7 @@ exports[`DataTable basic 1`] = `
   padding-bottom: 6px;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -409,7 +414,7 @@ exports[`DataTable basic 1`] = `
   padding-bottom: 6px;
 }
 
-.c3 {
+.c4 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -418,7 +423,7 @@ exports[`DataTable basic 1`] = `
   vertical-align: bottom;
 }
 
-.c6 {
+.c7 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -426,16 +431,21 @@ exports[`DataTable basic 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c3 {
   height: 100%;
 }
 
-.c5 {
+.c2 {
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+.c6 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c8 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -448,46 +458,46 @@ exports[`DataTable basic 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
@@ -497,37 +507,37 @@ exports[`DataTable basic 1`] = `
   className="c0"
 >
   <table
-    className="c1"
+    className="c1 c2"
   >
     <thead
       className=""
     >
       <tr
-        className="c2"
+        className="c3"
       >
         <th
-          className="c3"
+          className="c4"
           scope="col"
         >
           <div
-            className="c4"
+            className="c5"
           >
             <span
-              className="c5"
+              className="c6"
             >
               A
             </span>
           </div>
         </th>
         <th
-          className="c3"
+          className="c4"
           scope="col"
         >
           <div
-            className="c4"
+            className="c5"
           >
             <span
-              className="c5"
+              className="c6"
             >
               B
             </span>
@@ -539,30 +549,30 @@ exports[`DataTable basic 1`] = `
       className=""
     >
       <tr
-        className=""
+        className="c3"
       >
         <th
-          className="c6"
+          className="c7"
           scope="row"
         >
           <div
-            className="c7"
+            className="c8"
           >
             <span
-              className="c8"
+              className="c9"
             >
               one
             </span>
           </div>
         </th>
         <td
-          className="c6"
+          className="c7"
         >
           <div
-            className="c7"
+            className="c8"
           >
             <span
-              className="c5"
+              className="c6"
             >
               1
             </span>
@@ -570,30 +580,30 @@ exports[`DataTable basic 1`] = `
         </td>
       </tr>
       <tr
-        className=""
+        className="c3"
       >
         <th
-          className="c6"
+          className="c7"
           scope="row"
         >
           <div
-            className="c7"
+            className="c8"
           >
             <span
-              className="c8"
+              className="c9"
             >
               two
             </span>
           </div>
         </th>
         <td
-          className="c6"
+          className="c7"
         >
           <div
-            className="c7"
+            className="c8"
           >
             <span
-              className="c5"
+              className="c6"
             >
               2
             </span>
@@ -616,8 +626,13 @@ exports[`DataTable empty 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c3 {
   height: 100%;
+}
+
+.c2 {
+  border-spacing: 0;
+  border-collapse: collapse;
 }
 
 .c1 {
@@ -630,13 +645,13 @@ exports[`DataTable empty 1`] = `
   className="c0"
 >
   <table
-    className="c1"
+    className="c1 c2"
   >
     <thead
       className=""
     >
       <tr
-        className="c2"
+        className="c3"
       />
     </thead>
     <tbody
@@ -657,7 +672,7 @@ exports[`DataTable footer 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -684,7 +699,7 @@ exports[`DataTable footer 1`] = `
   padding-bottom: 6px;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -708,7 +723,7 @@ exports[`DataTable footer 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -734,7 +749,7 @@ exports[`DataTable footer 1`] = `
   padding-bottom: 6px;
 }
 
-.c3 {
+.c4 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -743,7 +758,7 @@ exports[`DataTable footer 1`] = `
   vertical-align: bottom;
 }
 
-.c6 {
+.c7 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -751,7 +766,7 @@ exports[`DataTable footer 1`] = `
   height: 100%;
 }
 
-.c9 {
+.c10 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -760,16 +775,21 @@ exports[`DataTable footer 1`] = `
   vertical-align: top;
 }
 
-.c2 {
+.c3 {
   height: 100%;
 }
 
-.c5 {
+.c2 {
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+.c6 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c8 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -782,72 +802,72 @@ exports[`DataTable footer 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c11 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c11 {
     border-top: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c11 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c11 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
@@ -857,37 +877,37 @@ exports[`DataTable footer 1`] = `
   className="c0"
 >
   <table
-    className="c1"
+    className="c1 c2"
   >
     <thead
       className=""
     >
       <tr
-        className="c2"
+        className="c3"
       >
         <th
-          className="c3"
+          className="c4"
           scope="col"
         >
           <div
-            className="c4"
+            className="c5"
           >
             <span
-              className="c5"
+              className="c6"
             >
               A
             </span>
           </div>
         </th>
         <th
-          className="c3"
+          className="c4"
           scope="col"
         >
           <div
-            className="c4"
+            className="c5"
           >
             <span
-              className="c5"
+              className="c6"
             >
               B
             </span>
@@ -899,30 +919,30 @@ exports[`DataTable footer 1`] = `
       className=""
     >
       <tr
-        className=""
+        className="c3"
       >
         <th
-          className="c6"
+          className="c7"
           scope="row"
         >
           <div
-            className="c7"
+            className="c8"
           >
             <span
-              className="c8"
+              className="c9"
             >
               one
             </span>
           </div>
         </th>
         <td
-          className="c6"
+          className="c7"
         >
           <div
-            className="c7"
+            className="c8"
           >
             <span
-              className="c5"
+              className="c6"
             >
               1
             </span>
@@ -930,30 +950,30 @@ exports[`DataTable footer 1`] = `
         </td>
       </tr>
       <tr
-        className=""
+        className="c3"
       >
         <th
-          className="c6"
+          className="c7"
           scope="row"
         >
           <div
-            className="c7"
+            className="c8"
           >
             <span
-              className="c8"
+              className="c9"
             >
               two
             </span>
           </div>
         </th>
         <td
-          className="c6"
+          className="c7"
         >
           <div
-            className="c7"
+            className="c8"
           >
             <span
-              className="c5"
+              className="c6"
             >
               2
             </span>
@@ -965,26 +985,26 @@ exports[`DataTable footer 1`] = `
       className=""
     >
       <tr
-        className="c2"
+        className="c3"
       >
         <td
-          className="c9"
+          className="c10"
         >
           <div
-            className="c10"
+            className="c11"
           >
             <span
-              className="c8"
+              className="c9"
             >
               Total
             </span>
           </div>
         </td>
         <td
-          className="c9"
+          className="c10"
         >
           <div
-            className="c10"
+            className="c11"
           />
         </td>
       </tr>
@@ -994,7 +1014,7 @@ exports[`DataTable footer 1`] = `
 `;
 
 exports[`DataTable groupBy 1`] = `
-.c6 {
+.c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -1005,25 +1025,25 @@ exports[`DataTable groupBy 1`] = `
   stroke: rgba(0,0,0,0.33);
 }
 
-.c6 g {
+.c7 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill="none"] {
+.c7 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*="#"],
-.c6 *[STROKE*="#"] {
+.c7 *[stroke*="#"],
+.c7 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*="#"],
-.c6 *[FILL*="#"] {
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*="#"],
+.c7 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -1038,7 +1058,7 @@ exports[`DataTable groupBy 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1065,7 +1085,7 @@ exports[`DataTable groupBy 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1089,7 +1109,7 @@ exports[`DataTable groupBy 1`] = `
   padding-bottom: 6px;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1112,7 +1132,7 @@ exports[`DataTable groupBy 1`] = `
   padding: 6px;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1133,7 +1153,7 @@ exports[`DataTable groupBy 1`] = `
   padding: 6px;
 }
 
-.c7 {
+.c8 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1142,7 +1162,7 @@ exports[`DataTable groupBy 1`] = `
   vertical-align: bottom;
 }
 
-.c11 {
+.c12 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1150,7 +1170,7 @@ exports[`DataTable groupBy 1`] = `
   height: 100%;
 }
 
-.c3 {
+.c4 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1162,16 +1182,21 @@ exports[`DataTable groupBy 1`] = `
   vertical-align: top;
 }
 
-.c2 {
+.c3 {
   height: 100%;
 }
 
-.c9 {
+.c2 {
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+.c10 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c4 {
+.c5 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1195,7 +1220,7 @@ exports[`DataTable groupBy 1`] = `
   flex: 1 0 auto;
 }
 
-.c4:hover {
+.c5:hover {
   background-color: rgba(221,221,221,0.4);
   color: #444444;
   color: #000000;
@@ -1208,77 +1233,77 @@ exports[`DataTable groupBy 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c9 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c9 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c9 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c9 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c12 {
+  .c13 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c12 {
+  .c13 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c12 {
+  .c13 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     padding: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c11 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c11 {
     padding: 3px;
   }
 }
@@ -1287,28 +1312,28 @@ exports[`DataTable groupBy 1`] = `
   class="c0"
 >
   <table
-    class="c1"
+    class="c1 c2"
   >
     <thead
       class=""
     >
       <tr
-        class="c2"
+        class="c3"
       >
         <td
-          class="c3"
+          class="c4"
         >
           <button
             aria-label="expand"
-            class="c4"
+            class="c5"
             type="button"
           >
             <div
-              class="c5"
+              class="c6"
             >
               <svg
                 aria-label="FormDown"
-                class="c6"
+                class="c7"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -1322,28 +1347,28 @@ exports[`DataTable groupBy 1`] = `
           </button>
         </td>
         <th
-          class="c7"
+          class="c8"
           scope="col"
         >
           <div
-            class="c8"
+            class="c9"
           >
             <span
-              class="c9"
+              class="c10"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="c7"
+          class="c8"
           scope="col"
         >
           <div
-            class="c8"
+            class="c9"
           >
             <span
-              class="c9"
+              class="c10"
             >
               B
             </span>
@@ -1355,22 +1380,22 @@ exports[`DataTable groupBy 1`] = `
       class=""
     >
       <tr
-        class=""
+        class="c3"
       >
         <td
-          class="c3"
+          class="c4"
         >
           <button
             aria-label="expand"
-            class="c4"
+            class="c5"
             type="button"
           >
             <div
-              class="c10"
+              class="c11"
             >
               <svg
                 aria-label="FormDown"
-                class="c6"
+                class="c7"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -1384,44 +1409,44 @@ exports[`DataTable groupBy 1`] = `
           </button>
         </td>
         <th
-          class="c11"
+          class="c12"
           scope="row"
         >
           <div
-            class="c12"
+            class="c13"
           >
             <span
-              class="c9"
+              class="c10"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c11"
+          class="c12"
         >
           <div
-            class="c12"
+            class="c13"
           />
         </td>
       </tr>
       <tr
-        class=""
+        class="c3"
       >
         <td
-          class="c3"
+          class="c4"
         >
           <button
             aria-label="expand"
-            class="c4"
+            class="c5"
             type="button"
           >
             <div
-              class="c10"
+              class="c11"
             >
               <svg
                 aria-label="FormDown"
-                class="c6"
+                class="c7"
                 viewBox="0 0 24 24"
               >
                 <polyline
@@ -1435,24 +1460,24 @@ exports[`DataTable groupBy 1`] = `
           </button>
         </td>
         <th
-          class="c11"
+          class="c12"
           scope="row"
         >
           <div
-            class="c12"
+            class="c13"
           >
             <span
-              class="c9"
+              class="c10"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c11"
+          class="c12"
         >
           <div
-            class="c12"
+            class="c13"
           />
         </td>
       </tr>
@@ -1466,7 +1491,7 @@ exports[`DataTable groupBy 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lkVXQD"
 >
   <table
-    class="StyledDataTable-xrlyjm-0 kTrXKK"
+    class="StyledDataTable-xrlyjm-0 kTrXKK StyledTable-sc-1m3u5g-6 qwhVU"
   >
     <thead
       class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 bAIczD StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
@@ -1531,10 +1556,10 @@ exports[`DataTable groupBy 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledDataTable__StyledDataTableBody-xrlyjm-2 hbZQKY"
+      class="StyledDataTable__StyledDataTableBody-xrlyjm-2 hbZQKY StyledTable__StyledTableBody-sc-1m3u5g-3 dwInxx"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezoiKY"
@@ -1585,7 +1610,7 @@ exports[`DataTable groupBy 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezoiKY"
@@ -1651,7 +1676,7 @@ exports[`DataTable primaryKey 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1678,7 +1703,7 @@ exports[`DataTable primaryKey 1`] = `
   padding-bottom: 6px;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1702,7 +1727,7 @@ exports[`DataTable primaryKey 1`] = `
   padding-bottom: 6px;
 }
 
-.c3 {
+.c4 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1711,7 +1736,7 @@ exports[`DataTable primaryKey 1`] = `
   vertical-align: bottom;
 }
 
-.c6 {
+.c7 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1719,16 +1744,21 @@ exports[`DataTable primaryKey 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c3 {
   height: 100%;
 }
 
-.c5 {
+.c2 {
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+.c6 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c8 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -1741,46 +1771,46 @@ exports[`DataTable primaryKey 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
@@ -1790,37 +1820,37 @@ exports[`DataTable primaryKey 1`] = `
   className="c0"
 >
   <table
-    className="c1"
+    className="c1 c2"
   >
     <thead
       className=""
     >
       <tr
-        className="c2"
+        className="c3"
       >
         <th
-          className="c3"
+          className="c4"
           scope="col"
         >
           <div
-            className="c4"
+            className="c5"
           >
             <span
-              className="c5"
+              className="c6"
             >
               A
             </span>
           </div>
         </th>
         <th
-          className="c3"
+          className="c4"
           scope="col"
         >
           <div
-            className="c4"
+            className="c5"
           >
             <span
-              className="c5"
+              className="c6"
             >
               B
             </span>
@@ -1832,30 +1862,30 @@ exports[`DataTable primaryKey 1`] = `
       className=""
     >
       <tr
-        className=""
+        className="c3"
       >
         <td
-          className="c6"
+          className="c7"
         >
           <div
-            className="c7"
+            className="c8"
           >
             <span
-              className="c5"
+              className="c6"
             >
               one
             </span>
           </div>
         </td>
         <th
-          className="c6"
+          className="c7"
           scope="row"
         >
           <div
-            className="c7"
+            className="c8"
           >
             <span
-              className="c8"
+              className="c9"
             >
               1
             </span>
@@ -1863,30 +1893,30 @@ exports[`DataTable primaryKey 1`] = `
         </th>
       </tr>
       <tr
-        className=""
+        className="c3"
       >
         <td
-          className="c6"
+          className="c7"
         >
           <div
-            className="c7"
+            className="c8"
           >
             <span
-              className="c5"
+              className="c6"
             >
               two
             </span>
           </div>
         </td>
         <th
-          className="c6"
+          className="c7"
           scope="row"
         >
           <div
-            className="c7"
+            className="c8"
           >
             <span
-              className="c8"
+              className="c9"
             >
               2
             </span>
@@ -1909,7 +1939,7 @@ exports[`DataTable resizeable 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1934,6 +1964,332 @@ exports[`DataTable resizeable 1`] = `
   padding-right: 12px;
   padding-top: 6px;
   padding-bottom: 6px;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  padding: 0px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  border-right: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding: 0px;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  vertical-align: bottom;
+}
+
+.c10 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+}
+
+.c3 {
+  height: 100%;
+}
+
+.c2 {
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+.c7 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c12 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c8 {
+  cursor: col-resize;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  height: 100%;
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border-right: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    padding: 0px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <table
+    className="c1 c2"
+  >
+    <thead
+      className=""
+    >
+      <tr
+        className="c3"
+      >
+        <th
+          className="c4"
+          scope="col"
+        >
+          <div
+            className="c5"
+          >
+            <div
+              className="c6"
+            >
+              <span
+                className="c7"
+              >
+                A
+              </span>
+            </div>
+            <div
+              className="c8 c9"
+              onMouseDown={[Function]}
+            />
+          </div>
+        </th>
+        <th
+          className="c4"
+          scope="col"
+        >
+          <div
+            className="c5"
+          >
+            <div
+              className="c6"
+            >
+              <span
+                className="c7"
+              >
+                B
+              </span>
+            </div>
+            <div
+              className="c8 c9"
+              onMouseDown={[Function]}
+            />
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      className=""
+    >
+      <tr
+        className="c3"
+      >
+        <th
+          className="c10"
+          scope="row"
+        >
+          <div
+            className="c11"
+          >
+            <span
+              className="c12"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          className="c10"
+        >
+          <div
+            className="c11"
+          >
+            <span
+              className="c7"
+            >
+              1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        className="c3"
+      >
+        <th
+          className="c10"
+          scope="row"
+        >
+          <div
+            className="c11"
+          >
+            <span
+              className="c12"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          className="c10"
+        >
+          <div
+            className="c11"
+          >
+            <span
+              className="c7"
+            >
+              2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable sort 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 .c10 {
@@ -1960,328 +2316,7 @@ exports[`DataTable resizeable 1`] = `
   padding-bottom: 6px;
 }
 
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  margin: 0px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  width: 100%;
-  height: 100%;
-  padding: 0px;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  margin: 0px;
-  border-right: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding: 0px;
-}
-
-.c3 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  height: 100%;
-  vertical-align: bottom;
-}
-
-.c9 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  height: 100%;
-}
-
-.c2 {
-  height: 100%;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c11 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
 .c7 {
-  cursor: col-resize;
-}
-
-.c1 {
-  border-spacing: 0;
-  border-collapse: collapse;
-  height: 100%;
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
-    padding-left: 6px;
-    padding-right: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
-    padding-top: 3px;
-    padding-bottom: 3px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c10 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c10 {
-    padding-left: 6px;
-    padding-right: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c10 {
-    padding-top: 3px;
-    padding-bottom: 3px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c4 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c4 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c8 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c8 {
-    border-right: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c8 {
-    padding: 0px;
-  }
-}
-
-<div
-  className="c0"
->
-  <table
-    className="c1"
-  >
-    <thead
-      className=""
-    >
-      <tr
-        className="c2"
-      >
-        <th
-          className="c3"
-          scope="col"
-        >
-          <div
-            className="c4"
-          >
-            <div
-              className="c5"
-            >
-              <span
-                className="c6"
-              >
-                A
-              </span>
-            </div>
-            <div
-              className="c7 c8"
-              onMouseDown={[Function]}
-            />
-          </div>
-        </th>
-        <th
-          className="c3"
-          scope="col"
-        >
-          <div
-            className="c4"
-          >
-            <div
-              className="c5"
-            >
-              <span
-                className="c6"
-              >
-                B
-              </span>
-            </div>
-            <div
-              className="c7 c8"
-              onMouseDown={[Function]}
-            />
-          </div>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      className=""
-    >
-      <tr
-        className=""
-      >
-        <th
-          className="c9"
-          scope="row"
-        >
-          <div
-            className="c10"
-          >
-            <span
-              className="c11"
-            >
-              one
-            </span>
-          </div>
-        </th>
-        <td
-          className="c9"
-        >
-          <div
-            className="c10"
-          >
-            <span
-              className="c6"
-            >
-              1
-            </span>
-          </div>
-        </td>
-      </tr>
-      <tr
-        className=""
-      >
-        <th
-          className="c9"
-          scope="row"
-        >
-          <div
-            className="c10"
-          >
-            <span
-              className="c11"
-            >
-              two
-            </span>
-          </div>
-        </th>
-        <td
-          className="c9"
-        >
-          <div
-            className="c10"
-          >
-            <span
-              className="c6"
-            >
-              2
-            </span>
-          </div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-`;
-
-exports[`DataTable sort 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  margin: 0px;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2311,7 +2346,7 @@ exports[`DataTable sort 1`] = `
   padding-bottom: 6px;
 }
 
-.c3 {
+.c4 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -2320,7 +2355,7 @@ exports[`DataTable sort 1`] = `
   vertical-align: bottom;
 }
 
-.c8 {
+.c9 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -2328,22 +2363,27 @@ exports[`DataTable sort 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c3 {
   height: 100%;
 }
 
-.c7 {
+.c2 {
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+.c8 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c10 {
+.c11 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c5 {
+.c6 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2367,13 +2407,13 @@ exports[`DataTable sort 1`] = `
   flex: 1 0 auto;
 }
 
-.c5:hover {
+.c6:hover {
   background-color: rgba(221,221,221,0.4);
   color: #444444;
   color: #000000;
 }
 
-.c4 {
+.c5 {
   -webkit-flex-shrink: 1;
   -ms-flex-negative: 1;
   flex-shrink: 1;
@@ -2387,46 +2427,46 @@ exports[`DataTable sort 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c10 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c10 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c10 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c7 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c7 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c7 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c7 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
@@ -2436,27 +2476,27 @@ exports[`DataTable sort 1`] = `
   class="c0"
 >
   <table
-    class="c1"
+    class="c1 c2"
   >
     <thead
       class=""
     >
       <tr
-        class="c2"
+        class="c3"
       >
         <th
-          class="c3"
+          class="c4"
           scope="col"
         >
           <button
-            class="c4 c5"
+            class="c5 c6"
             type="button"
           >
             <div
-              class="c6"
+              class="c7"
             >
               <span
-                class="c7"
+                class="c8"
               >
                 A
               </span>
@@ -2464,18 +2504,18 @@ exports[`DataTable sort 1`] = `
           </button>
         </th>
         <th
-          class="c3"
+          class="c4"
           scope="col"
         >
           <button
-            class="c4 c5"
+            class="c5 c6"
             type="button"
           >
             <div
-              class="c6"
+              class="c7"
             >
               <span
-                class="c7"
+                class="c8"
               >
                 B
               </span>
@@ -2488,30 +2528,30 @@ exports[`DataTable sort 1`] = `
       class=""
     >
       <tr
-        class=""
+        class="c3"
       >
         <th
-          class="c8"
+          class="c9"
           scope="row"
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c10"
+              class="c11"
             >
               zero
             </span>
           </div>
         </th>
         <td
-          class="c8"
+          class="c9"
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c7"
+              class="c8"
             >
               0
             </span>
@@ -2519,30 +2559,30 @@ exports[`DataTable sort 1`] = `
         </td>
       </tr>
       <tr
-        class=""
+        class="c3"
       >
         <th
-          class="c8"
+          class="c9"
           scope="row"
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c10"
+              class="c11"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c8"
+          class="c9"
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c7"
+              class="c8"
             >
               1
             </span>
@@ -2550,30 +2590,30 @@ exports[`DataTable sort 1`] = `
         </td>
       </tr>
       <tr
-        class=""
+        class="c3"
       >
         <th
-          class="c8"
+          class="c9"
           scope="row"
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c10"
+              class="c11"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c8"
+          class="c9"
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c7"
+              class="c8"
             >
               2
             </span>
@@ -2590,7 +2630,7 @@ exports[`DataTable sort 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lkVXQD"
 >
   <table
-    class="StyledDataTable-xrlyjm-0 kTrXKK"
+    class="StyledDataTable-xrlyjm-0 kTrXKK StyledTable-sc-1m3u5g-6 qwhVU"
   >
     <thead
       class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 bAIczD StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
@@ -2695,9 +2735,9 @@ exports[`DataTable sort 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledDataTable__StyledDataTableBody-xrlyjm-2 hbZQKY"
+      class="StyledDataTable__StyledDataTableBody-xrlyjm-2 hbZQKY StyledTable__StyledTableBody-sc-1m3u5g-3 dwInxx"
     >
-      .c1 {
+      .c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2721,7 +2761,7 @@ exports[`DataTable sort 2`] = `
   padding-bottom: 6px;
 }
 
-.c0 {
+.c1 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -2729,62 +2769,66 @@ exports[`DataTable sort 2`] = `
   height: 100%;
 }
 
-.c3 {
+.c0 {
+  height: 100%;
+}
+
+.c4 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c2 {
+.c3 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c2 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c2 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
 }
 
 <tr
-        class=""
+        class="c0"
       >
         <th
-          class="c0"
+          class="c1"
           scope="row"
         >
           <div
-            class="c1"
+            class="c2"
           >
             <span
-              class="c2"
+              class="c3"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c0"
+          class="c1"
         >
           <div
-            class="c1"
+            class="c2"
           >
             <span
-              class="c3"
+              class="c4"
             >
               1
             </span>
@@ -2792,7 +2836,7 @@ exports[`DataTable sort 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
       >
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
@@ -2822,7 +2866,7 @@ exports[`DataTable sort 2`] = `
           </div>
         </td>
       </tr>
-      .c1 {
+      .c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2846,7 +2890,7 @@ exports[`DataTable sort 2`] = `
   padding-bottom: 6px;
 }
 
-.c0 {
+.c1 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -2854,62 +2898,66 @@ exports[`DataTable sort 2`] = `
   height: 100%;
 }
 
-.c3 {
+.c0 {
+  height: 100%;
+}
+
+.c4 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c2 {
+.c3 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c2 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c2 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
 }
 
 <tr
-        class=""
+        class="c0"
       >
         <th
-          class="c0"
+          class="c1"
           scope="row"
         >
           <div
-            class="c1"
+            class="c2"
           >
             <span
-              class="c2"
+              class="c3"
             >
               zero
             </span>
           </div>
         </th>
         <td
-          class="c0"
+          class="c1"
         >
           <div
-            class="c1"
+            class="c2"
           >
             <span
-              class="c3"
+              class="c4"
             >
               0
             </span>

--- a/src/js/components/DataTable/datatable.stories.js
+++ b/src/js/components/DataTable/datatable.stories.js
@@ -211,12 +211,11 @@ class ServedDataTable extends Component {
   }
 }
 
-const controlledColumns = [...columns];
-const name = controlledColumns[0];
-const totals = controlledColumns[4];
-delete name.footer;
-delete totals.footer;
-delete totals.aggregate;
+const controlledColumns = columns.map(col => Object.assign({}, col));
+delete controlledColumns[0].footer;
+delete controlledColumns[3].footer;
+delete controlledColumns[4].footer;
+delete controlledColumns[4].aggregate;
 
 class ControlledDataTable extends Component {
   state = {


### PR DESCRIPTION
Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

* First step into some refactoring for DataTable. Not it only uses Table* components (with some extra styling). This should enable later to add functionnalities in the Table components that will be inherited in DataTable (such as onRowClick). ref #2640 

* Fixed storybook DataTable with some issues introduced by #2639 and shallow copies of the columns.

#### Where should the reviewer start?

StyledDataTable.js

#### What testing has been done on this PR?

Updated the unit-tests and compared local storybook with existing one

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
#2640 
#2527 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
nope
#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
compatible