### PR TITLE
[WIP] Grommet box primitives INITIAL WIP - DO NOT MERGE

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
   },
   "peerDependencies": {
     "react": ">= 16.6.1",
+    "react-art": ">= 16.9.0",
     "react-dom": ">= 16.6.1",
+    "react-native-web": ">= 0.11.7",
+    "react-primitives": ">= 0.8.0",
     "styled-components": ">= 4.X"
   },
   "dependencies": {
@@ -111,8 +114,11 @@
     "prettier": "^1.16.4",
     "pretty-quick": "^1.8.0",
     "react": "^16.8.3",
+    "react-art": "^16.9.0",
     "react-dev-utils": "^9.0.3",
     "react-dom": "^16.8.3",
+    "react-native-web": "^0.11.7",
+    "react-primitives": "^0.8.0",
     "react-test-renderer": "^16.8.3",
     "regenerator-runtime": "^0.13.1",
     "require-reload": "^0.2.2",

--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -15,7 +15,9 @@ class Box extends Component {
 
   static defaultProps = {
     direction: 'column',
+    /* XXX TBD WORKAROUND for issue with primitives: {{{
     margin: 'none',
+    // ** XXX END of WORKAROUND }}} */
     pad: 'none',
     responsive: true,
   };

--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -42,7 +42,13 @@ class Box extends Component {
       theme: propsTheme,
       ...rest
     } = this.props;
+    /* ** XXX TBD QUICK WORKAROUND for React Native:
     const theme = this.context || propsTheme;
+    // ** XXX ... */
+    const theme = this.context && this.context.global
+      ? this.context
+      : propsTheme;
+    // ** XXX END OF QUICK WORKAROUND for React Native
     let contents = children;
     if (gap) {
       contents = [];

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -1,4 +1,4 @@
-import styled, { css, keyframes } from 'styled-components';
+import styled, { css } from '../../styled-imports';
 
 import { defaultProps } from '../../default-props';
 

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -537,7 +537,7 @@ const StyledBox = styled.View`
     edgeStyle(
       'padding',
       props.pad,
-      props.responsive,
+      false, /* XXX TBD NOT WORKING on React Native: props.responsive, */
       props.theme.box.responsiveBreakpoint,
       props.theme,
     )}

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -385,6 +385,7 @@ const animationEnding = type => {
   return 'forwards';
 };
 
+/* ** XXX TBD WORKAROUND for issue with primitives: {{{
 const animationObjectStyle = (animation, theme) => {
   const bounds = animationBounds(animation.type, animation.size);
   if (bounds) {
@@ -466,6 +467,7 @@ const animationStyle = css`
     animation: ${animationItemStyle(props.animation, props.theme)};
   `};
 `;
+// ** XXX END OF WORKAROUND }}} */
 
 const getSize = (props, size) => props.theme.global.size[size] || size;
 
@@ -542,7 +544,7 @@ const StyledBox = styled.div`
   ${props => props.wrapProp && wrapStyle}
   ${props => props.overflowProp && overflowStyle(props.overflowProp)}
   ${props => props.elevationProp && elevationStyle}
-  ${props => props.animation && animationStyle}
+  ${/* XXX TBD */ null /* props => props.animation && animationStyle */}
   ${props => props.theme.box && props.theme.box.extend}
 `;
 

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -506,7 +506,7 @@ const widthStyle = css`
 `;
 
 // NOTE: basis must be after flex! Otherwise, flex overrides basis
-const StyledBox = styled.div`
+const StyledBox = styled.View`
   display: flex;
   box-sizing: border-box;
   outline: none;
@@ -584,7 +584,7 @@ const gapStyle = (directionProp, gap, responsive, theme) => {
 StyledBox.defaultProps = {};
 Object.setPrototypeOf(StyledBox.defaultProps, defaultProps);
 
-const StyledBoxGap = styled.div`
+const StyledBoxGap = styled.View`
   flex: 0 0 auto;
   ${props =>
     props.gap &&

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -508,8 +508,10 @@ const widthStyle = css`
 // NOTE: basis must be after flex! Otherwise, flex overrides basis
 const StyledBox = styled.View`
   display: flex;
+  ${ /* XXX TBD NOT WORKING on React Native: }
   box-sizing: border-box;
   outline: none;
+  ${ /* XXX END OF TBD NOT WORKING on React Native ** */ undefined }
   ${props => !props.basis && 'max-width: 100%;'};
 
   ${genericStyles}

--- a/src/js/components/Grommet/Grommet.js
+++ b/src/js/components/Grommet/Grommet.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
-import { createGlobalStyle } from 'styled-components';
+// XXX TBD NOT SUPPORTED:
+// import { createGlobalStyle } from 'styled-components';
 
 import { colorIsDark } from 'grommet-styles';
 import { ResponsiveContext, ThemeContext } from '../../contexts';
@@ -7,9 +8,11 @@ import { deepMerge, getBreakpoint, getDeviceBreakpoint } from '../../utils';
 import { base as baseTheme } from '../../themes';
 import { StyledGrommet } from './StyledGrommet';
 
+/* ** XXX TBD NOT SUPPORTED {{{
 const FullGlobalStyle = createGlobalStyle`
   body { margin: 0; }
 `;
+// ** XXX END TBD NOT SUPPORTED }}} */
 
 class Grommet extends Component {
   static displayName = 'Grommet';
@@ -100,7 +103,7 @@ class Grommet extends Component {
           <StyledGrommet full={full} {...rest}>
             {children}
           </StyledGrommet>
-          {full && <FullGlobalStyle />}
+          {/* XXX TBD NOT SUPPORTED */ null /* full && <FullGlobalStyle /> */}
         </ResponsiveContext.Provider>
       </ThemeContext.Provider>
     );

--- a/src/js/components/Grommet/Grommet.js
+++ b/src/js/components/Grommet/Grommet.js
@@ -41,6 +41,7 @@ class Grommet extends Component {
 
   state = {};
 
+  /* ** XXX TBD NOT SUPPORTED on React Native {{{
   componentDidMount() {
     window.addEventListener('resize', this.onResize);
     this.onResize();
@@ -49,6 +50,7 @@ class Grommet extends Component {
   componentWillUnmount() {
     window.removeEventListener('resize', this.onResize);
   }
+  // *** XXX END TBD NOT SUPPORTED on React Native  }}} */
 
   onResize = () => {
     const { theme, responsive } = this.state;

--- a/src/js/components/Grommet/StyledGrommet.js
+++ b/src/js/components/Grommet/StyledGrommet.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from '../../styled-imports';
 
 import { baseStyle } from '../../utils';
 import { defaultProps } from '../../default-props';
@@ -9,8 +9,8 @@ const fullStyle = css`
   overflow: auto;
 `;
 
-const StyledGrommet = styled.div`
-  ${props => !props.plain && baseStyle}
+const StyledGrommet = styled.View`
+  ${/* XXX TBD ??? */ null /* props => !props.plain && baseStyle */}
   ${props => props.full && fullStyle}
   ${props => props.theme.global.font.face}
   ${props => props.theme.grommet.extend}

--- a/src/js/components/hocs.js
+++ b/src/js/components/hocs.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react';
 import getDisplayName from 'recompose/getDisplayName';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { withTheme } from 'styled-components';
+import { withTheme } from '../styled-imports';
 import { AnnounceContext } from '../contexts';
 
 export const withFocus = ({ focusWithMouse } = {}) => WrappedComponent => {

--- a/src/js/contexts/ThemeContext/ThemeContext.js
+++ b/src/js/contexts/ThemeContext/ThemeContext.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ThemeContext } from 'styled-components';
+import { ThemeContext } from '../../styled-imports';
 
 import { deepMerge } from '../../utils';
 

--- a/src/js/styled-imports.js
+++ b/src/js/styled-imports.js
@@ -1,7 +1,9 @@
-import {
+import styled, {
   ThemeContext,
   css,
   withTheme
 } from 'styled-components';
 
 export { ThemeContext, css, withTheme };
+
+export default styled;

--- a/src/js/styled-imports.js
+++ b/src/js/styled-imports.js
@@ -2,7 +2,7 @@ import styled, {
   ThemeContext,
   css,
   withTheme
-} from 'styled-components';
+} from 'styled-components/primitives';
 
 export { ThemeContext, css, withTheme };
 

--- a/src/js/styled-imports.js
+++ b/src/js/styled-imports.js
@@ -1,0 +1,7 @@
+import {
+  ThemeContext,
+  css,
+  withTheme
+} from 'styled-components';
+
+export { ThemeContext, css, withTheme };

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1,5 +1,5 @@
 import { rgba } from 'polished';
-import { css } from 'styled-components';
+import { css } from '../styled-imports';
 
 import { Actions } from 'grommet-icons/icons/Actions';
 import { ClosedCaption } from 'grommet-icons/icons/ClosedCaption';

--- a/src/js/themes/dark.js
+++ b/src/js/themes/dark.js
@@ -1,5 +1,5 @@
 import { rgba } from 'polished';
-import { css } from 'styled-components';
+import { css } from '../styled-imports';
 
 import { deepFreeze } from '../utils/object';
 import { normalizeColor } from '../utils/colors';

--- a/src/js/themes/grommet.js
+++ b/src/js/themes/grommet.js
@@ -1,4 +1,4 @@
-import { css } from 'styled-components';
+import { css } from '../styled-imports';
 
 import { deepFreeze } from '../utils/object';
 

--- a/src/js/utils/background.js
+++ b/src/js/utils/background.js
@@ -1,4 +1,4 @@
-import { css } from 'styled-components';
+import { css } from '../styled-imports';
 
 import { colorIsDark, getRGBA, normalizeColor } from './colors';
 import { evalStyle } from './styles';

--- a/src/js/utils/mixins.js
+++ b/src/js/utils/mixins.js
@@ -1,4 +1,4 @@
-import { css } from 'styled-components';
+import { css } from '../styled-imports';
 
 export const parseMetricToNum = fontAsString => {
   if (fontAsString.match(/\s/) && process.env.NODE_ENV !== 'production') {

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -1,4 +1,4 @@
-import { css } from 'styled-components';
+import { css } from '../styled-imports';
 
 import { normalizeColor } from './colors';
 import { breakpointStyle, parseMetricToNum } from './mixins';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2146,6 +2146,14 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+animated@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/animated/-/animated-0.2.2.tgz#04af7846ad0b9b8d1f0472cc53d82b8efeb4a751"
+  integrity sha512-7pMzS0Sk2lA6/JT6he+apuy3GnDWUWVCurHMrpsbT9ugeLe80kpDQWjZQvkFiU9o7LsPGydPnoZpJsmt1HPPMA==
+  dependencies:
+    invariant "^2.2.0"
+    normalize-css-color "^1.0.1"
+
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"
@@ -2266,6 +2274,11 @@ array-filter@~0.0.0:
   resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
   integrity sha1-fajPLiZijtcygDWB/SH2fKzS7uw=
 
+array-find-index@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
+  integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -2333,6 +2346,11 @@ arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
+
+art@^0.10.1:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/art/-/art-0.10.3.tgz#b01d84a968ccce6208df55a733838c96caeeaea2"
+  integrity sha512-HXwbdofRTiJT6qZX/FnchtldzJjS3vkLJxQilc3Xj+ma2MXjY4UAyQ0ls1XZYVnDvVIBiFZbC6QsvtW86TD6tQ==
 
 asap@~2.0.3:
   version "2.0.6"
@@ -3665,7 +3683,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.4.0, core-js@^2.6.5:
+core-js@^2.4.0, core-js@^2.4.1, core-js@^2.6.5:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
@@ -3728,6 +3746,15 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-react-class@^15.6.2, create-react-class@^15.6.3:
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
+  integrity sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 create-react-context@^0.2.1:
   version "0.2.3"
@@ -3794,6 +3821,14 @@ css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
   integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
+
+css-in-js-utils@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"
+  integrity sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==
+  dependencies:
+    hyphenate-style-name "^1.0.2"
+    isobject "^3.0.1"
 
 css-loader@^2.1.1:
   version "2.1.1"
@@ -3937,6 +3972,11 @@ date-now@^0.1.4:
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
   integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
+debounce@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
+  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -3981,6 +4021,13 @@ decompress-response@^3.3.0:
   integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
   dependencies:
     mimic-response "^1.0.0"
+
+deep-assign@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/deep-assign/-/deep-assign-3.0.0.tgz#c8e4c4d401cba25550a2f0f486a2e75bc5f219a2"
+  integrity sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==
+  dependencies:
+    is-obj "^1.0.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -4942,12 +4989,31 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.0, fbjs@^0.8.1:
+fbjs-css-vars@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
+  integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
+
+fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
   dependencies:
     core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
+
+fbjs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-1.0.0.tgz#52c215e0883a3c86af2a7a776ed51525ae8e0a5a"
+  integrity sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==
+  dependencies:
+    core-js "^2.4.1"
+    fbjs-css-vars "^1.0.0"
     isomorphic-fetch "^2.1.1"
     loose-envify "^1.0.0"
     object-assign "^4.1.0"
@@ -5820,6 +5886,11 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
+hyphenate-style-name@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
+  integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -5973,6 +6044,13 @@ ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
+inline-style-prefixer@^5.0.3:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-5.1.0.tgz#cb63195f9456dcda25cf59743e45c4d9815b0811"
+  integrity sha512-giteQHPMrApQOSjNSjteO5ZGSGMRf9gas14fRy2lg2buSc1nRnj6o6xuNds5cMTKrkncyrTu3gJn/yflFMVdmg==
+  dependencies:
+    css-in-js-utils "^2.0.0"
+
 inquirer@6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.0.tgz#2303317efc9a4ea7ec2e2df6f86569b734accf42"
@@ -6016,7 +6094,7 @@ interpret@1.2.0, interpret@^1.0.0, interpret@^1.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
-invariant@2.2.4, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.0, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -6239,6 +6317,11 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
 is-path-cwd@^2.0.0, is-path-cwd@^2.2.0:
   version "2.2.0"
@@ -7144,7 +7227,7 @@ lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -7737,6 +7820,11 @@ nopt@^4.0.1:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
+
+normalize-css-color@^1.0.1, normalize-css-color@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/normalize-css-color/-/normalize-css-color-1.0.2.tgz#02991e97cccec6623fe573afbbf0de6a1f3e9f8d"
+  integrity sha1-Apkel8zOxmI/5XOvu/Deah8+n40=
 
 normalize-package-data@^2.3.2:
   version "2.5.0"
@@ -8818,6 +8906,18 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-art@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-art/-/react-art-16.9.0.tgz#72b7ebf3b6bcff78f6f547981805570bffaf303f"
+  integrity sha512-gQGSf5ZzA8bZWhJpl1/FVyfS6C+uWZat1xQ78gxYBE4kQjO23zcrzJDIy8tBoXbkKnSQp9FoN0EVPBpBiorfJw==
+  dependencies:
+    art "^0.10.1"
+    create-react-class "^15.6.2"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.15.0"
+
 react-clientside-effect@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"
@@ -8940,6 +9040,22 @@ react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-native-web@^0.11.7:
+  version "0.11.7"
+  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.11.7.tgz#d173d5a9b58db23b6d442c4bc4c81e9939adac23"
+  integrity sha512-w1KAxX2FYLS2GAi3w3BnEZg/IUu7FdgHnLmFKHplRnHMV3u1OPB2EVA7ndNdfu7ds4Rn2OZjSXoNh6F61g3gkA==
+  dependencies:
+    array-find-index "^1.0.2"
+    create-react-class "^15.6.2"
+    debounce "^1.2.0"
+    deep-assign "^3.0.0"
+    fbjs "^1.0.0"
+    hyphenate-style-name "^1.0.2"
+    inline-style-prefixer "^5.0.3"
+    normalize-css-color "^1.0.2"
+    prop-types "^15.6.0"
+    react-timer-mixin "^0.13.4"
+
 react-popper-tooltip@^2.8.3:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/react-popper-tooltip/-/react-popper-tooltip-2.8.3.tgz#1c63e7473a96362bd93be6c94fa404470a265197"
@@ -8959,6 +9075,16 @@ react-popper@^1.3.3:
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
     warning "^4.0.2"
+
+react-primitives@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/react-primitives/-/react-primitives-0.8.0.tgz#1cba0b1bd1463df158c963cabd5130b017e35e45"
+  integrity sha512-LyzURw3K2dSlpWBhW1IpoRVzZtlpKyUAEhd+dmAD5hIRFkaJ+v3dM7+5AuFqg76B4ASxFxb/Wq9FFJ/UqMSUPA==
+  dependencies:
+    animated "^0.2.2"
+    create-react-class "^15.6.3"
+    prop-types "^15.7.2"
+    react-timer-mixin "^0.13.4"
 
 react-resize-detector@^4.0.5:
   version "4.2.0"
@@ -8999,6 +9125,11 @@ react-textarea-autosize@^7.1.0:
   dependencies:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
+
+react-timer-mixin@^0.13.4:
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz#75a00c3c94c13abe29b43d63b4c65a88fc8264d3"
+  integrity sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q==
 
 react@^16.8.3:
   version "16.9.0"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

**INTIIAL DRAFT WIP:**

`Box` and themed `Grommet` components now partially working on web and React Native using `styled-components/primitives`, with a few workarounds that are hopefully temporary.

Unfortunately the padding is not working at this time. I would have to investigate it further. My initial purpose is to prove Grommet able to run with some basic components on both web and native using react-primitives.

NOTE that this PR is coming from an initial-wip branch and is not intended to ever be merged. I would expect some deep rework will be needed before we should consider merging. I will also completely understand if some of the initial coding decisions such as adding the new `styled-imports.js` module would not be accepted.

There are some additional peer dependencies, which would be needed as documented in the following locations:
- <https://github.com/lelandrichardson/react-primitives#installation>
- <https://github.com/necolas/react-native-web/blob/master/docs/guides/getting-started.md#install>

#### Where should the reviewer start?

I made a new module in `src/js/styled-imports.js` that imports from `styled-components/primitives`, and this module is used in the `StyledBox.js`, `StyledGrommet.js`, `hoc.js`, and other common JavaScript sources. The new module was introduced in f3f2b4a & 98fa9fb6b53605b03cf76122575310cb8d2ae2f0, then adapted in 8f215db359c21b2a759375f9785ff9922f5b1323 to import from `styled-components/primitives` rather than `styled-components`.

I made a few workarounds that were needed to work on react-primitives and react-native. Most of the workarounds changes are in individual commits. As I said before I hope the workaround solutions can be replaced by better solutions.

The actual change from `styled-components` to `styled-components/primitives` was done in the following commits:
- 8f215db359c21b2a759375f9785ff9922f5b1323
- d7563866b9dd300ce6ade333e5d47b305f183825

#### What testing has been done on this PR?

I made a test app in <https://github.com/brodybits/grommet-primitives-box-testapp-wip> based on code generated by both create-react-app and `expo init`. This test app is able to run a very basic Grommet demo on both web and Expo using react-primitives.

The test app uses a git submodule to run a version of Grommet with these changes from <https://github.com/brodybits/grommet-primitives-fork>.

In the future I would like to do the testing using Storybook and Expobook (see <https://blog.expo.io/introducing-expobook-8fbf7a125a9d>).

#### How should this be manually tested?

Major tools needed:

- Yarn (**highly recommended**, I generally do not work on this kind of application without Yarn)
- expo-cli (it should be no problem to get the test app to work with react-native-cli instead, if needed)

Major steps:

- Clone <https://github.com/brodybits/grommet-primitives-box-testapp-wip>
- In the test app do `git submodule update --init --recursive` (see <https://github.blog/2016-02-01-working-with-submodules/>)
- To test the web version do `yarn start-web` (I generally do `BROWSER=none yarn start-web` and then navigate to <http://localhost:3000/>)
- To test on Expo: do `yarn start-expo` or `expo start` then view the app on my Android & iPhone devices

#### Any background context you want to provide?

I would like to help make it easier for web and mobile app developers to develop applications that work seamlessly across the major web and device technologies. My idea is that it should be possible for developers to start with online and PWA apps, then be able to make a smooth transition to native mobile GUIs at will. React Primitives was a major step in this direction, and I think another major step has been taken by `styled-components`: <https://medium.com/styled-components/announcing-primitives-support-for-truly-universal-component-systems-5772c7d14bc7>

Grommet seemed like a perfect fit since it is already designed to support Material Design using `styled-components`.

I would also like to revive `react-primitives` or a similar kind of framework and think this kind of a port could really prove the usefulness.

#### What are the relevant issues?

- #2991
- #2748
- styled-components/styled-components#2313

#### Screenshots (if appropriate)

**From a web browser:**

<img width="348" alt="Screen Shot 2019-04-18 at 1 52 40 AM" src="https://user-images.githubusercontent.com/1559888/56339564-c2969c00-617c-11e9-818a-d5037c3be15d.png">

**From React Native Expo on my iPhone:**

![Grommet-primitives-iPhone](https://user-images.githubusercontent.com/1559888/56339677-39339980-617d-11e9-8583-536544f5f009.jpg)


#### Do the grommet docs need to be updated?

TBD

#### Should this PR be mentioned in the release notes?

Not this PR since it is intended to remain a WIP PR.

#### Is this change backwards compatible or is it a breaking change?

I would definitely consider this to be a breaking change since it would need `react-primitives` and other related packages in order to work at all.