### PR TITLE
Style disabled textinput and textarea

### DIFF
--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -348,7 +348,7 @@ undefined
 
 **button.disabled.opacity**
 
-The opacity when the button is disabled. To be deprecated in V3, use global.disabled.opacity instead. Expects `number`.
+The opacity when the button is disabled. Expects `number`.
 
 Defaults to
 
@@ -396,7 +396,7 @@ Defaults to
 focus
 ```
 
-**global.disabled.opacity**
+**global.control.disabled.opacity**
 
 The opacity when a component is disabled. Expects `number`.
 

--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -348,7 +348,7 @@ undefined
 
 **button.disabled.opacity**
 
-The opacity when the button is disabled. Expects `number`.
+The opacity when the button is disabled. To be deprecated in V3, use global.disabled.opacity instead. Expects `number`.
 
 Defaults to
 
@@ -394,4 +394,14 @@ Defaults to
 
 ```
 focus
+```
+
+**global.disabled.opacity**
+
+The opacity when a component is disabled. Expects `number`.
+
+Defaults to
+
+```
+0.3
 ```

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -3,10 +3,10 @@ import styled, { css } from 'styled-components';
 import {
   activeStyle,
   backgroundStyle,
+  disabledStyle,
   focusStyle,
   genericStyles,
   normalizeColor,
-  disabledStyle,
 } from '../../utils';
 import { defaultProps } from '../../default-props';
 

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -6,6 +6,7 @@ import {
   focusStyle,
   genericStyles,
   normalizeColor,
+  disabledStyle,
 } from '../../utils';
 import { defaultProps } from '../../default-props';
 
@@ -33,11 +34,6 @@ const primaryStyle = props => css`
     props.theme.button.color,
   )}
   border-radius: ${props.theme.button.border.radius};
-`;
-
-const disabledStyle = css`
-  opacity: ${props => props.theme.button.disabled.opacity};
-  cursor: default;
 `;
 
 function getHoverColor(props) {
@@ -89,6 +85,7 @@ const plainStyle = css`
   text-align: inherit;
 `;
 
+// Deprecate props.theme.button.disabled.opacity in V3
 const StyledButton = styled.button`
   display: inline-block;
   box-sizing: border-box;
@@ -109,7 +106,11 @@ const StyledButton = styled.button`
   ${props => !props.disabled && !props.focus && hoverStyle}
 
   ${props => !props.disabled && props.active && activeStyle}
-  ${props => props.disabled && disabledStyle}
+  ${props =>
+    props.disabled &&
+    disabledStyle(
+      props.theme.button.disabled && props.theme.button.disabled.opacity,
+    )}
   ${props =>
     props.focus && (!props.plain || props.focusIndicator) && focusStyle}
   ${props =>

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -134,8 +134,7 @@ export const themeDoc = {
     type: 'string | { dark: string, light: string }',
   },
   'button.disabled.opacity': {
-    description:
-      'The opacity when the button is disabled. To be deprecated in V3, use global.disabled.opacity instead.',
+    description: 'The opacity when the button is disabled.',
     type: 'number',
     defaultValue: 0.3,
   },

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -134,7 +134,8 @@ export const themeDoc = {
     type: 'string | { dark: string, light: string }',
   },
   'button.disabled.opacity': {
-    description: 'The opacity when the button is disabled.',
+    description:
+      'The opacity when the button is disabled. To be deprecated in V3, use global.disabled.opacity instead.',
     type: 'number',
     defaultValue: 0.3,
   },
@@ -153,4 +154,5 @@ export const themeDoc = {
     type: 'string | (props) => {}',
   },
   ...themeDocUtils.focusStyle,
+  ...themeDocUtils.disabledStyle,
 };

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -547,7 +547,7 @@ exports[`Select complex options and children 2`] = `
       >
         <input
           autocomplete="off"
-          class="Select__SelectTextInput-sc-17idtfo-0 lmyIUy StyledTextInput-sc-1x30a0s-0 cuRQxH"
+          class="Select__SelectTextInput-sc-17idtfo-0 lmyIUy StyledTextInput-sc-1x30a0s-0 bYBgFP"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -1573,7 +1573,7 @@ exports[`Select disabled 2`] = `
       >
         <input
           autocomplete="off"
-          class="Select__SelectTextInput-sc-17idtfo-0 lmyIUy StyledTextInput-sc-1x30a0s-0 cuRQxH"
+          class="Select__SelectTextInput-sc-17idtfo-0 lmyIUy StyledTextInput-sc-1x30a0s-0 bYBgFP"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -3200,7 +3200,7 @@ exports[`Select multiple values 2`] = `
       >
         <input
           autocomplete="off"
-          class="Select__SelectTextInput-sc-17idtfo-0 lmyIUy StyledTextInput-sc-1x30a0s-0 cuRQxH"
+          class="Select__SelectTextInput-sc-17idtfo-0 lmyIUy StyledTextInput-sc-1x30a0s-0 bYBgFP"
           id="test-select__input"
           multiple=""
           placeholder="test select"
@@ -4037,7 +4037,7 @@ exports[`Select opens 2`] = `
       >
         <input
           autocomplete="off"
-          class="Select__SelectTextInput-sc-17idtfo-0 lmyIUy StyledTextInput-sc-1x30a0s-0 cuRQxH"
+          class="Select__SelectTextInput-sc-17idtfo-0 lmyIUy StyledTextInput-sc-1x30a0s-0 bYBgFP"
           id="test-select__input"
           placeholder="test select"
           readonly=""

--- a/src/js/components/TextArea/README.md
+++ b/src/js/components/TextArea/README.md
@@ -103,6 +103,16 @@ Defaults to
 undefined
 ```
 
+**textArea.disabled.opacity**
+
+The opacity when the textArea is disabled. Expects `number`.
+
+Defaults to
+
+```
+0.3
+```
+
 **global.control.border**
 
 The border of the textarea. Expects `object`.
@@ -163,7 +173,7 @@ Defaults to
 12px
 ```
 
-**global.disabled.opacity**
+**global.control.disabled.opacity**
 
 The opacity when a component is disabled. Expects `number`.
 

--- a/src/js/components/TextArea/README.md
+++ b/src/js/components/TextArea/README.md
@@ -103,6 +103,16 @@ Defaults to
 undefined
 ```
 
+**textArea.disabled.opacity**
+
+The opacity when the textArea is disabled. Expects `number`.
+
+Defaults to
+
+```
+0.3
+```
+
 **global.control.border**
 
 The border of the textarea. Expects `object`.

--- a/src/js/components/TextArea/README.md
+++ b/src/js/components/TextArea/README.md
@@ -103,16 +103,6 @@ Defaults to
 undefined
 ```
 
-**textArea.disabled.opacity**
-
-The opacity when the textArea is disabled. Expects `number`.
-
-Defaults to
-
-```
-0.3
-```
-
 **global.control.border**
 
 The border of the textarea. Expects `object`.
@@ -171,4 +161,14 @@ Defaults to
 
 ```
 12px
+```
+
+**global.disabled.opacity**
+
+The opacity when a component is disabled. Expects `number`.
+
+Defaults to
+
+```
+0.3
 ```

--- a/src/js/components/TextArea/StyledTextArea.js
+++ b/src/js/components/TextArea/StyledTextArea.js
@@ -1,10 +1,10 @@
 import styled, { css } from 'styled-components';
 
 import {
+  disabledStyle,
   focusStyle,
   inputStyle,
   placeholderStyle,
-  disabledStyle,
 } from '../../utils';
 import { defaultProps } from '../../default-props';
 

--- a/src/js/components/TextArea/StyledTextArea.js
+++ b/src/js/components/TextArea/StyledTextArea.js
@@ -22,12 +22,18 @@ const resizeStyle = resize => {
   return 'resize: none;';
 };
 
+const disabledStyle = css`
+  opacity: ${props => props.theme.textArea.disabled.opacity};
+  cursor: default;
+`;
+
 const StyledTextArea = styled.textarea`
   ${inputStyle} width: 100%;
   ${props => props.resize !== undefined && resizeStyle(props.resize)}
 
   ${props => props.fillArg && 'height: 100%;'}
   ${props => props.plain && plainStyle}
+  ${props => props.disabled && disabledStyle}
 
   ${placeholderStyle}
 

--- a/src/js/components/TextArea/StyledTextArea.js
+++ b/src/js/components/TextArea/StyledTextArea.js
@@ -1,6 +1,11 @@
 import styled, { css } from 'styled-components';
 
-import { focusStyle, inputStyle, placeholderStyle } from '../../utils';
+import {
+  focusStyle,
+  inputStyle,
+  placeholderStyle,
+  disabledStyle,
+} from '../../utils';
 import { defaultProps } from '../../default-props';
 
 const plainStyle = css`
@@ -22,18 +27,13 @@ const resizeStyle = resize => {
   return 'resize: none;';
 };
 
-const disabledStyle = css`
-  opacity: ${props => props.theme.textArea.disabled.opacity};
-  cursor: default;
-`;
-
 const StyledTextArea = styled.textarea`
   ${inputStyle} width: 100%;
   ${props => props.resize !== undefined && resizeStyle(props.resize)}
 
   ${props => props.fillArg && 'height: 100%;'}
   ${props => props.plain && plainStyle}
-  ${props => props.disabled && disabledStyle}
+  ${props => props.disabled && disabledStyle()}
 
   ${placeholderStyle}
 

--- a/src/js/components/TextArea/StyledTextArea.js
+++ b/src/js/components/TextArea/StyledTextArea.js
@@ -33,7 +33,11 @@ const StyledTextArea = styled.textarea`
 
   ${props => props.fillArg && 'height: 100%;'}
   ${props => props.plain && plainStyle}
-  ${props => props.disabled && disabledStyle()}
+  ${props =>
+    props.disabled &&
+    disabledStyle(
+      props.theme.textArea.disabled && props.theme.textArea.disabled.opacity,
+    )}
 
   ${placeholderStyle}
 

--- a/src/js/components/TextArea/__tests__/TextArea-test.js
+++ b/src/js/components/TextArea/__tests__/TextArea-test.js
@@ -38,6 +38,16 @@ describe('TextArea', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  test('disabled', () => {
+    const component = renderer.create(
+      <Grommet>
+        <TextArea disabled id="item" name="item" plain />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   test('focusIndicator', () => {
     const component = renderer.create(
       <Grommet>

--- a/src/js/components/TextArea/__tests__/__snapshots__/TextArea-test.js.snap
+++ b/src/js/components/TextArea/__tests__/__snapshots__/TextArea-test.js.snap
@@ -62,6 +62,74 @@ exports[`TextArea basic 1`] = `
 </div>
 `;
 
+exports[`TextArea disabled 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  box-sizing: border-box;
+  font-size: inherit;
+  border: none;
+  -webkit-appearance: none;
+  padding: 11px;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  width: 100%;
+  border: none;
+  width: 100%;
+  -webkit-appearance: none;
+  opacity: 0.3;
+  cursor: default;
+}
+
+.c1::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c1::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c1:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+<div
+  className="c0"
+>
+  <textarea
+    className="c1"
+    disabled={true}
+    id="item"
+    name="item"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+  />
+</div>
+`;
+
 exports[`TextArea fill 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/TextArea/doc.js
+++ b/src/js/components/TextArea/doc.js
@@ -49,11 +49,6 @@ export const themeDoc = {
     type: 'string | (props) => {}',
     defaultValue: undefined,
   },
-  'textArea.disabled.opacity': {
-    description: 'The opacity when the textArea is disabled.',
-    type: 'number',
-    defaultValue: 0.3,
-  },
   'global.control.border': {
     description: 'The border of the textarea.',
     type: 'object',
@@ -74,4 +69,5 @@ export const themeDoc = {
   ...themeDocUtils.focusStyle,
   ...themeDocUtils.placeholderStyle,
   ...themeDocUtils.inputStyle,
+  ...themeDocUtils.disabledStyle,
 };

--- a/src/js/components/TextArea/doc.js
+++ b/src/js/components/TextArea/doc.js
@@ -49,6 +49,11 @@ export const themeDoc = {
     type: 'string | (props) => {}',
     defaultValue: undefined,
   },
+  'textArea.disabled.opacity': {
+    description: 'The opacity when the textArea is disabled.',
+    type: 'number',
+    defaultValue: 0.3,
+  },
   'global.control.border': {
     description: 'The border of the textarea.',
     type: 'object',

--- a/src/js/components/TextInput/README.md
+++ b/src/js/components/TextInput/README.md
@@ -269,16 +269,6 @@ Defaults to
 undefined
 ```
 
-**textInput.disabled.opacity**
-
-The opacity when the textInput is disabled. Expects `number`.
-
-Defaults to
-
-```
-0.3
-```
-
 **global.control.border**
 
 The border of the input. Expects `object`.
@@ -317,6 +307,16 @@ Defaults to
 
 ```
 #AAAAAA
+```
+
+**global.disabled.opacity**
+
+The opacity when a component is disabled. Expects `number`.
+
+Defaults to
+
+```
+0.3
 ```
 
 **global.input.weight**

--- a/src/js/components/TextInput/README.md
+++ b/src/js/components/TextInput/README.md
@@ -269,6 +269,16 @@ Defaults to
 undefined
 ```
 
+**textInput.disabled.opacity**
+
+The opacity when the textInput is disabled. Expects `number`.
+
+Defaults to
+
+```
+0.3
+```
+
 **global.control.border**
 
 The border of the input. Expects `object`.
@@ -309,7 +319,7 @@ Defaults to
 #AAAAAA
 ```
 
-**global.disabled.opacity**
+**global.control.disabled.opacity**
 
 The opacity when a component is disabled. Expects `number`.
 

--- a/src/js/components/TextInput/README.md
+++ b/src/js/components/TextInput/README.md
@@ -269,6 +269,16 @@ Defaults to
 undefined
 ```
 
+**textInput.disabled.opacity**
+
+The opacity when the textInput is disabled. Expects `number`.
+
+Defaults to
+
+```
+0.3
+```
+
 **global.control.border**
 
 The border of the input. Expects `object`.

--- a/src/js/components/TextInput/StyledTextInput.js
+++ b/src/js/components/TextInput/StyledTextInput.js
@@ -20,6 +20,11 @@ const plainStyle = css`
   border: none;
 `;
 
+const disabledStyle = css`
+  opacity: ${props => props.theme.textInput.disabled.opacity};
+  cursor: default;
+`;
+
 const StyledTextInput = styled.input`
   ${inputStyle} width: 100%;
 
@@ -34,6 +39,7 @@ const StyledTextInput = styled.input`
   }
 
   ${props => props.focus && !props.plain && focusStyle};
+  ${props => props.disabled && disabledStyle}
   ${props => props.theme.textInput && props.theme.textInput.extend};
 `;
 

--- a/src/js/components/TextInput/StyledTextInput.js
+++ b/src/js/components/TextInput/StyledTextInput.js
@@ -1,11 +1,11 @@
 import styled, { css } from 'styled-components';
 
 import {
+  disabledStyle,
   focusStyle,
   inputStyle,
   parseMetricToNum,
   placeholderStyle,
-  disabledStyle,
 } from '../../utils';
 import { defaultProps } from '../../default-props';
 

--- a/src/js/components/TextInput/StyledTextInput.js
+++ b/src/js/components/TextInput/StyledTextInput.js
@@ -35,7 +35,11 @@ const StyledTextInput = styled.input`
   }
 
   ${props => props.focus && !props.plain && focusStyle};
-  ${props => props.disabled && disabledStyle()}
+  ${props =>
+    props.disabled &&
+    disabledStyle(
+      props.theme.textInput.disabled && props.theme.textInput.disabled.opacity,
+    )}
   ${props => props.theme.textInput && props.theme.textInput.extend};
 `;
 

--- a/src/js/components/TextInput/StyledTextInput.js
+++ b/src/js/components/TextInput/StyledTextInput.js
@@ -5,6 +5,7 @@ import {
   inputStyle,
   parseMetricToNum,
   placeholderStyle,
+  disabledStyle,
 } from '../../utils';
 import { defaultProps } from '../../default-props';
 
@@ -18,11 +19,6 @@ const sizeStyle = props => {
 
 const plainStyle = css`
   border: none;
-`;
-
-const disabledStyle = css`
-  opacity: ${props => props.theme.textInput.disabled.opacity};
-  cursor: default;
 `;
 
 const StyledTextInput = styled.input`
@@ -39,7 +35,7 @@ const StyledTextInput = styled.input`
   }
 
   ${props => props.focus && !props.plain && focusStyle};
-  ${props => props.disabled && disabledStyle}
+  ${props => props.disabled && disabledStyle()}
   ${props => props.theme.textInput && props.theme.textInput.extend};
 `;
 

--- a/src/js/components/TextInput/__tests__/TextInput-test.js
+++ b/src/js/components/TextInput/__tests__/TextInput-test.js
@@ -17,6 +17,11 @@ describe('TextInput', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('disabled', () => {
+    const { container } = render(<TextInput disabled name="item" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('suggestions', done => {
     const onChange = jest.fn();
     const onFocus = jest.fn();

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -432,7 +432,7 @@ exports[`TextInput close suggestion drop 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 iQGivQ"
+      class="StyledTextInput-sc-1x30a0s-0 bkKCTq"
       data-testid="test-input"
       id="item"
       name="item"
@@ -769,6 +769,64 @@ exports[`TextInput complex suggestions 3`] = `
 }"
 `;
 
+exports[`TextInput disabled 1`] = `
+.c1 {
+  box-sizing: border-box;
+  font-size: inherit;
+  border: none;
+  -webkit-appearance: none;
+  padding: 11px;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  width: 100%;
+  opacity: 0.3;
+  cursor: default;
+}
+
+.c1::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c1::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c1:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+}
+
+<div
+  class="c0"
+>
+  <input
+    autocomplete="off"
+    class="c1"
+    disabled=""
+    name="item"
+    value=""
+  />
+</div>
+`;
+
 exports[`TextInput handles next and previous without suggestion 1`] = `
 .c0 {
   font-size: 18px;
@@ -849,7 +907,7 @@ exports[`TextInput handles next and previous without suggestion 2`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 iQGivQ"
+      class="StyledTextInput-sc-1x30a0s-0 bkKCTq"
       data-testid="test-input"
       id="item"
       name="item"
@@ -1934,7 +1992,7 @@ exports[`TextInput select suggestion 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 krBnvJ"
+      class="StyledTextInput-sc-1x30a0s-0 eUDPhm"
       data-testid="test-input"
       id="item"
       name="item"

--- a/src/js/components/TextInput/doc.js
+++ b/src/js/components/TextInput/doc.js
@@ -155,11 +155,6 @@ export const themeDoc = {
     type: 'string | (props) => {}',
     defaultValue: undefined,
   },
-  'textInput.disabled.opacity': {
-    description: 'The opacity when the textInput is disabled.',
-    type: 'number',
-    defaultValue: 0.3,
-  },
   'global.control.border': {
     description: 'The border of the input.',
     type: 'object',
@@ -179,5 +174,6 @@ export const themeDoc = {
   },
   ...themeDocUtils.focusStyle,
   ...themeDocUtils.placeholderStyle,
+  ...themeDocUtils.disabledStyle,
   ...themeDocUtils.inputStyle,
 };

--- a/src/js/components/TextInput/doc.js
+++ b/src/js/components/TextInput/doc.js
@@ -155,6 +155,11 @@ export const themeDoc = {
     type: 'string | (props) => {}',
     defaultValue: undefined,
   },
+  'textInput.disabled.opacity': {
+    description: 'The opacity when the textInput is disabled.',
+    type: 'number',
+    defaultValue: 0.3,
+  },
   'global.control.border': {
     description: 'The border of the input.',
     type: 'object',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1676,7 +1676,7 @@ undefined
 
 **button.disabled.opacity**
 
-The opacity when the button is disabled. Expects \`number\`.
+The opacity when the button is disabled. To be deprecated in V3, use global.disabled.opacity instead. Expects \`number\`.
 
 Defaults to
 
@@ -1722,6 +1722,16 @@ Defaults to
 
 \`\`\`
 focus
+\`\`\`
+
+**global.disabled.opacity**
+
+The opacity when a component is disabled. Expects \`number\`.
+
+Defaults to
+
+\`\`\`
+0.3
 \`\`\`
 ",
   "Calendar": "## Calendar
@@ -8719,16 +8729,6 @@ Defaults to
 undefined
 \`\`\`
 
-**textArea.disabled.opacity**
-
-The opacity when the textArea is disabled. Expects \`number\`.
-
-Defaults to
-
-\`\`\`
-0.3
-\`\`\`
-
 **global.control.border**
 
 The border of the textarea. Expects \`object\`.
@@ -8787,6 +8787,16 @@ Defaults to
 
 \`\`\`
 12px
+\`\`\`
+
+**global.disabled.opacity**
+
+The opacity when a component is disabled. Expects \`number\`.
+
+Defaults to
+
+\`\`\`
+0.3
 \`\`\`
 ",
   "TextInput": "## TextInput
@@ -9060,16 +9070,6 @@ Defaults to
 undefined
 \`\`\`
 
-**textInput.disabled.opacity**
-
-The opacity when the textInput is disabled. Expects \`number\`.
-
-Defaults to
-
-\`\`\`
-0.3
-\`\`\`
-
 **global.control.border**
 
 The border of the input. Expects \`object\`.
@@ -9108,6 +9108,16 @@ Defaults to
 
 \`\`\`
 #AAAAAA
+\`\`\`
+
+**global.disabled.opacity**
+
+The opacity when a component is disabled. Expects \`number\`.
+
+Defaults to
+
+\`\`\`
+0.3
 \`\`\`
 
 **global.input.weight**

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1676,7 +1676,7 @@ undefined
 
 **button.disabled.opacity**
 
-The opacity when the button is disabled. To be deprecated in V3, use global.disabled.opacity instead. Expects \`number\`.
+The opacity when the button is disabled. Expects \`number\`.
 
 Defaults to
 
@@ -1724,7 +1724,7 @@ Defaults to
 focus
 \`\`\`
 
-**global.disabled.opacity**
+**global.control.disabled.opacity**
 
 The opacity when a component is disabled. Expects \`number\`.
 
@@ -8729,6 +8729,16 @@ Defaults to
 undefined
 \`\`\`
 
+**textArea.disabled.opacity**
+
+The opacity when the textArea is disabled. Expects \`number\`.
+
+Defaults to
+
+\`\`\`
+0.3
+\`\`\`
+
 **global.control.border**
 
 The border of the textarea. Expects \`object\`.
@@ -8789,7 +8799,7 @@ Defaults to
 12px
 \`\`\`
 
-**global.disabled.opacity**
+**global.control.disabled.opacity**
 
 The opacity when a component is disabled. Expects \`number\`.
 
@@ -9070,6 +9080,16 @@ Defaults to
 undefined
 \`\`\`
 
+**textInput.disabled.opacity**
+
+The opacity when the textInput is disabled. Expects \`number\`.
+
+Defaults to
+
+\`\`\`
+0.3
+\`\`\`
+
 **global.control.border**
 
 The border of the input. Expects \`object\`.
@@ -9110,7 +9130,7 @@ Defaults to
 #AAAAAA
 \`\`\`
 
-**global.disabled.opacity**
+**global.control.disabled.opacity**
 
 The opacity when a component is disabled. Expects \`number\`.
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -8719,6 +8719,16 @@ Defaults to
 undefined
 \`\`\`
 
+**textArea.disabled.opacity**
+
+The opacity when the textArea is disabled. Expects \`number\`.
+
+Defaults to
+
+\`\`\`
+0.3
+\`\`\`
+
 **global.control.border**
 
 The border of the textarea. Expects \`object\`.
@@ -9048,6 +9058,16 @@ Defaults to
 
 \`\`\`
 undefined
+\`\`\`
+
+**textInput.disabled.opacity**
+
+The opacity when the textInput is disabled. Expects \`number\`.
+
+Defaults to
+
+\`\`\`
+0.3
 \`\`\`
 
 **global.control.border**

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -785,18 +785,12 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       xlarge: { ...fontSizing(2) },
       xxlarge: { ...fontSizing(4) },
     },
-    textArea: {
-      disabled: {
-        opacity: 0.3,
-      },
-      extend: undefined,
-    },
-    textInput: {
-      disabled: {
-        opacity: 0.3,
-      },
-      extend: undefined,
-    },
+    // textArea: {
+    //   extend: undefined,
+    // },
+    // textInput: {
+    //   extend: undefined,
+    // },
     video: {
       captions: {
         background: 'rgba(0, 0, 0, 0.7)',

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -167,6 +167,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           radius: '4px',
           color: 'border',
         },
+        disabled: {
+          opacity: 0.3,
+        },
       },
       debounceDelay: 300, // The time to wait after the user stopped typing, measured in ms.
       drop: {
@@ -211,9 +214,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         border: {
           color: 'focus',
         },
-      },
-      disabled: {
-        opacity: 0.3,
       },
       font: {
         ...fontSizing(0),
@@ -299,6 +299,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       primary: {
         // color: { dark: undefined, light: undefined }
       },
+      disabled: undefined,
       padding: {
         vertical: `${baseSpacing / 4 - borderWidth}px`,
         horizontal: `${baseSpacing - borderWidth}px`,
@@ -785,12 +786,14 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       xlarge: { ...fontSizing(2) },
       xxlarge: { ...fontSizing(4) },
     },
-    // textArea: {
-    //   extend: undefined,
-    // },
-    // textInput: {
-    //   extend: undefined,
-    // },
+    textArea: {
+      extend: undefined,
+      disabled: undefined,
+    },
+    textInput: {
+      extend: undefined,
+      disabled: undefined,
+    },
     video: {
       captions: {
         background: 'rgba(0, 0, 0, 0.7)',

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -785,12 +785,18 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       xlarge: { ...fontSizing(2) },
       xxlarge: { ...fontSizing(4) },
     },
-    // textArea: {
-    //   extend: undefined,
-    // },
-    // textInput: {
-    //   extend: undefined,
-    // },
+    textArea: {
+      disabled: {
+        opacity: 0.3,
+      },
+      extend: undefined,
+    },
+    textInput: {
+      disabled: {
+        opacity: 0.3,
+      },
+      extend: undefined,
+    },
     video: {
       captions: {
         background: 'rgba(0, 0, 0, 0.7)',

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -299,7 +299,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       primary: {
         // color: { dark: undefined, light: undefined }
       },
-      disabled: undefined,
+      // disabled: { opacity: undefined },
       padding: {
         vertical: `${baseSpacing / 4 - borderWidth}px`,
         horizontal: `${baseSpacing - borderWidth}px`,
@@ -787,12 +787,12 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       xxlarge: { ...fontSizing(4) },
     },
     textArea: {
-      extend: undefined,
-      disabled: undefined,
+      // extend: undefined,
+      // disabled: { opacity: undefined },
     },
     textInput: {
-      extend: undefined,
-      disabled: undefined,
+      // extend: undefined,
+      // disabled: { opacity: undefined },
     },
     video: {
       captions: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -212,6 +212,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           color: 'focus',
         },
       },
+      disabled: {
+        opacity: 0.3,
+      },
       font: {
         ...fontSizing(0),
         // face: undefined,
@@ -295,9 +298,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // color: { dark: undefined, light: undefined }
       primary: {
         // color: { dark: undefined, light: undefined }
-      },
-      disabled: {
-        opacity: 0.3,
       },
       padding: {
         vertical: `${baseSpacing / 4 - borderWidth}px`,

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -252,3 +252,8 @@ export const genericStyles = css`
       props.theme,
     )}
 `;
+
+export const disabledStyle = componentStyle => css`
+  opacity: ${props => componentStyle || props.theme.global.disabled.opacity};
+  cursor: default;
+`;

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -254,6 +254,7 @@ export const genericStyles = css`
 `;
 
 export const disabledStyle = componentStyle => css`
-  opacity: ${props => componentStyle || props.theme.global.disabled.opacity};
+  opacity: ${props =>
+    componentStyle || props.theme.global.control.disabled.opacity};
   cursor: default;
 `;

--- a/src/js/utils/themeDocUtils.js
+++ b/src/js/utils/themeDocUtils.js
@@ -87,7 +87,7 @@ export const themeDocUtils = {
     },
   }),
   disabledStyle: {
-    'global.disabled.opacity': {
+    'global.control.disabled.opacity': {
       description: 'The opacity when a component is disabled.',
       type: 'number',
       defaultValue: 0.3,

--- a/src/js/utils/themeDocUtils.js
+++ b/src/js/utils/themeDocUtils.js
@@ -86,4 +86,11 @@ export const themeDocUtils = {
   }`,
     },
   }),
+  disabledStyle: {
+    'global.disabled.opacity': {
+      description: 'The opacity when a component is disabled.',
+      type: 'number',
+      defaultValue: 0.3,
+    },
+  },
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Styles disabled TextInput TextArea. as a side-effect Select is also styled when disabled
#### Where should the reviewer start?

I wonder whether we should have opacity style as a helper function and whether opacity style should first live in global section of theme. Like all the disabled things should be styled with the same way and then if user decides to override then ok.
it should remove some code-duplication from this PR. Didn't do this right now since currently we don't handle things in this way

#### What testing has been done on this PR?
Jest and manual on storybook
#### How should this be manually tested?
storybook
#### Any background context you want to provide?

#### What are the relevant issues?
#2825 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
compatible