### PR TITLE
Fix some typescript definitions

### DIFF
--- a/src/js/components/DropButton/index.d.ts
+++ b/src/js/components/DropButton/index.d.ts
@@ -2,11 +2,6 @@ import * as React from "react";
 import { ButtonProps } from "../Button";
 
 export interface DropButtonProps {
-  a11yTitle?: string;
-  alignSelf?: "start" | "center" | "end" | "stretch";
-  gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
-  disabled?: boolean;
   dropAlign?: {top?: "top" | "bottom",bottom?: "top" | "bottom",right?: "left" | "right",left?: "left" | "right"};
   dropContent: JSX.Element;
   dropTarget?: object;

--- a/src/js/components/RoutedAnchor/index.d.ts
+++ b/src/js/components/RoutedAnchor/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import AnchorProps from "../Anchor";
+import { AnchorProps } from "../Anchor";
 import { Omit } from "../../utils";
 
 export interface RoutedAnchorProps {

--- a/src/js/components/RoutedAnchor/index.d.ts
+++ b/src/js/components/RoutedAnchor/index.d.ts
@@ -1,10 +1,12 @@
 import * as React from "react";
+import AnchorProps from "../Anchor";
+import { Omit } from "../../utils";
 
 export interface RoutedAnchorProps {
   path: string;
   method?: "push" | "replace";
 }
 
-declare const RoutedAnchor: React.ComponentClass<RoutedAnchorProps & JSX.IntrinsicElements['a']>;
+declare const RoutedAnchor: React.ComponentClass<RoutedAnchorProps & Omit<AnchorProps, "href">>;
 
 export { RoutedAnchor };

--- a/src/js/components/RoutedButton/index.d.ts
+++ b/src/js/components/RoutedButton/index.d.ts
@@ -1,6 +1,5 @@
 import * as React from "react";
-
-import { ButtonProps  } from "../Button"
+import { ButtonProps } from "../Button"
 
 export interface RoutedButtonProps {
   path: string;

--- a/src/js/components/RoutedButton/index.d.ts
+++ b/src/js/components/RoutedButton/index.d.ts
@@ -1,10 +1,12 @@
 import * as React from "react";
 
+import { ButtonProps  } from "../Button"
+
 export interface RoutedButtonProps {
   path: string;
   method?: "push" | "replace";
 }
 
-declare const RoutedButton: React.ComponentClass<RoutedButtonProps & JSX.IntrinsicElements['button']>;
+declare const RoutedButton: React.ComponentClass<RoutedButtonProps & ButtonProps>;
 
 export { RoutedButton };


### PR DESCRIPTION
Routed* components can take props, that are not in `JSX.IntrinsicElements[...]`, but in appropriate underlaying components. E.g. Routed* components can take `margin` prop, but TS shows an error because of it. This PR fix it.

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fix TS definitions of RoutedAnchor and RoutedButton, also remove redundant properties from DropButton.

#### Where should the reviewer start?

Anywhere :)

#### What testing has been done on this PR?

I didn't test it, but it would be great, if you can tell me how test the types.

#### How should this be manually tested?

By using this components.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

It would be great :) 

#### Is this change backwards compatible or is it a breaking change?

Backward compatible and not change breaking.
