### PR TITLE
Add missing id type to <Select />'s props

### DIFF
--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -13,6 +13,7 @@ export interface SelectProps {
   dropHeight?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   dropTarget?: object;
   focusIndicator?: boolean;
+  id?: string;
   labelKey?: string | ((...args: any[]) => any);
   messages?: {multiple?: string};
   multiple?: boolean;


### PR DESCRIPTION
This PR adds the missing `id` type to `<Select />`'s props.