### PR TITLE
Creates an example using ResponsiveContext for a dynamic Grid

### DIFF
--- a/src/js/contexts/ResponsiveContext/responsive-context.stories.js
+++ b/src/js/contexts/ResponsiveContext/responsive-context.stories.js
@@ -4,7 +4,14 @@ import { storiesOf } from '@storybook/react';
 import { deepMerge } from 'grommet/utils';
 import { grommet } from 'grommet/themes';
 
-import { Box, Grommet, Heading, ResponsiveContext } from 'grommet';
+import {
+  Box,
+  Grid,
+  Paragraph,
+  Grommet,
+  Heading,
+  ResponsiveContext,
+} from 'grommet';
 
 const customBreakpoints = deepMerge(grommet, {
   global: {
@@ -23,14 +30,70 @@ const customBreakpoints = deepMerge(grommet, {
   },
 });
 
-storiesOf('ResponsiveContext', module).add('Custom Breakpoints', () => (
+const ResponsiveGrid = ({ children, areas, ...props }) => (
+  <ResponsiveContext.Consumer>
+    {size => (
+      <Grid areas={areas[size]} {...props}>
+        {children}
+      </Grid>
+    )}
+  </ResponsiveContext.Consumer>
+);
+
+const ResponsiveGridExample = () => (
   <Grommet theme={customBreakpoints} full>
-    <ResponsiveContext.Consumer>
-      {size => (
-        <Box fill background="brand">
-          <Heading>{`Hi, I'm ${size}, resize me!`}</Heading>
-        </Box>
-      )}
-    </ResponsiveContext.Consumer>
+    <ResponsiveGrid
+      columns={['25%', '25%', '25%', '25%']}
+      rows={['3em', '3em', '3em']}
+      areas={{
+        xsmall: [
+          { name: 'header', start: [0, 0], end: [3, 0] },
+          { name: 'one', start: [0, 1], end: [1, 1] },
+          { name: 'two', start: [2, 1], end: [3, 1] },
+          { name: 'three', start: [0, 2], end: [3, 2] },
+        ],
+        small: [
+          { name: 'header', start: [0, 0], end: [3, 0] },
+          { name: 'one', start: [0, 1], end: [1, 1] },
+          { name: 'two', start: [2, 1], end: [3, 1] },
+          { name: 'three', start: [0, 2], end: [3, 2] },
+        ],
+        medium: [
+          { name: 'header', start: [0, 0], end: [3, 0] },
+          { name: 'one', start: [0, 1], end: [0, 1] },
+          { name: 'two', start: [1, 1], end: [2, 1] },
+          { name: 'three', start: [3, 1], end: [3, 1] },
+        ],
+        middle: [
+          { name: 'header', start: [0, 0], end: [3, 0] },
+          { name: 'one', start: [0, 1], end: [0, 1] },
+          { name: 'two', start: [1, 1], end: [2, 1] },
+          { name: 'three', start: [3, 1], end: [3, 1] },
+        ],
+      }}
+    >
+      <Box gridArea="header" background="brand" />
+      <Box gridArea="one" background="dark-1" />
+      <Box gridArea="two" background="dark-2" />
+      <Box gridArea="three" background="dark-3" />
+    </ResponsiveGrid>
+    <Paragraph>
+      Below a certain threshold, Columns 1 &amp; 2 switch to 50% and Column 3
+      moves down to a new spot in the grid.
+    </Paragraph>
   </Grommet>
-));
+);
+
+storiesOf('ResponsiveContext', module)
+  .add('Custom Breakpoints', () => (
+    <Grommet theme={customBreakpoints} full>
+      <ResponsiveContext.Consumer>
+        {size => (
+          <Box fill background="brand">
+            <Heading>{`Hi, I'm ${size}, resize me!`}</Heading>
+          </Box>
+        )}
+      </ResponsiveContext.Consumer>
+    </Grommet>
+  ))
+  .add('Responsive Grid', () => <ResponsiveGridExample />);


### PR DESCRIPTION
This adds an example to the Storybook "ResponsiveContext > Resposive Grid" that demonstrates using the ResponsiveContext.Consumer object to create a grid with different-sized grid areas based on the available breakpoint(s).

#### What does this PR do?
Increases the available examples in Grommet's storybook based on a conversation in the Grommet Slack.

#### Where should the reviewer start?
* Stories -> Responsive Context -> Responsive Grid
* `src/js/contexts/ResponsiveContext/responsive-context.stories.js`

#### What testing has been done on this PR?
Ran the pre-commit hooks and also tested in Storybook. There are some unrelated pre-commit tests failing around snapshots, but I didn't think it was wise to change those as part of this commit.

#### How should this be manually tested?
* Check results via storybook

#### Any background context you want to provide?
From Slack:

> In case anyone is struggling to make `Grid` responsive, here's a super-simple component. It overloads `areas` to use an object (of the normal `areas` array) to support all breakpoints in `ResponsiveContext.Consumer`. I don't know why it took me so long to wrap my head around, but if you want a different layout at different breakpoints, here ya go!
>
> ```import React from 'react';
> import { Grid, ResponsiveContext } from 'grommet';
> 
> const ResponsiveGrid = ({children, areas, ...props}) => (<ResponsiveContext.Consumer>
>   {(size) => (<Grid areas={areas[size]} {...props}>{children}</Grid>)}
> </ResponsiveContext.Consumer>)
> 
> export default ResponsiveGrid;```

It was then suggested we create a Storybook item for this to not lose it.

#### What are the relevant issues?
n/a

#### Screenshots (if appropriate)
n/a

#### Do the grommet docs need to be updated?
Nope. Just another example of using grommets' awesome contexts.

#### Should this PR be mentioned in the release notes?
Not needed.

#### Is this change backwards compatible or is it a breaking change?
Backwards Compatible