### PR TITLE
Better theme support for FormField.

### DIFF
--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -1,7 +1,6 @@
 import React, { Children, cloneElement, Component } from 'react';
 import { compose } from 'recompose';
-
-import { withTheme } from 'styled-components';
+import styled, { withTheme } from 'styled-components';
 
 import { defaultProps } from '../../default-props';
 import { parseMetricToNum } from '../../utils';
@@ -28,9 +27,14 @@ const validateField = (required, validate, messages) => (value, data) => {
   return error;
 };
 
+const FormFieldBox = styled(Box)`
+  ${props => props.theme.formField.extend}
+`;
+
 class FormField extends Component {
   renderChildren = (value, update) => {
     const { name, component, required, ...rest } = this.props;
+    delete rest.className;
     const Input = component || TextInput;
     if (Input === CheckBox) {
       return (
@@ -57,6 +61,7 @@ class FormField extends Component {
   render() {
     const {
       children,
+      className,
       component,
       error,
       focus,
@@ -89,11 +94,7 @@ class FormField extends Component {
           }
 
           if (pad) {
-            contents = (
-              <Box pad={{ horizontal: 'small', bottom: 'small' }}>
-                {contents}
-              </Box>
-            );
+            contents = <Box {...formField.content}>{contents}</Box>;
           }
 
           let borderColor;
@@ -121,7 +122,6 @@ class FormField extends Component {
                   return child;
                 })
               : contents;
-
             contents = (
               <Box
                 ref={ref => {
@@ -164,28 +164,24 @@ class FormField extends Component {
           }
 
           return (
-            <Box
+            <FormFieldBox
+              className={className}
               border={
                 border && border.position === 'outer'
                   ? { ...border, color: borderColor }
                   : undefined
               }
-              margin={abut ? undefined : { bottom: 'small' }}
+              margin={abut ? undefined : { ...formField.margin }}
               style={outerStyle}
             >
               {(label && component !== CheckBox) || help ? (
-                <Box
-                  margin={{ vertical: 'xsmall', horizontal: 'small' }}
-                  gap="xsmall"
-                >
-                  {label && component !== CheckBox ? (
+                <>
+                  {label && component !== CheckBox && (
                     <Text as="label" htmlFor={htmlFor} {...formField.label}>
                       {label}
                     </Text>
-                  ) : (
-                    undefined
                   )}
-                  {help ? (
+                  {help && (
                     <Text
                       {...formField.help}
                       color={
@@ -194,27 +190,21 @@ class FormField extends Component {
                     >
                       {help}
                     </Text>
-                  ) : (
-                    undefined
                   )}
-                </Box>
+                </>
               ) : (
                 undefined
               )}
               {contents}
-              {normalizedError ? (
-                <Box margin={{ vertical: 'xsmall', horizontal: 'small' }}>
-                  <Text
-                    {...formField.error}
-                    color={formField.error.color[theme.dark ? 'dark' : 'light']}
-                  >
-                    {normalizedError}
-                  </Text>
-                </Box>
-              ) : (
-                undefined
+              {normalizedError && (
+                <Text
+                  {...formField.error}
+                  color={formField.error.color[theme.dark ? 'dark' : 'light']}
+                >
+                  {normalizedError}
+                </Text>
               )}
-            </Box>
+            </FormFieldBox>
           );
         }}
       </FormContext.Consumer>

--- a/src/js/components/FormField/__tests__/FormField-test.js
+++ b/src/js/components/FormField/__tests__/FormField-test.js
@@ -1,10 +1,15 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import styled from 'styled-components';
 import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
 import { FormField } from '..';
 import { TextInput } from '../../TextInput';
+
+const CustomFormField = styled(FormField)`
+  font-size: 40px;
+`;
 
 test('renders', () => {
   const component = renderer.create(
@@ -53,6 +58,16 @@ test('renders htmlFor', () => {
   const component = renderer.create(
     <Grommet>
       <FormField htmlFor="test-id" />
+    </Grommet>,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('renders custom formfield', () => {
+  const component = renderer.create(
+    <Grommet>
+      <CustomFormField htmlFor="test-id" />
     </Grommet>,
   );
   const tree = component.toJSON();

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -152,6 +152,99 @@ exports[`renders 1`] = `
 </div>
 `;
 
+exports[`renders custom formfield 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+.c1 {
+  font-size: 40px;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    padding: 0px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1 c2"
+  >
+    <div
+      className="c3"
+    />
+  </div>
+</div>
+`;
+
 exports[`renders error 1`] = `
 .c0 {
   font-size: 18px;
@@ -180,26 +273,6 @@ exports[`renders error 1`] = `
   padding: 0px;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 6px;
-  margin-bottom: 6px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding: 0px;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -218,9 +291,15 @@ exports[`renders error 1`] = `
   padding: 0px;
 }
 
-.c4 {
+.c3 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
+  margin-top: 6px;
+  margin-bottom: 6px;
   color: #FF4040;
 }
 
@@ -232,26 +311,6 @@ exports[`renders error 1`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
-    margin-left: 6px;
-    margin-right: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
-    margin-top: 3px;
-    margin-bottom: 3px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
     padding: 0px;
   }
 }
@@ -283,15 +342,11 @@ exports[`renders error 1`] = `
     <div
       className="c2"
     />
-    <div
+    <span
       className="c3"
     >
-      <span
-        className="c4"
-      >
-        test error
-      </span>
-    </div>
+      test error
+    </span>
   </div>
 </div>
 `;
@@ -324,7 +379,7 @@ exports[`renders help 1`] = `
   padding: 0px;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -343,28 +398,10 @@ exports[`renders help 1`] = `
 }
 
 .c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
   margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 6px;
-  margin-bottom: 6px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding: 0px;
-}
-
-.c3 {
   font-size: 18px;
   line-height: 24px;
+  margin-left: 12px;
   color: #777777;
 }
 
@@ -381,39 +418,19 @@ exports[`renders help 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c3 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c2 {
-    margin-left: 6px;
-    margin-right: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c2 {
-    margin-top: 3px;
-    margin-bottom: 3px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c2 {
+  .c3 {
     padding: 0px;
   }
 }
@@ -424,17 +441,13 @@ exports[`renders help 1`] = `
   <div
     className="c1"
   >
-    <div
+    <span
       className="c2"
     >
-      <span
-        className="c3"
-      >
-        test help
-      </span>
-    </div>
+      test help
+    </span>
     <div
-      className="c4"
+      className="c3"
     />
   </div>
 </div>
@@ -557,7 +570,7 @@ exports[`renders label 1`] = `
   padding: 0px;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -576,28 +589,14 @@ exports[`renders label 1`] = `
 }
 
 .c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
   margin-bottom: 6px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding: 0px;
-}
-
-.c3 {
   font-size: 18px;
   line-height: 24px;
+  margin-top: 6px;
+  margin-bottom: 6px;
 }
 
 @media only screen and (max-width:768px) {
@@ -613,39 +612,19 @@ exports[`renders label 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c3 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c2 {
-    margin-left: 6px;
-    margin-right: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c2 {
-    margin-top: 3px;
-    margin-bottom: 3px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c2 {
+  .c3 {
     padding: 0px;
   }
 }
@@ -656,17 +635,13 @@ exports[`renders label 1`] = `
   <div
     className="c1"
   >
-    <div
+    <label
       className="c2"
     >
-      <label
-        className="c3"
-      >
-        test label
-      </label>
-    </div>
+      test label
+    </label>
     <div
-      className="c4"
+      className="c3"
     />
   </div>
 </div>

--- a/src/js/components/FormField/formfield.stories.js
+++ b/src/js/components/FormField/formfield.stories.js
@@ -11,6 +11,7 @@ import {
   TextInput,
 } from 'grommet';
 import { grommet } from 'grommet/themes';
+import { deepMerge } from 'grommet/utils';
 
 const allSuggestions = Array(100)
   .fill()
@@ -133,10 +134,42 @@ const FormFieldHelpError = props => (
   </Grommet>
 );
 
+const customFormFieldTheme = {
+  global: {
+    font: {
+      size: '13px',
+    },
+    input: {
+      weight: 400,
+    },
+  },
+  formField: {
+    label: {
+      color: 'dark-3',
+      size: 'xsmall',
+      margin: { vertical: 0, bottom: 'small', horizontal: 0 },
+      weight: '600',
+    },
+    border: false,
+    margin: 0,
+  },
+};
+
+const CustomFormField = () => (
+  <Grommet theme={deepMerge(grommet, customFormFieldTheme)}>
+    <Box align="center" pad="large">
+      <FormField label="Label" htmlFor="text-area">
+        <TextArea id="text-area" placeholder="placeholder" />
+      </FormField>
+    </Box>
+  </Grommet>
+);
+
 storiesOf('FormField', module)
   .add('TextInput', () => <FormFieldTextInput />)
   .add('TextArea', () => <FormFieldTextArea />)
   .add('Select', () => <FormFieldSelect />)
   .add('CheckBox', () => <FormFieldCheckBox />)
   .add('Toggle', () => <FormFieldToggle />)
-  .add('Help and error', () => <FormFieldHelpError />);
+  .add('Help and error', () => <FormFieldHelpError />)
+  .add('Custom Theme', () => <CustomFormField />);

--- a/src/js/components/FormField/formfield.stories.js
+++ b/src/js/components/FormField/formfield.stories.js
@@ -147,8 +147,8 @@ const customFormFieldTheme = {
     label: {
       color: 'dark-3',
       size: 'xsmall',
-      margin: { vertical: 0, bottom: 'small', horizontal: 0 },
-      weight: '600',
+      margin: { vertical: '0', bottom: 'small', horizontal: '0' },
+      weight: 600,
     },
     border: false,
     margin: 0,

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -487,19 +487,33 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           },
         },
       },
+      content: {
+        pad: {
+          horizontal: 'small',
+          bottom: 'small',
+        },
+      },
       error: {
+        margin: { vertical: 'xsmall', horizontal: 'small' },
         color: {
           dark: 'status-critical',
           light: 'status-critical',
         },
       },
       help: {
+        margin: {
+          left: 'small',
+        },
         color: {
           dark: 'dark-3',
           light: 'dark-3',
         },
       },
-      label: {},
+      label: {
+        margin: { vertical: 'xsmall', horizontal: 'small' },
+      },
+      margin: { bottom: 'small' },
+      // extend: undefined,
     },
     grommet: {},
     heading: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5276,10 +5276,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
-grommet-icons@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.1.0.tgz#4705d2828461348ff38ddd2c42b8cd551e0569a0"
-  integrity sha512-S9TqY4R/J/xG6++xNXa5JoQeZ9/jO8b6FgmDOhHAD8Vdx/btPswp2hUliTdQiFZFxne4ILldQoCK0w1xwN9eSA==
+grommet-icons@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.2.0.tgz#7bcf7d4b37f694516ade084e2536c72b224c6a76"
+  integrity sha512-HMPLQa2pgnCZFImUXwfq+79VizL6oyP2/AAfAzQDw57x/6qgWouoqoRrrt+2zodTjTxtKXxliBY1w/o5uC+DpA==
   dependencies:
     grommet-styles "^0.2.0"
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Changes FormField to allow custom theme.

#### Where should the reviewer start?
FormField.js

#### What testing has been done on this PR?
added test for extend and add storybook story
#### How should this be manually tested?
open formfield stories and make sure it looks the same as https://storybook.grommet.io.
plus look at the new custom theme story to validate the new entries are supported.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #2765 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes, we need theme documentation for formfield!!

#### Should this PR be mentioned in the release notes?
yes

#### Is this change backwards compatible or is it a breaking change?
backwards