### PR TITLE
Infinite scroll fixed for IE,Edge browsers and also tested for electron

### DIFF
--- a/src/js/components/InfiniteScroll/InfiniteScroll.js
+++ b/src/js/components/InfiniteScroll/InfiniteScroll.js
@@ -114,15 +114,8 @@ class InfiniteScroll extends PureComponent {
       const endRect = findDOMNode(
         this.lastPageItemRef.current,
       ).getBoundingClientRect();
-      let nextPageHeight;
-      // IE & Edge
-      if (document.documentMode || /Edge/.test(window.navigator.userAgent)) {
-        nextPageHeight = endRect.top + endRect.height - beginRect.top;
-      }
-      // Other browsers
-      else {
-        nextPageHeight = endRect.y + endRect.height - beginRect.y;
-      }
+
+      const nextPageHeight = endRect.top + endRect.height - beginRect.top;
       // Check if the items are arranged in a single column or not.
       const multiColumn = nextPageHeight / step < endRect.height;
       const pageArea = endRect.height * endRect.width * step;

--- a/src/js/components/InfiniteScroll/InfiniteScroll.js
+++ b/src/js/components/InfiniteScroll/InfiniteScroll.js
@@ -114,8 +114,15 @@ class InfiniteScroll extends PureComponent {
       const endRect = findDOMNode(
         this.lastPageItemRef.current,
       ).getBoundingClientRect();
-      /* eslint-enable react/no-find-dom-node */
-      const nextPageHeight = endRect.y + endRect.height - beginRect.y;
+      let nextPageHeight;
+      // IE & Edge
+      if (document.documentMode || /Edge/.test(window.navigator.userAgent)) {
+        nextPageHeight = endRect.top + endRect.height - beginRect.top;
+      }
+      // Other browsers
+      else {
+        nextPageHeight = endRect.y + endRect.height - beginRect.y;
+      }
       // Check if the items are arranged in a single column or not.
       const multiColumn = nextPageHeight / step < endRect.height;
       const pageArea = endRect.height * endRect.width * step;


### PR DESCRIPTION
Infinite scroll fixed for IE,Edge browsers and also tested for electron. 

#### What does this PR do?
Page height calculation fixed when InfiniteScroll is triggered on IE and Edge browsers.

#### Where should the reviewer start?
InfiniteScroll.js

#### What testing has been done on this PR?
Storybook on IE11, MS Edge, Chrome, Safari, Chrome and Electron. 
 
#### How should this be manually tested?
Storybook

#### Any background context you want to provide?
#### What are the relevant issues?
#2901 

#### Screenshots (if appropriate)
#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Yes