### PR TITLE
fix(typescript): allow object colorSpec argument for normalizeColor

### DIFF
--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -1,7 +1,12 @@
 // colors.js
-declare const normalizeColor: (color: string, theme: object, required?: boolean) => string;
+declare const normalizeColor: (
+  color: string | { dark?: string; light?: string },
+  theme: object,
+  required?: boolean
+) => string;
 
 export {normalizeColor}
+
 // object.js
 export type DeepReadonly<T extends object> = {
   readonly [K in keyof T]: T[K] extends object ? DeepReadonly<T[K]> : T[K];


### PR DESCRIPTION
#### What does this PR do?

Tiny fixup for typescript utils PR I've made some time ago: https://github.com/grommet/grommet/pull/2655

Added missing type for `color` arg in `normalizeColor` to allow passing `{light: ..., dark: ...}`, not just theme key.

#### Questions
`Questions.map(question => question.answer("Nope"))`

#### Is this change backwards compatible or is it a breaking change?
Yes
