### PR TITLE
Added ThemeContext to webpack side effects config.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "main": "index.js",
   "module": "es6/index.js",
   "jsnext:main": "es6/index.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/js/contexts/ThemeContext/ThemeContext.js"
+  ],
   "description": "focus on the essential experience",
   "authors": [
     "Alan Souza",

--- a/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
+++ b/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
@@ -87,7 +87,7 @@ describe('MaskedInput', () => {
         expect.objectContaining({ target: { value: 'aa!' } }),
       );
       done();
-    }, 300);
+    }, 500);
   });
 
   test('option via keyboard', done => {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

Closes #2669 and https://github.com/grommet/grommet/issues/2710

#### What does this PR do?

changes grommet to tell webpack to not remove ThemeContext module when bundling things

#### Where should the reviewer start?
package.json

#### What testing has been done on this PR?
* yarn build-storybook


#### How should this be manually tested?
* make sure your production version of storybook can load Rich Accordion example

#### Any background context you want to provide?

#### What are the relevant issues?
#2669 
https://github.com/grommet/grommet/issues/2710
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
nope
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards