### PR TITLE
closes #2821 Text area and Text input docs

### DIFF
--- a/src/js/components/TextArea/README.md
+++ b/src/js/components/TextArea/README.md
@@ -95,7 +95,7 @@ textarea
   
 **global.colors.border**
 
-The color of the border. Expects `object`.
+The color of the border. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 

--- a/src/js/components/TextArea/README.md
+++ b/src/js/components/TextArea/README.md
@@ -93,6 +93,46 @@ textarea
 ```
 ## Theme
   
+**global.colors.border**
+
+The color of the border. Expects `object`.
+
+Defaults to
+
+```
+[object Object]
+```
+
+**global.control.border.color**
+
+The border color. Expects `string`.
+
+Defaults to
+
+```
+border
+```
+
+**global.control.border.radius**
+
+The border radius. Expects `string`.
+
+Defaults to
+
+```
+4px
+```
+
+**global.control.border.width**
+
+The border width. Expects `string`.
+
+Defaults to
+
+```
+1px
+```
+
 **textArea.extend**
 
 Any additional style for Text. Expects `string | (props) => {}`.
@@ -111,26 +151,6 @@ Defaults to
 
 ```
 0.3
-```
-
-**global.control.border**
-
-The border of the textarea. Expects `object`.
-
-Defaults to
-
-```
-[object Object]
-```
-
-**global.colors.border**
-
-The color of the borders Expects `object`.
-
-Defaults to
-
-```
-[object Object]
 ```
 
 **global.focus.border.color**

--- a/src/js/components/TextArea/doc.js
+++ b/src/js/components/TextArea/doc.js
@@ -46,7 +46,7 @@ Only use this when the containing context provides sufficient affordance.`,
 export const themeDoc = {
   'global.colors.border': {
     description: 'The color of the border.',
-    type: 'object',
+    type: 'string | { dark: string, light: string }',
     defaultValue: {
       dark: 'rgba(255, 255, 255, 0.33)',
       light: 'rgba(0, 0, 0, 0.33)',

--- a/src/js/components/TextArea/doc.js
+++ b/src/js/components/TextArea/doc.js
@@ -44,6 +44,29 @@ Only use this when the containing context provides sufficient affordance.`,
 };
 
 export const themeDoc = {
+  'global.colors.border': {
+    description: 'The color of the border.',
+    type: 'object',
+    defaultValue: {
+      dark: 'rgba(255, 255, 255, 0.33)',
+      light: 'rgba(0, 0, 0, 0.33)',
+    },
+  },
+  'global.control.border.color': {
+    description: 'The border color.',
+    type: 'string',
+    defaultValue: 'border',
+  },
+  'global.control.border.radius': {
+    description: 'The border radius.',
+    type: 'string',
+    defaultValue: '4px',
+  },
+  'global.control.border.width': {
+    description: 'The border width.',
+    type: 'string',
+    defaultValue: '1px',
+  },
   'textArea.extend': {
     description: 'Any additional style for Text.',
     type: 'string | (props) => {}',
@@ -53,23 +76,6 @@ export const themeDoc = {
     description: 'The opacity when the textArea is disabled.',
     type: 'number',
     defaultValue: 0.3,
-  },
-  'global.control.border': {
-    description: 'The border of the textarea.',
-    type: 'object',
-    defaultValue: {
-      width: '1px',
-      radius: '4px',
-      color: 'border',
-    },
-  },
-  'global.colors.border': {
-    description: 'The color of the borders',
-    type: 'object',
-    defaultValue: {
-      dark: 'rgba(255, 255, 255, 0.33)',
-      light: 'rgba(0, 0, 0, 0.33)',
-    },
   },
   ...themeDocUtils.focusStyle,
   ...themeDocUtils.placeholderStyle,

--- a/src/js/components/TextInput/README.md
+++ b/src/js/components/TextInput/README.md
@@ -194,6 +194,46 @@ input
 ```
 ## Theme
   
+**global.colors.border**
+
+The color of the border. Expects `object`.
+
+Defaults to
+
+```
+[object Object]
+```
+
+**global.control.border.color**
+
+The border color. Expects `string`.
+
+Defaults to
+
+```
+border
+```
+
+**global.control.border.radius**
+
+The border radius. Expects `string`.
+
+Defaults to
+
+```
+4px
+```
+
+**global.control.border.width**
+
+The border width. Expects `string`.
+
+Defaults to
+
+```
+1px
+```
+
 **select.step**
 
 How many suggestions to render at a time. Expects `number`.
@@ -277,26 +317,6 @@ Defaults to
 
 ```
 0.3
-```
-
-**global.control.border**
-
-The border of the input. Expects `object`.
-
-Defaults to
-
-```
-[object Object]
-```
-
-**global.colors.border**
-
-The color of the borders Expects `object`.
-
-Defaults to
-
-```
-[object Object]
 ```
 
 **global.focus.border.color**

--- a/src/js/components/TextInput/doc.js
+++ b/src/js/components/TextInput/doc.js
@@ -104,6 +104,29 @@ suggestions and instead rely on the user to type more.`,
 };
 
 export const themeDoc = {
+  'global.colors.border': {
+    description: 'The color of the border.',
+    type: 'object',
+    defaultValue: {
+      dark: 'rgba(255, 255, 255, 0.33)',
+      light: 'rgba(0, 0, 0, 0.33)',
+    },
+  },
+  'global.control.border.color': {
+    description: 'The border color.',
+    type: 'string',
+    defaultValue: 'border',
+  },
+  'global.control.border.radius': {
+    description: 'The border radius.',
+    type: 'string',
+    defaultValue: '4px',
+  },
+  'global.control.border.width': {
+    description: 'The border width.',
+    type: 'string',
+    defaultValue: '1px',
+  },
   'select.step': {
     description: 'How many suggestions to render at a time.',
     type: 'number',
@@ -159,23 +182,6 @@ export const themeDoc = {
     description: 'The opacity when the textInput is disabled.',
     type: 'number',
     defaultValue: 0.3,
-  },
-  'global.control.border': {
-    description: 'The border of the input.',
-    type: 'object',
-    defaultValue: {
-      width: '1px',
-      radius: '4px',
-      color: 'border',
-    },
-  },
-  'global.colors.border': {
-    description: 'The color of the borders',
-    type: 'object',
-    defaultValue: {
-      dark: 'rgba(255, 255, 255, 0.33)',
-      light: 'rgba(0, 0, 0, 0.33)',
-    },
   },
   ...themeDocUtils.focusStyle,
   ...themeDocUtils.placeholderStyle,

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -9070,7 +9070,7 @@ textarea
   
 **global.colors.border**
 
-The color of the border. Expects \`object\`.
+The color of the border. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -9068,6 +9068,46 @@ textarea
 \`\`\`
 ## Theme
   
+**global.colors.border**
+
+The color of the border. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+[object Object]
+\`\`\`
+
+**global.control.border.color**
+
+The border color. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+border
+\`\`\`
+
+**global.control.border.radius**
+
+The border radius. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+4px
+\`\`\`
+
+**global.control.border.width**
+
+The border width. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+1px
+\`\`\`
+
 **textArea.extend**
 
 Any additional style for Text. Expects \`string | (props) => {}\`.
@@ -9086,26 +9126,6 @@ Defaults to
 
 \`\`\`
 0.3
-\`\`\`
-
-**global.control.border**
-
-The border of the textarea. Expects \`object\`.
-
-Defaults to
-
-\`\`\`
-[object Object]
-\`\`\`
-
-**global.colors.border**
-
-The color of the borders Expects \`object\`.
-
-Defaults to
-
-\`\`\`
-[object Object]
 \`\`\`
 
 **global.focus.border.color**
@@ -9354,6 +9374,46 @@ input
 \`\`\`
 ## Theme
   
+**global.colors.border**
+
+The color of the border. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+[object Object]
+\`\`\`
+
+**global.control.border.color**
+
+The border color. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+border
+\`\`\`
+
+**global.control.border.radius**
+
+The border radius. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+4px
+\`\`\`
+
+**global.control.border.width**
+
+The border width. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+1px
+\`\`\`
+
 **select.step**
 
 How many suggestions to render at a time. Expects \`number\`.
@@ -9437,26 +9497,6 @@ Defaults to
 
 \`\`\`
 0.3
-\`\`\`
-
-**global.control.border**
-
-The border of the input. Expects \`object\`.
-
-Defaults to
-
-\`\`\`
-[object Object]
-\`\`\`
-
-**global.colors.border**
-
-The color of the borders Expects \`object\`.
-
-Defaults to
-
-\`\`\`
-[object Object]
 \`\`\`
 
 **global.focus.border.color**


### PR DESCRIPTION
What does this PR do?
Adds to textArea and textInput docs.

Where should the reviewer start?
textArea/docs.js and textInput/docs.js

What testing has been done on this PR?
None

What are the relevant issues?
#2821

Do the grommet docs need to be updated?
auto

Should this PR be mentioned in the release notes?
no

Is this change backwards compatible or is it a breaking change?
backwards compatible