### PR TITLE
Allow Select custom icon to receive a node.

### DIFF
--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -228,6 +228,7 @@ A custom icon to be used when rendering the select. You can use false to not ren
 ```
 boolean
 function
+node
 ```
 
 **labelKey**
@@ -457,6 +458,16 @@ undefined
 **select.control.extend**
 
 Any additional style for the control of the Select component. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```
+
+**select.icons.margin**
+
+The margin used for Select icons. Expects `object`.
 
 Defaults to
 

--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -467,7 +467,7 @@ undefined
 
 **select.icons.margin**
 
-The margin used for Select icons. Expects `object`.
+The margin used for Select icons. Expects `string | object`.
 
 Defaults to
 

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { isValidElement, Component } from 'react';
 import { compose } from 'recompose';
 import styled, { withTheme } from 'styled-components';
 
@@ -219,11 +219,15 @@ class Select extends Component {
             </Box>
             {SelectIcon && (
               <Box
-                margin={{ horizontal: 'small' }}
+                margin={theme.select.icons.margin}
                 flex={false}
                 style={{ minWidth: 'auto' }}
               >
-                <SelectIcon color={iconColor} size={size} />
+                {isValidElement(SelectIcon) ? (
+                  SelectIcon
+                ) : (
+                  <SelectIcon color={iconColor} size={size} />
+                )}
               </Box>
             )}
           </Box>

--- a/src/js/components/Select/doc.js
+++ b/src/js/components/Select/doc.js
@@ -213,7 +213,7 @@ export const themeDoc = {
   },
   'select.icons.margin': {
     description: 'The margin used for Select icons.',
-    type: 'object',
+    type: 'string | object',
     defaultValue: undefined,
   },
   'select.icons.color': {

--- a/src/js/components/Select/doc.js
+++ b/src/js/components/Select/doc.js
@@ -78,7 +78,11 @@ export const doc = Select => {
     focusIndicator: PropTypes.bool.description(
       "Whether when 'plain' it should receive a focus outline.",
     ),
-    icon: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]).description(
+    icon: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.func,
+      PropTypes.node,
+    ]).description(
       'A custom icon to be used when rendering the select. You can use false to not render an icon at all.',
     ),
     labelKey: PropTypes.oneOfType([
@@ -205,6 +209,11 @@ export const themeDoc = {
     description:
       'Any additional style for the control of the Select component.',
     type: 'string | (props) => {}',
+    defaultValue: undefined,
+  },
+  'select.icons.margin': {
+    description: 'The margin used for Select icons.',
+    type: 'object',
     defaultValue: undefined,
   },
   'select.icons.color': {

--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -15,7 +15,7 @@ export interface SelectProps {
   dropTarget?: object;
   dropProps?: DropProps;
   focusIndicator?: boolean;
-  icon?: boolean | ((...args: any[]) => any);
+  icon?: boolean | ((...args: any[]) => any) | React.ReactNode;
   id?: string;
   labelKey?: string | ((...args: any[]) => any);
   messages?: {multiple?: string};

--- a/src/js/components/Select/stories/select.stories.js
+++ b/src/js/components/Select/stories/select.stories.js
@@ -642,4 +642,12 @@ storiesOf('Select', module)
   .add('Custom', () => <SimpleSelect open theme={customRoundedTheme} />)
   .add('Lots of options', () => <ManyOptions />)
   .add('Custom Value', () => <CustomSelectValue />)
-  .add('Custom Icon', () => <CustomSelectValue icon={CaretDown} />);
+  .add('Custom Icon', () => (
+    <CustomSelectValue
+      icon={
+        <Box>
+          <CaretDown color="black" />
+        </Box>
+      }
+    />
+  ));

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -8164,6 +8164,7 @@ A custom icon to be used when rendering the select. You can use false to not ren
 \`\`\`
 boolean
 function
+node
 \`\`\`
 
 **labelKey**
@@ -8393,6 +8394,16 @@ undefined
 **select.control.extend**
 
 Any additional style for the control of the Select component. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**select.icons.margin**
+
+The margin used for Select icons. Expects \`object\`.
 
 Defaults to
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -8403,7 +8403,7 @@ undefined
 
 **select.icons.margin**
 
-The margin used for Select icons. Expects \`object\`.
+The margin used for Select icons. Expects \`string | object\`.
 
 Defaults to
 

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2736,7 +2736,8 @@ string",
       Object {
         "description": "A custom icon to be used when rendering the select. You can use false to not render an icon at all.",
         "format": "boolean
-function",
+function
+node",
         "name": "icon",
       },
       Object {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -693,6 +693,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
       icons: {
         // color: { dark: undefined, light: undefined },
+        margin: { horizontal: 'small' },
         down: FormDown,
       },
       options: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
changes select icon to allow for a custom icon component.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #3017 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards