### PR TITLE
Fixed the issue with table data overflow on FF browser

### DIFF
--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -213,6 +213,12 @@ exports[`DataTable aggregate 1`] = `
   }
 }
 
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c2 {
+    table-layout: fixed;
+  }
+}
+
 <div
   className="c0"
 >
@@ -505,6 +511,12 @@ exports[`DataTable basic 1`] = `
   }
 }
 
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c2 {
+    table-layout: fixed;
+  }
+}
+
 <div
   className="c0"
 >
@@ -642,6 +654,12 @@ exports[`DataTable empty 1`] = `
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c2 {
+    table-layout: fixed;
+  }
 }
 
 <div
@@ -874,6 +892,12 @@ exports[`DataTable footer 1`] = `
   .c11 {
     padding-top: 3px;
     padding-bottom: 3px;
+  }
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c2 {
+    table-layout: fixed;
   }
 }
 
@@ -1313,6 +1337,12 @@ exports[`DataTable groupBy 1`] = `
   }
 }
 
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c2 {
+    table-layout: fixed;
+  }
+}
+
 <div
   class="c0"
 >
@@ -1496,7 +1526,7 @@ exports[`DataTable groupBy 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 eUfLDp"
 >
   <table
-    class="StyledDataTable-xrlyjm-0 kTrXKK StyledTable-sc-1m3u5g-6 ksaVzW"
+    class="StyledDataTable-xrlyjm-0 kTrXKK StyledTable-sc-1m3u5g-6 fGUmP"
   >
     <thead
       class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 bAIczD StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
@@ -1819,6 +1849,12 @@ exports[`DataTable primaryKey 1`] = `
   .c8 {
     padding-top: 3px;
     padding-bottom: 3px;
+  }
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c2 {
+    table-layout: fixed;
   }
 }
 
@@ -2160,6 +2196,12 @@ exports[`DataTable resizeable 1`] = `
   }
 }
 
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c2 {
+    table-layout: fixed;
+  }
+}
+
 <div
   className="c0"
 >
@@ -2480,6 +2522,12 @@ exports[`DataTable sort 1`] = `
   }
 }
 
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c2 {
+    table-layout: fixed;
+  }
+}
+
 <div
   class="c0"
 >
@@ -2638,7 +2686,7 @@ exports[`DataTable sort 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 eUfLDp"
 >
   <table
-    class="StyledDataTable-xrlyjm-0 kTrXKK StyledTable-sc-1m3u5g-6 ksaVzW"
+    class="StyledDataTable-xrlyjm-0 kTrXKK StyledTable-sc-1m3u5g-6 fGUmP"
   >
     <thead
       class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 bAIczD StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"

--- a/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
+++ b/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
@@ -217,6 +217,12 @@ exports[`Markdown renders 1`] = `
   }
 }
 
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c7 {
+    table-layout: fixed;
+  }
+}
+
 <div
   className="c0"
 >

--- a/src/js/components/Table/StyledTable.js
+++ b/src/js/components/Table/StyledTable.js
@@ -68,6 +68,9 @@ const StyledTable = styled.table`
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
+  @media all and (min--moz-device-pixel-ratio: 0) {
+    table-layout: fixed;
+  }
   ${genericStyles} ${props => props.theme.table && props.theme.table.extend};
 `;
 

--- a/src/js/components/Table/__tests__/__snapshots__/Table-test.js.snap
+++ b/src/js/components/Table/__tests__/__snapshots__/Table-test.js.snap
@@ -21,6 +21,12 @@ exports[`Table caption renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
 <div
   className="c0"
 >
@@ -53,6 +59,12 @@ exports[`Table renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
 <div
   className="c0"
 >
@@ -77,6 +89,12 @@ exports[`TableBody renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
 }
 
 <div
@@ -120,6 +138,12 @@ exports[`TableCell plain renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
 }
 
 <div
@@ -338,6 +362,12 @@ exports[`TableCell renders 1`] = `
   }
 }
 
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
 <div
   className="c0"
 >
@@ -524,6 +554,12 @@ exports[`TableCell scope renders 1`] = `
   .c6 {
     padding-top: 3px;
     padding-bottom: 3px;
+  }
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
   }
 }
 
@@ -730,6 +766,12 @@ exports[`TableCell size renders 1`] = `
   .c4 {
     padding-top: 3px;
     padding-bottom: 3px;
+  }
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
   }
 }
 
@@ -967,6 +1009,12 @@ exports[`TableCell verticalAlign renders 1`] = `
   }
 }
 
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
 <div
   className="c0"
 >
@@ -1023,6 +1071,12 @@ exports[`TableFooter renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
 <div
   className="c0"
 >
@@ -1051,6 +1105,12 @@ exports[`TableHeader renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
 }
 
 <div
@@ -1085,6 +1145,12 @@ exports[`TableRow renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
 }
 
 <div

--- a/src/js/components/Table/stories/MeterInTable.js
+++ b/src/js/components/Table/stories/MeterInTable.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import {
+  Box,
+  Grommet,
+  Meter,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  Text,
+} from 'grommet';
+import { grommet } from 'grommet/themes';
+
+const values = [20, 40, 60, 80, 100];
+
+const MeterInTable = () => (
+  <Grommet theme={grommet}>
+    <Box align="center" pad="large">
+      <Box border>
+        <Table caption="Meter Inside Table">
+          <TableBody>
+            {values.map(val => (
+              <TableRow>
+                <TableCell>
+                  <Meter
+                    type="bar"
+                    values={[
+                      {
+                        value: val,
+                      },
+                    ]}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Text>{val}% complete</Text>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Box>
+    </Box>
+  </Grommet>
+);
+
+storiesOf('Table', module).add('Meter Inside Table', () => <MeterInTable />);


### PR DESCRIPTION
Fixed the issue with table data overflow on FF browser. `width: inherit` was not respected by FF browser and data overflow issues were seen as mentioned in #2656. 

#### What does this PR do?
For FF, `table-layout` is set as `fixed` on StyledTable to avoid overflow issues when parent div width is smaller than table data width. 

#### Where should the reviewer start?
StyledTable.js

#### What testing has been done on this PR?
storybook

#### How should this be manually tested?
storybook

#### Any background context you want to provide?
#### What are the relevant issues?
#2656 

#### Screenshots (if appropriate)
#### Do the grommet docs need to be updated?
no

#### Should this PR be mentioned in the release notes?
yes

#### Is this change backwards compatible or is it a breaking change?
backwards compatible