### PR TITLE
Add missing placeholder type to <MaskedInput />'s props

### DIFF
--- a/src/js/components/MaskedInput/index.d.ts
+++ b/src/js/components/MaskedInput/index.d.ts
@@ -5,7 +5,13 @@ export interface MaskedInputProps {
   name?: string;
   onChange?: ((...args: any[]) => any);
   onBlur?: ((...args: any[]) => any);
-  mask?: {length?: number | number[],fixed?: string,options?: string[],regexp?: {}}[];
+  mask?: Array<{
+    length?: number | number[];
+    fixed?: string;
+    options?: string[];
+    regexp?: {};
+    placeholder?: string;
+  }>;
   size?: "small" | "medium" | "large" | "xlarge" | string;
   value?: string;
 }


### PR DESCRIPTION
This PR adds the missing placeholder type to <MaskedInput />'s props.