### PR TITLE
fix(typings): distribution typings missing color

### DIFF
--- a/src/js/components/Distribution/index.d.ts
+++ b/src/js/components/Distribution/index.d.ts
@@ -8,7 +8,7 @@ export interface DistributionProps {
   children?: ((...args: any[]) => any);
   fill?: boolean;
   gap?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
-  values: {value: number, color: string}[];
+  values: {value: number, color?: string | {dark?: string,light?: string}}[];
 }
 
 declare const Distribution: React.ComponentClass<DistributionProps & JSX.IntrinsicElements['div']>;

--- a/src/js/components/Distribution/index.d.ts
+++ b/src/js/components/Distribution/index.d.ts
@@ -8,7 +8,7 @@ export interface DistributionProps {
   children?: ((...args: any[]) => any);
   fill?: boolean;
   gap?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
-  values: {value: number}[];
+  values: {value: number, color: string}[];
 }
 
 declare const Distribution: React.ComponentClass<DistributionProps & JSX.IntrinsicElements['div']>;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update distribution typings to match examples.

#### Where should the reviewer start?

Distribution/index.d.ts

#### What testing has been done on this PR?

Manual testing with type check

#### How should this be manually tested?

Creating a typescript Distribution component with value key/value of `color: "brand"`

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Update Typings?

#### Is this change backwards compatible or is it a breaking change?

No breaking change.