### PR TITLE
Feature/button gap configurable

### DIFF
--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -30,6 +30,7 @@ class Button extends Component {
   static defaultProps = {
     type: 'button',
     focusIndicator: true,
+    gap: 'small',
   };
 
   constructor(props) {
@@ -69,6 +70,7 @@ class Button extends Component {
       children,
       disabled,
       icon,
+      gap,
       fill, // munged to avoid styled-components putting it in the DOM
       focus,
       href,
@@ -102,7 +104,7 @@ class Button extends Component {
     let contents;
     if (first && second) {
       contents = (
-        <Box direction="row" align="center" justify="center" gap="small">
+        <Box direction="row" align="center" justify="center" gap={gap}>
           {first}
           {second}
         </Box>
@@ -123,6 +125,7 @@ class Button extends Component {
         colorValue={color}
         disabled={disabled}
         hasIcon={!!icon}
+        gap={gap}
         hasLabel={!!label}
         fillContainer={fill}
         focus={focus}

--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -189,6 +189,20 @@ Icon element to place in the button.
 element
 ```
 
+**gap**
+
+The amount of spacing between icon and label in the button. Defaults to `small`.
+
+```
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+string
+```
+
 **label**
 
 Label text to place in the button.

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -60,6 +60,21 @@ with plain Buttons.`,
       'If specified, the button will behave like an anchor tag.',
     ),
     icon: PropTypes.element.description('Icon element to place in the button.'),
+    gap: PropTypes.oneOfType([
+      PropTypes.oneOf([
+        'xxsmall',
+        'xsmall',
+        'small',
+        'medium',
+        'large',
+        'xlarge',
+      ]),
+      PropTypes.string,
+    ])
+      .description(
+        `The amount of spacing between icon and label in the button.`,
+      )
+      .defaultValue('small'),
     label: PropTypes.node.description('Label text to place in the button.'),
     onClick: PropTypes.func.description(
       `Click handler. Not setting this property and not specifying a href

--- a/src/js/components/Button/stories/IconLabel.js
+++ b/src/js/components/Button/stories/IconLabel.js
@@ -14,6 +14,13 @@ const IconLabel = () => (
       <Box align="center" pad="large" gap="small">
         <Button icon={<Add />} label="Add" onClick={() => {}} primary />
         <Button icon={<Add />} label="Add" onClick={() => {}} />
+        <Button icon={<Add />} label="Add" gap="xlarge" onClick={() => {}} />
+        <Button
+          icon={<Add />}
+          label="500px gap"
+          gap="500px"
+          onClick={() => {}}
+        />
       </Box>
     </Box>
   </Grommet>

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1543,6 +1543,20 @@ Icon element to place in the button.
 element
 \`\`\`
 
+**gap**
+
+The amount of spacing between icon and label in the button. Defaults to \`small\`.
+
+\`\`\`
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+string
+\`\`\`
+
 **label**
 
 Label text to place in the button.

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -878,6 +878,18 @@ background
         "name": "icon",
       },
       Object {
+        "defaultValue": "small",
+        "description": "The amount of spacing between icon and label in the button.",
+        "format": "xxsmall
+xsmall
+small
+medium
+large
+xlarge
+string",
+        "name": "gap",
+      },
+      Object {
         "description": "Label text to place in the button.",
         "format": "node",
         "name": "label",


### PR DESCRIPTION
Added the possibility to the user to set the `gap` between icon and label in `Button`.

Closes: https://github.com/grommet/grommet/issues/3015

#### What does this PR do?

Adds a new prop to Button named `gap`
Adds storybook to this prop.

#### Where should the reviewer start?

Check if the addition was done right, defaultProps and more.

#### How should this be manually tested?

Into Storybook. go to Button -> icon label

#### Any background context you want to provide?

Just needed to

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/3015

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

Done already;

#### Should this PR be mentioned in the release notes?

It's your call.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.