### PR TITLE
Fixed optional drop props being treated as required.

### DIFF
--- a/src/js/components/DropButton/index.d.ts
+++ b/src/js/components/DropButton/index.d.ts
@@ -6,7 +6,7 @@ export interface DropButtonProps {
   dropAlign?: {top?: "top" | "bottom",bottom?: "top" | "bottom",right?: "left" | "right",left?: "left" | "right"};
   dropContent: JSX.Element;
   dropTarget?: object;
-  dropProps: DropProps;
+  dropProps?: DropProps;
   onClose?: ((...args: any[]) => any);
   onOpen?: ((...args: any[]) => any);
   open?: boolean;

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -10,7 +10,7 @@ export interface MenuProps {
   dropAlign?: {top?: "top" | "bottom",bottom?: "top" | "bottom",left?: "right" | "left",right?: "right" | "left"};
   dropBackground?: string | {color?: string,opacity?: "weak" | "medium" | "strong" | boolean};
   dropTarget?: object;
-  dropProps: DropProps;
+  dropProps?: DropProps;
   justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
   icon?: boolean | React.ReactNode;
   items: object[];

--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -13,7 +13,7 @@ export interface SelectProps {
   dropAlign?: {top?: "top" | "bottom",bottom?: "top" | "bottom",right?: "left" | "right",left?: "left" | "right"};
   dropHeight?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   dropTarget?: object;
-  dropProps: DropProps;
+  dropProps?: DropProps;
   focusIndicator?: boolean;
   icon?: boolean | ((...args: any[]) => any);
   id?: string;

--- a/src/js/components/TextInput/index.d.ts
+++ b/src/js/components/TextInput/index.d.ts
@@ -6,7 +6,7 @@ export interface TextInputProps {
   dropAlign?: {top?: "top" | "bottom",bottom?: "top" | "bottom",right?: "left" | "right",left?: "left" | "right"};
   dropHeight?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   dropTarget?: object;
-  dropProps: DropProps;
+  dropProps?: DropProps;
   id?: string;
   focusIndicator?: boolean;
   messages?: {enterSelect?: string,suggestionsCount?: string,suggestionsExist?: string,suggestionIsOpen?: string};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
we probably we want to release a hot fix for this ASAP
#### What does this PR do?
by mistake our definitions shipped with dropProps being listed as required.
#### Where should the reviewer start?
index.d.ts for dropProps
#### What testing has been done on this PR?
manual
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards