### PR TITLE
Added to maskedInput docs to contribute to issue #2690

### DIFF
--- a/src/js/components/MaskedInput/README.md
+++ b/src/js/components/MaskedInput/README.md
@@ -103,7 +103,7 @@ undefined
 
 **text.medium**
 
-The size of the text for the maskedInput. Expects `string`.
+The size of the text for MaskedInput.. Expects `string`.
 
 Defaults to
 

--- a/src/js/components/MaskedInput/README.md
+++ b/src/js/components/MaskedInput/README.md
@@ -91,6 +91,26 @@ input
 ```
 ## Theme
   
+**maskedInput.extend**
+
+Any additional style for MaskedInput. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```
+
+**text.medium**
+
+The size of the text for the maskedInput. Expects `string`.
+
+Defaults to
+
+```
+18px
+```
+
 **global.focus.border.color**
 
 The color around the component when in focus. Expects `string | { dark: string, light: string }`.

--- a/src/js/components/MaskedInput/README.md
+++ b/src/js/components/MaskedInput/README.md
@@ -103,7 +103,7 @@ undefined
 
 **text.medium**
 
-The size of the text for MaskedInput.. Expects `string`.
+The size of the text for MaskedInput. Expects `string`.
 
 Defaults to
 

--- a/src/js/components/MaskedInput/doc.js
+++ b/src/js/components/MaskedInput/doc.js
@@ -50,6 +50,16 @@ export const doc = MaskedInput => {
 };
 
 export const themeDoc = {
+  'maskedInput.extend': {
+    description: 'Any additional style for MaskedInput.',
+    type: 'string | (props) => {}',
+    defaultValue: undefined,
+  },
+  'text.medium': {
+    description: 'The size of the text for the maskedInput.',
+    type: 'string',
+    defaultValue: '18px',
+  },
   ...themeDocUtils.focusStyle,
   ...themeDocUtils.placeholderStyle,
   ...themeDocUtils.inputStyle,

--- a/src/js/components/MaskedInput/doc.js
+++ b/src/js/components/MaskedInput/doc.js
@@ -56,7 +56,7 @@ export const themeDoc = {
     defaultValue: undefined,
   },
   'text.medium': {
-    description: 'The size of the text for MaskedInput..',
+    description: 'The size of the text for MaskedInput.',
     type: 'string',
     defaultValue: '18px',
   },

--- a/src/js/components/MaskedInput/doc.js
+++ b/src/js/components/MaskedInput/doc.js
@@ -56,7 +56,7 @@ export const themeDoc = {
     defaultValue: undefined,
   },
   'text.medium': {
-    description: 'The size of the text for the maskedInput.',
+    description: 'The size of the text for MaskedInput..',
     type: 'string',
     defaultValue: '18px',
   },

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5720,7 +5720,7 @@ undefined
 
 **text.medium**
 
-The size of the text for the maskedInput. Expects \`string\`.
+The size of the text for MaskedInput.. Expects \`string\`.
 
 Defaults to
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5708,6 +5708,26 @@ input
 \`\`\`
 ## Theme
   
+**maskedInput.extend**
+
+Any additional style for MaskedInput. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**text.medium**
+
+The size of the text for the maskedInput. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+18px
+\`\`\`
+
 **global.focus.border.color**
 
 The color around the component when in focus. Expects \`string | { dark: string, light: string }\`.

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5720,7 +5720,7 @@ undefined
 
 **text.medium**
 
-The size of the text for MaskedInput.. Expects \`string\`.
+The size of the text for MaskedInput. Expects \`string\`.
 
 Defaults to
 

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -601,6 +601,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       responsiveBreakpoint: 'small', // when Layer takes over the full screen
       zIndex: '10',
     },
+    maskedInput: {
+      // extend: undefined,
+    },
     menu: {
       // background: undefined,
       // extend: undefined,


### PR DESCRIPTION
What does this PR do?
The PR adds the themes to the documentation for maskedInput

Where should the reviewer start?
MaskedInput/doc.js

What testing has been done on this PR?
How should this be manually tested?
Any background context you want to provide?
What are the relevant issues?
#2690

Screenshots (if appropriate)
Do the grommet docs need to be updated?
auto

Should this PR be mentioned in the release notes?
No

Is this change backwards compatible or is it a breaking change?
Backwards compatible