### PR TITLE
Box - Added xxsmall to the gap doc

### DIFF
--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -358,6 +358,7 @@ The amount of spacing between child elements. This
         will not wrap gracefully.
 
 ```
+xxsmall
 xsmall
 small
 medium

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -172,7 +172,14 @@ export const doc = Box => {
       'Whether the width and/or height should fill the container.',
     ),
     gap: PropTypes.oneOfType([
-      PropTypes.oneOf(['xsmall', 'small', 'medium', 'large', 'xlarge']),
+      PropTypes.oneOf([
+        'xxsmall',
+        'xsmall',
+        'small',
+        'medium',
+        'large',
+        'xlarge',
+      ]),
       PropTypes.string,
     ]).description(`The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -15,7 +15,7 @@ export interface BoxProps {
   elevation?: "none" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   flex?: "grow" | "shrink" | boolean | {grow?: number,shrink?: number};
   fill?: "horizontal" | "vertical" | boolean;
-  gap?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
+  gap?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   height?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   justify?: "start" | "center" | "between" | "around" | "evenly" | "end";
   overflow?: "auto" | "hidden" | "scroll" | "visible" | {horizontal?: "auto" | "hidden" | "scroll" | "visible",vertical?: "auto" | "hidden" | "scroll" | "visible"} | string;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -863,6 +863,7 @@ The amount of spacing between child elements. This
         will not wrap gracefully.
 
 \`\`\`
+xxsmall
 xsmall
 small
 medium

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -507,7 +507,8 @@ boolean",
         "description": "The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
         will not wrap gracefully.",
-        "format": "xsmall
+        "format": "xxsmall
+xsmall
 small
 medium
 large


### PR DESCRIPTION
What does this PR do?

Changed Box to update missing documentation, issues: #2761 
Where should the reviewer start?

Box/doc.js
What testing has been done on this PR?

none
How should this be manually tested?
Any background context you want to provide?
What are the relevant issues?

#2761
Screenshots (if appropriate)
Do the grommet docs need to be updated?

automatic
Should this PR be mentioned in the release notes?

no
Is this change backwards compatible or is it a breaking change?

backwards compatible