### PR TITLE
expose extend to additional components inside TextInput

### DIFF
--- a/src/js/components/TextInput/README.md
+++ b/src/js/components/TextInput/README.md
@@ -287,3 +287,23 @@ Defaults to
 ```
 undefined
 ```
+
+**textInput.placeholder.extend**
+
+Any additional style for non-string placeholder inside TextInput. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```
+
+**textInput.suggestions.extend**
+
+Any additional style for TextInput suggestions. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```

--- a/src/js/components/TextInput/StyledTextInput.js
+++ b/src/js/components/TextInput/StyledTextInput.js
@@ -57,6 +57,11 @@ const StyledPlaceholder = styled.div`
   transform: translateY(-50%);
   display: flex;
   justify-content: center;
+
+  ${props =>
+    props.theme.textInput &&
+    props.theme.textInput.placeholder &&
+    props.theme.textInput.placeholder.extend};
 `;
 
 StyledPlaceholder.defaultProps = {};
@@ -68,6 +73,11 @@ const StyledSuggestions = styled.ol`
   margin: 0;
   padding: 0;
   list-style-type: none;
+
+  ${props =>
+    props.theme.textInput &&
+    props.theme.textInput.suggestions &&
+    props.theme.textInput.suggestions.extend};
 `;
 
 StyledSuggestions.defaultProps = {};

--- a/src/js/components/TextInput/doc.js
+++ b/src/js/components/TextInput/doc.js
@@ -161,4 +161,15 @@ export const themeDoc = {
     type: 'string | (props) => {}',
     defaultValue: undefined,
   },
+  'textInput.placeholder.extend': {
+    description:
+      'Any additional style for non-string placeholder inside TextInput.',
+    type: 'string | (props) => {}',
+    defaultValue: undefined,
+  },
+  'textInput.suggestions.extend': {
+    description: 'Any additional style for TextInput suggestions.',
+    type: 'string | (props) => {}',
+    defaultValue: undefined,
+  },
 };

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -8175,6 +8175,26 @@ Defaults to
 \`\`\`
 undefined
 \`\`\`
+
+**textInput.placeholder.extend**
+
+Any additional style for non-string placeholder inside TextInput. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**textInput.suggestions.extend**
+
+Any additional style for TextInput suggestions. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
 ",
   "Video": "## Video
 A video player.


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Add `extend` to the suggestions and placeholder components inside TextInput so they can be styled

#### Where should the reviewer start?

Only small changes to files inside `src/js/components/TextInput/`

#### What testing has been done on this PR?

Tested locally with storybook

#### How should this be manually tested?

Add custom css styling to placeholder and suggestions in the TextInput component and verify manually.

#### Any background context you want to provide?

Should be pretty straightforward

#### What are the relevant issues?

None

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No, I've updated the docs.

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

Yes it's backwards compatible
