### PR TITLE
Allow theme coloring for plain buttons

### DIFF
--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -383,6 +383,16 @@ Defaults to
 undefined
 ```
 
+**button.plain.color**
+
+The color of the text label for plain buttons. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+undefined
+```
+
 **button.primary.color**
 
 The color of the background for primary buttons. Expects `string | { dark: string, light: string }`.

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -79,7 +79,12 @@ const fillStyle = `
 `;
 
 const plainStyle = props => css`
-  color: ${normalizeColor(props.colorValue || 'inherit', props.theme)};
+  color: ${normalizeColor(
+    props.colorValue ||
+      (props.theme.button.plain && props.theme.button.plain.color) ||
+      'inherit',
+    props.theme,
+  )};
   border: none;
   padding: 0;
   text-align: inherit;

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -165,6 +165,10 @@ export const themeDoc = {
     description: `The color of the text label.`,
     type: 'string | { dark: string, light: string }',
   },
+  'button.plain.color': {
+    description: `The color of the text label for plain buttons.`,
+    type: 'string | { dark: string, light: string }',
+  },
   'button.primary.color': {
     description: `The color of the background for primary buttons.`,
     type: 'string | { dark: string, light: string }',

--- a/src/js/components/Button/stories/CustomColor.js
+++ b/src/js/components/Button/stories/CustomColor.js
@@ -10,6 +10,9 @@ const customButtonColor = deepMerge(grommet, {
       light: 'white',
       dark: 'white',
     },
+    // plain: {
+    //   color: 'neutral-1',
+    // },
   },
 });
 
@@ -40,17 +43,12 @@ const Colored = props => (
       <Button primary color="#777" label="#777" onClick={() => {}} {...props} />
       <Button
         plain
-        color="red"
-        label="plain red"
+        color="neutral-2"
+        label="neutral-2 on plain"
         onClick={() => {}}
         {...props}
       />
-      <Button
-        plain
-        label="plain inherit"
-        onClick={() => {}}
-        {...props}
-      />
+      <Button plain label="plain inherit" onClick={() => {}} {...props} />
     </Box>
   </Grommet>
 );

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1737,6 +1737,16 @@ Defaults to
 undefined
 \`\`\`
 
+**button.plain.color**
+
+The color of the text label for plain buttons. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
 **button.primary.color**
 
 The color of the background for primary buttons. Expects \`string | { dark: string, light: string }\`.

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -300,13 +300,16 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         radius: `${baseSpacing * 0.75}px`,
       },
       // color: { dark: undefined, light: undefined }
-      primary: {
-        // color: { dark: undefined, light: undefined }
-      },
       // disabled: { opacity: undefined },
       padding: {
         vertical: `${baseSpacing / 4 - borderWidth}px`,
         horizontal: `${baseSpacing - borderWidth}px`,
+      },
+      // plain: {
+      //  color: { dark: undefined, light: undefined },
+      // },
+      primary: {
+        // color: { dark: undefined, light: undefined }
       },
     },
     calendar: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Allows theme coloring for plain buttons, so all plain buttons will be able to use the same color.

#### Where should the reviewer start?
doc.js
#### What testing has been done on this PR?
storybook, tested on the CustomColor story, and added a comment there to demonstrate how it should be used.
#### How should this be manually tested?
storybook
#### Any background context you want to provide?
This PR is completing the effort started on https://github.com/grommet/grommet/pull/3032
#### What are the relevant issues?
#3031 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
along the same lines of #3032 
#### Is this change backwards compatible or is it a breaking change?
backwards compatible 