### PR TITLE
feature/label-color-plain-button

### DIFF
--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -121,7 +121,7 @@ boolean
 
 **color**
 
-Fill color for primary, border color otherwise.
+Fill color for primary, label color for plain, border color otherwise.
 
 ```
 string

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -78,8 +78,8 @@ const fillStyle = `
   flex: 1 0 auto;
 `;
 
-const plainStyle = css`
-  color: inherit;
+const plainStyle = props => css`
+  color: ${normalizeColor(props.colorValue || 'inherit', props.theme)};
   border: none;
   padding: 0;
   text-align: inherit;
@@ -99,7 +99,7 @@ const StyledButton = styled.button`
   text-transform: none;
 
   ${genericStyles}
-  ${props => props.plain && plainStyle}
+  ${props => props.plain && plainStyle(props)}
   ${props => !props.plain && basicStyle(props)}
   ${props => props.primary && primaryStyle(props)}
 

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -28,7 +28,7 @@ export const doc = Button => {
       .description('Whether the button is active.')
       .defaultValue(false),
     color: colorPropType.description(
-      'Fill color for primary, border color otherwise.',
+      'Fill color for primary, label color for plain, border color otherwise.',
     ),
     disabled: PropTypes.bool
       .description('Whether the button is disabled.')

--- a/src/js/components/Button/stories/CustomColor.js
+++ b/src/js/components/Button/stories/CustomColor.js
@@ -38,6 +38,19 @@ const Colored = props => (
         {...props}
       />
       <Button primary color="#777" label="#777" onClick={() => {}} {...props} />
+      <Button
+        plain
+        color="red"
+        label="plain red"
+        onClick={() => {}}
+        {...props}
+      />
+      <Button
+        plain
+        label="plain inherit"
+        onClick={() => {}}
+        {...props}
+      />
     </Box>
   </Grommet>
 );

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1475,7 +1475,7 @@ boolean
 
 **color**
 
-Fill color for primary, border color otherwise.
+Fill color for primary, label color for plain, border color otherwise.
 
 \`\`\`
 string


### PR DESCRIPTION
`color` property of a `plain` <Button /> now changes the label color.

#### What does this PR do?

Fixes https://github.com/grommet/grommet/issues/3031

#### Where should the reviewer start?

Check storybook url:
http://localhost:9001/?path=/story/button--colored, or
https://deploy-preview-3032--sad-tereshkova-173d07.netlify.com/?path=/story/button--colored

#### What testing has been done on this PR?

Storybook link above.

#### How should this be manually tested?

Storybook link above.

#### Any background context you want to provide?

I wanted to be able to set an individual Button label color, using some existing logic.

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/3031

#### Do the grommet docs need to be updated?

Done already.

#### Should this PR be mentioned in the release notes?

I don't think it is THAT relevant.

#### Is this change backwards compatible or is it a breaking change?

Nope.
