### PR TITLE
Datatable interaction implementation

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -43,7 +43,8 @@ export class Body extends Component {
       primaryProperty,
       size,
       theme,
-      onSelect,
+      onClick,
+      onRowClick,
       selectable,
       ...rest
     } = this.props;
@@ -63,10 +64,10 @@ export class Body extends Component {
           >
             {(datum, index) => (
               <StyledDataTableRow
-                onClick={event => onSelect(event, datum)}
+                onClick={event => onClick(event, datum)}
                 key={datum[primaryProperty]}
                 size={size}
-                hoverIndicator={selectable}
+                hoverIndicator={selectable || onRowClick !== undefined}
                 ref={ref => {
                   this.rowRefs[index] = ref;
                 }}
@@ -78,7 +79,7 @@ export class Body extends Component {
                     column={column}
                     datum={datum}
                     isChecked={checked.indexOf(datum[primaryProperty]) !== -1}
-                    onClick={event => onSelect(event, datum)}
+                    onClick={event => onClick(event, datum)}
                     primaryProperty={primaryProperty}
                     scope={
                       column.primary || column.property === primaryProperty

--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -40,6 +40,7 @@ export const Body = ({
             onClick={evt => onClick(evt, datum)}
             key={datum[primaryProperty]}
             size={size}
+            hoverIndicator={onRowClick !== undefined}
           >
             {columns.map(column => (
               <Cell

--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -14,37 +14,50 @@ export const Body = ({
   primaryProperty,
   size,
   theme,
+  onRowClick,
   ...rest
-}) => (
-  <StyledDataTableBody size={size} {...rest}>
-    <InfiniteScroll
-      items={data}
-      onMore={onMore}
-      scrollableAncestor="window"
-      renderMarker={marker => (
-        <TableRow>
-          <TableCell>{marker}</TableCell>
-        </TableRow>
-      )}
-    >
-      {datum => (
-        <StyledDataTableRow key={datum[primaryProperty]} size={size}>
-          {columns.map(column => (
-            <Cell
-              key={column.property}
-              context="body"
-              column={column}
-              datum={datum}
-              primaryProperty={primaryProperty}
-              scope={
-                column.primary || column.property === primaryProperty
-                  ? 'row'
-                  : undefined
-              }
-            />
-          ))}
-        </StyledDataTableRow>
-      )}
-    </InfiniteScroll>
-  </StyledDataTableBody>
-);
+}) => {
+  const onClick = (evt, datum) => {
+    if (onRowClick) {
+      onRowClick(evt, datum);
+    }
+  };
+
+  return (
+    <StyledDataTableBody size={size} {...rest}>
+      <InfiniteScroll
+        items={data}
+        onMore={onMore}
+        scrollableAncestor="window"
+        renderMarker={marker => (
+          <TableRow>
+            <TableCell>{marker}</TableCell>
+          </TableRow>
+        )}
+      >
+        {datum => (
+          <StyledDataTableRow
+            onClick={evt => onClick(evt, datum)}
+            key={datum[primaryProperty]}
+            size={size}
+          >
+            {columns.map(column => (
+              <Cell
+                key={column.property}
+                context="body"
+                column={column}
+                datum={datum}
+                primaryProperty={primaryProperty}
+                scope={
+                  column.primary || column.property === primaryProperty
+                    ? 'row'
+                    : undefined
+                }
+              />
+            ))}
+          </StyledDataTableRow>
+        )}
+      </InfiniteScroll>
+    </StyledDataTableBody>
+  );
+};

--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -17,9 +17,9 @@ export const Body = ({
   onRowClick,
   ...rest
 }) => {
-  const onClick = (evt, datum) => {
+  const onClick = (event, datum) => {
     if (onRowClick) {
-      onRowClick(evt, datum);
+      onRowClick(event, datum);
     }
   };
 
@@ -37,7 +37,7 @@ export const Body = ({
       >
         {datum => (
           <StyledDataTableRow
-            onClick={evt => onClick(evt, datum)}
+            onClick={event => onClick(event, datum)}
             key={datum[primaryProperty]}
             size={size}
             hoverIndicator={onRowClick !== undefined}

--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -1,64 +1,97 @@
-import React from 'react';
+import React, { Component } from 'react';
 
 import { InfiniteScroll } from '../InfiniteScroll';
 import { TableRow } from '../TableRow';
 import { TableCell } from '../TableCell';
+import { Keyboard } from '../Keyboard';
 
 import { Cell } from './Cell';
 import { StyledDataTableBody, StyledDataTableRow } from './StyledDataTable';
 
-export const Body = ({
-  columns,
-  data,
-  onMore,
-  primaryProperty,
-  size,
-  theme,
-  onRowClick,
-  ...rest
-}) => {
-  const onClick = (event, datum) => {
-    if (onRowClick) {
-      onRowClick(event, datum);
+export class Body extends Component {
+  state = { rowIndex: 1 };
+
+  rowRefs = [];
+
+  onNext = () => {
+    const { data } = this.props;
+    const { rowIndex } = this.state;
+    if (rowIndex < data.length - 1) {
+      const nextIndex = rowIndex + 1;
+      this.setState({ rowIndex: nextIndex }, () => {
+        this.rowRefs[nextIndex].focus();
+      });
     }
   };
 
-  return (
-    <StyledDataTableBody size={size} {...rest}>
-      <InfiniteScroll
-        items={data}
-        onMore={onMore}
-        scrollableAncestor="window"
-        renderMarker={marker => (
-          <TableRow>
-            <TableCell>{marker}</TableCell>
-          </TableRow>
-        )}
-      >
-        {datum => (
-          <StyledDataTableRow
-            onClick={event => onClick(event, datum)}
-            key={datum[primaryProperty]}
-            size={size}
-            hoverIndicator={onRowClick !== undefined}
+  onPrevious = () => {
+    const { rowIndex } = this.state;
+    if (rowIndex > 0) {
+      const nextIndex = rowIndex - 1;
+      this.setState({ rowIndex: nextIndex }, () => {
+        this.rowRefs[nextIndex].focus();
+      });
+    }
+  };
+
+  render() {
+    const {
+      columns,
+      data,
+      onMore,
+      checked,
+      primaryProperty,
+      size,
+      theme,
+      onSelect,
+      selectable,
+      ...rest
+    } = this.props;
+
+    return (
+      <Keyboard onUp={this.onNext} onDown={this.onPrevious}>
+        <StyledDataTableBody ref={this.rowsRef} size={size} {...rest}>
+          <InfiniteScroll
+            items={data}
+            onMore={onMore}
+            scrollableAncestor="window"
+            renderMarker={marker => (
+              <TableRow>
+                <TableCell>{marker}</TableCell>
+              </TableRow>
+            )}
           >
-            {columns.map(column => (
-              <Cell
-                key={column.property}
-                context="body"
-                column={column}
-                datum={datum}
-                primaryProperty={primaryProperty}
-                scope={
-                  column.primary || column.property === primaryProperty
-                    ? 'row'
-                    : undefined
-                }
-              />
-            ))}
-          </StyledDataTableRow>
-        )}
-      </InfiniteScroll>
-    </StyledDataTableBody>
-  );
-};
+            {(datum, index) => (
+              <StyledDataTableRow
+                onClick={event => onSelect(event, datum)}
+                key={datum[primaryProperty]}
+                size={size}
+                hoverIndicator={selectable}
+                ref={ref => {
+                  this.rowRefs[index] = ref;
+                }}
+              >
+                {columns.map(column => (
+                  <Cell
+                    key={column.property}
+                    context="body"
+                    column={column}
+                    datum={datum}
+                    isChecked={checked.indexOf(datum[primaryProperty]) !== -1}
+                    onClick={event => onSelect(event, datum)}
+                    primaryProperty={primaryProperty}
+                    scope={
+                      column.primary || column.property === primaryProperty
+                        ? 'row'
+                        : undefined
+                    }
+                  />
+                ))}
+              </StyledDataTableRow>
+            )}
+          </InfiniteScroll>
+        </StyledDataTableBody>
+      </Keyboard>
+    );
+  }
+}

--- a/src/js/components/DataTable/Cell.js
+++ b/src/js/components/DataTable/Cell.js
@@ -5,6 +5,7 @@ import { withTheme } from 'styled-components';
 
 import { defaultProps } from '../../default-props';
 
+import { CheckBox } from '../CheckBox';
 import { TableCell } from '../TableCell';
 import { Text } from '../Text';
 
@@ -13,9 +14,37 @@ const Cell = ({
   context,
   datum,
   primaryProperty,
+  isChecked,
+  isIndeterminate,
+  onClick,
   scope,
   theme,
 }) => {
+  if (property === 'checkbox') {
+    if (context === 'footer') {
+      return (
+        <TableCell
+          scope={scope}
+          {...theme.dataTable[context]}
+          align={align || 'start'}
+        />
+      );
+    }
+    return (
+      <TableCell
+        scope={scope}
+        {...theme.dataTable[context]}
+        align={align || 'start'}
+      >
+        <CheckBox
+          checked={isChecked}
+          indeterminate={!isChecked && isIndeterminate}
+          onChange={onClick}
+        />
+      </TableCell>
+    );
+  }
+
   let content;
   if (render) {
     content = render(datum);

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -83,6 +83,7 @@ class DataTable extends Component {
       size,
       sortable,
       onSearch, // removing unknown DOM attributes
+      onRowClick,
       ...rest
     } = this.props;
     const {
@@ -135,6 +136,7 @@ class DataTable extends Component {
             onMore={onMore}
             primaryProperty={primaryProperty}
             size={size}
+            onRowClick={onRowClick}
           />
         )}
         {showFooter && (

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -97,6 +97,21 @@ class DataTable extends Component {
     });
   };
 
+  onClick = (event, datums) => {
+    const { selectable, onRowClick } = this.props;
+    if (selectable) {
+      if (!Array.isArray(datums)) {
+        this.onSelect([datums]);
+      } else {
+        this.onSelect(datums);
+      }
+    }
+
+    if (onRowClick) {
+      onRowClick(event, datums);
+    }
+  };
+
   render() {
     const {
       /* eslint-disable-next-line react/prop-types */
@@ -142,17 +157,6 @@ class DataTable extends Component {
       });
     }
 
-    const onClick = (event, datums) => {
-      if (!Array.isArray(datums)) {
-        this.onSelect([datums]);
-      } else {
-        this.onSelect(datums);
-      }
-      if (onRowClick) {
-        onRowClick(event, datums);
-      }
-    };
-
     return (
       <StyledDataTable {...rest}>
         <Header
@@ -187,7 +191,7 @@ class DataTable extends Component {
             onToggle={this.onToggleGroup}
             selectable={selectable}
             onRowClick={onRowClick}
-            onSelect={onClick}
+            onClick={this.onClick}
           />
         ) : (
           <Body
@@ -199,7 +203,7 @@ class DataTable extends Component {
             size={size}
             selectable={selectable}
             onRowClick={onRowClick}
-            onSelect={onClick}
+            onClick={this.onClick}
           />
         )}
         {showFooter && (

--- a/src/js/components/DataTable/GroupedBody.js
+++ b/src/js/components/DataTable/GroupedBody.js
@@ -17,7 +17,8 @@ export const GroupedBody = ({
   theme,
   checked,
   selectable,
-  onSelect,
+  onRowClick,
+  onClick,
   ...rest
 }) => (
   <StyledDataTableBody size={size} {...rest}>
@@ -47,7 +48,7 @@ export const GroupedBody = ({
               isIndeterminate={groupPrimaryProperties.some(item =>
                 checked.includes(item),
               )}
-              onClick={event => onSelect(event, group.data)}
+              onClick={event => onClick(event, group.data)}
             />
           ))}
         </StyledDataTableRow>
@@ -59,8 +60,8 @@ export const GroupedBody = ({
             {content}
             {group.data.map(datum => (
               <StyledDataTableRow
-                onClick={event => onSelect(event, datum)}
-                hoverIndicator={selectable}
+                onClick={event => onClick(event, datum)}
+                hoverIndicator={selectable || onRowClick !== undefined}
                 key={datum[primaryProperty]}
                 size={size}
               >
@@ -75,7 +76,7 @@ export const GroupedBody = ({
                     datum={datum}
                     scope={column.primary ? 'row' : undefined}
                     isChecked={checked.indexOf(datum[primaryProperty]) !== -1}
-                    onClick={event => onSelect(event, datum)}
+                    onClick={event => onClick(event, datum)}
                   />
                 ))}
               </StyledDataTableRow>

--- a/src/js/components/DataTable/GroupedBody.js
+++ b/src/js/components/DataTable/GroupedBody.js
@@ -15,11 +15,17 @@ export const GroupedBody = ({
   onToggle,
   size,
   theme,
+  checked,
+  selectable,
+  onSelect,
   ...rest
 }) => (
   <StyledDataTableBody size={size} {...rest}>
     {groups.map(group => {
       const { expanded } = groupState[group.key];
+      const groupPrimaryProperties = group.data.map(
+        datum => datum[primaryProperty],
+      );
 
       let content = (
         <StyledDataTableRow key={group.key} size={size}>
@@ -35,6 +41,13 @@ export const GroupedBody = ({
               column={column}
               datum={group.datum}
               scope={column.property === groupBy ? 'row' : undefined}
+              isChecked={groupPrimaryProperties.every(item =>
+                checked.includes(item),
+              )}
+              isIndeterminate={groupPrimaryProperties.some(item =>
+                checked.includes(item),
+              )}
+              onClick={event => onSelect(event, group.data)}
             />
           ))}
         </StyledDataTableRow>
@@ -45,7 +58,12 @@ export const GroupedBody = ({
           <Fragment key={group.key}>
             {content}
             {group.data.map(datum => (
-              <StyledDataTableRow key={datum[primaryProperty]} size={size}>
+              <StyledDataTableRow
+                onClick={event => onSelect(event, datum)}
+                hoverIndicator={selectable}
+                key={datum[primaryProperty]}
+                size={size}
+              >
                 <TableCell verticalAlign="bottom">
                   {groupState[group.key].expanded}
                 </TableCell>
@@ -56,6 +74,8 @@ export const GroupedBody = ({
                     column={column}
                     datum={datum}
                     scope={column.primary ? 'row' : undefined}
+                    isChecked={checked.indexOf(datum[primaryProperty]) !== -1}
+                    onClick={event => onSelect(event, datum)}
                   />
                 ))}
               </StyledDataTableRow>

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -8,6 +8,7 @@ import { defaultProps } from '../../default-props';
 import { Box } from '../Box';
 import { TableCell } from '../TableCell';
 import { Text } from '../Text';
+import { CheckBox } from '../CheckBox';
 
 import { Resizer } from './Resizer';
 import { Searcher } from './Searcher';
@@ -21,11 +22,14 @@ const Header = ({
   filters,
   groups,
   groupState,
+  headerChecked,
+  headerIndeterminate,
   onFilter,
   onFiltering,
   onResize,
   onSort,
   onToggle,
+  onSelectAll,
   sort,
   theme,
   widths,
@@ -43,6 +47,7 @@ const Header = ({
     background,
   }))(dataTableContextTheme);
   const { border, background, ...innerThemeProps } = dataTableContextTheme;
+
   return (
     <StyledDataTableHeader {...rest}>
       <StyledDataTableRow>
@@ -58,6 +63,26 @@ const Header = ({
         )}
 
         {columns.map(({ property, header, align, search, sortable }) => {
+          if (property === 'checkbox') {
+            return (
+              <TableCell
+                key={property}
+                scope="col"
+                style={
+                  widths && widths[property]
+                    ? { width: widths[property] }
+                    : undefined
+                }
+                align={align || 'start'}
+              >
+                <CheckBox
+                  checked={headerChecked}
+                  indeterminate={headerIndeterminate}
+                  onChange={event => onSelectAll(event)}
+                />
+              </TableCell>
+            );
+          }
           let content =
             typeof header === 'string' ? <Text>{header}</Text> : header;
           if (onSort && sortable !== false) {

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -197,6 +197,15 @@ When supplied, and when at least one column has 'search' enabled,
 function
 ```
 
+**onRowClick**
+
+When supplied, it will be called when a row is clicked and it will
+      provide you with the event and datum of the corresponding row.
+
+```
+function
+```
+
 **primaryKey**
 
 When supplied, indicates the property for a data object to use to

--- a/src/js/components/DataTable/StyledDataTable.js
+++ b/src/js/components/DataTable/StyledDataTable.js
@@ -18,6 +18,8 @@ const StyledDataTable = styled(Table)`
 StyledDataTable.defaultProps = {};
 Object.setPrototypeOf(StyledDataTable.defaultProps, defaultProps);
 
+
+
 const StyledDataTableRow = styled(TableRow)`
   ${props =>
     props.size &&

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -1503,7 +1503,7 @@ exports[`DataTable groupBy 2`] = `
       class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 bAIczD StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 drboDW"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezoiKY"
@@ -1565,7 +1565,7 @@ exports[`DataTable groupBy 2`] = `
       class="StyledDataTable__StyledDataTableBody-xrlyjm-2 hbZQKY StyledTable__StyledTableBody-sc-1m3u5g-3 dwInxx"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 drboDW"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezoiKY"
@@ -1616,7 +1616,7 @@ exports[`DataTable groupBy 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 drboDW"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezoiKY"
@@ -2646,7 +2646,7 @@ exports[`DataTable sort 2`] = `
       class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 bAIczD StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 drboDW"
       >
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 hNAgVv"
@@ -2846,7 +2846,7 @@ exports[`DataTable sort 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 drboDW"
       >
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -259,6 +259,7 @@ exports[`DataTable aggregate 1`] = `
     >
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <th
           className="c7"
@@ -290,6 +291,7 @@ exports[`DataTable aggregate 1`] = `
       </tr>
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <th
           className="c7"
@@ -550,6 +552,7 @@ exports[`DataTable basic 1`] = `
     >
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <th
           className="c7"
@@ -581,6 +584,7 @@ exports[`DataTable basic 1`] = `
       </tr>
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <th
           className="c7"
@@ -920,6 +924,7 @@ exports[`DataTable footer 1`] = `
     >
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <th
           className="c7"
@@ -951,6 +956,7 @@ exports[`DataTable footer 1`] = `
       </tr>
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <th
           className="c7"
@@ -1863,6 +1869,7 @@ exports[`DataTable primaryKey 1`] = `
     >
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <td
           className="c7"
@@ -1894,6 +1901,7 @@ exports[`DataTable primaryKey 1`] = `
       </tr>
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <td
           className="c7"
@@ -2216,6 +2224,7 @@ exports[`DataTable resizeable 1`] = `
     >
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <th
           className="c10"
@@ -2247,6 +2256,7 @@ exports[`DataTable resizeable 1`] = `
       </tr>
       <tr
         className="c3"
+        onClick={[Function]}
       >
         <th
           className="c10"

--- a/src/js/components/DataTable/datatable.stories.js
+++ b/src/js/components/DataTable/datatable.stories.js
@@ -222,20 +222,34 @@ class ControlledDataTable extends Component {
     checked: [],
   };
 
-  onCheck = (event, value) => {
+  handleCheck = (value) => {
     const { checked } = this.state;
-    if (event.target.checked) {
+    if (checked.indexOf(value) !== -1) {
+      this.setState({ checked: checked.filter(item => item !== value) });
+    } else {
       checked.push(value);
       this.setState({ checked });
-    } else {
-      this.setState({ checked: checked.filter(item => item !== value) });
     }
   };
+
+  onCheck = (value) => {
+    const { rowClick } = this.props;
+    if (!rowClick) {
+      this.handleCheck(value)
+    }
+  }
 
   onCheckAll = event =>
     this.setState({
       checked: event.target.checked ? DATA.map(datum => datum.name) : [],
     });
+
+  onRowClick = (_, datum) => {
+    const { rowClick } = this.props;
+    if (rowClick) {
+      this.handleCheck(datum.name)
+    }
+  };
 
   render() {
     const { checked } = this.state;
@@ -244,6 +258,7 @@ class ControlledDataTable extends Component {
       <Grommet theme={grommet}>
         <Box align="center" pad="medium">
           <DataTable
+            onRowClick={this.onRowClick}
             columns={[
               {
                 property: 'checkbox',
@@ -251,7 +266,7 @@ class ControlledDataTable extends Component {
                   <CheckBox
                     key={datum.name}
                     checked={checked.indexOf(datum.name) !== -1}
-                    onChange={e => this.onCheck(e, datum.name)}
+                    onChange={() => this.onCheck(datum.name)}
                   />
                 ),
                 header: (
@@ -283,4 +298,5 @@ storiesOf('DataTable', module)
   .add('Tunable DataTable', () => <TunableDataTable />)
   .add('Grouped DataTable', () => <GroupedDataTable />)
   .add('Served DataTable', () => <ServedDataTable />)
-  .add('Controlled DataTable', () => <ControlledDataTable />);
+  .add('Controlled DataTable', () => <ControlledDataTable />)
+  .add('Clickable rows DataTable', () => <ControlledDataTable rowClick />);

--- a/src/js/components/DataTable/datatable.stories.js
+++ b/src/js/components/DataTable/datatable.stories.js
@@ -166,9 +166,18 @@ groupColumns[1] = { ...first };
 groupColumns[0].footer = groupColumns[1].footer;
 delete groupColumns[1].footer;
 
-const GroupedDataTable = () => (
+const GroupedDataTable = ({ selectable }) => (
   <Grommet theme={grommet}>
-    <DataTable columns={groupColumns} data={DATA} groupBy="location" sortable />
+    <Box gap="medium">
+      <DataTable
+        columns={groupColumns}
+        data={DATA}
+        groupBy="location"
+        sortable
+        selectable={selectable}
+        primaryProperty="name"
+      />
+    </Box>
   </Grommet>
 );
 
@@ -293,6 +302,27 @@ class ControlledDataTable extends Component {
   }
 }
 
+const SelectableDataTable = () => (
+  <Grommet theme={grommet}>
+    <Box align="center" pad="medium">
+      <DataTable
+        columns={[
+          ...controlledColumns,
+          {
+            property: 'checkbox',
+            align: 'end',
+          },
+        ].map(col => ({ ...col }))}
+        data={DATA}
+        size="medium"
+        sortable
+        selectable
+        primaryProperty="name"
+      />
+    </Box>
+  </Grommet>
+);
+
 storiesOf('DataTable', module)
   .add('Simple DataTable', () => <SimpleDataTable />)
   .add('Sized DataTable', () => <SizedDataTable />)
@@ -300,4 +330,6 @@ storiesOf('DataTable', module)
   .add('Grouped DataTable', () => <GroupedDataTable />)
   .add('Served DataTable', () => <ServedDataTable />)
   .add('Controlled DataTable', () => <ControlledDataTable />)
-  .add('Clickable rows DataTable', () => <ControlledDataTable rowClick />);
+  .add('Clickable rows DataTable', () => <ControlledDataTable rowClick />)
+  .add('Selectable rows DataTable', () => <SelectableDataTable />)
+  .add('Selectable grouped DataTable', () => <GroupedDataTable selectable />);

--- a/src/js/components/DataTable/datatable.stories.js
+++ b/src/js/components/DataTable/datatable.stories.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
 
-import { Grommet, Box, DataTable, Meter, Text, CheckBox } from 'grommet';
+import { Grommet, Box, DataTable, Meter, Text } from 'grommet';
 import { grommet } from 'grommet/themes';
 
 const amountFormatter = new Intl.NumberFormat('en-US', {
@@ -226,81 +226,20 @@ delete controlledColumns[3].footer;
 delete controlledColumns[4].footer;
 delete controlledColumns[4].aggregate;
 
-class ControlledDataTable extends Component {
-  state = {
-    checked: [],
-  };
-
-  handleCheck = value => {
-    const { checked } = this.state;
-    if (checked.indexOf(value) !== -1) {
-      this.setState({ checked: checked.filter(item => item !== value) });
-    } else {
-      checked.push(value);
-      this.setState({ checked });
-    }
-  };
-
-  onCheck = value => {
-    const { rowClick } = this.props;
-    if (!rowClick) {
-      this.handleCheck(value);
-    }
-  };
-
-  onCheckAll = event =>
-    this.setState({
-      checked: event.target.checked ? DATA.map(datum => datum.name) : [],
-    });
-
-  onRowClick = (_, datum) => {
-    const { rowClick } = this.props;
-    if (rowClick) {
-      this.handleCheck(datum.name);
-    }
-  };
-
-  render() {
-    const { rowClick } = this.props;
-    const { checked } = this.state;
-
-    return (
-      <Grommet theme={grommet}>
-        <Box align="center" pad="medium">
-          <DataTable
-            onRowClick={rowClick && this.onRowClick}
-            columns={[
-              {
-                property: 'checkbox',
-                render: datum => (
-                  <CheckBox
-                    key={datum.name}
-                    checked={checked.indexOf(datum.name) !== -1}
-                    onChange={() => this.onCheck(datum.name)}
-                  />
-                ),
-                header: (
-                  <CheckBox
-                    checked={checked.length === DATA.length}
-                    indeterminate={
-                      checked.length > 0 && checked.length < DATA.length
-                    }
-                    onChange={this.onCheckAll}
-                  />
-                ),
-                sortable: false,
-              },
-              ...controlledColumns,
-            ].map(col => ({ ...col }))}
-            data={DATA}
-            sortable
-            size="medium"
-          />
-        </Box>
-      </Grommet>
-    );
-  }
-}
+const ControlledDataTable = () => (
+  <Grommet theme={grommet}>
+    <Box align="center" pad="medium" gap="small">
+      <Text>Event and datum received on clicked (logged on console)</Text>
+      <DataTable
+        onRowClick={(event, datum) => console.log(event, datum)}
+        columns={controlledColumns}
+        data={DATA}
+        sortable
+        size="medium"
+      />
+    </Box>
+  </Grommet>
+);
 
 const SelectableDataTable = () => (
   <Grommet theme={grommet}>
@@ -329,7 +268,6 @@ storiesOf('DataTable', module)
   .add('Tunable DataTable', () => <TunableDataTable />)
   .add('Grouped DataTable', () => <GroupedDataTable />)
   .add('Served DataTable', () => <ServedDataTable />)
-  .add('Controlled DataTable', () => <ControlledDataTable />)
-  .add('Clickable rows DataTable', () => <ControlledDataTable rowClick />)
+  .add('Clickable DataTable', () => <ControlledDataTable />)
   .add('Selectable rows DataTable', () => <SelectableDataTable />)
   .add('Selectable grouped DataTable', () => <GroupedDataTable selectable />);

--- a/src/js/components/DataTable/datatable.stories.js
+++ b/src/js/components/DataTable/datatable.stories.js
@@ -222,7 +222,7 @@ class ControlledDataTable extends Component {
     checked: [],
   };
 
-  handleCheck = (value) => {
+  handleCheck = value => {
     const { checked } = this.state;
     if (checked.indexOf(value) !== -1) {
       this.setState({ checked: checked.filter(item => item !== value) });
@@ -232,12 +232,12 @@ class ControlledDataTable extends Component {
     }
   };
 
-  onCheck = (value) => {
+  onCheck = value => {
     const { rowClick } = this.props;
     if (!rowClick) {
-      this.handleCheck(value)
+      this.handleCheck(value);
     }
-  }
+  };
 
   onCheckAll = event =>
     this.setState({
@@ -247,18 +247,19 @@ class ControlledDataTable extends Component {
   onRowClick = (_, datum) => {
     const { rowClick } = this.props;
     if (rowClick) {
-      this.handleCheck(datum.name)
+      this.handleCheck(datum.name);
     }
   };
 
   render() {
+    const { rowClick } = this.props;
     const { checked } = this.state;
 
     return (
       <Grommet theme={grommet}>
         <Box align="center" pad="medium">
           <DataTable
-            onRowClick={this.onRowClick}
+            onRowClick={rowClick && this.onRowClick}
             columns={[
               {
                 property: 'checkbox',

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -72,6 +72,10 @@ export const doc = DataTable => {
       names and values which are the search text strings. This is typically
       employed so a back-end can be used to search through the data.`,
     ),
+    onRowClick: PropTypes.func.description(
+      `When supplied, it will be called when a row is clicked and it will
+      provide you with the event and datum of the corresponding row.`,
+    ),
     primaryKey: PropTypes.string.description(
       `When supplied, indicates the property for a data object to use to
       get a unique identifier. See also the 'columns.primary' description.

--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -10,6 +10,7 @@ export interface DataTableProps {
   groupBy?: string;
   onMore?: ((...args: any[]) => any);
   onSearch?: ((...args: any[]) => any);
+  onRowClick?: ((...args: any[]) => any);
   primaryKey?: string;
   resizeable?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | string;

--- a/src/js/components/Table/StyledTable.js
+++ b/src/js/components/Table/StyledTable.js
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { genericStyles } from '../../utils';
+import { genericStyles, backgroundStyle, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';
 
 const SIZE_MAP = {
@@ -42,7 +42,16 @@ const StyledTableDataCaption = styled.caption`
 StyledTableDataCaption.defaultProps = {};
 Object.setPrototypeOf(StyledTableDataCaption.defaultProps, defaultProps);
 
+const hoverStyle = css`
+  &:hover {
+    ${props => backgroundStyle(props.theme.global.hover.background, props.theme)}
+    ${props => `color: ${normalizeColor(props.theme.global.hover.color, props.theme)}`};
+  }
+  cursor: pointer;
+`;
+
 const StyledTableRow = styled.tr`
+  ${props => props.hoverIndicator && hoverStyle}
   height: 100%;
 `;
 

--- a/src/js/components/TableRow/README.md
+++ b/src/js/components/TableRow/README.md
@@ -10,6 +10,13 @@ import { TableRow } from 'grommet';
 
 ## Properties
 
+**hoverIndicator**
+
+Whether to apply the hover indicator when the user is mousing over row.
+
+```
+boolean
+```
   
 ## Intrinsic element
 

--- a/src/js/components/TableRow/doc.js
+++ b/src/js/components/TableRow/doc.js
@@ -1,4 +1,4 @@
-import { describe } from 'react-desc';
+import { describe, PropTypes } from 'react-desc';
 
 export const doc = TableRow => {
   const DocumentedTableRow = describe(TableRow)
@@ -8,6 +8,14 @@ export const doc = TableRow => {
 <TableRow />`,
     )
     .intrinsicElement('tr');
+
+    DocumentedTableRow.propTypes = {
+      hoverIndicator: PropTypes.bool
+        .description(
+          'Whether to apply the hover indicator when the user is mousing over row.'
+        )
+        .defaultValue(false),
+    }
 
   return DocumentedTableRow;
 };

--- a/src/js/components/TableRow/index.d.ts
+++ b/src/js/components/TableRow/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 export interface TableRowProps {
-  
+  hoverIndicator?: boolean;
 }
 
 declare const TableRow: React.ComponentType<TableRowProps & JSX.IntrinsicElements['tr']>;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -3122,6 +3122,15 @@ When supplied, and when at least one column has 'search' enabled,
 function
 \`\`\`
 
+**onRowClick**
+
+When supplied, it will be called when a row is clicked and it will
+      provide you with the event and datum of the corresponding row.
+
+\`\`\`
+function
+\`\`\`
+
 **primaryKey**
 
 When supplied, indicates the property for a data object to use to

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -7391,6 +7391,13 @@ import { TableBody } from 'grommet';
 
 ## Properties
 
+**hoverIndicator**
+
+Whether to apply the hover indicator when the user is mousing over row.
+
+\`\`\`
+boolean
+\`\`\`
   
 ## Intrinsic element
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

- [x] Adds on row click to TableRow
- [x] Handle hovering when onRowClick is defined
- [x] Handles onRowClick in datatable
- [x] Handles selection in datatable 
- [ ] keyboard interaction is not there yet

#### Where should the reviewer start?

Code for handling selection makes a couple of assumptions

- (non breaking) user defines in list of columns an object describing the checkbox column. When not set and selectable is true we add our own "makeshift" checkbox column
- (probably breaking ) user sets primaryProperty (hence the warning when not set ). current state of things when not set is weird behaviour due to not knowing how to set proper keys for selection list

#### What testing has been done on this PR?

storybook. both of stories are good examples.

- [ ] i ll try and add unit-test  later

#### How should this be manually tested?

storybook

#### Any background context you want to provide?

#2708 

#### What are the relevant issues?
#2708
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
haven't touched yet
- [ ] documentation
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
yes