### PR TITLE
Specify modal-only application of onClickOutside

### DIFF
--- a/src/js/components/Layer/README.md
+++ b/src/js/components/Layer/README.md
@@ -101,7 +101,7 @@ boolean
 
 **onClickOutside**
 
-Function that will be invoked when the user clicks outside the layer.
+Function that will be invoked on modal layers when the user clicks outside the layer.
 
 ```
 function

--- a/src/js/components/Layer/doc.js
+++ b/src/js/components/Layer/doc.js
@@ -70,7 +70,7 @@ particular side of the layer`,
       )
       .defaultValue(true),
     onClickOutside: PropTypes.func.description(
-      'Function that will be invoked when the user clicks outside the layer.',
+      'Function that will be invoked on modal layers when the user clicks outside the layer.',
     ),
     onEsc: PropTypes.func.description(
       'Function that will be called when the user presses the escape key inside the layer.',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5348,7 +5348,7 @@ boolean
 
 **onClickOutside**
 
-Function that will be invoked when the user clicks outside the layer.
+Function that will be invoked on modal layers when the user clicks outside the layer.
 
 \`\`\`
 function


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Specify in the `Layer` doc that `onClickOutside={() => {}}` only applies if the layer is modal

#### Where should the reviewer start?

At the single line that was changed :slightly_smiling_face: 

#### Any background context you want to provide?

Discussed on Slack: https://grommet.slack.com/archives/C04LMHN59/p1551532992080800