### PR TITLE
Change imports of themes to support non-tree-shaking situations

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "generate-readme": "cross-env NODE_ENV=production babel-node ./tools/generate-readme",
     "build": "webpack --mode production && babel ./src/js/ --ignore '__tests__' --out-dir ./dist --copy-files && cross-env BABEL_ENV=es6 babel ./src/js/ --ignore '__tests__' --out-dir ./dist/es6 --copy-files",
+    "build-dev": "webpack --mode development && babel ./src/js/ --ignore '__tests__' --out-dir ./dist --copy-files && cross-env BABEL_ENV=es6 babel ./src/js/ --ignore '__tests__' --out-dir ./dist/es6 --copy-files",
     "release-stable": "babel-node ./tools/release-stable",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "scripts": {
     "generate-readme": "cross-env NODE_ENV=production babel-node ./tools/generate-readme",
     "build": "webpack --mode production && babel ./src/js/ --ignore '__tests__' --out-dir ./dist --copy-files && cross-env BABEL_ENV=es6 babel ./src/js/ --ignore '__tests__' --out-dir ./dist/es6 --copy-files",
-    "build-dev": "webpack --mode development && babel ./src/js/ --ignore '__tests__' --out-dir ./dist --copy-files && cross-env BABEL_ENV=es6 babel ./src/js/ --ignore '__tests__' --out-dir ./dist/es6 --copy-files",
     "release-stable": "babel-node ./tools/release-stable",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",

--- a/src/js/default-props.js
+++ b/src/js/default-props.js
@@ -1,5 +1,5 @@
 import { deepMerge } from './utils';
-import { base } from './themes';
+import { base } from './themes/base';
 
 export const defaultProps = {
   theme: base,

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -17,7 +17,8 @@ import { Volume } from 'grommet-icons/icons/Volume';
 import { VolumeLow } from 'grommet-icons/icons/VolumeLow';
 import { base as iconBase } from 'grommet-icons/themes/base';
 
-import { deepMerge, deepFreeze, normalizeColor } from '../utils';
+import { deepFreeze, deepMerge } from '../utils/object';
+import { normalizeColor } from '../utils/colors';
 
 const brandColor = '#7D4CDB';
 const accentColors = ['#6FFFB0', '#FD6FFF', '#81FCED', '#FFCA58'];

--- a/src/js/themes/dark.js
+++ b/src/js/themes/dark.js
@@ -1,7 +1,8 @@
 import { rgba } from 'polished';
 import { css } from 'styled-components';
 
-import { normalizeColor, deepFreeze } from '../utils';
+import { deepFreeze } from '../utils/object';
+import { normalizeColor } from '../utils/colors';
 
 const controlColor = '#FFCA58';
 const accentColors = ['#FD6FFF', '#60EB9F', '#60EBE1', '#FFCA58'];

--- a/src/js/themes/grommet.js
+++ b/src/js/themes/grommet.js
@@ -1,6 +1,6 @@
 import { css } from 'styled-components';
 
-import { deepFreeze } from '../utils';
+import { deepFreeze } from '../utils/object';
 
 export const grommet = deepFreeze({
   global: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changed how themes are imported to improve non-tree-shaking situations.
#### Where should the reviewer start?
any file that was changed
#### What testing has been done on this PR?
storybook for the components that were affected
#### How should this be manually tested?
storybook
#### Any background context you want to provide?

#### What are the relevant issues?
grommet/grommet-icons#83

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible