### PR TITLE
Add wrap-reverse flex support

### DIFF
--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -576,8 +576,7 @@ string
 
 **wrap**
 
-Whether children can wrap if they
-      can't all fit.
+Controls the wrap property of the flexbox
 
 ```
 boolean

--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -576,13 +576,11 @@ string
 
 **wrap**
 
-Controls the wrap property of the flexbox
+Whether children can wrap if they can't all fit.
 
 ```
 boolean
-wrap
-nowrap
-wrap-reverse
+reverse
 ```
   
 ## Intrinsic element

--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -580,6 +580,9 @@ Controls the wrap property of the flexbox
 
 ```
 boolean
+wrap
+nowrap
+wrap-reverse
 ```
   
 ## Intrinsic element

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -146,7 +146,9 @@ const justifyStyle = css`
   justify-content: ${props => JUSTIFY_MAP[props.justify]};
 `;
 
-const wrapStyle = 'flex-wrap: wrap;';
+const wrapStyle = css`
+  flex-wrap: ${props => (props.wrapProp === true ? 'wrap' : props.wrapProp)};
+`;
 
 const borderStyle = (data, responsive, theme) => {
   const styles = [];

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -146,8 +146,13 @@ const justifyStyle = css`
   justify-content: ${props => JUSTIFY_MAP[props.justify]};
 `;
 
+const WRAP_MAP = {
+  true: 'wrap',
+  reverse: 'wrap-reverse',
+};
+
 const wrapStyle = css`
-  flex-wrap: ${props => (props.wrapProp === true ? 'wrap' : 'wrap-reverse')};
+  flex-wrap: ${props => WRAP_MAP[props.wrapProp]};
 `;
 
 const borderStyle = (data, responsive, theme) => {

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -147,7 +147,7 @@ const justifyStyle = css`
 `;
 
 const wrapStyle = css`
-  flex-wrap: ${props => (props.wrapProp === true ? 'wrap' : props.wrapProp)};
+  flex-wrap: ${props => (props.wrapProp === true ? 'wrap' : 'wrap-reverse')};
 `;
 
 const borderStyle = (data, responsive, theme) => {

--- a/src/js/components/Box/__tests__/Box-test.js
+++ b/src/js/components/Box/__tests__/Box-test.js
@@ -44,8 +44,9 @@ describe('Box', () => {
   test('wrap', () => {
     const component = renderer.create(
       <Grommet>
-        <Box wrap />
-        <Box wrap={false} />
+        {[true, false, 'wrap', 'nowrap', 'wrap-reverse'].map(wrap => (
+          <Box wrap={wrap} />
+        ))}
       </Grommet>,
     );
     const tree = component.toJSON();

--- a/src/js/components/Box/__tests__/Box-test.js
+++ b/src/js/components/Box/__tests__/Box-test.js
@@ -44,8 +44,8 @@ describe('Box', () => {
   test('wrap', () => {
     const component = renderer.create(
       <Grommet>
-        {[true, false, 'wrap', 'nowrap', 'wrap-reverse'].map(wrap => (
-          <Box wrap={wrap} />
+        {[true, false, 'reverse'].map(wrap => (
+          <Box key={`${wrap}`} wrap={wrap} />
         ))}
       </Grommet>,
     );

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -5896,6 +5896,46 @@ exports[`Box wrap 1`] = `
   flex-wrap: wrap;
 }
 
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+  -webkit-flex-wrap: wrap-reverse;
+  -ms-flex-wrap: wrap-reverse;
+  flex-wrap: wrap-reverse;
+}
+
 @media only screen and (max-width:768px) {
   .c2 {
     margin: 0px;
@@ -5916,6 +5956,30 @@ exports[`Box wrap 1`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
     padding: 0px;
   }
 }
@@ -5928,6 +5992,15 @@ exports[`Box wrap 1`] = `
   />
   <div
     className="c2"
+  />
+  <div
+    className="c1"
+  />
+  <div
+    className="c3"
+  />
+  <div
+    className="c4"
   />
 </div>
 `;

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -5911,26 +5911,6 @@ exports[`Box wrap 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 0px;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  outline: none;
-  max-width: 100%;
-  margin: 0px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding: 0px;
   -webkit-flex-wrap: wrap-reverse;
   -ms-flex-wrap: wrap-reverse;
   flex-wrap: wrap-reverse;
@@ -5972,18 +5952,6 @@ exports[`Box wrap 1`] = `
   }
 }
 
-@media only screen and (max-width:768px) {
-  .c4 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c4 {
-    padding: 0px;
-  }
-}
-
 <div
   className="c0"
 >
@@ -5994,13 +5962,7 @@ exports[`Box wrap 1`] = `
     className="c2"
   />
   <div
-    className="c1"
-  />
-  <div
     className="c3"
-  />
-  <div
-    className="c4"
   />
 </div>
 `;

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -317,11 +317,8 @@ of indicating the DOM tag via the 'as' property.`,
       ]),
       PropTypes.string,
     ]).description('A fixed width.'),
-    wrap: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.oneOf(['wrap', 'nowrap', 'wrap-reverse']),
-    ])
-      .description(`Controls the wrap property of the flexbox`)
+    wrap: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['reverse'])])
+      .description(`Whether children can wrap if they can't all fit.`)
       .defaultValue(false),
   };
   return DocumentedBox;

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -317,10 +317,10 @@ of indicating the DOM tag via the 'as' property.`,
       ]),
       PropTypes.string,
     ]).description('A fixed width.'),
-    wrap: PropTypes.oneOfType(
+    wrap: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.oneOf(['wrap', 'nowrap', 'wrap-reverse']),
-    )
+    ])
       .description(`Controls the wrap property of the flexbox`)
       .defaultValue(false),
   };

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -317,11 +317,11 @@ of indicating the DOM tag via the 'as' property.`,
       ]),
       PropTypes.string,
     ]).description('A fixed width.'),
-    wrap: PropTypes.bool
-      .description(
-        `Whether children can wrap if they
-      can't all fit.`,
-      )
+    wrap: PropTypes.oneOfType(
+      PropTypes.bool,
+      PropTypes.oneOf(['wrap', 'nowrap', 'wrap-reverse']),
+    )
+      .description(`Controls the wrap property of the flexbox`)
       .defaultValue(false),
   };
   return DocumentedBox;

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -27,7 +27,7 @@ export interface BoxProps {
   tag?: PolymorphicType;
   as?: PolymorphicType;
   width?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" |string;
-  wrap?: boolean;
+  wrap?: boolean | "wrap" | "nowrap" | "wrap-reverse";
 }
 
 declare const Box: React.ComponentClass<BoxProps & JSX.IntrinsicElements['div']>;

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -27,7 +27,7 @@ export interface BoxProps {
   tag?: PolymorphicType;
   as?: PolymorphicType;
   width?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" |string;
-  wrap?: boolean | "wrap" | "nowrap" | "wrap-reverse";
+  wrap?: boolean | "reverse";
 }
 
 declare const Box: React.ComponentClass<BoxProps & JSX.IntrinsicElements['div']>;

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -567,7 +567,7 @@ exports[`Tabs change to second tab 2`] = `
     role="tablist"
   >
     <div
-      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 erckJo"
+      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 gZEJFb"
     >
       <button
         aria-expanded="false"
@@ -1361,7 +1361,7 @@ exports[`Tabs set on hover 2`] = `
     role="tablist"
   >
     <div
-      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 erckJo"
+      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 gZEJFb"
     >
       <button
         aria-expanded="true"
@@ -1418,7 +1418,7 @@ exports[`Tabs set on hover 3`] = `
     role="tablist"
   >
     <div
-      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 erckJo"
+      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 gZEJFb"
     >
       <button
         aria-expanded="true"
@@ -1475,7 +1475,7 @@ exports[`Tabs set on hover 4`] = `
     role="tablist"
   >
     <div
-      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 erckJo"
+      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 gZEJFb"
     >
       <button
         aria-expanded="true"
@@ -1532,7 +1532,7 @@ exports[`Tabs set on hover 5`] = `
     role="tablist"
   >
     <div
-      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 erckJo"
+      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 gZEJFb"
     >
       <button
         aria-expanded="true"

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1144,13 +1144,11 @@ string
 
 **wrap**
 
-Controls the wrap property of the flexbox
+Whether children can wrap if they can't all fit.
 
 \`\`\`
 boolean
-wrap
-nowrap
-wrap-reverse
+reverse
 \`\`\`
   
 ## Intrinsic element

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1148,6 +1148,9 @@ Controls the wrap property of the flexbox
 
 \`\`\`
 boolean
+wrap
+nowrap
+wrap-reverse
 \`\`\`
   
 ## Intrinsic element

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1144,8 +1144,7 @@ string
 
 **wrap**
 
-Whether children can wrap if they
-      can't all fit.
+Controls the wrap property of the flexbox
 
 \`\`\`
 boolean

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -704,8 +704,7 @@ string",
       },
       Object {
         "defaultValue": false,
-        "description": "Whether children can wrap if they
-      can't all fit.",
+        "description": "Controls the wrap property of the flexbox",
         "format": "boolean",
         "name": "wrap",
       },

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -704,11 +704,9 @@ string",
       },
       Object {
         "defaultValue": false,
-        "description": "Controls the wrap property of the flexbox",
+        "description": "Whether children can wrap if they can't all fit.",
         "format": "boolean
-wrap
-nowrap
-wrap-reverse",
+reverse",
         "name": "wrap",
       },
     ],

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -705,7 +705,10 @@ string",
       Object {
         "defaultValue": false,
         "description": "Controls the wrap property of the flexbox",
-        "format": "boolean",
+        "format": "boolean
+wrap
+nowrap
+wrap-reverse",
         "name": "wrap",
       },
     ],


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Add support for all flex-wrap properties
#### Where should the reviewer start?

#### What testing has been done on this PR?
unit-tests
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
#2754 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards