### PR TITLE
DataTable height set to auto

### DIFF
--- a/src/js/components/DataTable/StyledDataTable.js
+++ b/src/js/components/DataTable/StyledDataTable.js
@@ -12,6 +12,11 @@ const StyledDataTable = styled(Table)`
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
+
+  /* Firefox hack to get table contents to not overflow */
+  @-moz-document url-prefix() {
+    height: auto;
+  }
   ${genericStyles};
 `;
 

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -1526,7 +1526,7 @@ exports[`DataTable groupBy 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 eUfLDp"
 >
   <table
-    class="StyledDataTable-xrlyjm-0 kTrXKK StyledTable-sc-1m3u5g-6 fGUmP"
+    class="StyledDataTable-xrlyjm-0 tpKnu StyledTable-sc-1m3u5g-6 fGUmP"
   >
     <thead
       class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 bAIczD StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
@@ -2686,7 +2686,7 @@ exports[`DataTable sort 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 eUfLDp"
 >
   <table
-    class="StyledDataTable-xrlyjm-0 kTrXKK StyledTable-sc-1m3u5g-6 fGUmP"
+    class="StyledDataTable-xrlyjm-0 tpKnu StyledTable-sc-1m3u5g-6 fGUmP"
   >
     <thead
       class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 bAIczD StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"


### PR DESCRIPTION
DataTable height set to auto to fix overflow when DataTable wrapped in two levels of div. 

#### What does this PR do?
FIxes Datatable overflow issue #3059 . 

#### Where should the reviewer start?
StyledDataTable.js

#### What testing has been done on this PR?
Storybook

#### How should this be manually tested?
Storybook

#### Any background context you want to provide?
#### What are the relevant issues?
#3059 

#### Screenshots (if appropriate)
#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Yes