### PR TITLE
Chart - add custom css support for size

### DIFF
--- a/src/js/components/Chart/Chart.js
+++ b/src/js/components/Chart/Chart.js
@@ -180,11 +180,11 @@ class Chart extends Component {
     const width =
       sizeWidth === 'full'
         ? containerWidth
-        : parseMetricToNum(theme.global.size[sizeWidth]);
+        : parseMetricToNum(theme.global.size[sizeWidth] || sizeWidth);
     const height =
       sizeHeight === 'full'
         ? containerHeight
-        : parseMetricToNum(theme.global.size[sizeHeight]);
+        : parseMetricToNum(theme.global.size[sizeHeight] || sizeHeight);
     const strokeWidth = parseMetricToNum(theme.global.edgeSize[thickness]);
     const scale = [
       width / (bounds[0][1] - bounds[0][0]),

--- a/src/js/components/Chart/chart.stories.js
+++ b/src/js/components/Chart/chart.stories.js
@@ -17,7 +17,7 @@ const BarChart = () => (
 const LineChart = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
-      <Chart type="line" values={[20, 30, 15]} />
+      <Chart type="line" values={[20, 30, 15]} size="290px" />
     </Box>
   </Grommet>
 );


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
adds custom CSS support for sizing of Chart
#### Where should the reviewer start?
Chart.js
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
storybook - see the added example on `Line` `size="290px"`
#### Any background context you want to provide?

#### What are the relevant issues?
#2750 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible 