### PR TITLE
[TS] type refinement for FormField

### DIFF
--- a/src/js/components/FormField/index.d.ts
+++ b/src/js/components/FormField/index.d.ts
@@ -1,4 +1,7 @@
 import * as React from "react";
+import { CheckBoxProps } from "../CheckBox";
+import { RadioButtonGroupProps } from "../RadioButtonGroup";
+import { SelectProps } from "../Select";
 
 export interface FormFieldProps {
   error?: string | React.ReactNode;
@@ -8,10 +11,10 @@ export interface FormFieldProps {
   name?: string;
   pad?: boolean;
   required?: boolean;
-  component?: React.ComponentType<any>;
+  component?: React.ComponentType<any> | React.ReactNode;
   validate?: {regexp?: object,message?: string} | ((...args: any[]) => any);
 }
 
-declare const FormField: React.ComponentClass<FormFieldProps & JSX.IntrinsicElements['input']>;
+declare const FormField: React.ComponentClass<FormFieldProps & JSX.IntrinsicElements['input'] & CheckBoxProps & RadioButtonGroupProps & SelectProps>;
 
 export { FormField };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR is derived from the discussion in #3014  and addresses two problems:
1. FormField `component` type error - @roger-king please share inputs on how this error didn't reproduce on your end, were you using a function?
2. missing type for `options` prop that is not directly a FormField prop but is used when `component={Select}` is applied (or any other component that uses `options` as a prop)

FormField can use different components, hence `options` prop is only one example of potential missing prop types for FormField.
In this PR I'm including the props of potential components that will be used in FormField to avoid missing types definitions.

To reproduce the problem, use https://codesandbox.io/s/olxj16ox66.

#### Where should the reviewer start?
index.d.ts
#### What testing has been done on this PR?
sandbox and ts testing.
#### How should this be manually tested?
with a TS project.
#### Any background context you want to provide?
#3014 
#### What are the relevant issues?
none
#### Screenshots (if appropriate)
N/A
#### Do the grommet docs need to be updated?
N/A
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible