### PR TITLE
FormField regexp validation issue

### DIFF
--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -19,7 +19,7 @@ const validateField = (required, validate, messages) => (value, data) => {
     if (typeof validate === 'function') {
       error = validate(value, data);
     } else if (validate.regexp) {
-      if (!validate.regexp.test(data)) {
+      if (!validate.regexp.test(value)) {
         error = validate.message || messages.invalid;
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes bug when used regexp validation in FormField component
#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
1. Add FormField component inside Form component, along with Submit button
2. Add validate property with regex object (f.e. { regexp: /^[a-z]/i })
3. Press submit button and observe error message
4. Type any text into input field.
5. Press submit button again

Expected result:
Error message disappeared, form submitted

Actual result:
Error message is displayed, form didn't submit
#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/10975462/53196143-52f6ab80-3628-11e9-84b9-e401f0d02825.png)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
