### PR TITLE
Remove overflow prop from accordion

### DIFF
--- a/src/js/components/Accordion/Accordion.js
+++ b/src/js/components/Accordion/Accordion.js
@@ -67,7 +67,7 @@ class Accordion extends Component {
     delete rest.onActive;
 
     return (
-      <Box role="tablist" {...rest} overflow="auto">
+      <Box role="tablist" {...rest}>
         {Children.toArray(children).map((panel, index) => (
           <AccordionContext.Provider
             key={`accordion-panel_${index + 0}`}

--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -50,7 +50,6 @@ exports[`Accordion AccordionPanel 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 0px;
-  overflow: auto;
 }
 
 .c2 {
@@ -144,23 +143,6 @@ exports[`Accordion AccordionPanel 1`] = `
   max-width: 100%;
   margin: 0px;
   border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding: 0px;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -290,18 +272,6 @@ exports[`Accordion AccordionPanel 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c11 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
   .c6 {
     font-size: 18px;
     line-height: 24px;
@@ -366,7 +336,7 @@ exports[`Accordion AccordionPanel 1`] = `
       >
         <div
           aria-hidden={true}
-          className="c10 c11"
+          className="c10 c1"
           open={false}
         >
           Panel body 1
@@ -423,7 +393,7 @@ exports[`Accordion AccordionPanel 1`] = `
       >
         <div
           aria-hidden={true}
-          className="c10 c11"
+          className="c10 c1"
           open={false}
         >
           Panel body 2
@@ -484,7 +454,6 @@ exports[`Accordion change active index 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 0px;
-  overflow: auto;
 }
 
 .c2 {
@@ -816,7 +785,7 @@ exports[`Accordion change active index 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lkVXQD"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cYihDV"
+    class="StyledBox-sc-13pk1d4-0 IRSNj"
     role="tablist"
   >
     <div
@@ -964,7 +933,6 @@ exports[`Accordion change to second Panel 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 0px;
-  overflow: auto;
 }
 
 .c2 {
@@ -1058,23 +1026,6 @@ exports[`Accordion change to second Panel 1`] = `
   max-width: 100%;
   margin: 0px;
   border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding: 0px;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1204,18 +1155,6 @@ exports[`Accordion change to second Panel 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c11 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
   .c6 {
     font-size: 18px;
     line-height: 24px;
@@ -1275,7 +1214,7 @@ exports[`Accordion change to second Panel 1`] = `
       >
         <div
           aria-hidden="true"
-          class="c10 c11"
+          class="c10 c1"
         >
           Panel body 1
         </div>
@@ -1326,7 +1265,7 @@ exports[`Accordion change to second Panel 1`] = `
       >
         <div
           aria-hidden="true"
-          class="c10 c11"
+          class="c10 c1"
         >
           Panel body 2
         </div>
@@ -1341,7 +1280,7 @@ exports[`Accordion change to second Panel 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lkVXQD"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cYihDV"
+    class="StyledBox-sc-13pk1d4-0 IRSNj"
     role="tablist"
   >
     <div
@@ -1536,7 +1475,6 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 0px;
-  overflow: auto;
 }
 
 .c2 {
@@ -1865,7 +1803,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lkVXQD"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cYihDV"
+    class="StyledBox-sc-13pk1d4-0 IRSNj"
     role="tablist"
   >
     <div
@@ -2013,7 +1951,6 @@ exports[`Accordion complex header 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 0px;
-  overflow: auto;
 }
 
 .c2 {
@@ -2233,7 +2170,6 @@ exports[`Accordion complex title 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 0px;
-  overflow: auto;
 }
 
 .c3 {
@@ -2297,23 +2233,6 @@ exports[`Accordion complex title 1`] = `
   flex-direction: column;
   padding-left: 12px;
   padding-right: 12px;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  margin: 0px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding: 0px;
 }
 
 .c1 {
@@ -2436,18 +2355,6 @@ exports[`Accordion complex title 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c10 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
   .c1 {
     margin: 0px;
   }
@@ -2531,7 +2438,7 @@ exports[`Accordion complex title 1`] = `
         >
           <div
             aria-hidden={true}
-            className="c9 c10"
+            className="c9 c2"
             open={false}
           >
             Panel body 1
@@ -2582,7 +2489,7 @@ exports[`Accordion complex title 1`] = `
         >
           <div
             aria-hidden={true}
-            className="c9 c10"
+            className="c9 c2"
             open={false}
           >
             Panel body 2
@@ -2644,7 +2551,6 @@ exports[`Accordion multiple panels 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 0px;
-  overflow: auto;
 }
 
 .c2 {
@@ -2973,7 +2879,7 @@ exports[`Accordion multiple panels 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lkVXQD"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cYihDV"
+    class="StyledBox-sc-13pk1d4-0 IRSNj"
     role="tablist"
   >
     <div
@@ -3110,7 +3016,7 @@ exports[`Accordion multiple panels 3`] = `
   class="StyledGrommet-sc-19lkkz7-0 lkVXQD"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cYihDV"
+    class="StyledBox-sc-13pk1d4-0 IRSNj"
     role="tablist"
   >
     <div
@@ -3250,7 +3156,7 @@ exports[`Accordion multiple panels 4`] = `
   class="StyledGrommet-sc-19lkkz7-0 lkVXQD"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cYihDV"
+    class="StyledBox-sc-13pk1d4-0 IRSNj"
     role="tablist"
   >
     <div
@@ -3387,7 +3293,7 @@ exports[`Accordion multiple panels 5`] = `
   class="StyledGrommet-sc-19lkkz7-0 lkVXQD"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cYihDV"
+    class="StyledBox-sc-13pk1d4-0 IRSNj"
     role="tablist"
   >
     <div
@@ -3532,7 +3438,6 @@ exports[`Accordion no AccordionPanel 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 0px;
-  overflow: auto;
 }
 
 .c0 {
@@ -3617,7 +3522,6 @@ exports[`Accordion set on hover 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 0px;
-  overflow: auto;
 }
 
 .c2 {
@@ -3711,23 +3615,6 @@ exports[`Accordion set on hover 1`] = `
   max-width: 100%;
   margin: 0px;
   border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding: 0px;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  margin: 0px;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3857,18 +3744,6 @@ exports[`Accordion set on hover 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c11 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
   .c6 {
     font-size: 18px;
     line-height: 24px;
@@ -3928,7 +3803,7 @@ exports[`Accordion set on hover 1`] = `
       >
         <div
           aria-hidden="true"
-          class="c10 c11"
+          class="c10 c1"
         >
           Panel body 1
         </div>
@@ -3979,7 +3854,7 @@ exports[`Accordion set on hover 1`] = `
       >
         <div
           aria-hidden="true"
-          class="c10 c11"
+          class="c10 c1"
         >
           Panel body 2
         </div>
@@ -3994,7 +3869,7 @@ exports[`Accordion set on hover 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lkVXQD"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cYihDV"
+    class="StyledBox-sc-13pk1d4-0 IRSNj"
     role="tablist"
   >
     <div
@@ -4108,7 +3983,7 @@ exports[`Accordion set on hover 3`] = `
   class="StyledGrommet-sc-19lkkz7-0 lkVXQD"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cYihDV"
+    class="StyledBox-sc-13pk1d4-0 IRSNj"
     role="tablist"
   >
     <div
@@ -4222,7 +4097,7 @@ exports[`Accordion set on hover 4`] = `
   class="StyledGrommet-sc-19lkkz7-0 lkVXQD"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cYihDV"
+    class="StyledBox-sc-13pk1d4-0 IRSNj"
     role="tablist"
   >
     <div
@@ -4336,7 +4211,7 @@ exports[`Accordion set on hover 5`] = `
   class="StyledGrommet-sc-19lkkz7-0 lkVXQD"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 cYihDV"
+    class="StyledBox-sc-13pk1d4-0 IRSNj"
     role="tablist"
   >
     <div


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This fixes the issue brought up in #2757 by removing the overflow prop from the Box container in the Accordion.
#### Where should the reviewer start?
Just check out the code - its a small change.
#### What testing has been done on this PR?
None - should be as simple as removing the overflow and letting the user set it through ...rest if desired.
#### How should this be manually tested?
Make sure the accordion no longer has unwanted y-overflow scrolling.

#### Any background context you want to provide?
N/A
#### What are the relevant issues?
#2757 
#### Screenshots (if appropriate)
N/A
#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible and non-breaking