### PR TITLE
Add justifyContent prop to Menu to customize menu label

### DIFF
--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -28,6 +28,7 @@ class Menu extends Component {
     dropAlign: { top: 'top', left: 'left' },
     items: [],
     messages: { openMenu: 'Open Menu', closeMenu: 'Close Menu' },
+    justifyContent: 'start',
   };
 
   state = { activeItemIndex: -1, open: false };
@@ -95,6 +96,7 @@ class Menu extends Component {
       dropBackground,
       dropTarget,
       forwardRef,
+      justifyContent,
       icon,
       items,
       label,
@@ -112,7 +114,7 @@ class Menu extends Component {
     const content = children || (
       <Box
         direction="row"
-        justify="start"
+        justify={justifyContent}
         align="center"
         pad="small"
         gap={label && icon !== false ? 'small' : undefined}

--- a/src/js/components/Menu/README.md
+++ b/src/js/components/Menu/README.md
@@ -171,6 +171,19 @@ Target where the drop will be aligned to. This should be
 object
 ```
 
+**justifyContent**
+
+How to align the contents along the row axis. Defaults to `start`.
+
+```
+start
+center
+end
+between
+around
+stretch
+```
+
 **icon**
 
 Indicates the icon shown as a control to open it.

--- a/src/js/components/Menu/__tests__/Menu-test.js
+++ b/src/js/components/Menu/__tests__/Menu-test.js
@@ -40,6 +40,24 @@ describe('Menu', () => {
     expect(component.toJSON()).toMatchSnapshot();
   });
 
+  test('justify content', () => {
+    const component = renderer.create(
+      <Grommet>
+        {['start', 'center', 'end', 'between', 'around', 'stretch'].map(
+          justifyContent => (
+            <Menu
+              label={`${justifyContent} Menu`}
+              messages={{ openMenu: 'Abrir Menu' }}
+              items={[{ label: 'Item 1' }, { label: 'Item 2' }]}
+              justifyContent={justifyContent}
+            />
+          ),
+        )}
+      </Grommet>,
+    );
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
   test('open and close on click', () => {
     window.scrollTo = jest.fn();
     const { getByText, container } = render(

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -675,6 +675,66 @@ exports[`Menu close by clicking outside 3`] = `
   }
 }
 
+@media only screen and (max-width:768px) {
+  .cVwgrz {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .cVwgrz {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .ivYkuG {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .ivYkuG {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .fvxKol {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .fvxKol {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .cbpbOe {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .cbpbOe {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .gfbxOq {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .gfbxOq {
+    padding: 6px;
+  }
+}
+
 .iVWgBr {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1387,6 +1447,509 @@ exports[`Menu disabled 1`] = `
           points="18 9 12 15 6 9"
           stroke="#000"
           stroke-width="2"
+        />
+      </svg>
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Menu justify content 1`] = `
+.c5 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c5 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c5 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c5 *[stroke*="#"],
+.c5 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c5 *[fill-rule],
+.c5 *[FILL-RULE],
+.c5 *[fill*="#"],
+.c5 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  padding: 12px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 12px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  padding: 12px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+  padding: 12px;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 12px;
+}
+
+.c4 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 12px;
+}
+
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    padding: 6px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <button
+    aria-label="Abrir Menu"
+    className="c1"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    type="button"
+  >
+    <div
+      className="c2"
+    >
+      <span
+        className="c3"
+      >
+        start Menu
+      </span>
+      <div
+        className="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        className="c5"
+        viewBox="0 0 24 24"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          strokeWidth="2"
+        />
+      </svg>
+    </div>
+  </button>
+  <button
+    aria-label="Abrir Menu"
+    className="c1"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    type="button"
+  >
+    <div
+      className="c6"
+    >
+      <span
+        className="c3"
+      >
+        center Menu
+      </span>
+      <div
+        className="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        className="c5"
+        viewBox="0 0 24 24"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          strokeWidth="2"
+        />
+      </svg>
+    </div>
+  </button>
+  <button
+    aria-label="Abrir Menu"
+    className="c1"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    type="button"
+  >
+    <div
+      className="c7"
+    >
+      <span
+        className="c3"
+      >
+        end Menu
+      </span>
+      <div
+        className="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        className="c5"
+        viewBox="0 0 24 24"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          strokeWidth="2"
+        />
+      </svg>
+    </div>
+  </button>
+  <button
+    aria-label="Abrir Menu"
+    className="c1"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    type="button"
+  >
+    <div
+      className="c8"
+    >
+      <span
+        className="c3"
+      >
+        between Menu
+      </span>
+      <div
+        className="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        className="c5"
+        viewBox="0 0 24 24"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          strokeWidth="2"
+        />
+      </svg>
+    </div>
+  </button>
+  <button
+    aria-label="Abrir Menu"
+    className="c1"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    type="button"
+  >
+    <div
+      className="c9"
+    >
+      <span
+        className="c3"
+      >
+        around Menu
+      </span>
+      <div
+        className="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        className="c5"
+        viewBox="0 0 24 24"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          strokeWidth="2"
+        />
+      </svg>
+    </div>
+  </button>
+  <button
+    aria-label="Abrir Menu"
+    className="c1"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    type="button"
+  >
+    <div
+      className="c10"
+    >
+      <span
+        className="c3"
+      >
+        stretch Menu
+      </span>
+      <div
+        className="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        className="c5"
+        viewBox="0 0 24 24"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          strokeWidth="2"
         />
       </svg>
     </div>
@@ -2181,6 +2744,66 @@ exports[`Menu open and close on click 4`] = `
 
 @media only screen and (max-width:768px) {
   .lgRCHI {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .cVwgrz {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .cVwgrz {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .ivYkuG {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .ivYkuG {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .fvxKol {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .fvxKol {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .cbpbOe {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .cbpbOe {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .gfbxOq {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .gfbxOq {
     padding: 6px;
   }
 }
@@ -3014,6 +3637,66 @@ exports[`Menu with dropAlign renders 3`] = `
 
 @media only screen and (max-width:768px) {
   .lgRCHI {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .cVwgrz {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .cVwgrz {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .ivYkuG {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .ivYkuG {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .fvxKol {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .fvxKol {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .cbpbOe {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .cbpbOe {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .gfbxOq {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .gfbxOq {
     padding: 6px;
   }
 }

--- a/src/js/components/Menu/doc.js
+++ b/src/js/components/Menu/doc.js
@@ -53,6 +53,16 @@ one of top or bottom should be specified.`,
       a React reference. Typically, this is not required as the drop will be
       aligned to the Menu itself by default.`,
     ),
+    justifyContent: PropTypes.oneOf([
+      'start',
+      'center',
+      'end',
+      'between',
+      'around',
+      'stretch',
+    ])
+      .description('How to align the contents along the row axis.')
+      .defaultValue('start'),
     icon: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]).description(
       'Indicates the icon shown as a control to open it.',
     ),

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -9,6 +9,7 @@ export interface MenuProps {
   dropAlign?: {top?: "top" | "bottom",bottom?: "top" | "bottom",left?: "right" | "left",right?: "right" | "left"};
   dropBackground?: string | {color?: string,opacity?: "weak" | "medium" | "strong" | boolean};
   dropTarget?: object;
+  justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
   icon?: boolean | React.ReactNode;
   items: object[];
   label?: string | React.ReactNode;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5436,6 +5436,19 @@ Target where the drop will be aligned to. This should be
 object
 \`\`\`
 
+**justifyContent**
+
+How to align the contents along the row axis. Defaults to \`start\`.
+
+\`\`\`
+start
+center
+end
+between
+around
+stretch
+\`\`\`
+
 **icon**
 
 Indicates the icon shown as a control to open it.

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2245,6 +2245,17 @@ one of top or bottom should be specified.",
         "name": "dropTarget",
       },
       Object {
+        "defaultValue": "start",
+        "description": "How to align the contents along the row axis.",
+        "format": "start
+center
+end
+between
+around
+stretch",
+        "name": "justifyContent",
+      },
+      Object {
         "description": "Indicates the icon shown as a control to open it.",
         "format": "boolean
 node",


### PR DESCRIPTION
Fix: #2670

Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Enable user to customize label and icon justify prop

#### Where should the reviewer start?

Menu

#### What testing has been done on this PR?

added unit-tests

#### How should this be manually tested?

didn't add a storybook i think the diff is quite minimal

#### Any background context you want to provide?

#### What are the relevant issues?
#2670
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
did
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
compatible