### PR TITLE
Changed RangeInput to fix theme track height issue #2830

### DIFF
--- a/src/js/components/RangeInput/StyledRangeInput.js
+++ b/src/js/components/RangeInput/StyledRangeInput.js
@@ -73,7 +73,7 @@ const StyledRangeInput = styled.input`
   }
 
   &::-webkit-slider-thumb {
-    margin-top: -${props => parseMetricToNum(props.theme.global.spacing) * 0.425}px;
+    margin-top: -${props => (parseMetricToNum(props.theme.global.spacing) - parseMetricToNum(props.theme.rangeInput.track.height || 0)) * 0.5}px;
     ${rangeThumbStyle}
 
     ${props =>

--- a/src/js/components/RangeInput/__tests__/__snapshots__/RangeInput-test.js.snap
+++ b/src/js/components/RangeInput/__tests__/__snapshots__/RangeInput-test.js.snap
@@ -43,7 +43,7 @@ exports[`RangeInput renders 1`] = `
 }
 
 .c1::-webkit-slider-thumb {
-  margin-top: -10.2px;
+  margin-top: -10px;
   box-sizing: border-box;
   position: relative;
   border-radius: 24px;

--- a/src/js/components/RangeInput/rangeinput.stories.js
+++ b/src/js/components/RangeInput/rangeinput.stories.js
@@ -36,9 +36,6 @@ const customThemeRangeInput = deepMerge(grommet, {
     },
     thumb: {
       color: 'neutral-2',
-      extend: () => `
-        margin: 0;
-        `,
     },
   },
 });


### PR DESCRIPTION
#### What does this PR do?

Changed RangeInput to fix theme track height issue.
Calculate the thumb margin based on the track and thumb height.

#### Where should the reviewer start?

StyledRangeInput.js

#### What testing has been done on this PR?

storybook

#### How should this be manually tested?

storybook

#### Any background context you want to provide?

#### What are the relevant issues?

#2830 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
