### PR TITLE
Fix custom rangeInput on Edge

### DIFF
--- a/src/js/components/RangeInput/rangeinput.stories.js
+++ b/src/js/components/RangeInput/rangeinput.stories.js
@@ -51,7 +51,7 @@ class CustomRangeInput extends Component {
       <Grommet theme={customThemeRangeInput}>
         <Box direction="row" align="center" pad="large" gap="small">
           <Volume color="neutral-2" />
-          <Box align="center">
+          <Box align="center" width="small">
             <RangeInput
               min={0}
               max={1}

--- a/src/js/components/RangeInput/rangeinput.stories.js
+++ b/src/js/components/RangeInput/rangeinput.stories.js
@@ -67,5 +67,5 @@ class CustomRangeInput extends Component {
 }
 
 storiesOf('RangeInput', module)
-  .add('Simple RangeInput', () => <SimpleRangeInput />)
-  .add('Custom RangeInput', () => <CustomRangeInput />);
+  .add('Simple', () => <SimpleRangeInput />)
+  .add('Custom', () => <CustomRangeInput />);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
adding an explicit width to Box
#### Where should the reviewer start?
the story 
#### What testing has been done on this PR?
browserstack Edge browser for Custom RangeInput storybook
#### How should this be manually tested?
using Edge browser for Custom RangeInput storybook
#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/2955
#### Screenshots (if appropriate)
![Screen Shot 2019-03-20 at 7 27 20 PM](https://user-images.githubusercontent.com/6320236/54728945-3aee4b00-4b46-11e9-84b6-69919cd3a0d2.png)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible