### PR TITLE
add heading customization in accordion theme

### DIFF
--- a/src/js/components/Accordion/__tests__/Accordion-test.js
+++ b/src/js/components/Accordion/__tests__/Accordion-test.js
@@ -5,6 +5,12 @@ import { cleanup, render, fireEvent } from 'react-testing-library';
 
 import { Accordion, AccordionPanel, Box, Grommet } from '../..';
 
+const customTheme = {
+  accordion: {
+    heading: { level: '3' },
+  },
+};
+
 describe('Accordion', () => {
   afterEach(cleanup);
 
@@ -139,6 +145,17 @@ describe('Accordion', () => {
     expect(onActive).toBeCalledWith([]);
 
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('custom accordion', () => {
+    const component = renderer.create(
+      <Grommet theme={customTheme}>
+        <Accordion>
+          <AccordionPanel label="Panel 1">Panel body 1</AccordionPanel>
+        </Accordion>
+      </Grommet>,
+    );
+    expect(component.toJSON()).toMatchSnapshot();
   });
 
   test('change active index', () => {

--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -2504,6 +2504,354 @@ exports[`Accordion complex title 1`] = `
 </div>
 `;
 
+exports[`Accordion custom accordion 1`] = `
+.c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding: 0px;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0px;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c10 {
+  max-height: 0;
+  visibility: hidden;
+  overflow: hidden;
+}
+
+.c6 {
+  font-size: 26px;
+  line-height: 32px;
+  max-width: 624px;
+  font-weight: 600;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 3px;
+    padding-right: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+    role="tablist"
+  >
+    <div
+      className="c2"
+    >
+      <button
+        aria-expanded={false}
+        aria-selected={false}
+        className="c3"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+        role="tab"
+        type="button"
+      >
+        <div
+          className="c4"
+        >
+          <div
+            className="c5"
+          >
+            <h3
+              className="c6"
+            >
+              Panel 1
+            </h3>
+          </div>
+          <div
+            className="c7"
+          >
+            <svg
+              aria-label="FormDown"
+              className="c8"
+              viewBox="0 0 24 24"
+            >
+              <polyline
+                fill="none"
+                points="18 9 12 15 6 9"
+                stroke="#000"
+                strokeWidth="2"
+              />
+            </svg>
+          </div>
+        </div>
+      </button>
+      <div
+        className="c9"
+      >
+        <div
+          aria-hidden={true}
+          className="c10 c1"
+          open={false}
+        >
+          Panel body 1
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Accordion multiple panels 1`] = `
 .c8 {
   display: inline-block;

--- a/src/js/components/Accordion/stories/Custom.js
+++ b/src/js/components/Accordion/stories/Custom.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { SubtractCircle, AddCircle } from 'grommet-icons';
+
+import { Accordion, AccordionPanel, Box, Grommet, Text } from 'grommet';
+
+const CustomAccordionTheme = {
+  accordion: {
+    heading: { level: '3' },
+    icons: {
+      collapse: SubtractCircle,
+      expand: AddCircle,
+      color: 'hotpink',
+    },
+    border: undefined,
+  },
+};
+
+const CustomAccordion = ({ animate, multiple, ...rest }) => (
+  <Grommet theme={CustomAccordionTheme}>
+    <Box {...rest} pad="large" align="center" justify="center">
+      <Accordion animate={animate} multiple>
+        <AccordionPanel
+          label={<Text size="large">Panel 1 - uses large Text size</Text>}
+        >
+          <Box background="light-2" height="small">
+            Important Info
+          </Box>
+        </AccordionPanel>
+        <AccordionPanel
+          label={
+            <Text size="xlarge" margin="vertical">
+              Panel 2 - uses xlarge Text size
+            </Text>
+          }
+        >
+          <Box background="light-2" height="xsmall">
+            <Text size="small">Important Info</Text>
+          </Box>
+        </AccordionPanel>
+        <AccordionPanel label="Panel 3 - uses custom theme heading level for sizing">
+          <Box background="light-2" height="xsmall">
+            <Text size="small">Important Info</Text>
+          </Box>
+        </AccordionPanel>
+      </Accordion>
+    </Box>
+  </Grommet>
+);
+
+storiesOf('Accordion', module).add('Custom', () => <CustomAccordion />);

--- a/src/js/components/Accordion/stories/CustomHeader.js
+++ b/src/js/components/Accordion/stories/CustomHeader.js
@@ -1,0 +1,68 @@
+import React, { Component } from 'react';
+import { storiesOf } from '@storybook/react';
+
+import {
+  Accordion,
+  AccordionPanel,
+  Box,
+  Grommet,
+  Text,
+  TextInput,
+} from 'grommet';
+import { grommet } from 'grommet/themes';
+
+const renderPanelHeader = (title, active) => (
+  <Box direction="row" align="center" pad="medium" gap="small">
+    <strong>
+      <Text>{title}</Text>
+    </strong>
+    <Text color="brand">{active ? '-' : '+'}</Text>
+  </Box>
+);
+
+class CustomHeaderAccordion extends Component {
+  state = {
+    activeIndex: [0],
+  };
+
+  render() {
+    const { activeIndex } = this.state;
+    return (
+      <Grommet theme={grommet}>
+        <Accordion
+          activeIndex={activeIndex}
+          onActive={newActiveIndex =>
+            this.setState({ activeIndex: newActiveIndex })
+          }
+        >
+          <AccordionPanel
+            header={renderPanelHeader('Panel 1', activeIndex.includes(0))}
+          >
+            <Box pad="medium" background="light-2" style={{ height: '800px' }}>
+              <Text>Panel 1 contents</Text>
+              <TextInput />
+            </Box>
+          </AccordionPanel>
+          <AccordionPanel
+            header={renderPanelHeader('Panel 2', activeIndex.includes(1))}
+          >
+            <Box pad="medium" background="light-2" style={{ height: '50px' }}>
+              <Text>Panel 2 contents</Text>
+            </Box>
+          </AccordionPanel>
+          <AccordionPanel
+            header={renderPanelHeader('Panel 3', activeIndex.includes(2))}
+          >
+            <Box pad="medium" background="light-2" style={{ height: '300px' }}>
+              <Text>Panel 3 contents</Text>
+            </Box>
+          </AccordionPanel>
+        </Accordion>
+      </Grommet>
+    );
+  }
+}
+
+storiesOf('Accordion', module).add('Custom Header', () => (
+  <CustomHeaderAccordion />
+));

--- a/src/js/components/Accordion/stories/Rich.js
+++ b/src/js/components/Accordion/stories/Rich.js
@@ -6,8 +6,6 @@ import {
   CircleInformation,
   FormSubtract,
   FormAdd,
-  SubtractCircle,
-  AddCircle,
   User,
 } from 'grommet-icons';
 
@@ -18,7 +16,6 @@ import {
   Grommet,
   Heading,
   Text,
-  TextInput,
   ThemeContext,
 } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -31,65 +28,6 @@ const richAccordionTheme = {
     },
   },
 };
-
-const CustomAccordionTheme = {
-  accordion: {
-    icons: {
-      collapse: SubtractCircle,
-      expand: AddCircle,
-      color: 'hotpink',
-    },
-    border: undefined,
-  },
-};
-
-const SimpleAccordion = props => {
-  const { animate, multiple, ...rest } = props;
-  return (
-    <Grommet theme={grommet}>
-      <Box {...rest}>
-        <Accordion animate={animate} multiple={multiple}>
-          <AccordionPanel label="Panel 1">
-            <Box background="light-2" overflow="auto" height="medium">
-              <Box height="large" flex={false}>
-                Panel 1 contents
-              </Box>
-            </Box>
-          </AccordionPanel>
-          <AccordionPanel label="Panel 2">
-            <Box background="light-2" style={{ height: '50px' }}>
-              Panel 2 contents
-            </Box>
-          </AccordionPanel>
-          <AccordionPanel label="Panel 3">
-            <Box background="light-2" style={{ height: '300px' }}>
-              Panel 3 contents
-            </Box>
-          </AccordionPanel>
-        </Accordion>
-      </Box>
-    </Grommet>
-  );
-};
-
-const CustomAccordion = ({ animate, multiple, ...rest }) => (
-  <Grommet theme={CustomAccordionTheme}>
-    <Box {...rest}>
-      <Accordion animate={animate} multiple>
-        <AccordionPanel label={<Text size="large">Panel 1</Text>}>
-          <Box background="light-2" height="small">
-            Important Info
-          </Box>
-        </AccordionPanel>
-        <AccordionPanel label={<Text size="medium">Panel 2</Text>}>
-          <Box background="light-2" height="xsmall">
-            <Text size="small">Important Info</Text>
-          </Box>
-        </AccordionPanel>
-      </Accordion>
-    </Box>
-  </Grommet>
-);
 
 class RichPanel extends Component {
   state = {
@@ -326,64 +264,4 @@ class RichAccordion extends Component {
   }
 }
 
-const renderPanelHeader = (title, active) => (
-  <Box direction="row" align="center" pad="medium" gap="small">
-    <strong>
-      <Text>{title}</Text>
-    </strong>
-    <Text color="brand">{active ? '-' : '+'}</Text>
-  </Box>
-);
-
-class CustomHeaderAccordion extends Component {
-  state = {
-    activeIndex: [0],
-  };
-
-  render() {
-    const { activeIndex } = this.state;
-    return (
-      <Grommet theme={grommet}>
-        <Accordion
-          activeIndex={activeIndex}
-          onActive={newActiveIndex =>
-            this.setState({ activeIndex: newActiveIndex })
-          }
-        >
-          <AccordionPanel
-            header={renderPanelHeader('Panel 1', activeIndex.includes(0))}
-          >
-            <Box pad="medium" background="light-2" style={{ height: '800px' }}>
-              <Text>Panel 1 contents</Text>
-              <TextInput />
-            </Box>
-          </AccordionPanel>
-          <AccordionPanel
-            header={renderPanelHeader('Panel 2', activeIndex.includes(1))}
-          >
-            <Box pad="medium" background="light-2" style={{ height: '50px' }}>
-              <Text>Panel 2 contents</Text>
-            </Box>
-          </AccordionPanel>
-          <AccordionPanel
-            header={renderPanelHeader('Panel 3', activeIndex.includes(2))}
-          >
-            <Box pad="medium" background="light-2" style={{ height: '300px' }}>
-              <Text>Panel 3 contents</Text>
-            </Box>
-          </AccordionPanel>
-        </Accordion>
-      </Grommet>
-    );
-  }
-}
-
-storiesOf('Accordion', module)
-  .add('Simple', () => <SimpleAccordion />)
-  .add('Custom Theme', () => <CustomAccordion />)
-  .add('Dark no animation', () => (
-    <SimpleAccordion animate={false} background="dark-2" />
-  ))
-  .add('Multiple', () => <SimpleAccordion multiple />)
-  .add('Rich', () => <RichAccordion />)
-  .add('Custom Header', () => <CustomHeaderAccordion />);
+storiesOf('Accordion', module).add('Rich', () => <RichAccordion />);

--- a/src/js/components/Accordion/stories/Simple.js
+++ b/src/js/components/Accordion/stories/Simple.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { Accordion, AccordionPanel, Box, Grommet } from 'grommet';
+import { grommet } from 'grommet/themes';
+
+const SimpleAccordion = props => {
+  const { animate, multiple, ...rest } = props;
+  return (
+    <Grommet theme={grommet}>
+      <Box {...rest}>
+        <Accordion animate={animate} multiple={multiple}>
+          <AccordionPanel label="Panel 1">
+            <Box background="light-2" overflow="auto" height="medium">
+              <Box height="large" flex={false}>
+                Panel 1 contents
+              </Box>
+            </Box>
+          </AccordionPanel>
+          <AccordionPanel label="Panel 2">
+            <Box background="light-2" style={{ height: '50px' }}>
+              Panel 2 contents
+            </Box>
+          </AccordionPanel>
+          <AccordionPanel label="Panel 3">
+            <Box background="light-2" style={{ height: '300px' }}>
+              Panel 3 contents
+            </Box>
+          </AccordionPanel>
+        </Accordion>
+      </Box>
+    </Grommet>
+  );
+};
+
+storiesOf('Accordion', module)
+  .add('Simple', () => <SimpleAccordion />)
+  .add('Dark no animation', () => (
+    <SimpleAccordion animate={false} background="dark-2" />
+  ))
+  .add('Multiple', () => <SimpleAccordion multiple />);

--- a/src/js/components/AccordionPanel/AccordionPanel.js
+++ b/src/js/components/AccordionPanel/AccordionPanel.js
@@ -105,7 +105,14 @@ class AccordionPanel extends Component {
                   >
                     {typeof label === 'string' ? (
                       <Box pad={{ horizontal: 'xsmall' }}>
-                        <Heading level={4} color={hover}>
+                        <Heading
+                          level={
+                            (theme.accordion.heading &&
+                              theme.accordion.heading.level) ||
+                            4
+                          }
+                          color={hover}
+                        >
                           {label}
                         </Heading>
                       </Box>

--- a/src/js/components/AccordionPanel/README.md
+++ b/src/js/components/AccordionPanel/README.md
@@ -28,6 +28,16 @@ div
 ```
 ## Theme
   
+**accordion.heading.level**
+
+The heading level used for the accordion. Expects `number`.
+
+Defaults to
+
+```
+4
+```
+
 **accordion.icons.collapse**
 
 The icon to use when the panel is expanded. Expects `React.Element`.

--- a/src/js/components/AccordionPanel/doc.js
+++ b/src/js/components/AccordionPanel/doc.js
@@ -16,6 +16,11 @@ export function doc(Panel) {
 }
 
 export const themeDoc = {
+  'accordion.heading.level': {
+    description: 'The heading level used for the accordion.',
+    type: 'number',
+    defaultValue: '4',
+  },
   'accordion.icons.collapse': {
     description: 'The icon to use when the panel is expanded.',
     type: 'React.Element',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -205,6 +205,16 @@ div
 \`\`\`
 ## Theme
   
+**accordion.heading.level**
+
+The heading level used for the accordion. Expects \`number\`.
+
+Defaults to
+
+\`\`\`
+4
+\`\`\`
+
 **accordion.icons.collapse**
 
 The icon to use when the panel is expanded. Expects \`React.Element\`.

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -260,14 +260,15 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
     },
     accordion: {
+      border: {
+        side: 'bottom',
+        color: 'border',
+      },
+      heading: { level: '4' }, // level ranges from 1-6
       icons: {
         collapse: FormUp,
         expand: FormDown,
         // color: { dark: undefined, light: undefined },
-      },
-      border: {
-        side: 'bottom',
-        color: 'border',
       },
     },
     anchor: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
allows the user to customize the heading level in Accordion.
#### Where should the reviewer start?
doc.js
#### What testing has been done on this PR?
storybook, specifically the Custom story in Accordion
#### How should this be manually tested?
storybook, specifically the Custom story in Accordion
#### Any background context you want to provide?
no ability to customize Accordions cross-app
#### What are the relevant issues?
#2894 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible