### PR TITLE
typescript - cross color support

### DIFF
--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -16,6 +16,6 @@ export interface AnchorProps {
   as?: string;
 }
 
-declare const Anchor: React.ComponentClass<AnchorProps & Omit<JSX.IntrinsicElements['a'], 'color'|'string'>>;
+declare const Anchor: React.ComponentClass<AnchorProps & Omit<JSX.IntrinsicElements['a'], 'color'>>;
 
 export { Anchor };

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Omit } from "../../utils";
 
 export interface AnchorProps {
   a11yTitle?: string;
@@ -15,6 +16,6 @@ export interface AnchorProps {
   as?: string;
 }
 
-declare const Anchor: React.ComponentClass<AnchorProps & JSX.IntrinsicElements['a']>;
+declare const Anchor: React.ComponentClass<AnchorProps & Omit<JSX.IntrinsicElements['a'], 'color'|'string'>>;
 
 export { Anchor };

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -23,6 +23,6 @@ export interface ButtonProps {
   as?: string;
 }
 
-declare const Button: React.ComponentClass<ButtonProps & Omit<JSX.IntrinsicElements['button'], 'color' | 'string'>>;
+declare const Button: React.ComponentClass<ButtonProps & Omit<JSX.IntrinsicElements['button'], 'color'>>;
 
 export { Button };

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Omit } from "../../utils";
 
 export interface ButtonProps {
   a11yTitle?: string;
@@ -22,6 +23,6 @@ export interface ButtonProps {
   as?: string;
 }
 
-declare const Button: React.ComponentClass<ButtonProps & JSX.IntrinsicElements['button']>;
+declare const Button: React.ComponentClass<ButtonProps & Omit<JSX.IntrinsicElements['button'], 'color' | 'string'>>;
 
 export { Button };

--- a/src/js/components/Heading/index.d.ts
+++ b/src/js/components/Heading/index.d.ts
@@ -1,8 +1,10 @@
 import * as React from "react";
+import { Omit } from "../../utils";
 
 export interface HeadingProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
+  as?: string;
   gridArea?: string;
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   color?: string | {dark?: string,light?: string};
@@ -13,6 +15,12 @@ export interface HeadingProps {
   truncate?: boolean;
 }
 
-declare const Heading: React.FC<HeadingProps & (JSX.IntrinsicElements['h1'] | JSX.IntrinsicElements['h2'] | JSX.IntrinsicElements['h3'] | JSX.IntrinsicElements['h4'])>;
+declare const Heading: React.FC<HeadingProps & (
+  Omit<JSX.IntrinsicElements['h1'], 'color' | 'string'> 
+  | Omit<JSX.IntrinsicElements['h2'], 'color' | 'string'>
+  | Omit<JSX.IntrinsicElements['h3'], 'color' | 'string'> 
+  | Omit<JSX.IntrinsicElements['h4'], 'color' | 'string'> 
+  | Omit<JSX.IntrinsicElements['h5'], 'color' | 'string'> 
+  | Omit<JSX.IntrinsicElements['h6'], 'color' | 'string'>)>;
 
 export { Heading };

--- a/src/js/components/Heading/index.d.ts
+++ b/src/js/components/Heading/index.d.ts
@@ -16,11 +16,11 @@ export interface HeadingProps {
 }
 
 declare const Heading: React.FC<HeadingProps & (
-  Omit<JSX.IntrinsicElements['h1'], 'color' | 'string'> 
-  | Omit<JSX.IntrinsicElements['h2'], 'color' | 'string'>
-  | Omit<JSX.IntrinsicElements['h3'], 'color' | 'string'> 
-  | Omit<JSX.IntrinsicElements['h4'], 'color' | 'string'> 
-  | Omit<JSX.IntrinsicElements['h5'], 'color' | 'string'> 
-  | Omit<JSX.IntrinsicElements['h6'], 'color' | 'string'>)>;
+  Omit<JSX.IntrinsicElements['h1'], 'color'> 
+  | Omit<JSX.IntrinsicElements['h2'], 'color'>
+  | Omit<JSX.IntrinsicElements['h3'], 'color'> 
+  | Omit<JSX.IntrinsicElements['h4'], 'color'> 
+  | Omit<JSX.IntrinsicElements['h5'], 'color'> 
+  | Omit<JSX.IntrinsicElements['h6'], 'color'>)>;
 
 export { Heading };

--- a/src/js/components/Paragraph/index.d.ts
+++ b/src/js/components/Paragraph/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Omit } from "../../utils";
 
 export interface ParagraphProps {
   a11yTitle?: string;
@@ -11,6 +12,6 @@ export interface ParagraphProps {
   textAlign?: "start" | "center" | "end";
 }
 
-declare const Paragraph: React.FC<ParagraphProps & JSX.IntrinsicElements['p']>;
+declare const Paragraph: React.FC<ParagraphProps & Omit<JSX.IntrinsicElements['p'], 'color'|'string'>>;
 
 export { Paragraph };

--- a/src/js/components/Paragraph/index.d.ts
+++ b/src/js/components/Paragraph/index.d.ts
@@ -12,6 +12,6 @@ export interface ParagraphProps {
   textAlign?: "start" | "center" | "end";
 }
 
-declare const Paragraph: React.FC<ParagraphProps & Omit<JSX.IntrinsicElements['p'], 'color'|'string'>>;
+declare const Paragraph: React.FC<ParagraphProps & Omit<JSX.IntrinsicElements['p'], 'color'>>;
 
 export { Paragraph };

--- a/src/js/components/RangeSelector/index.d.ts
+++ b/src/js/components/RangeSelector/index.d.ts
@@ -16,6 +16,6 @@ export interface RangeSelectorProps {
   values: number[];
 }
 
-declare const RangeSelector: React.ComponentClass<RangeSelectorProps & Omit<JSX.IntrinsicElements['div'], 'color'|'string'>>;
+declare const RangeSelector: React.ComponentClass<RangeSelectorProps & Omit<JSX.IntrinsicElements['div'], 'color'>>;
 
 export { RangeSelector };

--- a/src/js/components/RangeSelector/index.d.ts
+++ b/src/js/components/RangeSelector/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Omit } from "../../utils";
 
 export interface RangeSelectorProps {
   color?: string | {dark?: string,light?: string};
@@ -15,6 +16,6 @@ export interface RangeSelectorProps {
   values: number[];
 }
 
-declare const RangeSelector: React.ComponentClass<RangeSelectorProps & JSX.IntrinsicElements['div']>;
+declare const RangeSelector: React.ComponentClass<RangeSelectorProps & Omit<JSX.IntrinsicElements['div'], 'color'|'string'>>;
 
 export { RangeSelector };

--- a/src/js/components/TextInput/index.d.ts
+++ b/src/js/components/TextInput/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Omit } from "../../utils";
 
 export interface TextInputProps {
   dropAlign?: {top?: "top" | "bottom",bottom?: "top" | "bottom",right?: "left" | "right",left?: "left" | "right"};
@@ -17,8 +18,6 @@ export interface TextInputProps {
   suggestions?: ({label?: React.ReactNode,value?: any} | string)[];
   value?: string | number;
 }
-
-type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 
 declare const TextInput: React.ComponentClass<TextInputProps & Omit<JSX.IntrinsicElements['input'], 'onSelect' | 'size'>>;
 

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -19,6 +19,8 @@ export interface DeepMerge {
   <T extends object, S extends object[]>(target: T, ...sources: S): T & S[number];
 }
 
+export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
 declare const isObject: (item:any) => boolean;
 declare const deepFreeze: DeepFreeze;
 declare const deepMerge: DeepMerge;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
`HTMLAttributes` interface has `color?: string` which collides with grommet 
`color?: string | {dark?: string,light?: string};`
hence doesn't allow setting of `{dark: string,light: string}` to `color` prop.

#### Where should the reviewer start?
src/js/utils/index.d.ts

#### What testing has been done on this PR?
Using this block of code in the v2-launch-slides TS repo
```    <Heading color={{ dark: "white", light: "black" }}>Title</Heading>
    <Paragraph color={{ dark: "white", light: "black" }}>Title</Paragraph>
    <RangeSelector values={[]} color={{ dark: "white", light: "black" }}>
      Title
    </RangeSelector>
    <Anchor color={{ dark: "white", light: "black" }} />
    <Button color={{ dark: "white", light: "black" }}>Shimi</Button>
    <TextInput> Shimi</TextInput>
```
#### How should this be manually tested?
use the block of code above in any Grommet+TS repo, and see all the errors before testing it with this branch. the errors should be gone after applying the PR fixes. 
#### Any background context you want to provide?

#### What are the relevant issues?
#2851 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Separate PR filed on grommet-site https://github.com/grommet/grommet-site/pull/91
#### Should this PR be mentioned in the release notes?
as a general TS improvements
#### Is this change backwards compatible or is it a breaking change?
backwards compatible