### PR TITLE
Fix TextInput typings.

### DIFF
--- a/src/js/components/TextInput/index.d.ts
+++ b/src/js/components/TextInput/index.d.ts
@@ -8,8 +8,7 @@ export interface TextInputProps {
   focusIndicator?: boolean;
   messages?: {enterSelect?: string,suggestionsCount?: string,suggestionsExist?: string,suggestionIsOpen?: string};
   name?: string;
-  onChange?: ((...args: any[]) => any);
-  onSelect?: ((...args: any[]) => any);
+  onSelect?: ((x: { target: React.RefObject<HTMLElement>['current'], suggestion: any }) => void);
   onSuggestionsOpen?: ((...args: any[]) => any);
   onSuggestionsClose?: ((...args: any[]) => any);
   placeholder?: string | React.ReactNode;
@@ -19,6 +18,8 @@ export interface TextInputProps {
   value?: string;
 }
 
-declare const TextInput: React.ComponentType<TextInputProps & JSX.IntrinsicElements['input']>;
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
+
+declare const TextInput: React.ComponentType<TextInputProps & Omit<JSX.IntrinsicElements['input'], 'onSelect'>>;
 
 export { TextInput };


### PR DESCRIPTION
This PR fixes the `onSelect` signature of `TextInput` component and omit the one from the `JSX.IntrinsicElements['input']` type (wich creates a unusable product type).

Also, removes the `onChange` signature in order to get it from `JSX.IntrinsicElements['input']`.

#### What are the relevant issues?
TypeScript users are not able to use this component correctly.
