### PR TITLE
Fix Tag/as ProTypes

### DIFF
--- a/src/js/components/AccordionPanel/README.md
+++ b/src/js/components/AccordionPanel/README.md
@@ -30,7 +30,7 @@ div
   
 **accordion.icons.collapse**
 
-The icon to use when the panel is expanded. Expects `React.element`.
+The icon to use when the panel is expanded. Expects `React.Element`.
 
 Defaults to
 
@@ -40,7 +40,7 @@ Defaults to
 
 **accordion.icons.expand**
 
-The icon to use when the panel is collapsed. Expects `React.element`.
+The icon to use when the panel is collapsed. Expects `React.Element`.
 
 Defaults to
 
@@ -50,7 +50,7 @@ Defaults to
 
 **accordion.border**
 
-The border to use in the accordion. Expects `React.element`.
+The border to use in the accordion. Expects `React.Element`.
 
 Defaults to
 

--- a/src/js/components/AccordionPanel/doc.js
+++ b/src/js/components/AccordionPanel/doc.js
@@ -18,17 +18,17 @@ export function doc(Panel) {
 export const themeDoc = {
   'accordion.icons.collapse': {
     description: 'The icon to use when the panel is expanded.',
-    type: 'React.element',
+    type: 'React.Element',
     defaultValue: '<FormUp />',
   },
   'accordion.icons.expand': {
     description: 'The icon to use when the panel is collapsed.',
-    type: 'React.element',
+    type: 'React.Element',
     defaultValue: '<FormDown />',
   },
   'accordion.border': {
     description: 'The border to use in the accordion.',
-    type: 'React.element',
+    type: 'React.Element',
     defaultValue: 'side: bottom, color: border',
   },
 };

--- a/src/js/components/Anchor/README.md
+++ b/src/js/components/Anchor/README.md
@@ -183,7 +183,7 @@ string
 
 **as**
 
-The DOM tag to use for the element.
+The DOM tag or react component to use for the element.
 
 ```
 string

--- a/src/js/components/Anchor/README.md
+++ b/src/js/components/Anchor/README.md
@@ -187,6 +187,7 @@ The DOM tag to use for the element.
 
 ```
 string
+function
 ```
   
 ## Intrinsic element

--- a/src/js/components/Anchor/doc.js
+++ b/src/js/components/Anchor/doc.js
@@ -59,7 +59,9 @@ or just use children.`,
 this component. But, it can be adjusted directly via this size property, typically
 when it is not contained in a 'Heading', 'Paragraph', or 'Text'.`,
     ),
-    as: PropTypes.string.description(`The DOM tag to use for the element.`),
+    as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).description(
+      `The DOM tag to use for the element.`,
+    ),
   };
 
   return DocumentedAnchor;

--- a/src/js/components/Anchor/doc.js
+++ b/src/js/components/Anchor/doc.js
@@ -60,7 +60,7 @@ this component. But, it can be adjusted directly via this size property, typical
 when it is not contained in a 'Heading', 'Paragraph', or 'Text'.`,
     ),
     as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).description(
-      `The DOM tag to use for the element.`,
+      `The DOM tag or react component to use for the element.`,
     ),
   };
 

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Omit } from "../../utils";
+import { Omit, PolymorphicType } from "../../utils";
 
 export interface AnchorProps {
   a11yTitle?: string;
@@ -13,7 +13,7 @@ export interface AnchorProps {
   onClick?: ((...args: any[]) => any);
   reverse?: boolean;
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
-  as?: string | React.Component | React.FC | ((...args: any[]) => any);
+  as?: PolymorphicType;
 }
 
 declare const Anchor: React.ComponentClass<AnchorProps & Omit<JSX.IntrinsicElements['a'], 'color'>>;

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -13,7 +13,7 @@ export interface AnchorProps {
   onClick?: ((...args: any[]) => any);
   reverse?: boolean;
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
-  as?: string;
+  as?: string | React.Component | React.FC | ((...args: any[]) => any);
 }
 
 declare const Anchor: React.ComponentClass<AnchorProps & Omit<JSX.IntrinsicElements['a'], 'color'>>;

--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -545,11 +545,12 @@ of indicating the DOM tag via the 'as' property.
 
 ```
 string
+function
 ```
 
 **as**
 
-The DOM tag to use for the element. Defaults to `div`.
+The DOM tag or react component to use for the element. Defaults to `div`.
 
 ```
 string

--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -553,6 +553,7 @@ The DOM tag to use for the element. Defaults to `div`.
 
 ```
 string
+function
 ```
 
 **width**

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -289,7 +289,8 @@ export const doc = Box => {
     ])
       .description('How much to round the corners.')
       .defaultValue(false),
-    tag: PropTypes.string.description(
+    tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+      .description(
       `The DOM tag to use for the element. NOTE: This is deprecated in favor
 of indicating the DOM tag via the 'as' property.`,
     ),

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -289,13 +289,12 @@ export const doc = Box => {
     ])
       .description('How much to round the corners.')
       .defaultValue(false),
-    tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
-      .description(
+    tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).description(
       `The DOM tag to use for the element. NOTE: This is deprecated in favor
 of indicating the DOM tag via the 'as' property.`,
     ),
     as: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
-      .description('The DOM tag to use for the element.')
+      .description('The DOM tag or react component to use for the element.')
       .defaultValue('div'),
     width: PropTypes.oneOfType([
       PropTypes.oneOf([

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -293,7 +293,7 @@ export const doc = Box => {
       `The DOM tag to use for the element. NOTE: This is deprecated in favor
 of indicating the DOM tag via the 'as' property.`,
     ),
-    as: PropTypes.string
+    as: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
       .description('The DOM tag to use for the element.')
       .defaultValue('div'),
     width: PropTypes.oneOfType([

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -22,8 +22,8 @@ export interface BoxProps {
   pad?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   responsive?: boolean;
   round?: boolean | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | string | {corner?: "top" | "left" | "bottom" | "right" | "top-left" | "top-right" | "bottom-left" | "bottom-right",size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string};
-  tag?: string;
-  as?: string;
+  tag?: string | React.Component | React.FC | ((...args: any[]) => any);
+  as?: string | React.Component | React.FC | ((...args: any[]) => any);
   width?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" |string;
   wrap?: boolean;
 }

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -1,4 +1,6 @@
 import * as React from "react";
+import { PolymorphicType } from "../../utils";
+
 
 export interface BoxProps {
   a11yTitle?: string;
@@ -22,8 +24,8 @@ export interface BoxProps {
   pad?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   responsive?: boolean;
   round?: boolean | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | string | {corner?: "top" | "left" | "bottom" | "right" | "top-left" | "top-right" | "bottom-left" | "bottom-right",size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string};
-  tag?: string | React.Component | React.FC | ((...args: any[]) => any);
-  as?: string | React.Component | React.FC | ((...args: any[]) => any);
+  tag?: PolymorphicType;
+  as?: PolymorphicType;
   width?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" |string;
   wrap?: boolean;
 }

--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -247,6 +247,7 @@ The DOM tag to use for the element.
 
 ```
 string
+function
 ```
   
 ## Intrinsic element

--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -243,7 +243,7 @@ submit
 
 **as**
 
-The DOM tag to use for the element.
+The DOM tag or react component to use for the element.
 
 ```
 string

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -84,7 +84,9 @@ end of the anchor.`,
         'The type of button. Set the type to submit for the default button on forms.',
       )
       .defaultValue('button'),
-    as: PropTypes.string.description(`The DOM tag to use for the element.`),
+    as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).description(
+      `The DOM tag to use for the element.`,
+    ),
   };
 
   return DocumentedButton;

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -85,7 +85,7 @@ end of the anchor.`,
       )
       .defaultValue('button'),
     as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).description(
-      `The DOM tag to use for the element.`,
+      `The DOM tag or react component to use for the element.`,
     ),
   };
 

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Omit } from "../../utils";
+import { Omit, PolymorphicType } from "../../utils";
 
 export interface ButtonProps {
   a11yTitle?: string;
@@ -20,7 +20,7 @@ export interface ButtonProps {
   primary?: boolean;
   reverse?: boolean;
   type?: "button" | "reset" | "submit";
-  as?: string | React.Component | React.FC | ((...args: any[]) => any);
+  as?: PolymorphicType;
 }
 
 declare const Button: React.ComponentClass<ButtonProps & Omit<JSX.IntrinsicElements['button'], 'color'>>;

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -20,7 +20,7 @@ export interface ButtonProps {
   primary?: boolean;
   reverse?: boolean;
   type?: "button" | "reset" | "submit";
-  as?: string;
+  as?: string | React.Component | React.FC | ((...args: any[]) => any);
 }
 
 declare const Button: React.ComponentClass<ButtonProps & Omit<JSX.IntrinsicElements['button'], 'color'>>;

--- a/src/js/components/Grid/README.md
+++ b/src/js/components/Grid/README.md
@@ -161,6 +161,23 @@ Column sizes.
 
 ```
 [
+  [
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    full
+    1/2
+    1/3
+    2/3
+    1/4
+    2/4
+    3/4
+    flex
+    auto
+    string
+  ]
   xsmall
   small
   medium
@@ -175,20 +192,6 @@ Column sizes.
   3/4
   flex
   auto
-  [xsmall
-small
-medium
-large
-xlarge
-full
-1/2
-1/3
-2/3
-1/4
-2/4
-3/4
-flex
-auto]
   string
 ]
 xsmall
@@ -297,6 +300,23 @@ Row sizes.
 
 ```
 [
+  [
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    full
+    1/2
+    1/3
+    2/3
+    1/4
+    2/4
+    3/4
+    flex
+    auto
+    string
+  ]
   xsmall
   small
   medium
@@ -311,20 +331,6 @@ Row sizes.
   3/4
   flex
   auto
-  [xsmall
-small
-medium
-large
-xlarge
-full
-1/2
-1/3
-2/3
-1/4
-2/4
-3/4
-flex
-auto]
   string
 ]
 xsmall
@@ -337,16 +343,17 @@ string
 
 **tag**
 
-The DOM tag to use for the element. NOTE: This is deprecated in favor
-of indicating the DOM tag via the 'as' property.
+The DOM tag to use for the element. NOTE: This is deprecated
+      in favor of indicating the DOM tag via the 'as' property.
 
 ```
 string
+function
 ```
 
 **as**
 
-The DOM tag to use for the element. Defaults to `div`.
+The DOM tag or react component to use for the element. Defaults to `div`.
 
 ```
 string

--- a/src/js/components/Grid/README.md
+++ b/src/js/components/Grid/README.md
@@ -350,6 +350,7 @@ The DOM tag to use for the element. Defaults to `div`.
 
 ```
 string
+function
 ```
   
 ## Intrinsic element

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -64,7 +64,7 @@ space in the column axis.`,
     columns: PropTypes.oneOfType([
       PropTypes.arrayOf(
         PropTypes.oneOfType([
-          PropTypes.arrayOf(PropTypes.OneOfType([
+          PropTypes.arrayOf(PropTypes.oneOfType([
             PropTypes.oneOf(sizes),
             PropTypes.string
           ])),
@@ -131,7 +131,7 @@ space in the row axis.`,
     rows: PropTypes.oneOfType([
       PropTypes.arrayOf(
         PropTypes.oneOfType([
-          PropTypes.arrayOf(PropTypes.OneOfType([
+          PropTypes.arrayOf(PropTypes.oneOfType([
             PropTypes.oneOf(sizes),
             PropTypes.string
           ])),

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -64,7 +64,7 @@ space in the column axis.`,
     columns: PropTypes.oneOfType([
       PropTypes.arrayOf(
         PropTypes.oneOfType([
-          PropTypes.arrayOf(PropTypes.OneOfTypes([
+          PropTypes.arrayOf(PropTypes.OneOfType([
             PropTypes.oneOf(sizes),
             PropTypes.string
           ])),
@@ -131,7 +131,7 @@ space in the row axis.`,
     rows: PropTypes.oneOfType([
       PropTypes.arrayOf(
         PropTypes.oneOfType([
-          PropTypes.arrayOf(PropTypes.OneOfTypes([
+          PropTypes.arrayOf(PropTypes.OneOfType([
             PropTypes.oneOf(sizes),
             PropTypes.string
           ])),

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -1,6 +1,6 @@
-import { describe, PropTypes } from 'react-desc';
+import {describe, PropTypes} from 'react-desc';
 
-import { genericProps, getAvailableAtBadge, themeDocUtils } from '../../utils';
+import {genericProps, getAvailableAtBadge, themeDocUtils} from '../../utils';
 
 const fixedSizes = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
 const sizes = [
@@ -64,8 +64,11 @@ space in the column axis.`,
     columns: PropTypes.oneOfType([
       PropTypes.arrayOf(
         PropTypes.oneOfType([
+          PropTypes.arrayOf(PropTypes.OneOfTypes([
+            PropTypes.oneOf(sizes),
+            PropTypes.string
+          ])),
           PropTypes.oneOf(sizes),
-          PropTypes.arrayOf(PropTypes.oneOf(sizes)),
           PropTypes.string,
         ]),
       ),
@@ -128,8 +131,11 @@ space in the row axis.`,
     rows: PropTypes.oneOfType([
       PropTypes.arrayOf(
         PropTypes.oneOfType([
+          PropTypes.arrayOf(PropTypes.OneOfTypes([
+            PropTypes.oneOf(sizes),
+            PropTypes.string
+          ])),
           PropTypes.oneOf(sizes),
-          PropTypes.arrayOf(PropTypes.oneOf(sizes)),
           PropTypes.string,
         ]),
       ),
@@ -142,10 +148,10 @@ space in the row axis.`,
       Specifying a single string will cause automatically added rows to be
       the specified size.`,
     ),
-    tag: PropTypes.string.description(
-      `The DOM tag to use for the element. NOTE: This is deprecated in favor
-of indicating the DOM tag via the 'as' property.`,
-    ),
+    tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+      .description(`The DOM tag to use for the element. NOTE: This is deprecated
+      in favor of indicating the DOM tag via the 'as' property.`,
+      ),
     as: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
       .description('The DOM tag to use for the element.')
       .defaultValue('div'),

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -1,6 +1,6 @@
-import {describe, PropTypes} from 'react-desc';
+import { describe, PropTypes } from 'react-desc';
 
-import {genericProps, getAvailableAtBadge, themeDocUtils} from '../../utils';
+import { genericProps, getAvailableAtBadge, themeDocUtils } from '../../utils';
 
 const fixedSizes = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
 const sizes = [
@@ -64,10 +64,9 @@ space in the column axis.`,
     columns: PropTypes.oneOfType([
       PropTypes.arrayOf(
         PropTypes.oneOfType([
-          PropTypes.arrayOf(PropTypes.oneOfType([
-            PropTypes.oneOf(sizes),
-            PropTypes.string
-          ])),
+          PropTypes.arrayOf(
+            PropTypes.oneOfType([PropTypes.oneOf(sizes), PropTypes.string]),
+          ),
           PropTypes.oneOf(sizes),
           PropTypes.string,
         ]),
@@ -131,10 +130,9 @@ space in the row axis.`,
     rows: PropTypes.oneOfType([
       PropTypes.arrayOf(
         PropTypes.oneOfType([
-          PropTypes.arrayOf(PropTypes.oneOfType([
-            PropTypes.oneOf(sizes),
-            PropTypes.string
-          ])),
+          PropTypes.arrayOf(
+            PropTypes.oneOfType([PropTypes.oneOf(sizes), PropTypes.string]),
+          ),
           PropTypes.oneOf(sizes),
           PropTypes.string,
         ]),
@@ -150,10 +148,9 @@ space in the row axis.`,
     ),
     tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
       .description(`The DOM tag to use for the element. NOTE: This is deprecated
-      in favor of indicating the DOM tag via the 'as' property.`,
-      ),
+      in favor of indicating the DOM tag via the 'as' property.`),
     as: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
-      .description('The DOM tag to use for the element.')
+      .description('The DOM tag or react component to use for the element.')
       .defaultValue('div'),
   };
 

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -146,7 +146,7 @@ space in the row axis.`,
       `The DOM tag to use for the element. NOTE: This is deprecated in favor
 of indicating the DOM tag via the 'as' property.`,
     ),
-    as: PropTypes.string
+    as: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
       .description('The DOM tag to use for the element.')
       .defaultValue('div'),
   };

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { PolymorphicType } from "../../utils";
 
 export interface GridProps {
   a11yTitle?: string;
@@ -14,8 +15,8 @@ export interface GridProps {
   justify?: "start" | "center" | "end" | "stretch";
   justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
   rows?: ("xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | string | string[])[] | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
-  tag?: string | React.Component | React.FC | ((...args: any[]) => any);
-  as?: string | React.Component | React.FC | ((...args: any[]) => any);
+  tag?: PolymorphicType;
+  as?: PolymorphicType;
 }
 
 declare const Grid: React.FC<GridProps & JSX.IntrinsicElements['div']>;

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -14,8 +14,8 @@ export interface GridProps {
   justify?: "start" | "center" | "end" | "stretch";
   justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
   rows?: ("xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | string | string[])[] | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
-  tag?: string | React.component | React.fc | ((...args: any[]) => any);
-  as?: string | React.component | React.fc | ((...args: any[]) => any);
+  tag?: string | React.Component | React.FC | ((...args: any[]) => any);
+  as?: string | React.Component | React.FC | ((...args: any[]) => any);
 }
 
 declare const Grid: React.FC<GridProps & JSX.IntrinsicElements['div']>;

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -14,8 +14,8 @@ export interface GridProps {
   justify?: "start" | "center" | "end" | "stretch";
   justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
   rows?: ("xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | string | string[])[] | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
-  tag?: string;
-  as?: string;
+  tag?: string | React.component | React.fc | ((...args: any[]) => any);
+  as?: string | React.component | React.fc | ((...args: any[]) => any);
 }
 
 declare const Grid: React.FC<GridProps & JSX.IntrinsicElements['div']>;

--- a/src/js/components/Heading/index.d.ts
+++ b/src/js/components/Heading/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { Omit } from "../../utils";
+import { Omit, PolymorphicType } from "../../utils";
 
 export interface HeadingProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
-  as?: string;
+  as?: PolymorphicType;
   gridArea?: string;
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   color?: string | {dark?: string,light?: string};
@@ -16,11 +16,11 @@ export interface HeadingProps {
 }
 
 declare const Heading: React.FC<HeadingProps & (
-  Omit<JSX.IntrinsicElements['h1'], 'color'> 
+  Omit<JSX.IntrinsicElements['h1'], 'color'>
   | Omit<JSX.IntrinsicElements['h2'], 'color'>
-  | Omit<JSX.IntrinsicElements['h3'], 'color'> 
-  | Omit<JSX.IntrinsicElements['h4'], 'color'> 
-  | Omit<JSX.IntrinsicElements['h5'], 'color'> 
+  | Omit<JSX.IntrinsicElements['h3'], 'color'>
+  | Omit<JSX.IntrinsicElements['h4'], 'color'>
+  | Omit<JSX.IntrinsicElements['h5'], 'color'>
   | Omit<JSX.IntrinsicElements['h6'], 'color'>)>;
 
 export { Heading };

--- a/src/js/components/Menu/README.md
+++ b/src/js/components/Menu/README.md
@@ -280,7 +280,7 @@ undefined
 
 **menu.icons.down**
 
-The icon to show to the right of the label. Expects `React.element`.
+The icon to show to the right of the label. Expects `React.Element`.
 
 Defaults to
 

--- a/src/js/components/Menu/doc.js
+++ b/src/js/components/Menu/doc.js
@@ -112,7 +112,7 @@ export const themeDoc = {
   },
   'menu.icons.down': {
     description: 'The icon to show to the right of the label.',
-    type: 'React.element',
+    type: 'React.Element',
     defaultValue: '<FormDown />',
   },
 };

--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -451,7 +451,7 @@ undefined
 
 **select.icons.down**
 
-The down icon to use for opening the Select. Expects `React.element`.
+The down icon to use for opening the Select. Expects `React.Element`.
 
 Defaults to
 

--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -461,7 +461,7 @@ Defaults to
 
 **select.searchInput**
 
-Component for the Select search input field. Expects `React.component`.
+Component for the Select search input field. Expects `React.Component`.
 
 Defaults to
 

--- a/src/js/components/Select/doc.js
+++ b/src/js/components/Select/doc.js
@@ -209,12 +209,12 @@ export const themeDoc = {
   },
   'select.icons.down': {
     description: 'The down icon to use for opening the Select.',
-    type: 'React.element',
+    type: 'React.Element',
     defaultValue: '<FormDown />',
   },
   'select.searchInput': {
     description: `Component for the Select search input field.`,
-    type: 'React.component',
+    type: 'React.Component',
     defaultValue: undefined,
   },
   'select.step': {

--- a/src/js/components/Text/README.md
+++ b/src/js/components/Text/README.md
@@ -139,15 +139,16 @@ string
 **tag**
 
 The DOM tag to use for the element. NOTE: This is deprecated in favor
-of indicating the DOM tag via the 'as' property.
+         of indicating the DOM tag via the 'as' property.
 
 ```
 string
+function
 ```
 
 **as**
 
-The DOM tag to use for the element. Defaults to `span`.
+The DOM tag or react component to use for the element. Defaults to `span`.
 
 ```
 string

--- a/src/js/components/Text/README.md
+++ b/src/js/components/Text/README.md
@@ -151,6 +151,7 @@ The DOM tag to use for the element. Defaults to `span`.
 
 ```
 string
+function
 ```
 
 **textAlign**

--- a/src/js/components/Text/doc.js
+++ b/src/js/components/Text/doc.js
@@ -42,7 +42,7 @@ adjustments.`,
       `The DOM tag to use for the element. NOTE: This is deprecated in favor
 of indicating the DOM tag via the 'as' property.`,
     ),
-    as: PropTypes.string
+    as: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
       .description(`The DOM tag to use for the element.`)
       .defaultValue('span'),
     textAlign: PropTypes.oneOf(['start', 'center', 'end'])

--- a/src/js/components/Text/doc.js
+++ b/src/js/components/Text/doc.js
@@ -1,4 +1,4 @@
-import { describe, PropTypes } from 'react-desc';
+import {describe, PropTypes} from 'react-desc';
 
 import {
   colorPropType,
@@ -38,10 +38,11 @@ be adjusted via this size property. The tag should be set for semantic
 correctness and accessibility. This size property allows for stylistic
 adjustments.`,
     ),
-    tag: PropTypes.string.description(
-      `The DOM tag to use for the element. NOTE: This is deprecated in favor
-of indicating the DOM tag via the 'as' property.`,
-    ),
+    tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+      .description(
+        `The DOM tag to use for the element. NOTE: This is deprecated in favor 
+         of indicating the DOM tag via the 'as' property.`,
+      ),
     as: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
       .description(`The DOM tag to use for the element.`)
       .defaultValue('span'),

--- a/src/js/components/Text/doc.js
+++ b/src/js/components/Text/doc.js
@@ -1,4 +1,4 @@
-import {describe, PropTypes} from 'react-desc';
+import { describe, PropTypes } from 'react-desc';
 
 import {
   colorPropType,
@@ -38,13 +38,12 @@ be adjusted via this size property. The tag should be set for semantic
 correctness and accessibility. This size property allows for stylistic
 adjustments.`,
     ),
-    tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
-      .description(
-        `The DOM tag to use for the element. NOTE: This is deprecated in favor 
+    tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).description(
+      `The DOM tag to use for the element. NOTE: This is deprecated in favor
          of indicating the DOM tag via the 'as' property.`,
-      ),
+    ),
     as: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
-      .description(`The DOM tag to use for the element.`)
+      .description(`The DOM tag or react component to use for the element.`)
       .defaultValue('span'),
     textAlign: PropTypes.oneOf(['start', 'center', 'end'])
       .description('How to align the text inside the component.')

--- a/src/js/components/Text/index.d.ts
+++ b/src/js/components/Text/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { PolymorphicType } from "../../utils";
 
 export interface TextProps {
   a11yTitle?: string;
@@ -7,8 +8,8 @@ export interface TextProps {
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   color?: string | {dark?: string,light?: string};
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
-  tag?: string | React.Component | React.FC | ((...args: any[]) => any);
-  as?: string | React.Component | React.FC | ((...args: any[]) => any);
+  tag?: PolymorphicType;
+  as?: PolymorphicType;
   textAlign?: "start" | "center" | "end";
   truncate?: boolean;
   weight?: "normal" | "bold" | number;

--- a/src/js/components/Text/index.d.ts
+++ b/src/js/components/Text/index.d.ts
@@ -7,8 +7,8 @@ export interface TextProps {
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   color?: string | {dark?: string,light?: string};
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
-  tag?: string | React.component | React.fc | ((...args: any[]) => any);
-  as?: string | React.component | React.fc | ((...args: any[]) => any);
+  tag?: string | React.Component | React.FC | ((...args: any[]) => any);
+  as?: string | React.Component | React.FC | ((...args: any[]) => any);
   textAlign?: "start" | "center" | "end";
   truncate?: boolean;
   weight?: "normal" | "bold" | number;

--- a/src/js/components/Text/index.d.ts
+++ b/src/js/components/Text/index.d.ts
@@ -7,8 +7,8 @@ export interface TextProps {
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   color?: string | {dark?: string,light?: string};
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
-  tag?: string;
-  as?: string;
+  tag?: string | React.component | React.fc | ((...args: any[]) => any);
+  as?: string | React.component | React.fc | ((...args: any[]) => any);
   textAlign?: "start" | "center" | "end";
   truncate?: boolean;
   weight?: "normal" | "bold" | number;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -7480,7 +7480,7 @@ Defaults to
 
 **select.searchInput**
 
-Component for the Select search input field. Expects \`React.component\`.
+Component for the Select search input field. Expects \`React.Component\`.
 
 Defaults to
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -207,7 +207,7 @@ div
   
 **accordion.icons.collapse**
 
-The icon to use when the panel is expanded. Expects \`React.element\`.
+The icon to use when the panel is expanded. Expects \`React.Element\`.
 
 Defaults to
 
@@ -217,7 +217,7 @@ Defaults to
 
 **accordion.icons.expand**
 
-The icon to use when the panel is collapsed. Expects \`React.element\`.
+The icon to use when the panel is collapsed. Expects \`React.Element\`.
 
 Defaults to
 
@@ -227,7 +227,7 @@ Defaults to
 
 **accordion.border**
 
-The border to use in the accordion. Expects \`React.element\`.
+The border to use in the accordion. Expects \`React.Element\`.
 
 Defaults to
 
@@ -420,10 +420,11 @@ string
 
 **as**
 
-The DOM tag to use for the element.
+The DOM tag or react component to use for the element.
 
 \`\`\`
 string
+function
 \`\`\`
   
 ## Intrinsic element
@@ -1102,14 +1103,16 @@ of indicating the DOM tag via the 'as' property.
 
 \`\`\`
 string
+function
 \`\`\`
 
 **as**
 
-The DOM tag to use for the element. Defaults to \`div\`.
+The DOM tag or react component to use for the element. Defaults to \`div\`.
 
 \`\`\`
 string
+function
 \`\`\`
 
 **width**
@@ -1571,10 +1574,11 @@ submit
 
 **as**
 
-The DOM tag to use for the element.
+The DOM tag or react component to use for the element.
 
 \`\`\`
 string
+function
 \`\`\`
   
 ## Intrinsic element
@@ -4247,6 +4251,23 @@ Column sizes.
 
 \`\`\`
 [
+  [
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    full
+    1/2
+    1/3
+    2/3
+    1/4
+    2/4
+    3/4
+    flex
+    auto
+    string
+  ]
   xsmall
   small
   medium
@@ -4261,20 +4282,6 @@ Column sizes.
   3/4
   flex
   auto
-  [xsmall
-small
-medium
-large
-xlarge
-full
-1/2
-1/3
-2/3
-1/4
-2/4
-3/4
-flex
-auto]
   string
 ]
 xsmall
@@ -4383,6 +4390,23 @@ Row sizes.
 
 \`\`\`
 [
+  [
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    full
+    1/2
+    1/3
+    2/3
+    1/4
+    2/4
+    3/4
+    flex
+    auto
+    string
+  ]
   xsmall
   small
   medium
@@ -4397,20 +4421,6 @@ Row sizes.
   3/4
   flex
   auto
-  [xsmall
-small
-medium
-large
-xlarge
-full
-1/2
-1/3
-2/3
-1/4
-2/4
-3/4
-flex
-auto]
   string
 ]
 xsmall
@@ -4423,19 +4433,21 @@ string
 
 **tag**
 
-The DOM tag to use for the element. NOTE: This is deprecated in favor
-of indicating the DOM tag via the 'as' property.
+The DOM tag to use for the element. NOTE: This is deprecated
+      in favor of indicating the DOM tag via the 'as' property.
 
 \`\`\`
 string
+function
 \`\`\`
 
 **as**
 
-The DOM tag to use for the element. Defaults to \`div\`.
+The DOM tag or react component to use for the element. Defaults to \`div\`.
 
 \`\`\`
 string
+function
 \`\`\`
   
 ## Intrinsic element
@@ -5961,7 +5973,7 @@ undefined
 
 **menu.icons.down**
 
-The icon to show to the right of the label. Expects \`React.element\`.
+The icon to show to the right of the label. Expects \`React.Element\`.
 
 Defaults to
 
@@ -7470,7 +7482,7 @@ undefined
 
 **select.icons.down**
 
-The down icon to use for opening the Select. Expects \`React.element\`.
+The down icon to use for opening the Select. Expects \`React.Element\`.
 
 Defaults to
 
@@ -8495,18 +8507,20 @@ string
 **tag**
 
 The DOM tag to use for the element. NOTE: This is deprecated in favor
-of indicating the DOM tag via the 'as' property.
+         of indicating the DOM tag via the 'as' property.
 
 \`\`\`
 string
+function
 \`\`\`
 
 **as**
 
-The DOM tag to use for the element. Defaults to \`span\`.
+The DOM tag or react component to use for the element. Defaults to \`span\`.
 
 \`\`\`
 string
+function
 \`\`\`
 
 **textAlign**

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -176,8 +176,9 @@ string",
         "name": "size",
       },
       Object {
-        "description": "The DOM tag to use for the element.",
-        "format": "string",
+        "description": "The DOM tag or react component to use for the element.",
+        "format": "string
+function",
         "name": "as",
       },
     ],
@@ -676,13 +677,15 @@ string
       Object {
         "description": "The DOM tag to use for the element. NOTE: This is deprecated in favor
 of indicating the DOM tag via the 'as' property.",
-        "format": "string",
+        "format": "string
+function",
         "name": "tag",
       },
       Object {
         "defaultValue": "div",
-        "description": "The DOM tag to use for the element.",
-        "format": "string",
+        "description": "The DOM tag or react component to use for the element.",
+        "format": "string
+function",
         "name": "as",
       },
       Object {
@@ -910,8 +913,9 @@ submit",
         "name": "type",
       },
       Object {
-        "description": "The DOM tag to use for the element.",
-        "format": "string",
+        "description": "The DOM tag or react component to use for the element.",
+        "format": "string
+function",
         "name": "as",
       },
     ],

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -20,6 +20,7 @@ export interface DeepMerge {
 }
 
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+export type PolymorphicType = keyof JSX.IntrinsicElements | React.ComponentType<any>
 
 declare const isObject: (item:any) => boolean;
 declare const deepFreeze: DeepFreeze;


### PR DESCRIPTION
See #2869 

#### What testing has been done on this PR?

Using function components for the tag instead.

#### What are the relevant issues?

Now, because custom components are passed in as tag, `grommet` might be adding extra styling props to those children. This leads to prop warnings as in #2870 

#### Do the grommet docs need to be updated?

No, already generating the new types.

#### Should this PR be mentioned in the release notes?

Yes.

#### Is this change backwards compatible or is it a breaking change?

it is backwards compatible.