### PR TITLE
Document formfield prop forwarding

### DIFF
--- a/src/js/components/FormField/README.md
+++ b/src/js/components/FormField/README.md
@@ -15,7 +15,7 @@ import { FormField } from 'grommet';
 
 **component**
 
-The component to insert in the FormField. Grommet will add update the form values when this field changes
+The component to insert in the FormField. Grommet will add update the form values when this field changes. Any additional properties (such as initial value) you pass to FormField will be forwarded to this component.
 
 ```
 function

--- a/src/js/components/FormField/doc.js
+++ b/src/js/components/FormField/doc.js
@@ -18,7 +18,7 @@ export const doc = FormField => {
 
   DocumentedFormField.propTypes = {
     component: PropTypes.func.description(
-      `The component to insert in the FormField. Grommet will add update the form values when this field changes`,
+      `The component to insert in the FormField. Grommet will add update the form values when this field changes. Any additional properties (such as initial value) you pass to FormField will be forwarded to this component.`,
     ),
     error: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).description(
       'Any error text describing issues with the field',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4316,7 +4316,7 @@ import { FormField } from 'grommet';
 
 **component**
 
-The component to insert in the FormField. Grommet will add update the form values when this field changes
+The component to insert in the FormField. Grommet will add update the form values when this field changes. Any additional properties (such as initial value) you pass to FormField will be forwarded to this component.
 
 \`\`\`
 function

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1885,7 +1885,7 @@ string",
     "name": "FormField",
     "properties": Array [
       Object {
-        "description": "The component to insert in the FormField. Grommet will add update the form values when this field changes",
+        "description": "The component to insert in the FormField. Grommet will add update the form values when this field changes. Any additional properties (such as initial value) you pass to FormField will be forwarded to this component.",
         "format": "function",
         "name": "component",
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Mentions in documentation that formfield forwards additional properties to the component
#### Where should the reviewer start?
doc.js
#### What testing has been done on this PR?
none
#### How should this be manually tested?
no
#### Any background context you want to provide?

#### What are the relevant issues?
#2937 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
yes