### PR TITLE
Select: Allow box and text customization inside SelectContainer.

### DIFF
--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -399,6 +399,26 @@ Defaults to
 undefined
 ```
 
+**select.container.box**
+
+Any valid Box prop for the drop container. Expects `object`.
+
+Defaults to
+
+```
+{ align: 'start', pad: 'small' }
+```
+
+**select.container.text**
+
+Any valid Text prop for text used inside drop container. Expects `object`.
+
+Defaults to
+
+```
+{ margin: 'none }
+```
+
 **select.container.extend**
 
 Any additional style for the container of the Select component. Expects `string | (props) => {}`.

--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -399,9 +399,9 @@ Defaults to
 undefined
 ```
 
-**select.container.box**
+**select.options.container**
 
-Any valid Box prop for the drop container. Expects `object`.
+Any valid Box prop for the options container. Expects `object`.
 
 Defaults to
 
@@ -409,9 +409,9 @@ Defaults to
 { align: 'start', pad: 'small' }
 ```
 
-**select.container.text**
+**select.options.text**
 
-Any valid Text prop for text used inside drop container. Expects `object`.
+Any valid Text prop for text used inside the options container. Expects `object`.
 
 Defaults to
 

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -428,10 +428,10 @@ class SelectContainer extends Component {
                         })
                       ) : (
                         <OptionBox
-                          {...theme.select.container.box}
+                          {...theme.select.options.box}
                           selected={isSelected}
                         >
-                          <Text {...theme.select.container.text}>
+                          <Text {...theme.select.options.text}>
                             {this.optionLabel(index)}
                           </Text>
                         </OptionBox>
@@ -446,7 +446,7 @@ class SelectContainer extends Component {
                 disabled
                 option={emptySearchMessage}
               >
-                <OptionBox {...theme.select.container.box}>
+                <OptionBox {...theme.select.options.box}>
                   <Text {...theme.select.container.text}>
                     {emptySearchMessage}
                   </Text>

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -428,11 +428,12 @@ class SelectContainer extends Component {
                         })
                       ) : (
                         <OptionBox
-                          align="start"
-                          pad="small"
+                          {...theme.select.container.box}
                           selected={isSelected}
                         >
-                          <Text margin="none">{this.optionLabel(index)}</Text>
+                          <Text {...theme.select.container.text}>
+                            {this.optionLabel(index)}
+                          </Text>
                         </OptionBox>
                       )}
                     </SelectOption>
@@ -445,8 +446,10 @@ class SelectContainer extends Component {
                 disabled
                 option={emptySearchMessage}
               >
-                <OptionBox align="start" pad="small">
-                  <Text margin="none">{emptySearchMessage}</Text>
+                <OptionBox {...theme.select.container.box}>
+                  <Text {...theme.select.container.text}>
+                    {emptySearchMessage}
+                  </Text>
                 </OptionBox>
               </SelectOption>
             )}

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -1812,13 +1812,8 @@ exports[`Select empty results search 1`] = `
 }
 
 .c12 {
-  margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
 }
 
 .c2 {

--- a/src/js/components/Select/doc.js
+++ b/src/js/components/Select/doc.js
@@ -179,13 +179,14 @@ export const themeDoc = {
     type: 'string',
     defaultValue: undefined,
   },
-  'select.container.box': {
-    description: 'Any valid Box prop for the drop container.',
+  'select.options.container': {
+    description: 'Any valid Box prop for the options container.',
     type: 'object',
     defaultValue: "{ align: 'start', pad: 'small' }",
   },
-  'select.container.text': {
-    description: 'Any valid Text prop for text used inside drop container.',
+  'select.options.text': {
+    description:
+      'Any valid Text prop for text used inside the options container.',
     type: 'object',
     defaultValue: "{ margin: 'none }",
   },

--- a/src/js/components/Select/doc.js
+++ b/src/js/components/Select/doc.js
@@ -179,6 +179,16 @@ export const themeDoc = {
     type: 'string',
     defaultValue: undefined,
   },
+  'select.container.box': {
+    description: 'Any valid Box prop for the drop container.',
+    type: 'object',
+    defaultValue: "{ align: 'start', pad: 'small' }",
+  },
+  'select.container.text': {
+    description: 'Any valid Text prop for text used inside drop container.',
+    type: 'object',
+    defaultValue: "{ margin: 'none }",
+  },
   'select.container.extend': {
     description:
       'Any additional style for the container of the Select component.',

--- a/src/js/components/Select/stories/theme.js
+++ b/src/js/components/Select/stories/theme.js
@@ -75,6 +75,9 @@ export const theme = {
     },
     searchInput: SearchInput,
     container: {
+      text: {
+        size: 'small',
+      },
       extend: 'max-height: 250px;',
     },
   },

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -7246,6 +7246,26 @@ Defaults to
 undefined
 \`\`\`
 
+**select.container.box**
+
+Any valid Box prop for the drop container. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{ align: 'start', pad: 'small' }
+\`\`\`
+
+**select.container.text**
+
+Any valid Text prop for text used inside drop container. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{ margin: 'none }
+\`\`\`
+
 **select.container.extend**
 
 Any additional style for the container of the Select component. Expects \`string | (props) => {}\`.

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -7246,9 +7246,9 @@ Defaults to
 undefined
 \`\`\`
 
-**select.container.box**
+**select.options.container**
 
-Any valid Box prop for the drop container. Expects \`object\`.
+Any valid Box prop for the options container. Expects \`object\`.
 
 Defaults to
 
@@ -7256,9 +7256,9 @@ Defaults to
 { align: 'start', pad: 'small' }
 \`\`\`
 
-**select.container.text**
+**select.options.text**
 
-Any valid Text prop for text used inside drop container. Expects \`object\`.
+Any valid Text prop for text used inside the options container. Expects \`object\`.
 
 Defaults to
 

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -648,6 +648,13 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     select: {
       // background: undefined,
       container: {
+        box: {
+          align: 'start',
+          pad: 'small',
+        },
+        text: {
+          margin: 'none',
+        },
         // extend: undefined,
       },
       control: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -648,13 +648,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     select: {
       // background: undefined,
       container: {
-        box: {
-          align: 'start',
-          pad: 'small',
-        },
-        text: {
-          margin: 'none',
-        },
         // extend: undefined,
       },
       control: {
@@ -663,6 +656,15 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       icons: {
         // color: { dark: undefined, light: undefined },
         down: FormDown,
+      },
+      options: {
+        box: {
+          align: 'start',
+          pad: 'small',
+        },
+        text: {
+          margin: 'none',
+        },
       },
       // searchInput: undefined,
       step: 20,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
changes Select theme object to allow for additional theme entries to customize the box and text inside the container.
#### Where should the reviewer start?
storybook
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
open Custom Search select story. type a random text. notice that "No matches found" font size is not small.
#### Any background context you want to provide?

#### What are the relevant issues?
Closes #2795 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards