### PR TITLE
Changed how grommet-icons are imported to improve non-tree-shaking situations.

### DIFF
--- a/src/js/components/DataTable/Searcher.js
+++ b/src/js/components/DataTable/Searcher.js
@@ -4,7 +4,7 @@ import { compose } from 'recompose';
 
 import { withTheme } from 'styled-components';
 
-import { FormSearch } from 'grommet-icons';
+import { FormSearch } from 'grommet-icons/icons/FormSearch';
 
 import { defaultProps } from '../../default-props';
 

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1,23 +1,21 @@
 import { rgba } from 'polished';
 import { css } from 'styled-components';
 
-import {
-  Actions,
-  ClosedCaption,
-  Expand,
-  FormDown,
-  FormNext,
-  FormPrevious,
-  FormUp,
-  Next,
-  Pause,
-  Play,
-  Previous,
-  Subtract,
-  Volume,
-  VolumeLow,
-} from 'grommet-icons';
-import { base as iconBase } from 'grommet-icons/themes';
+import { Actions } from 'grommet-icons/icons/Actions';
+import { ClosedCaption } from 'grommet-icons/icons/ClosedCaption';
+import { Expand } from 'grommet-icons/icons/Expand';
+import { FormDown } from 'grommet-icons/icons/FormDown';
+import { FormNext } from 'grommet-icons/icons/FormNext';
+import { FormPrevious } from 'grommet-icons/icons/FormPrevious';
+import { FormUp } from 'grommet-icons/icons/FormUp';
+import { Next } from 'grommet-icons/icons/Next';
+import { Pause } from 'grommet-icons/icons/Pause';
+import { Play } from 'grommet-icons/icons/Play';
+import { Previous } from 'grommet-icons/icons/Previous';
+import { Subtract } from 'grommet-icons/icons/Subtract';
+import { Volume } from 'grommet-icons/icons/Volume';
+import { VolumeLow } from 'grommet-icons/icons/VolumeLow';
+import { base as iconBase } from 'grommet-icons/themes/base';
 
 import { deepMerge, deepFreeze, normalizeColor } from '../utils';
 


### PR DESCRIPTION
#### What does this PR do?

Changed how grommet-icons are imported to improve non-tree-shaking situations.

#### Where should the reviewer start?

src/js/themes/base.js

#### What testing has been done on this PR?

Built a nextjs project with next-bundle-analyzer to verify that all grommet-icons weren't included.
Verified Accordion and Video in storybook to make sure icons were working.

#### How should this be manually tested?

storybook should be enough

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet-icons/issues/83

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
