### PR TITLE
Fix sideEffect path to point where user is going to import file

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "module": "es6/index.js",
   "jsnext:main": "es6/index.js",
   "sideEffects": [
-    "./src/js/contexts/ThemeContext/ThemeContext.js"
+    "./es6/contexts/ThemeContext/ThemeContext.js"
   ],
   "description": "focus on the essential experience",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "module": "es6/index.js",
   "jsnext:main": "es6/index.js",
   "sideEffects": [
+    "./src/js/contexts/ThemeContext/ThemeContext.js",
     "./es6/contexts/ThemeContext/ThemeContext.js"
   ],
   "description": "focus on the essential experience",


### PR DESCRIPTION
Fix: #2669

<!--- Provide a general summary of the PR in the Title above -->
So i got digging and reading documentation and talking with people :D and it seems that sideEffects should point to the file user is going to import.

I only tested this in the example provided in the issue above. i went into `node_modules/grommet/` and modified my self.

what got me into this fix was that i could import ThemeContext from the direct path

`import {ThemeContext} from "grommet/contexts"`