### PR TITLE
Allow user to set select open from the props

### DIFF
--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -292,6 +292,14 @@ Required. Options can be either a string or an object. If an object is used, use
 ]
 ```
 
+**open**
+
+Initial state of the select component
+
+```
+boolean
+```
+
 **placeholder**
 
 Placeholder text to use when no value is provided.

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -35,9 +35,13 @@ class Select extends Component {
     messages: { multiple: 'multiple' },
   };
 
-  state = { open: false };
-
   inputRef = React.createRef();
+
+  constructor(props) {
+    super(props);
+
+    this.state = { open: props.open };
+  }
 
   onOpen = () => {
     const { onOpen } = this.props;

--- a/src/js/components/Select/__tests__/Select-test.js
+++ b/src/js/components/Select/__tests__/Select-test.js
@@ -343,4 +343,17 @@ describe('Select', () => {
 
     expect(document.activeElement).toMatchSnapshot();
   });
+
+  test('open default state', () => {
+    render(
+      <Select
+        open
+        id="test-select"
+        placeholder="test select"
+        options={['one', 'two']}
+      />,
+    );
+
+    expect(document.getElementById('test-select__drop')).not.toBeNull();
+  });
 });

--- a/src/js/components/Select/doc.js
+++ b/src/js/components/Select/doc.js
@@ -116,6 +116,7 @@ export const doc = Select => {
       `Options can be either a string or an object. If an object is used, use
       children callback in order to render anything based on the current item.`,
     ).isRequired,
+    open: PropTypes.bool.description(`Initial state of the select component`),
     placeholder: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.node,

--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -22,6 +22,7 @@ export interface SelectProps {
   onOpen?: ((...args: any[]) => any);
   onSearch?: ((...args: any[]) => any);
   options: (string | JSX.Element | object)[];
+  open?: boolean;
   placeholder?: string | React.ReactNode;
   plain?: boolean;
   searchPlaceholder?: string;

--- a/src/js/components/Select/stories/select.stories.js
+++ b/src/js/components/Select/stories/select.stories.js
@@ -53,7 +53,7 @@ class SimpleSelect extends Component {
   };
 
   render() {
-    const { theme } = this.props;
+    const { theme, ...rest } = this.props;
     const { options, value } = this.state;
     return (
       <Grommet full theme={theme || grommet}>
@@ -65,6 +65,7 @@ class SimpleSelect extends Component {
             value={value}
             options={options}
             onChange={({ option }) => this.setState({ value: option })}
+            {...rest}
           />
         </Box>
       </Grommet>
@@ -599,5 +600,5 @@ storiesOf('Select', module)
       }}
     />
   ))
-  .add('Custom Rounded', () => <SimpleSelect theme={customRoundedTheme} />)
+  .add('Custom', () => <SimpleSelect open theme={customRoundedTheme} />)
   .add('Lots of options', () => <ManyOptions />);

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -7355,6 +7355,14 @@ Required. Options can be either a string or an object. If an object is used, use
 ]
 \`\`\`
 
+**open**
+
+Initial state of the select component
+
+\`\`\`
+boolean
+\`\`\`
+
 **placeholder**
 
 Placeholder text to use when no value is provided.

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2868,6 +2868,11 @@ function",
         "required": true,
       },
       Object {
+        "description": "Initial state of the select component",
+        "format": "boolean",
+        "name": "open",
+      },
+      Object {
         "description": "Placeholder text to use when no value is provided.",
         "format": "string
 node",


### PR DESCRIPTION
Fix: #2884

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Allows user to set open state of select from props

#### Where should the reviewer start?

#### What testing has been done on this PR?
unit-test and tested on storybook
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
#2884
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
compat