### PR TITLE
fix docs for Chart fill area color

### DIFF
--- a/src/js/components/Chart/README.md
+++ b/src/js/components/Chart/README.md
@@ -276,30 +276,7 @@ color options used for Chart fill area. Expects `object`.
 Defaults to
 
 ```
-  
-      active: rgba(221, 221, 221, 0.5),
-      black: '#000000',
-      border: {
-        dark: rgba(255, 255, 255, 0.33),
-        light: rgba(0, 0, 0, 0.33),
-      },
-      brand: brandColor,
-      control: {
-        dark: 'accent-1',
-        light: 'brand',
-      },
-      focus: focusColor,
-      placeholder: '#AAAAAA',
-      selected: 'brand',
-      text: {
-        dark: '#f8f8f8',
-        light: '#444444',
-      },
-      icon: {
-        dark: '#f8f8f8',
-        light: '#666666',
-      },
-      white: '#FFFFFF',
+undefined
 ```
 
 **global.edgeSize**

--- a/src/js/components/Chart/README.md
+++ b/src/js/components/Chart/README.md
@@ -276,7 +276,7 @@ color options used for Chart fill area. Expects `object`.
 Defaults to
 
 ```
-undefined
+accent-1
 ```
 
 **global.edgeSize**

--- a/src/js/components/Chart/doc.js
+++ b/src/js/components/Chart/doc.js
@@ -154,30 +154,7 @@ export const themeDoc = {
   'global.colors': {
     description: 'color options used for Chart fill area.',
     type: 'object',
-    defaultValue: `  
-      active: rgba(221, 221, 221, 0.5),
-      black: '#000000',
-      border: {
-        dark: rgba(255, 255, 255, 0.33),
-        light: rgba(0, 0, 0, 0.33),
-      },
-      brand: brandColor,
-      control: {
-        dark: 'accent-1',
-        light: 'brand',
-      },
-      focus: focusColor,
-      placeholder: '#AAAAAA',
-      selected: 'brand',
-      text: {
-        dark: '#f8f8f8',
-        light: '#444444',
-      },
-      icon: {
-        dark: '#f8f8f8',
-        light: '#666666',
-      },
-      white: '#FFFFFF',`,
+    defaultValue: undefined,
   },
   'global.edgeSize': {
     description: 'The possible sizes for the thickness in the Chart.',

--- a/src/js/components/Chart/doc.js
+++ b/src/js/components/Chart/doc.js
@@ -154,7 +154,7 @@ export const themeDoc = {
   'global.colors': {
     description: 'color options used for Chart fill area.',
     type: 'object',
-    defaultValue: undefined,
+    defaultValue: 'accent-1',
   },
   'global.edgeSize': {
     description: 'The possible sizes for the thickness in the Chart.',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -2611,7 +2611,7 @@ color options used for Chart fill area. Expects \`object\`.
 Defaults to
 
 \`\`\`
-undefined
+accent-1
 \`\`\`
 
 **global.edgeSize**

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -2611,30 +2611,7 @@ color options used for Chart fill area. Expects \`object\`.
 Defaults to
 
 \`\`\`
-  
-      active: rgba(221, 221, 221, 0.5),
-      black: '#000000',
-      border: {
-        dark: rgba(255, 255, 255, 0.33),
-        light: rgba(0, 0, 0, 0.33),
-      },
-      brand: brandColor,
-      control: {
-        dark: 'accent-1',
-        light: 'brand',
-      },
-      focus: focusColor,
-      placeholder: '#AAAAAA',
-      selected: 'brand',
-      text: {
-        dark: '#f8f8f8',
-        light: '#444444',
-      },
-      icon: {
-        dark: '#f8f8f8',
-        light: '#666666',
-      },
-      white: '#FFFFFF',
+undefined
 \`\`\`
 
 **global.edgeSize**


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
documenting the accurate default value of Chart fill color instead of listing all colors options.
#### Where should the reviewer start?
doc.js
#### What testing has been done on this PR?
Storybook Chart Bar
#### How should this be manually tested?
Storybook Chart Bar
Chart.js
#### Any background context you want to provide?

#### What are the relevant issues?
#2775
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible