### PR TITLE
Fix Broken types that prevent using fill={true}.

### DIFF
--- a/components/Grid/index.d.ts
+++ b/components/Grid/index.d.ts
@@ -9,7 +9,7 @@ export interface GridProps {
   alignContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
   areas?: {name: string,start: number[],end: number[]}[];
   columns?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto"[] | string[] | "xsmall" | "small" | "medium" | "large" | "xlarge" | {count: "fit" | "fill" | number,size: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto"[] | string} | string;
-  fill?: "horizontal" | "vertical" | "true" | "false";
+  fill?: "horizontal" | "vertical" | true | false;
   gap?: "small" | "medium" | "large" | "none" | {row: "small" | "medium" | "large" | "none" | string,column: "small" | "medium" | "large" | "none" | string} | string;
   justify?: "start" | "center" | "end" | "stretch";
   justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch";


### PR DESCRIPTION
The `Grid` component has its `fill` prop typed incorrectly. It has `true` and `false` in quotes, which prevents passing boolean values.

Very simple fix.
