### PR TITLE
Datatable add on onrowclick event with hover indicator

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -40,6 +40,7 @@ export const Body = ({
             onClick={evt => onClick(evt, datum)}
             key={datum[primaryProperty]}
             size={size}
+            hoverIndicator={onRowClick !== undefined}
           >
             {columns.map(column => (
               <Cell

--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -14,37 +14,50 @@ export const Body = ({
   primaryProperty,
   size,
   theme,
+  onRowClick,
   ...rest
-}) => (
-  <StyledDataTableBody size={size} {...rest}>
-    <InfiniteScroll
-      items={data}
-      onMore={onMore}
-      scrollableAncestor="window"
-      renderMarker={marker => (
-        <TableRow>
-          <TableCell>{marker}</TableCell>
-        </TableRow>
-      )}
-    >
-      {datum => (
-        <StyledDataTableRow key={datum[primaryProperty]} size={size}>
-          {columns.map(column => (
-            <Cell
-              key={column.property}
-              context="body"
-              column={column}
-              datum={datum}
-              primaryProperty={primaryProperty}
-              scope={
-                column.primary || column.property === primaryProperty
-                  ? 'row'
-                  : undefined
-              }
-            />
-          ))}
-        </StyledDataTableRow>
-      )}
-    </InfiniteScroll>
-  </StyledDataTableBody>
-);
+}) => {
+  const onClick = (evt, datum) => {
+    if (onRowClick) {
+      onRowClick(evt, datum);
+    }
+  };
+
+  return (
+    <StyledDataTableBody size={size} {...rest}>
+      <InfiniteScroll
+        items={data}
+        onMore={onMore}
+        scrollableAncestor="window"
+        renderMarker={marker => (
+          <TableRow>
+            <TableCell>{marker}</TableCell>
+          </TableRow>
+        )}
+      >
+        {datum => (
+          <StyledDataTableRow
+            onClick={evt => onClick(evt, datum)}
+            key={datum[primaryProperty]}
+            size={size}
+          >
+            {columns.map(column => (
+              <Cell
+                key={column.property}
+                context="body"
+                column={column}
+                datum={datum}
+                primaryProperty={primaryProperty}
+                scope={
+                  column.primary || column.property === primaryProperty
+                    ? 'row'
+                    : undefined
+                }
+              />
+            ))}
+          </StyledDataTableRow>
+        )}
+      </InfiniteScroll>
+    </StyledDataTableBody>
+  );
+};

--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -17,9 +17,9 @@ export const Body = ({
   onRowClick,
   ...rest
 }) => {
-  const onClick = (evt, datum) => {
+  const onClick = (event, datum) => {
     if (onRowClick) {
-      onRowClick(evt, datum);
+      onRowClick(event, datum);
     }
   };
 
@@ -37,7 +37,7 @@ export const Body = ({
       >
         {datum => (
           <StyledDataTableRow
-            onClick={evt => onClick(evt, datum)}
+            onClick={event => onClick(event, datum)}
             key={datum[primaryProperty]}
             size={size}
             hoverIndicator={onRowClick !== undefined}

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -83,6 +83,7 @@ class DataTable extends Component {
       size,
       sortable,
       onSearch, // removing unknown DOM attributes
+      onRowClick,
       ...rest
     } = this.props;
     const {
@@ -135,6 +136,7 @@ class DataTable extends Component {
             onMore={onMore}
             primaryProperty={primaryProperty}
             size={size}
+            onRowClick={onRowClick}
           />
         )}
         {showFooter && (

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -197,6 +197,15 @@ When supplied, and when at least one column has 'search' enabled,
 function
 ```
 
+**onRowClick**
+
+When supplied, it will be called when a row is clicked and it will
+      provide you with the event and datum of the corresponding row.
+
+```
+function
+```
+
 **primaryKey**
 
 When supplied, indicates the property for a data object to use to

--- a/src/js/components/DataTable/StyledDataTable.js
+++ b/src/js/components/DataTable/StyledDataTable.js
@@ -18,6 +18,8 @@ const StyledDataTable = styled(Table)`
 StyledDataTable.defaultProps = {};
 Object.setPrototypeOf(StyledDataTable.defaultProps, defaultProps);
 
+
+
 const StyledDataTableRow = styled(TableRow)`
   ${props =>
     props.size &&

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -1503,7 +1503,7 @@ exports[`DataTable groupBy 2`] = `
       class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 bAIczD StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 drboDW"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezoiKY"
@@ -1565,7 +1565,7 @@ exports[`DataTable groupBy 2`] = `
       class="StyledDataTable__StyledDataTableBody-xrlyjm-2 hbZQKY StyledTable__StyledTableBody-sc-1m3u5g-3 dwInxx"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 drboDW"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezoiKY"
@@ -1616,7 +1616,7 @@ exports[`DataTable groupBy 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 drboDW"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezoiKY"
@@ -2646,7 +2646,7 @@ exports[`DataTable sort 2`] = `
       class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 bAIczD StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 drboDW"
       >
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 hNAgVv"
@@ -2846,7 +2846,7 @@ exports[`DataTable sort 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 drboDW"
       >
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -259,6 +259,7 @@ exports[`DataTable aggregate 1`] = `
     >
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <th
           className="c7"
@@ -290,6 +291,7 @@ exports[`DataTable aggregate 1`] = `
       </tr>
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <th
           className="c7"
@@ -550,6 +552,7 @@ exports[`DataTable basic 1`] = `
     >
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <th
           className="c7"
@@ -581,6 +584,7 @@ exports[`DataTable basic 1`] = `
       </tr>
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <th
           className="c7"
@@ -920,6 +924,7 @@ exports[`DataTable footer 1`] = `
     >
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <th
           className="c7"
@@ -951,6 +956,7 @@ exports[`DataTable footer 1`] = `
       </tr>
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <th
           className="c7"
@@ -1863,6 +1869,7 @@ exports[`DataTable primaryKey 1`] = `
     >
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <td
           className="c7"
@@ -1894,6 +1901,7 @@ exports[`DataTable primaryKey 1`] = `
       </tr>
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <td
           className="c7"
@@ -2216,6 +2224,7 @@ exports[`DataTable resizeable 1`] = `
     >
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <th
           className="c10"
@@ -2247,6 +2256,7 @@ exports[`DataTable resizeable 1`] = `
       </tr>
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <th
           className="c10"

--- a/src/js/components/DataTable/datatable.stories.js
+++ b/src/js/components/DataTable/datatable.stories.js
@@ -222,20 +222,34 @@ class ControlledDataTable extends Component {
     checked: [],
   };
 
-  onCheck = (event, value) => {
+  handleCheck = (value) => {
     const { checked } = this.state;
-    if (event.target.checked) {
+    if (checked.indexOf(value) !== -1) {
+      this.setState({ checked: checked.filter(item => item !== value) });
+    } else {
       checked.push(value);
       this.setState({ checked });
-    } else {
-      this.setState({ checked: checked.filter(item => item !== value) });
     }
   };
+
+  onCheck = (value) => {
+    const { rowClick } = this.props;
+    if (!rowClick) {
+      this.handleCheck(value)
+    }
+  }
 
   onCheckAll = event =>
     this.setState({
       checked: event.target.checked ? DATA.map(datum => datum.name) : [],
     });
+
+  onRowClick = (_, datum) => {
+    const { rowClick } = this.props;
+    if (rowClick) {
+      this.handleCheck(datum.name)
+    }
+  };
 
   render() {
     const { checked } = this.state;
@@ -244,6 +258,7 @@ class ControlledDataTable extends Component {
       <Grommet theme={grommet}>
         <Box align="center" pad="medium">
           <DataTable
+            onRowClick={this.onRowClick}
             columns={[
               {
                 property: 'checkbox',
@@ -251,7 +266,7 @@ class ControlledDataTable extends Component {
                   <CheckBox
                     key={datum.name}
                     checked={checked.indexOf(datum.name) !== -1}
-                    onChange={e => this.onCheck(e, datum.name)}
+                    onChange={() => this.onCheck(datum.name)}
                   />
                 ),
                 header: (
@@ -283,4 +298,5 @@ storiesOf('DataTable', module)
   .add('Tunable DataTable', () => <TunableDataTable />)
   .add('Grouped DataTable', () => <GroupedDataTable />)
   .add('Served DataTable', () => <ServedDataTable />)
-  .add('Controlled DataTable', () => <ControlledDataTable />);
+  .add('Controlled DataTable', () => <ControlledDataTable />)
+  .add('Clickable rows DataTable', () => <ControlledDataTable rowClick />);

--- a/src/js/components/DataTable/datatable.stories.js
+++ b/src/js/components/DataTable/datatable.stories.js
@@ -222,7 +222,7 @@ class ControlledDataTable extends Component {
     checked: [],
   };
 
-  handleCheck = (value) => {
+  handleCheck = value => {
     const { checked } = this.state;
     if (checked.indexOf(value) !== -1) {
       this.setState({ checked: checked.filter(item => item !== value) });
@@ -232,12 +232,12 @@ class ControlledDataTable extends Component {
     }
   };
 
-  onCheck = (value) => {
+  onCheck = value => {
     const { rowClick } = this.props;
     if (!rowClick) {
-      this.handleCheck(value)
+      this.handleCheck(value);
     }
-  }
+  };
 
   onCheckAll = event =>
     this.setState({
@@ -247,18 +247,19 @@ class ControlledDataTable extends Component {
   onRowClick = (_, datum) => {
     const { rowClick } = this.props;
     if (rowClick) {
-      this.handleCheck(datum.name)
+      this.handleCheck(datum.name);
     }
   };
 
   render() {
+    const { rowClick } = this.props;
     const { checked } = this.state;
 
     return (
       <Grommet theme={grommet}>
         <Box align="center" pad="medium">
           <DataTable
-            onRowClick={this.onRowClick}
+            onRowClick={rowClick && this.onRowClick}
             columns={[
               {
                 property: 'checkbox',

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -72,6 +72,10 @@ export const doc = DataTable => {
       names and values which are the search text strings. This is typically
       employed so a back-end can be used to search through the data.`,
     ),
+    onRowClick: PropTypes.func.description(
+      `When supplied, it will be called when a row is clicked and it will
+      provide you with the event and datum of the corresponding row.`,
+    ),
     primaryKey: PropTypes.string.description(
       `When supplied, indicates the property for a data object to use to
       get a unique identifier. See also the 'columns.primary' description.

--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -10,6 +10,7 @@ export interface DataTableProps {
   groupBy?: string;
   onMore?: ((...args: any[]) => any);
   onSearch?: ((...args: any[]) => any);
+  onRowClick?: ((...args: any[]) => any);
   primaryKey?: string;
   resizeable?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | string;

--- a/src/js/components/Table/StyledTable.js
+++ b/src/js/components/Table/StyledTable.js
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { genericStyles } from '../../utils';
+import { genericStyles, backgroundStyle, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';
 
 const SIZE_MAP = {
@@ -42,7 +42,16 @@ const StyledTableDataCaption = styled.caption`
 StyledTableDataCaption.defaultProps = {};
 Object.setPrototypeOf(StyledTableDataCaption.defaultProps, defaultProps);
 
+const hoverStyle = css`
+  &:hover {
+    ${props => backgroundStyle(props.theme.global.hover.background, props.theme)}
+    ${props => `color: ${normalizeColor(props.theme.global.hover.color, props.theme)}`};
+  }
+  cursor: pointer;
+`;
+
 const StyledTableRow = styled.tr`
+  ${props => props.hoverIndicator && hoverStyle}
   height: 100%;
 `;
 

--- a/src/js/components/TableRow/README.md
+++ b/src/js/components/TableRow/README.md
@@ -10,6 +10,13 @@ import { TableRow } from 'grommet';
 
 ## Properties
 
+**hoverIndicator**
+
+Whether to apply the hover indicator when the user is mousing over row.
+
+```
+boolean
+```
   
 ## Intrinsic element
 

--- a/src/js/components/TableRow/doc.js
+++ b/src/js/components/TableRow/doc.js
@@ -1,4 +1,4 @@
-import { describe } from 'react-desc';
+import { describe, PropTypes } from 'react-desc';
 
 export const doc = TableRow => {
   const DocumentedTableRow = describe(TableRow)
@@ -8,6 +8,14 @@ export const doc = TableRow => {
 <TableRow />`,
     )
     .intrinsicElement('tr');
+
+    DocumentedTableRow.propTypes = {
+      hoverIndicator: PropTypes.bool
+        .description(
+          'Whether to apply the hover indicator when the user is mousing over row.'
+        )
+        .defaultValue(false),
+    }
 
   return DocumentedTableRow;
 };

--- a/src/js/components/TableRow/index.d.ts
+++ b/src/js/components/TableRow/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 export interface TableRowProps {
-  
+  hoverIndicator?: boolean;
 }
 
 declare const TableRow: React.ComponentType<TableRowProps & JSX.IntrinsicElements['tr']>;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -3120,6 +3120,15 @@ When supplied, and when at least one column has 'search' enabled,
 function
 \`\`\`
 
+**onRowClick**
+
+When supplied, it will be called when a row is clicked and it will
+      provide you with the event and datum of the corresponding row.
+
+\`\`\`
+function
+\`\`\`
+
 **primaryKey**
 
 When supplied, indicates the property for a data object to use to

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -7292,6 +7292,13 @@ import { TableRow } from 'grommet';
 
 ## Properties
 
+**hoverIndicator**
+
+Whether to apply the hover indicator when the user is mousing over row.
+
+\`\`\`
+boolean
+\`\`\`
   
 ## Intrinsic element
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This is a follow up on #2662  (and it contains its commits so that should be merged first) that adds the onRowClick event on datatable.

In the end it is not needed to add this callback directly in TableRow since that would just send the event to the callback so the callback is not needed whereas the DataTable can send the datum clicked as well. OTOH i added the hoverIndicator to the TableRow since it can be used there as well.

#### Where should the reviewer start?



#### What testing has been done on this PR?

Storybook mainly

#### How should this be manually tested?

#### Any background context you want to provide?

#2640 
#2662

#### What are the relevant issues?

#2527 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
did it
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
the default prop for hoverIndicator is false so that this is fully backward compatible.