### PR TITLE
fix issue #2794 - optimize margin rules on styledText by removing marginStyle function

### DIFF
--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -1568,7 +1568,7 @@ exports[`DataTable groupBy 2`] = `
             class="StyledBox-sc-13pk1d4-0 folWQp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 fWSbXS"
+              class="StyledText-sc-1sadyjn-0 fSnogx"
             >
               A
             </span>
@@ -1582,7 +1582,7 @@ exports[`DataTable groupBy 2`] = `
             class="StyledBox-sc-13pk1d4-0 folWQp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 fWSbXS"
+              class="StyledText-sc-1sadyjn-0 fSnogx"
             >
               B
             </span>
@@ -1630,7 +1630,7 @@ exports[`DataTable groupBy 2`] = `
             class="StyledBox-sc-13pk1d4-0 eAAZJM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 fWSbXS"
+              class="StyledText-sc-1sadyjn-0 fSnogx"
             >
               one
             </span>
@@ -1681,7 +1681,7 @@ exports[`DataTable groupBy 2`] = `
             class="StyledBox-sc-13pk1d4-0 eAAZJM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 fWSbXS"
+              class="StyledText-sc-1sadyjn-0 fSnogx"
             >
               two
             </span>
@@ -2706,7 +2706,7 @@ exports[`DataTable sort 2`] = `
               class="StyledBox-sc-13pk1d4-0 fAhsMq"
             >
               <span
-                class="StyledText-sc-1sadyjn-0 fWSbXS"
+                class="StyledText-sc-1sadyjn-0 fSnogx"
               >
                 A
               </span>
@@ -2781,7 +2781,7 @@ exports[`DataTable sort 2`] = `
               class="StyledBox-sc-13pk1d4-0 fAhsMq"
             >
               <span
-                class="StyledText-sc-1sadyjn-0 fWSbXS"
+                class="StyledText-sc-1sadyjn-0 fSnogx"
               >
                 B
               </span>
@@ -2902,7 +2902,7 @@ exports[`DataTable sort 2`] = `
             class="StyledBox-sc-13pk1d4-0 eAAZJM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 dndifk"
+              class="StyledText-sc-1sadyjn-0 evsoIF"
             >
               two
             </span>
@@ -2915,7 +2915,7 @@ exports[`DataTable sort 2`] = `
             class="StyledBox-sc-13pk1d4-0 eAAZJM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 fWSbXS"
+              class="StyledText-sc-1sadyjn-0 fSnogx"
             >
               2
             </span>

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
@@ -29,8 +29,6 @@ exports[`Form regexp validation 1`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 6px;
-  margin-bottom: 6px;
   color: #FF4040;
 }
 
@@ -49,8 +47,6 @@ exports[`Form required validation 1`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 6px;
-  margin-bottom: 6px;
   color: #FF4040;
 }
 

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -298,8 +298,6 @@ exports[`renders error 1`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 6px;
-  margin-bottom: 6px;
   color: #FF4040;
 }
 
@@ -401,7 +399,6 @@ exports[`renders help 1`] = `
   margin-left: 12px;
   font-size: 18px;
   line-height: 24px;
-  margin-left: 12px;
   color: #777777;
 }
 
@@ -595,8 +592,6 @@ exports[`renders label 1`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 6px;
-  margin-bottom: 6px;
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -2287,7 +2287,7 @@ exports[`Menu open and close on click 2`] = `
       class="StyledBox-sc-13pk1d4-0 lgRCHI"
     >
       <span
-        class="StyledText-sc-1sadyjn-0 fWSbXS"
+        class="StyledText-sc-1sadyjn-0 fSnogx"
       >
         Test
       </span>

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -2140,10 +2140,6 @@ exports[`Select large drop container height 1`] = `
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
 }
 
 .c2 {
@@ -2478,10 +2474,6 @@ exports[`Select medium drop container height 1`] = `
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
 }
 
 .c2 {
@@ -3398,10 +3390,6 @@ exports[`Select multiple values 3`] = `
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
 }
 
 .c2 {
@@ -4234,10 +4222,6 @@ exports[`Select opens 3`] = `
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
 }
 
 .c2 {
@@ -4598,7 +4582,7 @@ exports[`Select opens 5`] = `
         class="SelectContainer__OptionBox-sc-1wi0ul8-1 ixLLDr StyledBox-sc-13pk1d4-0 eEPVhE"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 fLjoaM"
+          class="StyledText-sc-1sadyjn-0 eFEfWf"
         >
           one
         </span>
@@ -4618,7 +4602,7 @@ exports[`Select opens 5`] = `
         class="SelectContainer__OptionBox-sc-1wi0ul8-1 ixLLDr StyledBox-sc-13pk1d4-0 eEPVhE"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 fLjoaM"
+          class="StyledText-sc-1sadyjn-0 eFEfWf"
         >
           two
         </span>
@@ -5843,10 +5827,6 @@ exports[`Select search 2`] = `
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
 }
 
 .c2 {
@@ -7637,10 +7617,6 @@ exports[`Select small drop container height 1`] = `
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
 }
 
 .c2 {

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -580,7 +580,7 @@ exports[`Tabs change to second tab 2`] = `
           class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 ePEJdL"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 gnzBzL"
+            class="StyledText-sc-1sadyjn-0 cGKySO"
           >
             Tab 1
           </span>
@@ -597,7 +597,7 @@ exports[`Tabs change to second tab 2`] = `
           class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 kvUzDk"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 iEgnbY"
+            class="StyledText-sc-1sadyjn-0 jPfrqI"
           >
             Tab 2
           </span>
@@ -1374,7 +1374,7 @@ exports[`Tabs set on hover 2`] = `
           class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 kvUzDk"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 iEgnbY"
+            class="StyledText-sc-1sadyjn-0 jPfrqI"
           >
             Tab 1
           </span>
@@ -1391,7 +1391,7 @@ exports[`Tabs set on hover 2`] = `
           class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 ePEJdL"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 gnzBzL"
+            class="StyledText-sc-1sadyjn-0 cGKySO"
           >
             Tab 2
           </span>
@@ -1431,7 +1431,7 @@ exports[`Tabs set on hover 3`] = `
           class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 kvUzDk"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 iEgnbY"
+            class="StyledText-sc-1sadyjn-0 jPfrqI"
           >
             Tab 1
           </span>
@@ -1448,7 +1448,7 @@ exports[`Tabs set on hover 3`] = `
           class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 ePEJdL"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 gnzBzL"
+            class="StyledText-sc-1sadyjn-0 cGKySO"
           >
             Tab 2
           </span>
@@ -1488,7 +1488,7 @@ exports[`Tabs set on hover 4`] = `
           class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 kvUzDk"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 iEgnbY"
+            class="StyledText-sc-1sadyjn-0 jPfrqI"
           >
             Tab 1
           </span>
@@ -1505,7 +1505,7 @@ exports[`Tabs set on hover 4`] = `
           class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 ePEJdL"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 gnzBzL"
+            class="StyledText-sc-1sadyjn-0 cGKySO"
           >
             Tab 2
           </span>
@@ -1545,7 +1545,7 @@ exports[`Tabs set on hover 5`] = `
           class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 kvUzDk"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 iEgnbY"
+            class="StyledText-sc-1sadyjn-0 jPfrqI"
           >
             Tab 1
           </span>
@@ -1562,7 +1562,7 @@ exports[`Tabs set on hover 5`] = `
           class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 ePEJdL"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 gnzBzL"
+            class="StyledText-sc-1sadyjn-0 cGKySO"
           >
             Tab 2
           </span>

--- a/src/js/components/Text/StyledText.js
+++ b/src/js/components/Text/StyledText.js
@@ -3,45 +3,6 @@ import styled, { css } from 'styled-components';
 import { genericStyles, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';
 
-const marginStyle = props => {
-  if (typeof props.margin === 'string') {
-    const margin = props.theme.global.edgeSize[props.margin];
-    return `
-      margin-top: ${margin};
-      margin-bottom: ${margin};
-      margin-left: ${margin};
-      margin-right: ${margin};
-    `;
-  }
-  if (props.margin.vertical) {
-    return `
-      margin-top: ${props.theme.global.edgeSize[props.margin.vertical]};
-      margin-bottom: ${props.theme.global.edgeSize[props.margin.vertical]};
-    `;
-  }
-  if (props.margin.horizontal) {
-    return `
-      margin-left: ${props.theme.global.edgeSize[props.margin.horizontal]};
-      margin-right: ${props.theme.global.edgeSize[props.margin.horizontal]};
-    `;
-  }
-  if (props.margin.top) {
-    return `margin-top: ${props.theme.global.edgeSize[props.margin.top]};`;
-  }
-  if (props.margin.bottom) {
-    return `margin-bottom: ${
-      props.theme.global.edgeSize[props.margin.bottom]
-    };`;
-  }
-  if (props.margin.left) {
-    return `margin-left: ${props.theme.global.edgeSize[props.margin.left]};`;
-  }
-  if (props.margin.right) {
-    return `margin-right: ${props.theme.global.edgeSize[props.margin.right]};`;
-  }
-  return '';
-};
-
 const sizeStyle = props => {
   const size = props.size || 'medium';
   const data = props.theme.text[size];
@@ -84,7 +45,6 @@ const weightStyle = css`
 const StyledText = styled.span`
   ${genericStyles}
   ${props => sizeStyle(props)}
-  ${props => props.margin && marginStyle(props)}
   ${props => props.textAlign && textAlignStyle}
   ${props => props.truncate && truncateStyle}
   ${props => props.colorProp && colorStyle}

--- a/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
+++ b/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
@@ -68,40 +68,24 @@ exports[`renders margin 1`] = `
   margin: 12px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 12px;
-  margin-bottom: 12px;
-  margin-left: 12px;
-  margin-right: 12px;
 }
 
 .c2 {
   margin: 24px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 24px;
-  margin-bottom: 24px;
-  margin-left: 24px;
-  margin-right: 24px;
 }
 
 .c3 {
   margin: 48px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 48px;
-  margin-bottom: 48px;
-  margin-left: 48px;
-  margin-right: 48px;
 }
 
 .c4 {
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
 }
 
 .c5 {
@@ -109,8 +93,6 @@ exports[`renders margin 1`] = `
   margin-bottom: 12px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 12px;
-  margin-bottom: 12px;
 }
 
 .c6 {
@@ -118,36 +100,30 @@ exports[`renders margin 1`] = `
   margin-right: 12px;
   font-size: 18px;
   line-height: 24px;
-  margin-left: 12px;
-  margin-right: 12px;
 }
 
 .c7 {
   margin-bottom: 12px;
   font-size: 18px;
   line-height: 24px;
-  margin-bottom: 12px;
 }
 
 .c8 {
   margin-top: 12px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 12px;
 }
 
 .c9 {
   margin-left: 12px;
   font-size: 18px;
   line-height: 24px;
-  margin-left: 12px;
 }
 
 .c10 {
   margin-right: 12px;
   font-size: 18px;
   line-height: 24px;
-  margin-right: 12px;
 }
 
 <div

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -214,10 +214,6 @@ exports[`Video autoPlay renders 1`] = `
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
 }
 
 .c18 {
@@ -806,10 +802,6 @@ exports[`Video controls renders 1`] = `
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
 }
 
 .c18 {
@@ -1485,10 +1477,6 @@ exports[`Video fit renders 1`] = `
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
 }
 
 .c18 {
@@ -2162,10 +2150,6 @@ exports[`Video loop renders 1`] = `
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
 }
 
 .c18 {
@@ -2669,10 +2653,6 @@ exports[`Video mute renders 1`] = `
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
 }
 
 .c18 {
@@ -3176,10 +3156,6 @@ exports[`Video renders 1`] = `
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  margin-left: 0px;
-  margin-right: 0px;
 }
 
 .c18 {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Currently, any styled text that has a margin applied to it will get a `margin: X` rule as well as a rule for top, right, bottom, and left which causes each text node to have 5 lines of CSS for margin, 4 of which are not needed. After looking into the styling, there's already a generic style for margin being applied via `${genericStyles}` which makes the function in `StyledText.js` not necessary, so I've removed it and updated all the text snapshots. 

#### Where should the reviewer start?
`StyledText.js`

#### What testing has been done on this PR?
All snapshots have been updated and all tests run successfully via the test command. 

#### How should this be manually tested?
Apply a margin of `small` to a `<Text>` element and see that there is only 1 margin rule applied, not 5. 

#### Any background context you want to provide?
See issue #2794 for context on why this was done. 

#### What are the relevant issues?
#2794 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
If desired

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible. 
