### PR TITLE
Revert Box architecture refactoring to fix Parcel build

### DIFF
--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -1,19 +1,14 @@
 import React, { Children, Component } from 'react';
 import { compose } from 'recompose';
 
-import { withForwardRef, withDocs } from '../hocs';
+import { withForwardRef, withTheme } from '../hocs';
 import { ThemeContext } from '../../contexts';
 import { defaultProps } from '../../default-props';
 import { backgroundIsDark } from '../../utils';
 
 import { StyledBox, StyledBoxGap } from './StyledBox';
 
-const wrapWithHocs = compose(
-  withForwardRef,
-  withDocs('Box'),
-);
-
-class BoxImpl extends Component {
+class Box extends Component {
   static contextType = ThemeContext;
 
   static displayName = 'Box';
@@ -110,6 +105,15 @@ class BoxImpl extends Component {
   }
 }
 
-Object.setPrototypeOf(BoxImpl.defaultProps, defaultProps);
+Object.setPrototypeOf(Box.defaultProps, defaultProps);
 
-export const Box = wrapWithHocs(BoxImpl);
+let BoxDoc;
+if (process.env.NODE_ENV !== 'production') {
+  BoxDoc = require('./doc').doc(Box); // eslint-disable-line global-require
+}
+const BoxWrapper = compose(
+  withTheme,
+  withForwardRef,
+)(BoxDoc || Box);
+
+export { BoxWrapper as Box };

--- a/src/js/components/Grommet/Grommet.js
+++ b/src/js/components/Grommet/Grommet.js
@@ -2,22 +2,16 @@ import React, { Component } from 'react';
 import { createGlobalStyle } from 'styled-components';
 
 import { colorIsDark } from 'grommet-styles';
-
 import { ResponsiveContext, ThemeContext } from '../../contexts';
 import { deepMerge, getBreakpoint, getDeviceBreakpoint } from '../../utils';
 import { base as baseTheme } from '../../themes';
-
-import { withDocs } from '../hocs';
-
 import { StyledGrommet } from './StyledGrommet';
-
-const wrapWithHocs = withDocs('Grommet');
 
 const FullGlobalStyle = createGlobalStyle`
   body { margin: 0; }
 `;
 
-class GrommetImpl extends Component {
+class Grommet extends Component {
   static displayName = 'Grommet';
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -113,4 +107,10 @@ class GrommetImpl extends Component {
   }
 }
 
-export const Grommet = wrapWithHocs(GrommetImpl);
+let GrommetDoc;
+if (process.env.NODE_ENV !== 'production') {
+  GrommetDoc = require('./doc').doc(Grommet); // eslint-disable-line global-require
+}
+const GrommetWrapper = GrommetDoc || Grommet;
+
+export { GrommetWrapper as Grommet };

--- a/src/js/components/hocs.js
+++ b/src/js/components/hocs.js
@@ -5,15 +5,6 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import { withTheme } from 'styled-components';
 import { AnnounceContext } from '../contexts';
 
-let doc = () => x => x;
-
-// Do not use the documentation wrapper in production.
-if (process.env.NODE_ENV !== 'production') {
-  doc = component => require(`./${component}/doc`).doc; // eslint-disable-line
-}
-
-export const withDocs = doc;
-
 export const withFocus = ({ focusWithMouse } = {}) => WrappedComponent => {
   class FocusableComponent extends Component {
     static getDerivedStateFromProps(nextProps, prevState) {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Basically reverts changes to the way we are building docs in the rest of grommet for consistency and to fix parcel builds
#### Where should the reviewer start?

#### What testing has been done on this PR?
just a yarn build. i just reverted manually the following commit https://github.com/grommet/grommet/pull/2528
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
#2618 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
compatible