### PR TITLE
Start migrating to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,51 @@
+version: 2.1
+
+defaults: &defaults
+  working_directory: ~/grommet-ci
+  docker:
+    - image: circleci/node:10
+
+jobs:
+  build:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - yarn-cache-{{ checksum "yarn.lock" }}
+      - run: yarn --frozen-lockfile
+      - save_cache:
+          key: yarn-cache-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache
+            - ./node_modules
+      - persist_to_workspace:
+          root: grommet-ci
+          paths:
+            - ./
+  lint:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/grommet-ci
+      - run:
+          name: Running linter
+          command: yarn lint
+  jest:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/grommet-ci
+      - run:
+          name: Running jest
+          command: yarn test
+workflows:
+  build_test:
+    jobs:
+      - build
+      - lint:
+          requires:
+            - build
+      - jest:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
             - ~/.cache
             - ./node_modules
       - persist_to_workspace:
-          root: grommet-ci
+          root: ~/grommet-ci
           paths:
             - ./
   lint:


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
Starts migrating CI to circleci

* circleci didn't follow the project yet so it didn't run this PR yet.
* I propose that we let both circleci and travis run for now to be able to compare
* when preparing next release we discontinue travis and unfollow project
* add the release stage in circleci and release with circle ci.

Added an additional "test". when running yarn install i added `--frozen-lockfile` which will throw an error if the yarn.lock could be updated. That should help keep a synced lockfile.
