### PR TITLE
Always set colspan on table cells

### DIFF
--- a/src/js/components/TableCell/TableCell.js
+++ b/src/js/components/TableCell/TableCell.js
@@ -12,6 +12,7 @@ import { StyledTableCell } from '../Table/StyledTable';
 
 const TableCell = ({
   children,
+  colSpan,
   plain,
   scope,
   size,
@@ -41,6 +42,7 @@ const TableCell = ({
           as={scope ? 'th' : undefined}
           scope={scope}
           size={size}
+          colSpan={colSpan}
           tableContext={tableContext}
           tableContextTheme={tableContextTheme}
           verticalAlign={


### PR DESCRIPTION
Fix: #2668

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Always sets colspan prop on table cell

#### Where should the reviewer start?

#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
storybook using the code from the sandbox
#### Any background context you want to provide?

#### What are the relevant issues?
#2668
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
i think no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
compatible