### PR TITLE
Fix FormField validation to receive both value and all values

### DIFF
--- a/src/js/components/Form/__tests__/Form-test.js
+++ b/src/js/components/Form/__tests__/Form-test.js
@@ -48,23 +48,30 @@ describe('Form', () => {
             validate={validate}
             placeholder="test input"
           />
+          <FormField name="test2" placeholder="test-2 input" />
           <Button type="submit" primary label="Submit" />
         </Form>
       </Grommet>,
     );
     expect(container.firstChild).toMatchSnapshot();
-    fireEvent.click(getByText('Submit'));
     fireEvent.change(getByPlaceholderText('test input'), {
       target: { value: 'v' },
     });
-    expect(validate).toBeCalledWith('v');
+    fireEvent.click(getByText('Submit'));
+    expect(validate).toBeCalledWith('v', { test: 'v' });
     fireEvent.change(getByPlaceholderText('test input'), {
       target: { value: 'value' },
     });
-    expect(validate).toBeCalledWith('value');
+    fireEvent.change(getByPlaceholderText('test-2 input'), {
+      target: { value: 'value-2' },
+    });
     fireEvent.click(getByText('Submit'));
+    expect(validate).toBeCalledWith('value', {
+      test: 'value',
+      test2: 'value-2',
+    });
     expect(onSubmit).toBeCalledWith(
-      expect.objectContaining({ value: { test: 'value' } }),
+      expect.objectContaining({ value: { test: 'value', test2: 'value-2' } }),
     );
   });
 });

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
@@ -191,6 +191,25 @@ exports[`Form update 1`] = `
         </div>
       </div>
     </div>
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          <input
+            autocomplete="off"
+            class="c4"
+            name="test2"
+            placeholder="test-2 input"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
     <button
       class="c5"
       type="submit"

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -12,13 +12,13 @@ import { TextInput } from '../TextInput';
 import { withFocus } from '../hocs';
 import { FormContext } from '../Form/FormContext';
 
-const validateField = (required, validate, messages) => data => {
+const validateField = (required, validate, messages) => (value, data) => {
   let error;
   if (required && (data === undefined || data === '')) {
     error = messages.required;
   } else if (validate) {
     if (typeof validate === 'function') {
-      error = validate(data);
+      error = validate(value, data);
     } else if (validate.regexp) {
       if (!validate.regexp.test(data)) {
         error = validate.message || messages.invalid;


### PR DESCRIPTION
Fix: #2719

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes a small issue for form field validation
#### Where should the reviewer start?

#### What testing has been done on this PR?
storybook and modified unit-test
#### How should this be manually tested?
storybook
#### Any background context you want to provide?

#### What are the relevant issues?
#2719
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
compatible