### PR TITLE
Bug fix for issue 2631: Updated StyledTable to inherit width from parent

### DIFF
--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -121,6 +121,7 @@ exports[`DataTable aggregate 1`] = `
 .c2 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c6 {
@@ -438,6 +439,7 @@ exports[`DataTable basic 1`] = `
 .c2 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c6 {
@@ -633,6 +635,7 @@ exports[`DataTable empty 1`] = `
 .c2 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c1 {
@@ -782,6 +785,7 @@ exports[`DataTable footer 1`] = `
 .c2 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c6 {
@@ -1189,6 +1193,7 @@ exports[`DataTable groupBy 1`] = `
 .c2 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c10 {
@@ -1491,7 +1496,7 @@ exports[`DataTable groupBy 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lkVXQD"
 >
   <table
-    class="StyledDataTable-xrlyjm-0 kTrXKK StyledTable-sc-1m3u5g-6 qwhVU"
+    class="StyledDataTable-xrlyjm-0 kTrXKK StyledTable-sc-1m3u5g-6 ksaVzW"
   >
     <thead
       class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 bAIczD StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
@@ -1751,6 +1756,7 @@ exports[`DataTable primaryKey 1`] = `
 .c2 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c6 {
@@ -2054,6 +2060,7 @@ exports[`DataTable resizeable 1`] = `
 .c2 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c7 {
@@ -2370,6 +2377,7 @@ exports[`DataTable sort 1`] = `
 .c2 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c8 {
@@ -2630,7 +2638,7 @@ exports[`DataTable sort 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lkVXQD"
 >
   <table
-    class="StyledDataTable-xrlyjm-0 kTrXKK StyledTable-sc-1m3u5g-6 qwhVU"
+    class="StyledDataTable-xrlyjm-0 kTrXKK StyledTable-sc-1m3u5g-6 ksaVzW"
   >
     <thead
       class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 bAIczD StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"

--- a/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
+++ b/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
@@ -136,6 +136,7 @@ exports[`Markdown renders 1`] = `
 .c7 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/Table/StyledTable.js
+++ b/src/js/components/Table/StyledTable.js
@@ -67,7 +67,7 @@ Object.setPrototypeOf(StyledTableFooter.defaultProps, defaultProps);
 const StyledTable = styled.table`
   border-spacing: 0;
   border-collapse: collapse;
-
+  width: inherit;
   ${genericStyles} ${props => props.theme.table && props.theme.table.extend};
 `;
 

--- a/src/js/components/Table/__tests__/__snapshots__/Table-test.js.snap
+++ b/src/js/components/Table/__tests__/__snapshots__/Table-test.js.snap
@@ -8,6 +8,7 @@ exports[`Table caption renders 1`] = `
 .c1 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c0 {
@@ -39,6 +40,7 @@ exports[`Table renders 1`] = `
 .c1 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c0 {
@@ -64,6 +66,7 @@ exports[`TableBody renders 1`] = `
 .c1 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c0 {
@@ -106,6 +109,7 @@ exports[`TableCell plain renders 1`] = `
 .c1 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c0 {
@@ -249,6 +253,7 @@ exports[`TableCell renders 1`] = `
 .c1 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c0 {
@@ -463,6 +468,7 @@ exports[`TableCell scope renders 1`] = `
 .c1 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c0 {
@@ -694,6 +700,7 @@ exports[`TableCell size renders 1`] = `
 .c1 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c0 {
@@ -921,6 +928,7 @@ exports[`TableCell verticalAlign renders 1`] = `
 .c1 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c0 {
@@ -1002,6 +1010,7 @@ exports[`TableFooter renders 1`] = `
 .c1 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c0 {
@@ -1031,6 +1040,7 @@ exports[`TableHeader renders 1`] = `
 .c1 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c0 {
@@ -1064,6 +1074,7 @@ exports[`TableRow renders 1`] = `
 .c1 {
   border-spacing: 0;
   border-collapse: collapse;
+  width: inherit;
 }
 
 .c0 {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changed StyledTable to fix issue #2631 

#### Where should the reviewer start?
StyeldTable.js

#### What testing has been done on this PR?
storybook

#### How should this be manually tested?
storybook on FireFox, MS-Edge, Safari & Chrome

#### Any background context you want to provide?
#### What are the relevant issues?
#2631 

#### Screenshots (if appropriate)
#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible