### PR TITLE
Handle onReset event in Form

### DIFF
--- a/src/js/components/Form/Form.js
+++ b/src/js/components/Form/Form.js
@@ -71,6 +71,14 @@ class Form extends Component {
     }
   };
 
+  onReset = event => {
+    const { onReset } = this.props;
+    if (onReset) {
+      onReset(event);
+    }
+    this.setState({ errors: {}, value: {}, touched: {} });
+  };
+
   update = (name, data, error) => {
     const { errors, touched, value } = this.state;
     const nextValue = { ...value };
@@ -106,7 +114,7 @@ class Form extends Component {
     delete rest.value;
     const { errors, touched, value, messages } = this.state;
     return (
-      <form {...rest} onSubmit={this.onSubmit}>
+      <form {...rest} onReset={this.onReset} onSubmit={this.onSubmit}>
         <FormContext.Provider
           value={{
             addValidation: this.addValidation,

--- a/src/js/components/Form/README.md
+++ b/src/js/components/Form/README.md
@@ -54,6 +54,15 @@ Function that will be called when the form is submitted. The
 function
 ```
 
+**onReset**
+
+Function that will be called when the form is reset. The
+      single argument is the event provided by react.
+
+```
+function
+```
+
 **value**
 
 An object representing all of the data in the form. Defaults to `{}`.

--- a/src/js/components/Form/__tests__/Form-test.js
+++ b/src/js/components/Form/__tests__/Form-test.js
@@ -122,4 +122,21 @@ describe('Form', () => {
     });
     expect(queryByText('required')).toBeNull();
   });
+
+  test('reset clears form', () => {
+    const onReset = jest.fn();
+    const { getByPlaceholderText, getByText, queryByText } = render(
+      <Grommet>
+        <Form onReset={onReset}>
+          <FormField name="test" required placeholder="test input" />
+          <Button type="reset" primary label="Reset" />
+        </Form>
+      </Grommet>,
+    );
+    fireEvent.change(getByPlaceholderText('test input'), {
+      target: { value: 'Input has changed' },
+    });
+    fireEvent.click(getByText('Reset'));
+    expect(queryByText('Input has changed')).toBeNull();
+  });
 });

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
@@ -15,6 +15,7 @@ exports[`Form empty 1`] = `
   className="c0"
 >
   <form
+    onReset={[Function]}
     onSubmit={[Function]}
   />
 </div>
@@ -383,6 +384,7 @@ exports[`Form with field 1`] = `
   className="c0"
 >
   <form
+    onReset={[Function]}
     onSubmit={[Function]}
   >
     <div

--- a/src/js/components/Form/doc.js
+++ b/src/js/components/Form/doc.js
@@ -33,6 +33,10 @@ export const doc = Form => {
       single argument is an event containing the latest value object
       via \`event.value\`.`,
     ),
+    onReset: PropTypes.func.description(
+      `Function that will be called when the form is reset. The
+      single argument is the event provided by react.`,
+    ),
     value: PropTypes.shape({})
       .description('An object representing all of the data in the form.')
       .defaultValue({}),

--- a/src/js/components/Form/form.stories.js
+++ b/src/js/components/Form/form.stories.js
@@ -36,7 +36,10 @@ const Example = () => (
   <Grommet full theme={grommet}>
     <Box fill align="center" justify="center">
       <Box width="medium">
-        <Form onSubmit={({ value }) => console.log('Submit', value)}>
+        <Form
+          onReset={event => console.log(event)}
+          onSubmit={({ value }) => console.log('Submit', value)}
+        >
           <FormField
             label="Name"
             name="name"
@@ -93,6 +96,7 @@ const Example = () => (
           { */}
           <Box direction="row" justify="between" margin={{ top: 'medium' }}>
             <Button label="Cancel" />
+            <Button type="reset" label="Reset" />
             <Button type="submit" label="Update" primary />
           </Box>
         </Form>

--- a/src/js/components/Form/index.d.ts
+++ b/src/js/components/Form/index.d.ts
@@ -5,6 +5,7 @@ export interface FormProps {
   messages?: {invalid?: string,required?: string};
   onChange?: ((...args: any[]) => any);
   onSubmit?: ((...args: any[]) => any);
+  onReset?: ((event: React.SyntheticEvent) => any);
   value?: {};
 }
 

--- a/src/js/components/FormField/README.md
+++ b/src/js/components/FormField/README.md
@@ -13,6 +13,14 @@ import { FormField } from 'grommet';
 
 ## Properties
 
+**component**
+
+The component to insert in the FormField. Grommet will add update the form values when this field changes
+
+```
+function
+```
+
 **error**
 
 Any error text describing issues with the field

--- a/src/js/components/FormField/doc.js
+++ b/src/js/components/FormField/doc.js
@@ -17,6 +17,9 @@ export const doc = FormField => {
     .intrinsicElement('div');
 
   DocumentedFormField.propTypes = {
+    component: PropTypes.func.description(
+      `The component to insert in the FormField. Grommet will add update the form values when this field changes`,
+    ),
     error: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).description(
       'Any error text describing issues with the field',
     ),

--- a/src/js/components/FormField/index.d.ts
+++ b/src/js/components/FormField/index.d.ts
@@ -8,6 +8,7 @@ export interface FormFieldProps {
   name?: string;
   pad?: boolean;
   required?: boolean;
+  component?: React.ComponentType<any>;
   validate?: {regexp?: object,message?: string} | ((...args: any[]) => any);
 }
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -3973,6 +3973,15 @@ Function that will be called when the form is submitted. The
 function
 \`\`\`
 
+**onReset**
+
+Function that will be called when the form is reset. The
+      single argument is the event provided by react.
+
+\`\`\`
+function
+\`\`\`
+
 **value**
 
 An object representing all of the data in the form. Defaults to \`{}\`.
@@ -4002,6 +4011,14 @@ import { FormField } from 'grommet';
 \`\`\`
 
 ## Properties
+
+**component**
+
+The component to insert in the FormField. Grommet will add update the form values when this field changes
+
+\`\`\`
+function
+\`\`\`
 
 **error**
 

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1866,6 +1866,11 @@ string",
     "name": "FormField",
     "properties": Array [
       Object {
+        "description": "The component to insert in the FormField. Grommet will add update the form values when this field changes",
+        "format": "function",
+        "name": "component",
+      },
+      Object {
         "description": "Any error text describing issues with the field",
         "format": "string
 node",


### PR DESCRIPTION
Closes: #2876

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

- Handles reset form with button type reset
- Adds component in the documentation

#### Where should the reviewer start?

#### What testing has been done on this PR?
unit-tests and storybook
#### How should this be manually tested?
storybook
#### Any background context you want to provide?

#### What are the relevant issues?

#2876

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
compat