### PR TITLE
Collapsible - overflow fix, fixes #2539

### DIFF
--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -172,6 +172,7 @@ exports[`Accordion AccordionPanel 1`] = `
 .c10 {
   max-height: 0;
   visibility: hidden;
+  overflow: hidden;
 }
 
 .c6 {
@@ -1055,6 +1056,7 @@ exports[`Accordion change to second Panel 1`] = `
 .c10 {
   max-height: 0;
   visibility: hidden;
+  overflow: hidden;
 }
 
 .c6 {
@@ -1328,7 +1330,7 @@ exports[`Accordion change to second Panel 2`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 1
         </div>
@@ -2293,6 +2295,7 @@ exports[`Accordion complex title 1`] = `
 .c9 {
   max-height: 0;
   visibility: hidden;
+  overflow: hidden;
 }
 
 .c0 {
@@ -3644,6 +3647,7 @@ exports[`Accordion set on hover 1`] = `
 .c10 {
   max-height: 0;
   visibility: hidden;
+  overflow: hidden;
 }
 
 .c6 {
@@ -3917,7 +3921,7 @@ exports[`Accordion set on hover 2`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 1
         </div>
@@ -3968,7 +3972,7 @@ exports[`Accordion set on hover 2`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 2
         </div>
@@ -4031,7 +4035,7 @@ exports[`Accordion set on hover 3`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 1
         </div>
@@ -4082,7 +4086,7 @@ exports[`Accordion set on hover 3`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 2
         </div>
@@ -4145,7 +4149,7 @@ exports[`Accordion set on hover 4`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 1
         </div>
@@ -4196,7 +4200,7 @@ exports[`Accordion set on hover 4`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 2
         </div>
@@ -4259,7 +4263,7 @@ exports[`Accordion set on hover 5`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 1
         </div>
@@ -4310,7 +4314,7 @@ exports[`Accordion set on hover 5`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cURqdn StyledBox-sc-13pk1d4-0 IRSNj"
+          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 IRSNj"
         >
           Panel body 2
         </div>

--- a/src/js/components/Accordion/accordion.stories.js
+++ b/src/js/components/Accordion/accordion.stories.js
@@ -37,8 +37,10 @@ const SimpleAccordion = props => {
       <Box {...rest}>
         <Accordion animate={animate} multiple={multiple}>
           <AccordionPanel label="Panel 1">
-            <Box background="light-2" style={{ height: '800px' }}>
-              Panel 1 contents
+            <Box background="light-2" overflow="auto" height="medium">
+              <Box height="large" flex={false}>
+                Panel 1 contents
+              </Box>
             </Box>
           </AccordionPanel>
           <AccordionPanel label="Panel 2">

--- a/src/js/components/Collapsible/Collapsible.js
+++ b/src/js/components/Collapsible/Collapsible.js
@@ -20,6 +20,7 @@ const AnimatedBox = styled(Box)`
       : `
     max-${animatedBoxProperty(props.collapsibleDirection)}: 0;
     visibility: hidden;
+    overflow: hidden;
   `)};
 `;
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Setting Collapsible children not to take any space when closed, (even when using the pad prop)
#### Where should the reviewer start?
Collapsible.js
#### What testing has been done on this PR?
adjusting the Accordion stories to include a collapsible with scroll scenario.
#### How should this be manually tested?
Accordion story 
#### Any background context you want to provide?

#### What are the relevant issues?
#2539
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible