### PR TITLE
incorporating feedback on Accordion stories

### DIFF
--- a/src/js/components/Accordion/accordion.stories.js
+++ b/src/js/components/Accordion/accordion.stories.js
@@ -76,14 +76,14 @@ const CustomAccordion = ({ animate, multiple, ...rest }) => (
   <Grommet theme={CustomAccordionTheme}>
     <Box {...rest}>
       <Accordion animate={animate} multiple>
-        <AccordionPanel label="Panel 1">
+        <AccordionPanel label={<Text size="large">Panel 1</Text>}>
           <Box background="light-2" height="small">
             Important Info
           </Box>
         </AccordionPanel>
-        <AccordionPanel label="Panel 2">
+        <AccordionPanel label={<Text size="medium">Panel 2</Text>}>
           <Box background="light-2" height="xsmall">
-            Important Info
+            <Text size="small">Important Info</Text>
           </Box>
         </AccordionPanel>
       </Accordion>

--- a/src/js/components/Collapsible/collapsible.stories.js
+++ b/src/js/components/Collapsible/collapsible.stories.js
@@ -178,7 +178,7 @@ class HorizontalCollapsible extends Component {
           </Box>
           <Box flex direction="row">
             <Box flex align="center" justify="center">
-              Dashboard content goes here
+              Dashboard content goes here, click on the notification icon
             </Box>
             <Collapsible direction="horizontal" open={openNotification}>
               <Box
@@ -188,7 +188,7 @@ class HorizontalCollapsible extends Component {
                 pad="small"
                 elevation="small"
               >
-                Sidebar
+                <Text size="xlarge">Sidebar</Text>
               </Box>
             </Collapsible>
           </Box>


### PR DESCRIPTION
Quick PR. I received some feedback today on not being able to customize `Accordion`, so I added a few examples to demonstrate the customization better. 

No need to mention in the release notes.
backward compatible.