### PR TITLE
Specify components as function or class types

### DIFF
--- a/src/js/components/Accordion/index.d.ts
+++ b/src/js/components/Accordion/index.d.ts
@@ -13,6 +13,6 @@ export interface AccordionProps {
   messages?: {tabContents?: string};
 }
 
-declare const Accordion: React.ComponentType<AccordionProps & JSX.IntrinsicElements['div']>;
+declare const Accordion: React.ComponentClass<AccordionProps & JSX.IntrinsicElements['div']>;
 
 export { Accordion };

--- a/src/js/components/AccordionPanel/index.d.ts
+++ b/src/js/components/AccordionPanel/index.d.ts
@@ -5,6 +5,6 @@ export interface AccordionPanelProps {
   header?: React.ReactNode;
 }
 
-declare const AccordionPanel: React.ComponentType<AccordionPanelProps & JSX.IntrinsicElements['div']>;
+declare const AccordionPanel: React.ComponentClass<AccordionPanelProps & JSX.IntrinsicElements['div']>;
 
 export { AccordionPanel };

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -15,6 +15,6 @@ export interface AnchorProps {
   as?: string;
 }
 
-declare const Anchor: React.ComponentType<AnchorProps & JSX.IntrinsicElements['a']>;
+declare const Anchor: React.ComponentClass<AnchorProps & JSX.IntrinsicElements['a']>;
 
 export { Anchor };

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -28,6 +28,6 @@ export interface BoxProps {
   wrap?: boolean;
 }
 
-declare const Box: React.ComponentType<BoxProps & JSX.IntrinsicElements['div']>;
+declare const Box: React.ComponentClass<BoxProps & JSX.IntrinsicElements['div']>;
 
 export { Box };

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -22,6 +22,6 @@ export interface ButtonProps {
   as?: string;
 }
 
-declare const Button: React.ComponentType<ButtonProps & JSX.IntrinsicElements['button']>;
+declare const Button: React.ComponentClass<ButtonProps & JSX.IntrinsicElements['button']>;
 
 export { Button };

--- a/src/js/components/Calendar/index.d.ts
+++ b/src/js/components/Calendar/index.d.ts
@@ -21,6 +21,6 @@ export interface CalendarProps {
   size?: "small" | "medium" | "large" | string;
 }
 
-declare const Calendar: React.ComponentType<CalendarProps & JSX.IntrinsicElements['div']>;
+declare const Calendar: React.ComponentClass<CalendarProps & JSX.IntrinsicElements['div']>;
 
 export { Calendar };

--- a/src/js/components/Carousel/index.d.ts
+++ b/src/js/components/Carousel/index.d.ts
@@ -9,6 +9,6 @@ export interface CarouselProps {
   play?: number;
 }
 
-declare const Carousel: React.ComponentType<CarouselProps & JSX.IntrinsicElements['div']>;
+declare const Carousel: React.ComponentClass<CarouselProps & JSX.IntrinsicElements['div']>;
 
 export { Carousel };

--- a/src/js/components/Chart/index.d.ts
+++ b/src/js/components/Chart/index.d.ts
@@ -17,6 +17,6 @@ export interface ChartProps {
   values: (number | number[] | {label?: string,onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any),value: number | number[]})[];
 }
 
-declare const Chart: React.ComponentType<ChartProps>;
+declare const Chart: React.ComponentClass<ChartProps>;
 
 export { Chart };

--- a/src/js/components/CheckBox/index.d.ts
+++ b/src/js/components/CheckBox/index.d.ts
@@ -12,6 +12,6 @@ export interface CheckBoxProps {
   indeterminate?: boolean;
 }
 
-declare const CheckBox: React.ComponentType<CheckBoxProps & JSX.IntrinsicElements['input']>;
+declare const CheckBox: React.ComponentClass<CheckBoxProps & JSX.IntrinsicElements['input']>;
 
 export { CheckBox };

--- a/src/js/components/Clock/index.d.ts
+++ b/src/js/components/Clock/index.d.ts
@@ -14,6 +14,6 @@ export interface ClockProps {
   type?: "analog" | "digital";
 }
 
-declare const Clock: React.ComponentType<ClockProps & (JSX.IntrinsicElements['div'] | JSX.IntrinsicElements['svg'])>;
+declare const Clock: React.ComponentClass<ClockProps & (JSX.IntrinsicElements['div'] | JSX.IntrinsicElements['svg'])>;
 
 export { Clock };

--- a/src/js/components/Collapsible/index.d.ts
+++ b/src/js/components/Collapsible/index.d.ts
@@ -5,6 +5,6 @@ export interface CollapsibleProps {
   direction?: "horizontal" | "vertical";
 }
 
-declare const Collapsible: React.ComponentType<CollapsibleProps & JSX.IntrinsicElements['div']>;
+declare const Collapsible: React.ComponentClass<CollapsibleProps & JSX.IntrinsicElements['div']>;
 
 export { Collapsible };

--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -16,6 +16,6 @@ export interface DataTableProps {
   sortable?: boolean;
 }
 
-declare const DataTable: React.ComponentType<DataTableProps & JSX.IntrinsicElements['table']>;
+declare const DataTable: React.ComponentClass<DataTableProps & JSX.IntrinsicElements['table']>;
 
 export { DataTable };

--- a/src/js/components/Diagram/index.d.ts
+++ b/src/js/components/Diagram/index.d.ts
@@ -4,6 +4,6 @@ export interface DiagramProps {
   connections: {anchor?: "center" | "vertical" | "horizontal",color?: string | {dark?: string,light?: string},fromTarget: string | object,label?: string,offset?: "xsmall" | "small" | "medium" | "large" | string,thickness?: "hair" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,toTarget: string | object,type?: "direct" | "curved" | "rectilinear"}[];
 }
 
-declare const Diagram: React.ComponentType<DiagramProps & JSX.IntrinsicElements['svg']>;
+declare const Diagram: React.ComponentClass<DiagramProps & JSX.IntrinsicElements['svg']>;
 
 export { Diagram };

--- a/src/js/components/Distribution/index.d.ts
+++ b/src/js/components/Distribution/index.d.ts
@@ -11,6 +11,6 @@ export interface DistributionProps {
   values: {value: number}[];
 }
 
-declare const Distribution: React.ComponentType<DistributionProps & JSX.IntrinsicElements['div']>;
+declare const Distribution: React.ComponentClass<DistributionProps & JSX.IntrinsicElements['div']>;
 
 export { Distribution };

--- a/src/js/components/Drop/index.d.ts
+++ b/src/js/components/Drop/index.d.ts
@@ -12,6 +12,6 @@ export interface DropProps {
   plain?: boolean;
 }
 
-declare const Drop: React.ComponentType<DropProps & JSX.IntrinsicElements['div']>;
+declare const Drop: React.ComponentClass<DropProps & JSX.IntrinsicElements['div']>;
 
 export { Drop };

--- a/src/js/components/DropButton/index.d.ts
+++ b/src/js/components/DropButton/index.d.ts
@@ -15,6 +15,6 @@ export interface DropButtonProps {
   open?: boolean;
 }
 
-declare const DropButton: React.ComponentType<DropButtonProps & ButtonProps>;
+declare const DropButton: React.ComponentClass<DropButtonProps & ButtonProps>;
 
 export { DropButton };

--- a/src/js/components/Form/index.d.ts
+++ b/src/js/components/Form/index.d.ts
@@ -8,6 +8,6 @@ export interface FormProps {
   value?: {};
 }
 
-declare const Form: React.ComponentType<FormProps & JSX.IntrinsicElements['form']>;
+declare const Form: React.ComponentClass<FormProps & JSX.IntrinsicElements['form']>;
 
 export { Form };

--- a/src/js/components/FormField/index.d.ts
+++ b/src/js/components/FormField/index.d.ts
@@ -11,6 +11,6 @@ export interface FormFieldProps {
   validate?: {regexp?: object,message?: string} | ((...args: any[]) => any);
 }
 
-declare const FormField: React.ComponentType<FormFieldProps & JSX.IntrinsicElements['div']>;
+declare const FormField: React.ComponentClass<FormFieldProps & JSX.IntrinsicElements['div']>;
 
 export { FormField };

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -18,6 +18,6 @@ export interface GridProps {
   as?: string;
 }
 
-declare const Grid: React.ComponentType<GridProps & JSX.IntrinsicElements['div']>;
+declare const Grid: React.FC<GridProps & JSX.IntrinsicElements['div']>;
 
 export { Grid };

--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -7,6 +7,6 @@ export interface GrommetProps {
   userAgent?: string;
 }
 
-declare const Grommet: React.ComponentType<GrommetProps & JSX.IntrinsicElements['div']>;
+declare const Grommet: React.ComponentClass<GrommetProps & JSX.IntrinsicElements['div']>;
 
 export { Grommet };

--- a/src/js/components/Heading/index.d.ts
+++ b/src/js/components/Heading/index.d.ts
@@ -13,6 +13,6 @@ export interface HeadingProps {
   truncate?: boolean;
 }
 
-declare const Heading: React.ComponentType<HeadingProps & (JSX.IntrinsicElements['h1'] | JSX.IntrinsicElements['h2'] | JSX.IntrinsicElements['h3'] | JSX.IntrinsicElements['h4'])>;
+declare const Heading: React.FC<HeadingProps & (JSX.IntrinsicElements['h1'] | JSX.IntrinsicElements['h2'] | JSX.IntrinsicElements['h3'] | JSX.IntrinsicElements['h4'])>;
 
 export { Heading };

--- a/src/js/components/Image/index.d.ts
+++ b/src/js/components/Image/index.d.ts
@@ -8,6 +8,6 @@ export interface ImageProps {
   fit?: "cover" | "contain";
 }
 
-declare const Image: React.ComponentType<ImageProps & JSX.IntrinsicElements['img']>;
+declare const Image: React.FC<ImageProps & JSX.IntrinsicElements['img']>;
 
 export { Image };

--- a/src/js/components/InfiniteScroll/index.d.ts
+++ b/src/js/components/InfiniteScroll/index.d.ts
@@ -11,6 +11,6 @@ export interface InfiniteScrollProps {
   step?: number;
 }
 
-declare const InfiniteScroll: React.ComponentType<InfiniteScrollProps>;
+declare const InfiniteScroll: React.ComponentClass<InfiniteScrollProps>;
 
 export { InfiniteScroll };

--- a/src/js/components/Keyboard/index.d.ts
+++ b/src/js/components/Keyboard/index.d.ts
@@ -16,6 +16,6 @@ export interface KeyboardProps {
   onUp?: ((...args: any[]) => any);
 }
 
-declare const Keyboard: React.ComponentType<KeyboardProps>;
+declare const Keyboard: React.ComponentClass<KeyboardProps>;
 
 export { Keyboard };

--- a/src/js/components/Layer/index.d.ts
+++ b/src/js/components/Layer/index.d.ts
@@ -12,6 +12,6 @@ export interface LayerProps {
   responsive?: boolean;
 }
 
-declare const Layer: React.ComponentType<LayerProps & JSX.IntrinsicElements['div']>;
+declare const Layer: React.ComponentClass<LayerProps & JSX.IntrinsicElements['div']>;
 
 export { Layer };

--- a/src/js/components/Markdown/index.d.ts
+++ b/src/js/components/Markdown/index.d.ts
@@ -4,6 +4,6 @@ export interface MarkdownProps {
   components?: {};
 }
 
-declare const Markdown: React.ComponentType<MarkdownProps & JSX.IntrinsicElements['div']>;
+declare const Markdown: React.ComponentClass<MarkdownProps & JSX.IntrinsicElements['div']>;
 
 export { Markdown };

--- a/src/js/components/MaskedInput/index.d.ts
+++ b/src/js/components/MaskedInput/index.d.ts
@@ -16,6 +16,6 @@ export interface MaskedInputProps {
   value?: string;
 }
 
-declare const MaskedInput: React.ComponentType<MaskedInputProps & JSX.IntrinsicElements['input']>;
+declare const MaskedInput: React.ComponentClass<MaskedInputProps & JSX.IntrinsicElements['input']>;
 
 export { MaskedInput };

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -17,6 +17,6 @@ export interface MenuProps {
   size?: "small" | "medium" | "large" | "xlarge" | string;
 }
 
-declare const Menu: React.ComponentType<MenuProps & JSX.IntrinsicElements['button']>;
+declare const Menu: React.ComponentClass<MenuProps & JSX.IntrinsicElements['button']>;
 
 export { Menu };

--- a/src/js/components/Meter/index.d.ts
+++ b/src/js/components/Meter/index.d.ts
@@ -13,6 +13,6 @@ export interface MeterProps {
   values?: {color?: string,highlight?: boolean,label: string,onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any),value: number}[];
 }
 
-declare const Meter: React.ComponentType<MeterProps>;
+declare const Meter: React.ComponentClass<MeterProps>;
 
 export { Meter };

--- a/src/js/components/Paragraph/index.d.ts
+++ b/src/js/components/Paragraph/index.d.ts
@@ -11,6 +11,6 @@ export interface ParagraphProps {
   textAlign?: "start" | "center" | "end";
 }
 
-declare const Paragraph: React.ComponentType<ParagraphProps & JSX.IntrinsicElements['p']>;
+declare const Paragraph: React.FC<ParagraphProps & JSX.IntrinsicElements['p']>;
 
 export { Paragraph };

--- a/src/js/components/RadioButton/index.d.ts
+++ b/src/js/components/RadioButton/index.d.ts
@@ -9,6 +9,6 @@ export interface RadioButtonProps {
   onChange?: ((...args: any[]) => any);
 }
 
-declare const RadioButton: React.ComponentType<RadioButtonProps & JSX.IntrinsicElements['input']>;
+declare const RadioButton: React.ComponentClass<RadioButtonProps & JSX.IntrinsicElements['input']>;
 
 export { RadioButton };

--- a/src/js/components/RadioButtonGroup/index.d.ts
+++ b/src/js/components/RadioButtonGroup/index.d.ts
@@ -7,6 +7,6 @@ export interface RadioButtonGroupProps {
   value?: string;
 }
 
-declare const RadioButtonGroup: React.ComponentType<RadioButtonGroupProps & JSX.IntrinsicElements['div']>;
+declare const RadioButtonGroup: React.ComponentClass<RadioButtonGroupProps & JSX.IntrinsicElements['div']>;
 
 export { RadioButtonGroup };

--- a/src/js/components/RangeInput/index.d.ts
+++ b/src/js/components/RangeInput/index.d.ts
@@ -10,6 +10,6 @@ export interface RangeInputProps {
   value?: number | string;
 }
 
-declare const RangeInput: React.ComponentType<RangeInputProps & JSX.IntrinsicElements['input']>;
+declare const RangeInput: React.ComponentClass<RangeInputProps & JSX.IntrinsicElements['input']>;
 
 export { RangeInput };

--- a/src/js/components/RangeSelector/index.d.ts
+++ b/src/js/components/RangeSelector/index.d.ts
@@ -15,6 +15,6 @@ export interface RangeSelectorProps {
   values: number[];
 }
 
-declare const RangeSelector: React.ComponentType<RangeSelectorProps & JSX.IntrinsicElements['div']>;
+declare const RangeSelector: React.ComponentClass<RangeSelectorProps & JSX.IntrinsicElements['div']>;
 
 export { RangeSelector };

--- a/src/js/components/RoutedAnchor/index.d.ts
+++ b/src/js/components/RoutedAnchor/index.d.ts
@@ -5,6 +5,6 @@ export interface RoutedAnchorProps {
   method?: "push" | "replace";
 }
 
-declare const RoutedAnchor: React.ComponentType<RoutedAnchorProps & JSX.IntrinsicElements['a']>;
+declare const RoutedAnchor: React.ComponentClass<RoutedAnchorProps & JSX.IntrinsicElements['a']>;
 
 export { RoutedAnchor };

--- a/src/js/components/RoutedButton/index.d.ts
+++ b/src/js/components/RoutedButton/index.d.ts
@@ -5,6 +5,6 @@ export interface RoutedButtonProps {
   method?: "push" | "replace";
 }
 
-declare const RoutedButton: React.ComponentType<RoutedButtonProps & JSX.IntrinsicElements['button']>;
+declare const RoutedButton: React.ComponentClass<RoutedButtonProps & JSX.IntrinsicElements['button']>;
 
 export { RoutedButton };

--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -33,6 +33,6 @@ export interface SelectProps {
   emptySearchMessage?: string;
 }
 
-declare const Select: React.ComponentType<SelectProps>;
+declare const Select: React.ComponentClass<SelectProps>;
 
 export { Select };

--- a/src/js/components/SkipLink/index.d.ts
+++ b/src/js/components/SkipLink/index.d.ts
@@ -5,6 +5,6 @@ export interface SkipLinkProps {
   label?: React.ReactNode;
 }
 
-declare const SkipLink: React.ComponentType<SkipLinkProps>;
+declare const SkipLink: React.FC<SkipLinkProps>;
 
 export { SkipLink };

--- a/src/js/components/SkipLinkTarget/index.d.ts
+++ b/src/js/components/SkipLinkTarget/index.d.ts
@@ -5,6 +5,6 @@ export interface SkipLinkTargetProps {
   label?: React.ReactNode;
 }
 
-declare const SkipLinkTarget: React.ComponentType<SkipLinkTargetProps>;
+declare const SkipLinkTarget: React.FC<SkipLinkTargetProps>;
 
 export { SkipLinkTarget };

--- a/src/js/components/SkipLinks/index.d.ts
+++ b/src/js/components/SkipLinks/index.d.ts
@@ -5,6 +5,6 @@ export interface SkipLinksProps {
   messages?: {skipTo?: string};
 }
 
-declare const SkipLinks: React.ComponentType<SkipLinksProps>;
+declare const SkipLinks: React.ComponentClass<SkipLinksProps>;
 
 export { SkipLinks };

--- a/src/js/components/Stack/index.d.ts
+++ b/src/js/components/Stack/index.d.ts
@@ -11,6 +11,6 @@ export interface StackProps {
   interactiveChild?: number | "first" | "last";
 }
 
-declare const Stack: React.ComponentType<StackProps & JSX.IntrinsicElements['div']>;
+declare const Stack: React.ComponentClass<StackProps & JSX.IntrinsicElements['div']>;
 
 export { Stack };

--- a/src/js/components/Tab/index.d.ts
+++ b/src/js/components/Tab/index.d.ts
@@ -5,6 +5,6 @@ export interface TabProps {
   title?: string | React.ReactNode;
 }
 
-declare const Tab: React.ComponentType<TabProps & JSX.IntrinsicElements['button']>;
+declare const Tab: React.ComponentClass<TabProps & JSX.IntrinsicElements['button']>;
 
 export { Tab };

--- a/src/js/components/Table/index.d.ts
+++ b/src/js/components/Table/index.d.ts
@@ -8,6 +8,6 @@ export interface TableProps {
   caption?: string;
 }
 
-declare const Table: React.ComponentType<TableProps & JSX.IntrinsicElements['table']>;
+declare const Table: React.FC<TableProps & JSX.IntrinsicElements['table']>;
 
 export { Table };

--- a/src/js/components/TableBody/index.d.ts
+++ b/src/js/components/TableBody/index.d.ts
@@ -4,6 +4,6 @@ export interface TableBodyProps {
   
 }
 
-declare const TableBody: React.ComponentType<TableBodyProps & JSX.IntrinsicElements['tbody']>;
+declare const TableBody: React.FC<TableBodyProps & JSX.IntrinsicElements['tbody']>;
 
 export { TableBody };

--- a/src/js/components/TableCell/index.d.ts
+++ b/src/js/components/TableCell/index.d.ts
@@ -7,6 +7,6 @@ export interface TableCellProps {
   verticalAlign?: "top" | "middle" | "bottom";
 }
 
-declare const TableCell: React.ComponentType<TableCellProps & JSX.IntrinsicElements['td']>;
+declare const TableCell: React.FC<TableCellProps & JSX.IntrinsicElements['td']>;
 
 export { TableCell };

--- a/src/js/components/TableFooter/index.d.ts
+++ b/src/js/components/TableFooter/index.d.ts
@@ -4,6 +4,6 @@ export interface TableFooterProps {
   
 }
 
-declare const TableFooter: React.ComponentType<TableFooterProps & JSX.IntrinsicElements['tfoot']>;
+declare const TableFooter: React.FC<TableFooterProps & JSX.IntrinsicElements['tfoot']>;
 
 export { TableFooter };

--- a/src/js/components/TableHeader/index.d.ts
+++ b/src/js/components/TableHeader/index.d.ts
@@ -4,6 +4,6 @@ export interface TableHeaderProps {
   
 }
 
-declare const TableHeader: React.ComponentType<TableHeaderProps & JSX.IntrinsicElements['thead']>;
+declare const TableHeader: React.FC<TableHeaderProps & JSX.IntrinsicElements['thead']>;
 
 export { TableHeader };

--- a/src/js/components/TableRow/index.d.ts
+++ b/src/js/components/TableRow/index.d.ts
@@ -4,6 +4,6 @@ export interface TableRowProps {
   
 }
 
-declare const TableRow: React.ComponentType<TableRowProps & JSX.IntrinsicElements['tr']>;
+declare const TableRow: React.FC<TableRowProps & JSX.IntrinsicElements['tr']>;
 
 export { TableRow };

--- a/src/js/components/Tabs/index.d.ts
+++ b/src/js/components/Tabs/index.d.ts
@@ -13,6 +13,6 @@ export interface TabsProps {
   onActive?: ((...args: any[]) => any);
 }
 
-declare const Tabs: React.ComponentType<TabsProps & JSX.IntrinsicElements['div']>;
+declare const Tabs: React.ComponentClass<TabsProps & JSX.IntrinsicElements['div']>;
 
 export { Tabs };

--- a/src/js/components/Text/index.d.ts
+++ b/src/js/components/Text/index.d.ts
@@ -14,6 +14,6 @@ export interface TextProps {
   weight?: "normal" | "bold" | number;
 }
 
-declare const Text: React.ComponentType<TextProps & JSX.IntrinsicElements['span']>;
+declare const Text: React.FC<TextProps & JSX.IntrinsicElements['span']>;
 
 export { Text };

--- a/src/js/components/TextArea/index.d.ts
+++ b/src/js/components/TextArea/index.d.ts
@@ -12,6 +12,6 @@ export interface TextAreaProps {
   resize?: "vertical" | "horizontal" | boolean;
 }
 
-declare const TextArea: React.ComponentType<TextAreaProps & JSX.IntrinsicElements['textarea']>;
+declare const TextArea: React.ComponentClass<TextAreaProps & JSX.IntrinsicElements['textarea']>;
 
 export { TextArea };

--- a/src/js/components/TextInput/index.d.ts
+++ b/src/js/components/TextInput/index.d.ts
@@ -20,6 +20,6 @@ export interface TextInputProps {
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 
-declare const TextInput: React.ComponentType<TextInputProps & Omit<JSX.IntrinsicElements['input'], 'onSelect' | 'size'>>;
+declare const TextInput: React.ComponentClass<TextInputProps & Omit<JSX.IntrinsicElements['input'], 'onSelect' | 'size'>>;
 
 export { TextInput };

--- a/src/js/components/Video/index.d.ts
+++ b/src/js/components/Video/index.d.ts
@@ -12,6 +12,6 @@ export interface VideoProps {
   mute?: boolean;
 }
 
-declare const Video: React.ComponentType<VideoProps & JSX.IntrinsicElements['video']>;
+declare const Video: React.ComponentClass<VideoProps & JSX.IntrinsicElements['video']>;
 
 export { Video };

--- a/src/js/components/WorldMap/index.d.ts
+++ b/src/js/components/WorldMap/index.d.ts
@@ -12,6 +12,6 @@ export interface WorldMapProps {
   hoverColor?: string | {dark?: string,light?: string};
 }
 
-declare const WorldMap: React.ComponentType<WorldMapProps & JSX.IntrinsicElements['svg']>;
+declare const WorldMap: React.ComponentClass<WorldMapProps & JSX.IntrinsicElements['svg']>;
 
 export { WorldMap };

--- a/src/js/contexts/ThemeContext/index.d.ts
+++ b/src/js/contexts/ThemeContext/index.d.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 export type ThemeValue = object;
 
 export interface ThemeContextI extends React.Context<ThemeValue> {
-  Extend: React.ComponentType<{ value: ThemeValue }>;
+  Extend: React.FC<{ value: ThemeValue }>;
 }
 
 declare const ThemeContext: ThemeContextI;


### PR DESCRIPTION
Signed-off-by: Patrick Nick <patrick.nick@konoma.ch>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix for #2628. Based on the discussion, I specified the `React.ComponentType` more accurately to either `ComponentClass` or `FunctionComponent`.

#### Where should the reviewer start?
Here is a simple example showing the issue: https://codesandbox.io/s/xr317vww4w
(Note: CodeSandbox doesn't show the issue initially. Switch files first to trigger the errors.)

#### What testing has been done on this PR?
Standard automated testing

#### How should this be manually tested?
I created a quick CRA setup with Typescript and created a `yarn link` between my forked Grommet version and my test setup. Make sure, your Grommet version has @types/react installed.

Use this test code:
```
import React, { Component } from 'react';
import { Button } from 'grommet';
import './App.css';
import styled from 'styled-components';

const StyledButton = styled(Button)`
  margin-top: 10px;
`;

class App extends Component {
  render() {
    return (
      <div className="App">
        <StyledButton label="Test" />
      </div>
    );
  }
}
```
No errors should appear.

#### Any background context you want to provide?
See the issue #2628 for more details.

#### What are the relevant issues?
#2628

#### Screenshots (if appropriate)
-

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Maybe, as TypeScript improvement

#### Is this change backwards compatible or is it a breaking change?
Should be backwards compatible.
