### PR TITLE
Don't publish tests on npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,9 @@ jobs:
           name: Authenticate with registry
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/grommet-ci/dist/.npmrc
       - run:
+          name: Add npmignore
+          command: echo "**/__tests__/**" > ~/grommet-ci/dist/.npmignore
+      - run:
           name: Publish package
           command: cd dist && npm publish
 workflows:


### PR DESCRIPTION
So i got curious by the CircleCI logs and looked that in dist we have tests even if we have the ignore option. Due to https://github.com/babel/babel/issues/6226

Stats:

\ | With npmignore | without npmignore
----------- | ------------ | -------------
packed | 940kb | 3mb
unpacked| 4.5mb | 10mb


Not sure if this is the correct path forward though since the latest build on github has the tests. 

A way to fix both would be to make a script to remove tests.. maybe rimraf can delete based on pattern.

Left the --ignore in package.json so that babel doesn't process these files. should be a bit faster.