### PR TITLE
Calendar - fix March daylight saving

### DIFF
--- a/src/js/components/Calendar/stories/DaylightSavings.js
+++ b/src/js/components/Calendar/stories/DaylightSavings.js
@@ -1,18 +1,44 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import { Box, Calendar, Grommet } from 'grommet';
+import { Box, Calendar, Grommet, Text } from 'grommet';
 import { grommet } from 'grommet/themes';
 
 // DSTCalendar has dates specifically chosen to identify issues with
 // crossing the daylight savings time boundary (from California).
 const DSTCalendar = () => (
   <Grommet theme={grommet}>
-    <Box align="center" pad="large">
-      <Calendar
-        date="2018-11-04T07:00:00.000Z"
-        bounds={['2013-11-06', '2018-12-06']}
-      />
+    <Box align="center" pad="large" direction="row" justify="center">
+      <Box align="center" pad="large" border="right">
+        <Text size="xlarge">Daylight MST</Text>
+        <Box align="center" pad={{ vertical: 'medium' }}>
+          <Calendar
+            date="2018-11-04T06:00:00.000Z"
+            bounds={['2013-11-06', '2018-12-06']}
+          />
+        </Box>
+        <Box align="center" pad={{ vertical: 'medium' }}>
+          <Calendar
+            date="2019-03-11T05:00:01.409Z"
+            bounds={['2019-03-01', '2019-03-31']}
+          />
+        </Box>
+      </Box>
+      <Box align="center" pad="large">
+        <Text size="xlarge">Daylight PST</Text>
+        <Box align="center" pad={{ vertical: 'medium' }}>
+          <Calendar
+            date="2018-11-04T07:00:00.000Z"
+            bounds={['2013-11-06', '2018-12-06']}
+          />
+        </Box>
+        <Box align="center" pad={{ vertical: 'medium' }}>
+          <Calendar
+            date="2019-03-15T06:00:01.409Z"
+            bounds={['2019-03-01', '2019-03-31']}
+          />
+        </Box>
+      </Box>
     </Box>
   </Grommet>
 );

--- a/src/js/components/Calendar/stories/Simple.js
+++ b/src/js/components/Calendar/stories/Simple.js
@@ -21,7 +21,7 @@ class SimpleCalendar extends Component {
             date={date}
             onSelect={this.onSelect}
             size="small"
-            bounds={['2018-09-08', '2018-12-13']}
+            bounds={['2018-09-08', '2020-12-13']}
           />
         </Box>
         <Box align="center" pad="large">
@@ -30,7 +30,7 @@ class SimpleCalendar extends Component {
             daysOfWeek
             onSelect={this.onSelect}
             size="small"
-            bounds={['2018-09-08', '2018-12-13']}
+            bounds={['2018-09-08', '2020-12-13']}
           />
         </Box>
       </Grommet>

--- a/src/js/components/Calendar/utils.js
+++ b/src/js/components/Calendar/utils.js
@@ -9,10 +9,12 @@ export const addDays = (date, days) => {
   // where adding a day's worth when the time is midnight results in
   // being a day off.
   let hourDelta = result.getHours() - date.getHours();
-  // At this point, hourDelta is typically 1 or 23, depending on which
-  // side of the switch we are on. Convert so that hourDelta is either +1 or -1.
-  if (hourDelta > 12) {
+  // At this point, hourDelta is typically 0 (normal day), +23 (November daylight saving), or -23 (March Daylight saving)
+  // depending on which side of the switch we are on. Convert so that hourDelta is either +1 or -1.
+  if (hourDelta === 23) {
     hourDelta -= 24;
+  } else if (hourDelta === -23) {
+    hourDelta += 24;
   }
   result.setHours(result.getHours() - hourDelta);
   return result;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
polish the date calculation during the daylight saving periods
#### Where should the reviewer start?
src/js/components/Calendar/utils.js
#### What testing has been done on this PR?
src/js/components/Calendar/stories/DaylightSavings.js
#### How should this be manually tested?
src/js/components/Calendar/stories/DaylightSavings.js
and storybook Calendar
#### Any background context you want to provide?
I added stories for both PST and MST so it will be easy for either of us to reproduce the issues and notice if a regression occur.
#### What are the relevant issues?
#2931 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible