### PR TITLE
Add number as possible prop type value in TextInput

### DIFF
--- a/src/js/components/TextInput/README.md
+++ b/src/js/components/TextInput/README.md
@@ -184,6 +184,7 @@ What text to put in the input.
 
 ```
 string
+number
 ```
   
 ## Intrinsic element

--- a/src/js/components/TextInput/doc.js
+++ b/src/js/components/TextInput/doc.js
@@ -94,7 +94,10 @@ Only use this when the containing context provides sufficient affordance`,
       `Suggestions to show. It is recommended to avoid showing too many
 suggestions and instead rely on the user to type more.`,
     ),
-    value: PropTypes.string.description('What text to put in the input.'),
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]).description('What text to put in the input.'),
   };
 
   return DocumentedTextInput;

--- a/src/js/components/TextInput/index.d.ts
+++ b/src/js/components/TextInput/index.d.ts
@@ -15,7 +15,7 @@ export interface TextInputProps {
   plain?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | string;
   suggestions?: ({label?: React.ReactNode,value?: any} | string)[];
-  value?: string;
+  value?: string | number;
 }
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -8074,6 +8074,7 @@ What text to put in the input.
 
 \`\`\`
 string
+number
 \`\`\`
   
 ## Intrinsic element

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -3287,7 +3287,8 @@ suggestions and instead rely on the user to type more.",
       },
       Object {
         "description": "What text to put in the input.",
-        "format": "string",
+        "format": "string
+number",
         "name": "value",
       },
     ],


### PR DESCRIPTION
Fix: #2658

Signed-off-by: Orestis Ioannou <oorestisime@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Since textInput can have a type that can be a number i added that prop type into the value prop. There are other types in the input reference but i think they are all covered by string and number

#### Where should the reviewer start?

#### What testing has been done on this PR?

played with storybook to make sure i didn't break something

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
#2658
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
did it
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
compatible.