### PR TITLE
Remove unused theme prop maxWidth and minWidth from button

### DIFF
--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -356,26 +356,6 @@ Defaults to
 0.3
 ```
 
-**button.minWidth**
-
-The minimum width. Expects `string`.
-
-Defaults to
-
-```
-96px
-```
-
-**button.maxWidth**
-
-The maximum width. Expects `string`.
-
-Defaults to
-
-```
-384px
-```
-
 **button.padding.horizontal**
 
 The horizontal padding. Expects `string`.

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -138,16 +138,6 @@ export const themeDoc = {
     type: 'number',
     defaultValue: 0.3,
   },
-  'button.minWidth': {
-    description: `The minimum width.`,
-    type: 'string',
-    defaultValue: '96px',
-  },
-  'button.maxWidth': {
-    description: `The maximum width.`,
-    type: 'string',
-    defaultValue: '384px',
-  },
   'button.padding.horizontal': {
     description: 'The horizontal padding.',
     type: 'string',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1674,26 +1674,6 @@ Defaults to
 0.3
 \`\`\`
 
-**button.minWidth**
-
-The minimum width. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-96px
-\`\`\`
-
-**button.maxWidth**
-
-The maximum width. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-384px
-\`\`\`
-
 **button.padding.horizontal**
 
 The horizontal padding. Expects \`string\`.

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -295,8 +295,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       disabled: {
         opacity: 0.3,
       },
-      minWidth: `${baseSpacing * 4}px`,
-      maxWidth: `${baseSpacing * 16}px`,
       padding: {
         vertical: `${baseSpacing / 4 - borderWidth}px`,
         horizontal: `${baseSpacing - borderWidth}px`,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Removes obselete theme values 
#### Where should the reviewer start?
theme
#### What testing has been done on this PR?
none
#### How should this be manually tested?
try to find any area these values where used
#### Any background context you want to provide?

#### What are the relevant issues?
#2828 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
