### PR TITLE
Menu - adding type of number to opacity

### DIFF
--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -224,11 +224,11 @@ string
   image: string,
   position: string,
   opacity: 
+    boolean
+    number
     weak
     medium
-    strong
-    boolean
-    number,
+    strong,
   repeat: 
     no-repeat
     repeat

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -81,9 +81,9 @@ export const doc = Box => {
         image: PropTypes.string,
         position: PropTypes.string,
         opacity: PropTypes.oneOfType([
-          PropTypes.oneOf(['weak', 'medium', 'strong']),
           PropTypes.bool,
           PropTypes.number,
+          PropTypes.oneOf(['weak', 'medium', 'strong']),
         ]),
         repeat: PropTypes.oneOfType([
           PropTypes.oneOf(['no-repeat', 'repeat']),

--- a/src/js/components/Menu/README.md
+++ b/src/js/components/Menu/README.md
@@ -158,10 +158,11 @@ string
 {
   color: string,
   opacity: 
+    boolean
+    number
     weak
     medium
     strong
-    boolean
 }
 ```
 

--- a/src/js/components/Menu/doc.js
+++ b/src/js/components/Menu/doc.js
@@ -46,8 +46,9 @@ one of top or bottom should be specified.`,
       PropTypes.shape({
         color: PropTypes.string,
         opacity: PropTypes.oneOfType([
-          PropTypes.oneOf(['weak', 'medium', 'strong']),
           PropTypes.bool,
+          PropTypes.number,
+          PropTypes.oneOf(['weak', 'medium', 'strong']),
         ]),
       }),
     ]).description('Background color when drop is active'),

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -8,7 +8,7 @@ export interface MenuProps {
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   disabled?: boolean;
   dropAlign?: {top?: "top" | "bottom",bottom?: "top" | "bottom",left?: "right" | "left",right?: "right" | "left"};
-  dropBackground?: string | {color?: string,opacity?: "weak" | "medium" | "strong" | boolean};
+  dropBackground?: string | {color?: string,opacity?: "weak" | "medium" | "strong" | boolean | number};
   dropTarget?: object;
   dropProps?: DropProps;
   justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch";

--- a/src/js/components/Menu/menu.stories.js
+++ b/src/js/components/Menu/menu.stories.js
@@ -23,7 +23,11 @@ const SimpleMenu = () => (
 
 const CustomMenu = () => (
   <Grommet theme={grommet}>
-    <Box align="center" pad="large" background="dark-2">
+    <Box
+      align="center"
+      pad="large"
+      background={{ color: 'dark-2', opacity: 0.7 }}
+    >
       <Menu
         plain
         items={[

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -802,11 +802,11 @@ string
   image: string,
   position: string,
   opacity: 
+    boolean
+    number
     weak
     medium
-    strong
-    boolean
-    number,
+    strong,
   repeat: 
     no-repeat
     repeat
@@ -6699,10 +6699,11 @@ string
 {
   color: string,
   opacity: 
+    boolean
+    number
     weak
     medium
     strong
-    boolean
 }
 \`\`\`
 

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -393,11 +393,11 @@ zoomOut
   image: string,
   position: string,
   opacity: 
+    boolean
+    number
     weak
     medium
-    strong
-    boolean
-    number,
+    strong,
   repeat: 
     no-repeat
     repeat
@@ -2172,10 +2172,11 @@ one of top or bottom should be specified.",
 {
   color: string,
   opacity: 
+    boolean
+    number
     weak
     medium
     strong
-    boolean
 }",
         "name": "dropBackground",
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
adding the type of number to opacity prop in menu 

#### Where should the reviewer start?
doc.js

#### What testing has been done on this PR?
storybook 

#### How should this be manually tested?
storybook  Menu
#### Any background context you want to provide?

#### What are the relevant issues?
#3022

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
no
#### Is this change backward compatible or is it a breaking change?
backward compatible 