### PR TITLE
Improve fallback image

### DIFF
--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -447,7 +447,6 @@ exports[`Carousel basic 1`] = `
         >
           <img
             className=""
-            onError={[Function]}
             src="//v2.grommet.io/assets/IMG_4245.jpg"
           />
         </div>
@@ -464,7 +463,6 @@ exports[`Carousel basic 1`] = `
         >
           <img
             className=""
-            onError={[Function]}
             src="//v2.grommet.io/assets/IMG_4210.jpg"
           />
         </div>

--- a/src/js/components/Image/Image.js
+++ b/src/js/components/Image/Image.js
@@ -1,12 +1,21 @@
 import React, { useState } from 'react';
 import { StyledImage } from './StyledImage';
 
-const Image = ({ src, fallback, ...rest }) => {
+const Image = ({ src, fallback, onError, ...rest }) => {
   const [imageMissing, setImageMissing] = useState(false);
+  const handleError = event => {
+    if (onError) {
+      onError(event);
+    }
+    setImageMissing(true);
+  };
+  const extraProps = {
+    onError: (onError || fallback) && handleError,
+  };
   return (
     <StyledImage
       {...rest}
-      onError={() => setImageMissing(true)}
+      {...extraProps}
       src={!imageMissing ? src : fallback}
     />
   );

--- a/src/js/components/Image/__tests__/__snapshots__/Image-test.js.snap
+++ b/src/js/components/Image/__tests__/__snapshots__/Image-test.js.snap
@@ -32,12 +32,10 @@ exports[`Image fit renders 1`] = `
 >
   <img
     className="c1"
-    onError={[Function]}
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
   <img
     className="c2"
-    onError={[Function]}
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
 </div>
@@ -59,7 +57,6 @@ exports[`Image renders 1`] = `
 >
   <img
     className=""
-    onError={[Function]}
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
 </div>

--- a/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
+++ b/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
@@ -275,7 +275,6 @@ exports[`Markdown renders 1`] = `
       <img
         alt="alt text"
         className=""
-        onError={[Function]}
         src="//v2.grommet.io/assets/IMG_4245.jpg"
         title="Markdown Image"
       />


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Based on feedback on already merged PR i improve the fallback image so that user can also define their own onError handler

#### Where should the reviewer start?

#### What testing has been done on this PR?
storybook
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
compat