### PR TITLE
Changed DOM findScrollParents to use document if only parent is body

### DIFF
--- a/src/js/components/InfiniteScroll/infinitescroll.stories.js
+++ b/src/js/components/InfiniteScroll/infinitescroll.stories.js
@@ -85,10 +85,10 @@ class LazyInfiniteScroll extends Component {
 
 const GridInfiniteScroll = () => (
   <Grommet theme={grommet}>
-    <Grid columns="xsmall">
+    <Grid columns="xsmall" rows="small">
       <InfiniteScroll items={allItems} step={12}>
         {item => (
-          <Box as="article" pad="xsmall">
+          <Box key={item} as="article" pad="xsmall">
             <Image src="https://via.placeholder.com/350x150" />
             <Text>{item}</Text>
           </Box>

--- a/src/js/utils/DOM.js
+++ b/src/js/utils/DOM.js
@@ -40,6 +40,9 @@ export const findScrollParents = (element, horizontal) => {
     // if nothing else is scrollable in the page
     if (result.length === 0) {
       result.push(document);
+    } else if (result[0].tagName.toLowerCase() === 'body') {
+      result.length = 0;
+      result.push(document);
     }
   }
   return result;


### PR DESCRIPTION
#### What does this PR do?

Changed DOM findScrollParents to use document if only parent is body.
Without this change, InfiniteScroll wouldn't work if the scrollable ancestor is a body element whose height is driven by the content. Since `<Grommet>` doesn't control the `<body>` size, the expectation is that  the document height should be used as the visible window.

#### Where should the reviewer start?

DOM.js

#### What testing has been done on this PR?

storybook InfiniteScroll, Select, and TextInput

#### How should this be manually tested?

storybook InfiniteScroll, Select, and TextInput

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/2805

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
