### PR TITLE
add focusWithMouse option to withFocus HOC

### DIFF
--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -91,7 +91,7 @@ if (process.env.NODE_ENV !== 'production') {
   AnchorDoc = require('./doc').doc(Anchor); // eslint-disable-line global-require
 }
 const AnchorWrapper = compose(
-  withFocus,
+  withFocus(),
   withTheme,
   withForwardRef,
 )(AnchorDoc || Anchor);

--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -127,7 +127,7 @@ if (process.env.NODE_ENV !== 'production') {
   ButtonDoc = require('./doc').doc(Button); // eslint-disable-line global-require
 }
 const ButtonWrapper = compose(
-  withFocus,
+  withFocus(),
   withTheme,
   withForwardRef,
 )(ButtonDoc || Button);

--- a/src/js/components/Carousel/Carousel.js
+++ b/src/js/components/Carousel/Carousel.js
@@ -185,7 +185,7 @@ if (process.env.NODE_ENV !== 'production') {
   CarouselDoc = require('./doc').doc(Carousel); // eslint-disable-line global-require
 }
 const CarouselWrapper = compose(
-  withFocus,
+  withFocus(),
   withTheme,
 )(CarouselDoc || Carousel);
 

--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -193,7 +193,7 @@ if (process.env.NODE_ENV !== 'production') {
   CheckBoxDoc = require('./doc').doc(CheckBox); // eslint-disable-line global-require
 }
 const CheckBoxWrapper = compose(
-  withFocus,
+  withFocus(),
   withTheme,
   withForwardRef,
 )(CheckBoxDoc || CheckBox);

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -226,7 +226,7 @@ if (process.env.NODE_ENV !== 'production') {
   FormFieldDoc = require('./doc').doc(FormField); // eslint-disable-line global-require
 }
 const FormFieldWrapper = compose(
-  withFocus,
+  withFocus({ focusWithMouse: true }),
   withTheme,
 )(FormFieldDoc || FormField);
 

--- a/src/js/components/MaskedInput/MaskedInput.js
+++ b/src/js/components/MaskedInput/MaskedInput.js
@@ -368,7 +368,7 @@ if (process.env.NODE_ENV !== 'production') {
   MaskedInputDoc = require('./doc').doc(MaskedInput); // eslint-disable-line global-require
 }
 const MaskedInputWrapper = compose(
-  withFocus,
+  withFocus({ focusWithMouse: true }),
   withForwardRef,
 )(MaskedInputDoc || MaskedInput);
 

--- a/src/js/components/RadioButton/RadioButton.js
+++ b/src/js/components/RadioButton/RadioButton.js
@@ -110,7 +110,7 @@ if (process.env.NODE_ENV !== 'production') {
   RadioButtonDoc = require('./doc').doc(RadioButton); // eslint-disable-line global-require
 }
 const RadioButtonWrapper = compose(
-  withFocus,
+  withFocus(),
   withTheme,
   withForwardRef,
 )(RadioButtonDoc || RadioButton);

--- a/src/js/components/RangeInput/RangeInput.js
+++ b/src/js/components/RangeInput/RangeInput.js
@@ -16,7 +16,7 @@ if (process.env.NODE_ENV !== 'production') {
   RangeInputDoc = require('./doc').doc(RangeInput); // eslint-disable-line global-require
 }
 const RangeInputWrapper = compose(
-  withFocus,
+  withFocus(),
   withForwardRef,
 )(RangeInputDoc || RangeInput);
 

--- a/src/js/components/TextArea/TextArea.js
+++ b/src/js/components/TextArea/TextArea.js
@@ -29,7 +29,7 @@ if (process.env.NODE_ENV !== 'production') {
   TextAreaDoc = require('./doc').doc(TextArea); // eslint-disable-line global-require
 }
 const TextAreaWrapper = compose(
-  withFocus,
+  withFocus({ focusWithMouse: true }),
   withForwardRef,
 )(TextAreaDoc || TextArea);
 

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -396,7 +396,7 @@ if (process.env.NODE_ENV !== 'production') {
   TextInputDoc = require('./doc').doc(TextInput); // eslint-disable-line global-require
 }
 const TextInputWrapper = compose(
-  withFocus,
+  withFocus({ focusWithMouse: true }),
   withTheme,
   withAnnounce,
   withForwardRef,

--- a/src/js/components/__tests__/hocs-test.js
+++ b/src/js/components/__tests__/hocs-test.js
@@ -10,7 +10,7 @@ const TestDiv = props => {
   return <div {...rest}>{focus ? 'focus' : 'no focus'}</div>;
 };
 
-const Test = withFocus(TestDiv);
+const Test = withFocus()(TestDiv);
 
 test('withFocus set focus', done => {
   const component = renderer.create(<Test />);

--- a/src/js/components/hocs.js
+++ b/src/js/components/hocs.js
@@ -14,7 +14,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 export const withDocs = doc;
 
-export const withFocus = WrappedComponent => {
+export const withFocus = ({ focusWithMouse } = {}) => WrappedComponent => {
   class FocusableComponent extends Component {
     static getDerivedStateFromProps(nextProps, prevState) {
       const { withFocusRef } = nextProps;
@@ -35,7 +35,12 @@ export const withFocus = WrappedComponent => {
 
     componentDidMount = () => {
       const { wrappedRef } = this.state;
-      window.addEventListener('mousedown', this.handleActiveMouse);
+
+      // components such as anchors and buttons should not retain focus after
+      // being clicked while text-based components should
+      if (!focusWithMouse) {
+        window.addEventListener('mousedown', this.handleActiveMouse);
+      }
 
       // we could be using onFocus in the wrapper node itself
       // but react does not invoke it if you programically


### PR DESCRIPTION
#### What does this PR do?
The current `withFocus` HOC works well with click-once components such as buttons and anchors, but it breaks when applied to text-base components such as TextInput. When focusing a text input programmatically or with tabs, focus works as expected. However, when the user attempts to focus an input by clicking it with a mouse, the focus border (or whatever CSS is applied for focus on that particular component) does not show up. This is because the mechanic used to prevent "button focus hell" works very well with buttons but also raises false positives for text-inputs.

#### Where should the reviewer start?
Only the `withFocs` HOC and components wrapped by it were modified.

#### What testing has been done on this PR?
Visual manual testing with storybook.

#### How should this be manually tested?
Load up storybook and test each component with the `withFocus` HOC applied. This includes anchors, buttons, inputs, ranged inputs, and carousel. All text-based components such as TextInput, MaskedInput, Textarea should have "focus" css applied (green border is the default) when clicked with a mouse. Click-based components such as buttons and anchors should not have "focus" css applied when clicked with a mouse (but should if focused by tabbing).

#### Any background context you want to provide?
No

#### What are the relevant issues?
No

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Probably not

#### Is this change backwards compatible or is it a breaking change?
`withFocus` requires options to be passed in now, but most developers probably don't use this HOC directly from grommet