### PR TITLE
fixes button extend

### DIFF
--- a/src/js/components/RangeSelector/README.md
+++ b/src/js/components/RangeSelector/README.md
@@ -211,7 +211,7 @@ light-4
 
 **rangeSelector.edge.type**
 
-The edge style type. Expects `string`.
+The edge style type. Expects `'bar' | 'disc'`.
 
 Defaults to
 

--- a/src/js/components/RangeSelector/doc.js
+++ b/src/js/components/RangeSelector/doc.js
@@ -117,7 +117,7 @@ export const themeDoc = {
   },
   'rangeSelector.edge.type': {
     description: 'The edge style type.',
-    type: 'string',
+    type: "'bar' | 'disc'",
     defaultValue: undefined,
   },
   'global.spacing': {

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -7362,7 +7362,7 @@ light-4
 
 **rangeSelector.edge.type**
 
-The edge style type. Expects \`string\`.
+The edge style type. Expects \`'bar' | 'disc'\`.
 
 Defaults to
 

--- a/src/js/themes/grommet.js
+++ b/src/js/themes/grommet.js
@@ -14,7 +14,7 @@ export const grommet = deepFreeze({
   },
   button: {
     extend: css`
-      ${props => !props.plain && 'font-weight: bold;'};
+      ${props => !props.plain && 'font-weight: bold;'}
     `,
   },
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
* fixes button.extend on grommet theme
* showing the type options of the ThemeProps in RangeSelector
#### Where should the reviewer start?
themes/grommet.js

#### How should this be manually tested?
with grommet-site

#### Screenshots (if appropriate)
![Screen Shot 2019-03-22 at 3 11 54 PM](https://user-images.githubusercontent.com/6320236/54854597-0f3fa200-4cb9-11e9-9b74-b65bf89622fe.png)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible