### PR TITLE
Added tag filters for CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,12 +79,21 @@ workflows:
       - lint:
           requires:
             - checkout
+          filters:
+            tags:
+              only: /.*/
       - jest:
           requires:
             - checkout
+          filters:
+            tags:
+              only: /.*/
       - build:
           requires:
             - checkout
+          filters:
+            tags:
+              only: /.*/
       - release:
           requires:
             - jest


### PR DESCRIPTION
Based on the guidance here:

https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag

Adding tags filters for all jobs needed for publish.