### PR TITLE
fix(typings): missing prop

### DIFF
--- a/src/js/components/FormField/index.d.ts
+++ b/src/js/components/FormField/index.d.ts
@@ -10,6 +10,7 @@ export interface FormFieldProps {
   required?: boolean;
   component?: React.ComponentType<any>;
   validate?: {regexp?: object,message?: string} | ((...args: any[]) => any);
+  options?: string[];
 }
 
 declare const FormField: React.ComponentClass<FormFieldProps & JSX.IntrinsicElements['input']>;


### PR DESCRIPTION
FormField missing options for Radio Group

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds missing options prop on formfield

#### Where should the reviewer start?

src/js/components/FormField/index.d.ts

#### What testing has been done on this PR?

Manual type check

#### How should this be manually tested?

Create FormField with options props and RadioGroup component

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
