### PR TITLE
Update Markdown files (README & CONTRIBUTING)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,79 +1,81 @@
 # Contributing
 
-Thank you for reaching the contribution page and showing the true gremlin in you!
-In Grommet we do believe that the more the merrier, and we are welcoming you for making this step of joining our contribution community and helping us make Grommet the best way to streamline the way you develop apps.
-You came to the right place to start your contribution, follow the guidlines and let us know if we can help with anything else.
+Thank you for reaching the contribution page and showing the true gremlin in
+you! In Grommet we do believe that the more the merrier – Welcome! Thank you for
+making this step of joining and contributing to our community, and for helping
+us make Grommet the best tool for streamlining the way you develop apps. You
+came to the right place to start your contribution! Follow the guidelines and
+let us know if we can help with anything else.
 
-## Grommet projects
+## Grommet Projects
 
-Grommet is divided into a several projects; the following are notable:
+Grommet is divided into several projects, the following are notable:
 
-- [grommet](https://github.com/grommet/grommet) - the primary
-  Grommet 2.X project is actively developped and contributing is more than welcome! Be sure to check the [good first issues](https://github.com/grommet/grommet/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-- [grommet-icons](https://github.com/grommet/grommet-icons) -
-  Iconography for Grommet and React.js
-- [react-desc](https://github.com/grommet/react-desc)
-  Add a schema to your React components based on React PropTypes
-- [design-kit](https://github.com/grommet/design-kit)
-  The Grommet Design Kit provides a set of sticker sheets and templates to help bootstrap your design process.
+- [grommet] – the primary Grommet 2.X project is actively developed and
+  contributions are more than welcome! Be sure to check the [good first issues].
+- [grommet-icons] – iconography for Grommet and React.js.
+- [react-desc] – add a schema to your React components based on React
+  [`PropTypes`][prop-types].
+- [design-kit] – the Grommet Design Kit provides a set of sticker sheets and
+  templates to help bootstrap your design process.
 
-## YOU can Become a Contributor
+## You can Become a Contributor
 
-Quick steps and ideas of how you can become a contributor!
+Afterall, that’s why you’re here, right?
+Quick steps and ideas of how you can contribute to Grommet:
 
-1.  Code Code Code (and file Pull Request)
-2.  Create design assets or style guide revsions
-3.  Submit updates and improvements to the documentation.
-4.  Submit articles and guides which are also part of the documentation.
-5.  Join the Slack to help and interact with grommet users
-6.  Help a Grommet designer or developer by answering questions on
-    StackOverflow, Slack and GitHub.
-7.  Report bugs and proposing new features by filing issues on Github or ask in our Slack community
-8.  Share with us exciting projects using grommet on Slack
+1. Code, code, code… (and make a Pull Request).
+1. Create design assets or style guide revisions.
+1. Submit updates and improvements to the documentation.
+1. Submit articles and guides which are also part of the documentation.
+1. Join the [Slack community] to interact with and help Grommet users.
+1. Help a Grommet designer or developer by answering questions on
+   [Stack Overflow], [Slack][slack community], or [GitHub][grommet issues].
+1. Report bugs and propose new features by [filing issues on
+   GitHub][grommet issues], or come talk to us and fellow contributors in our
+   [Slack community] about your issue or idea.
+1. Share with us exciting projects using Grommet in our [Slack community].
 
-## Contributing
+## How to Contribute
 
 The best way to collaborate with the project contributors is through the Grommet
 organization on GitHub: <https://github.com/grommet>.
 
-You are invited to contribute new features, fixes, or updates, large or small; we
-are always thrilled to receive pull requests, and do our best to process them as
-fast as we can.
+You are invited to contribute new features, fixes, or updates – large or small.
+We are always thrilled to receive pull requests, and do our best to process them
+as fast as we can.
 
 Before you start to code, we recommend discussing your plans through a GitHub
-issue, especially for more ambitious contributions. This gives other contributors
-a chance to point you in the right direction, give you feedback on your design,
-and help you find out if someone else is working on the same thing.
+issue, especially for more ambitious contributions. This gives other
+contributors a chance to point you in the right direction, give you feedback on
+your design, and help you find out if someone else is working on the same thing.
 
-- If you want to contribute design assets or style guide revisions,
-  please open a [GitHub pull
-  request](https://github.com/grommet/design-kit/pulls) or open a
-  [GitHub issue](https://github.com/grommet/design-kit/issues) against the
-  design-kit project.
-- If you want to raise an issue such as a defect or an enhancement
-  request please open a GitHub issue for the appropriate project. Please
-  keep the following in mind:
-  - Try to reduce your code to the bare minimum required to
-    reproduce the issue.
-  - If we can't reproduce the issue, we can't fix it. Please list
-    the exact steps required to reproduce the issue.
+- If you want to contribute design assets or style guide revisions, please open
+  a [GitHub pull request][design-kit pulls] or open a
+  [GitHub issue][design-kit issues] against the `design-kit` project.
+- If you want to raise an issue such as a defect or an enhancement request,
+  please open a GitHub issue for the appropriate project. Please keep the
+  following in mind:
+  - Try to reduce your code to the bare minimum required to reproduce the issue.
+  - If we can’t reproduce the issue, we can’t fix it. Please list the exact
+    steps required to reproduce the issue.
 
-We review issues and pull requests on a weekly basis (sometimes more frequent).
-When we require more information from you, we'll ask. In order to keep the
-issue and pull request clean, we ask that you respond within **one week** or we'll
-close the issue pending your response.
+We review issues and pull requests on a weekly basis (sometimes more
+frequently). When we require more information from you, we’ll ask. In order to
+keep the issue and pull request queue clean, we ask that you respond within
+**one week** or we’ll close the issue pending your response.
 
 After an issue is created or a pull request is submitted, contributors and/or
 maintainers will offer feedback. If the pull request passes review, a maintainer
 will accept it with a comment.
 
-When a pull request for code contributions fails testing, the author is
-expected to update the pull request to address the failure until it
-passes testing and the pull request merges successfully.
+When a pull request for code contribution fails testing, the author is
+expected to update the pull request to address the failure(s) until it
+passes testing and the pull request can merge cleanly.
 
 At least one review from a maintainer is required for all patches.
 
-### Developer's Certificate of Origin
+### Developer’s Certificate of Origin
 
 All contributions must include acceptance of the DCO:
 
@@ -109,10 +111,10 @@ All contributions must include acceptance of the DCO:
 > indefinitely and may be redistributed consistent with this project or
 > the open source license(s) involved.
 
-### Sign your work
+### Sign Your Work
 
 To accept the DCO, simply add this line to each commit message with your
-name and email address (git commit -s will do this for you):
+name and email address (`git commit -s` will do this for you):
 
     Signed-off-by: Jane Example <jane@example.com>
 
@@ -123,68 +125,92 @@ accepted.
 
 The Grommet community values contributions on the design side of the
 project. The Grommet style guide and designer assets are open for
-contributions just as the development platform. You may either submit an
+contributions just as the development platform is. You may either submit an
 issue on GitHub with a detailed recommendation, or open a pull request
 with the updated assets.
-Please open a [GitHub pull request](https://github.com/grommet/grommet-design/pulls)or open a [GitHub issue](https://github.com/grommet/grommet-design/issues) against the grommet-design project.
+Please open a [GitHub pull request][grommet-design pulls] or open a
+[GitHub issue][grommet-design issues] against the `grommet-design` project.
 
 ## Submitting Code Pull Requests
 
 We encourage and support contributions from the community. No fix is too
 small. We strive to process all pull requests as soon as possible and
 with constructive feedback. If your pull request is not accepted at
-first, please try again after addressing the feedback you received.
+first, please try again after addressing the feedback you receive.
 
 To make a pull request you will need a GitHub account. For help, see
-GitHub's documentation on forking and pull requests.
+GitHub’s documentation on [forking] and [pull requests].
 
 Development happens on the `master` branch. In order for you to get
 started you should:
 
-- First fork the grommet repository
-- clone it `git clone https://github.com/<your-username>/grommet.git`
-- install dependencies using `yarn install`
+1. fork the `grommet` repository
+1. clone it `git clone https://github.com/<your-username>/grommet.git`
+1. install dependencies using: `yarn install`
 
-The components code is living in `src/js/components`. The structure of the
-project is a bit particular since it is using lots of internal tooling to try and
-and produce up to date documentation and minimise bugs. A few gotchas while you
-contribute might be:
+The components code lives in `src/js/components`. The structure of the
+project is a bit particular since it is using lots of internal tooling to try to
+produce up-to-date documentation and minimise bugs. A few gotchas you may run
+into while contributing could include:
 
-- the readme files in the components are auto-generated. You won't need to update
-  them. A big chunk of the documentation and prop-type validation is happening on the `doc.js` files.
-- code coverage and unit-testing is an important process of the development. A
-  pre-commit hook exists that runs jest tests. To manually run them you should run
-  `yarn test`. If you need to update snapshots then run `yarn test-update`
-- we are actively working on providing a seamless Typescript experience.
-  Don't forget to update the corresponding `index.d.ts` files.
-- for code syntax alignment on your pull request, use 'prettier'.
-- pull requests with code should include tests that validate your change.
+- The read-me files in the components are auto-generated. You won’t need to
+  update them. A big chunk of the documentation and prop-type validation is
+  happening via the `doc.js` files.
+- Code coverage and unit-testing is an important process of development.
+  A pre-commit hook exists which runs the test suite and aborts the commit if
+  any fail. To manually run tests, you should run `yarn test`. If you need to
+  update snapshots then run `yarn test-update`.
+- We are actively working on providing a seamless TypeScript experience. Don’t
+  forget to update corresponding `index.d.ts` files.
+- For code syntax alignment in your pull request, use [prettier].
+- Pull requests with code should include tests that validate the changes.
 
-We review issues and pull requests on a weekly basis (sometimes more frequent). If you feel we missed yours don't hesitate to ping us on slack!
+We review issues and pull requests on a weekly basis (sometimes more
+frequently). If you feel we missed yours don’t hesitate to ping us on
+[Slack][slack community]!
 
-## Contributing to the documentation
+## Contributing to the Documentation
 
 Grommet uses an internal tool for most of its documentation. If you are looking
-to modify component to documentation then you only need to have a look at the
+to modify component documentation then you only need to have a look at the
 `doc.js` files.
 
-These files are used to generate the documentation on the grommet website. That
-code lives at the [grommet-site](https://github.com/grommet/grommet-site) repository.
+These files are used to generate the documentation on the Grommet website. That
+code lives in the [grommet-site] repository.
 
-Found an error in the documentation? [File an issue](https://github.com/grommet/grommet/issues).
+Found an error in the documentation? [File an issue][grommet issues].
 
-## Need more help?
+## Need More Help?
 
-Watch this [video](https://vimeo.com/129681048) to learn how to contribute to Grommet. The Github
-contribution workflow is somehow complex and we want to make sure we
-don't lose your contributions because of that.
-Note that the video is outdated and points to contributing on Grommet 1.X, but it may still be helpful for new users.
+Watch this [video] to learn how to contribute to Grommet. The GitHub
+contribution workflow is a bit complex and we want to make sure we don’t lose
+your valuable contributions because of that. Note that the video is outdated and
+talks about contributing to Grommet 1.X, but it may still be helpful for new
+users.
 
 ## References
 
-This contribution guide was inspired by the contribution guides for
-[Grunt](http://gruntjs.com/contributing),
-[CloudSlang](http://www.cloudslang.io/#/docs#contributing-code), and
-[Docker Library](https://github.com/docker-library/docs/tree/master/node).
+This contribution guide was inspired by the contribution guides for [Grunt],
+[CloudSlang], and [Docker Library].
 
-
+[cloudslang]: http://www.cloudslang.io/#/docs#contributing-code
+[design-kit]: https://github.com/grommet/design-kit
+[design-kit issues]: https://github.com/grommet/design-kit/issues
+[design-kit pulls]: https://github.com/grommet/design-kit/pulls
+[docker library]: https://github.com/docker-library/docs/tree/master/node
+[forking]: https://help.github.com/en/articles/fork-a-repo
+[good first issues]: https://github.com/grommet/grommet/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+[grommet]: https://github.com/grommet/grommet
+[grommet issues]: https://github.com/grommet/grommet/issues
+[grommet-design issues]: https://github.com/grommet/grommet-design/issues
+[grommet-design pulls]: https://github.com/grommet/grommet-design/pulls
+[grommet-icons]: https://github.com/grommet/grommet-icons
+[grommet-site]: https://github.com/grommet/grommet-site
+[grunt]: http://gruntjs.com/contributing
+[prettier]: https://prettier.io/docs/en/editors.html
+[prop-types]: https://www.npmjs.com/package/prop-types
+[pull requests]: https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
+[react-desc]: https://github.com/grommet/react-desc
+[slack community]: http://slackin.grommet.io/
+[stack overflow]: https://stackoverflow.com/questions/tagged/grommet
+[video]: https://vimeo.com/129681048

--- a/README.md
+++ b/README.md
@@ -1,56 +1,85 @@
 # Grommet: focus on the essential experience
 
-[![PRs Welcome](https://img.shields.io/badge/pr's-welcome-7d4cdb.svg)](https://github.com/grommet/grommet/blob/master/CONTRIBUTING.md)
-[![slack](https://img.shields.io/badge/join%20the%20community-slack-fd6fff.svg)](http://slackin.grommet.io)
-[![follow](https://img.shields.io/twitter/follow/grommet_io.svg?label=follow%20&style=social)](https://twitter.com/grommet_io)
-[![blogs](https://img.shields.io/badge/view%20blogs%20on-medium-000000.svg)](https://medium.com/grommet-io)
-[![npm package](https://img.shields.io/npm/v/grommet.svg?color=ffca58)](https://www.npmjs.com/package/grommet)
-[![npm downloads](https://img.shields.io/npm/dm/grommet.svg?color=3d138d)](https://www.npmjs.com/package/grommet)
-[![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+[![PRs Welcome](https://img.shields.io/badge/pr's-welcome-7d4cdb.svg)][contributing]
+[![slack](https://img.shields.io/badge/join%20the%20community-slack-fd6fff.svg)][slack]
+[![follow](https://img.shields.io/twitter/follow/grommet_io.svg?label=follow%20&style=social)][twitter]
+[![blogs](https://img.shields.io/badge/view%20blogs%20on-medium-000000.svg)][medium]
+[![npm package](https://img.shields.io/npm/v/grommet.svg?color=ffca58)][npm]
+[![npm downloads](https://img.shields.io/npm/dm/grommet.svg?color=3d138d)][npm]
+[![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)][prettier]
 
 <img align="right" height="260" src="https://v2.grommet.io/img/stak-hurrah.svg">
 
-### Documentation
+## Documentation
 
-Visit the [Grommet v2](https://v2.grommet.io/) website for more information.
+Visit the [Grommet v2] website for more information.
 
-### Support / Contributing
+## Support / Contributing
 
-Before opening an issue or pull request, please read the [Contributing](https://github.com/grommet/grommet/blob/master/CONTRIBUTING.md) guide.
+Before opening an issue or pull request, please read the [Contributing] guide.
 
-### Install
+## Install
 
 You can install Grommet using either of the methods below.
 
-For NPM users:
+For npm users:
 
-```
+```shell
   $ npm install grommet styled-components --save
 ```
 
-Detailed instructions are on the [Get Started](https://v2.grommet.io/use) page.
+For Yarn users:
 
-### Explore
-
-1. [Storybook](https://storybook.grommet.io) examples per component, you can see them by running:
-```
-  $ npm run storybook
+```shell
+  $ yarn add grommet styled-components
 ```
 
-2. Basic [code-sandbox playgrounds](https://codesandbox.io/s/github/grommet/grommet-sandbox) for each component
+There are more detailed instructions in the [Grommet Starter] app tutorial for
+new apps. For incorporating Grommet into an existing app, see the [Existing App]
+version.
 
-3. [Templates, patterns and starters](https://codesandbox.io/u/grommetux/sandboxes) feel free to share with us more pattern ideas on [slack](http://slackin.grommet.io)
+## Explore
 
-4. End-2-End project examples from our community on [#i-made-this](http://slackin.grommet.io) channel
+1. [Storybook] examples per component, you can create them locally by running:
 
-5. Read more from the Grommet team on [Medium](https://medium.com/grommet-io)
+   ```shell
+     $ npm run storybook
+   ```
 
-### Release History
+   or
 
-See the [Change Log](https://github.com/grommet/grommet/wiki/Change-Log).
+   ```shell
+     $ yarn storybook
+   ```
 
-### Tools Behind Grommet
+1. Basic [code-sandbox playgrounds][playground] for each component.
+1. [Templates, patterns, and starters][sandboxes]: feel free to share with us
+   more pattern ideas on [Slack].
+1. End-to-end project examples from our community in the
+   [#i-made-this Slack channel][slack].
+1. Read more from the Grommet team on [Medium].
 
-Grommet is produced using this great tool
+## Release History
 
-- [Circle CI](https://circleci.com/gh/grommet/grommet/) for continuous integration
+See the [Change Log].
+
+## Tools Behind Grommet
+
+Grommet is produced using this great tool:
+
+- [Circle CI] for continuous integration.
+
+[change log]: https://github.com/grommet/grommet/wiki/Change-Log
+[circle ci]: https://circleci.com/gh/grommet/grommet/
+[contributing]: CONTRIBUTING.md
+[existing app]: https://github.com/grommet/grommet-starter-existing-app
+[grommet starter]: https://github.com/grommet/grommet-starter-new-app
+[grommet v2]: https://v2.grommet.io/
+[medium]: https://medium.com/grommet-io
+[npm]: https://www.npmjs.com/package/grommet
+[playground]: https://codesandbox.io/s/github/grommet/grommet-sandbox
+[prettier]: https://github.com/prettier/prettier
+[sandboxes]: https://codesandbox.io/u/grommetux/sandboxes
+[slack]: http://slackin.grommet.io
+[storybook]: https://storybook.grommet.io
+[twitter]: https://twitter.com/grommet_io


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR makes a number of changes, most of them quite simple in nature, to the two Markdown documentation files (README & CONTRIBUTING) found in the base of the repo:

- Fix typos & awkward phrasing
- Be consistent with line-width & spacing
- Be consistent with capitalization of proper nouns (like Slack, GitHub, and Grommet) and section titles
- Give fenced-in code blocks a language
- Use reference style links for easier-to-read Markdown source
- Use a generic number (i.e. `1. `) for all ordered list items
- Use curvy/angled apostrophes & quotes (e.g. it’s “these”, it's not "these")
- Add a few more handy links

#### Where should the reviewer start?

A couple things that make the changes seem more expansive than they really are:

- I tried to create consistency with line length – sometimes things were forcibly wrapping, other times not. I settled on good old fashioned 80 character width.
- I moved pretty much all URL references for links down to the bottom of the page as reference style links instead of inline style links.

#### What testing has been done on this PR?

Not much testing is needed, but I have clicked through a number of the links to make sure they are still working correctly.

#### How should this be manually tested?

Give it a read-over, click on some of the key links, make sure everything still jives with the style & voice of Grommet.

#### Any background context you want to provide?

I learn best by getting my hands dirty, and I like editing things like this – seemed like a win-win!

#### What are the relevant issues?

#3010 

#### Screenshots (if appropriate)

N/A

#### Do the grommet docs need to be updated?

They are! 😄 

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

Good question. My only concern might be in how I handled the links from the README to the CONTRIBUTING page. They used to be very specific (i.e. `https://github.com/grommet/grommet/blob/master/CONTRIBUTING.md`) and are now relative (i.e. `CONTRIBUTING.md`), which means that for each tagged version, each branch, each commit-specific version of the README they point to the corresponding commit-specific version of the CONTRIBUTING file, not to the latest, most up-to-date version of that file. That is easily fixable, though, if it is deemed a concern.