### PR TITLE
DataTable - add step support for onMore loading

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -21,6 +21,7 @@ export const Body = ({
       items={data}
       onMore={onMore}
       scrollableAncestor="window"
+      step={theme.dataTable.step}
       renderMarker={marker => (
         <TableRow>
           <TableCell>{marker}</TableCell>

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -1,4 +1,7 @@
 import React, { Component } from 'react';
+import { compose } from 'recompose';
+
+import { withTheme } from 'styled-components';
 
 import { Header } from './Header';
 import { Footer } from './Footer';
@@ -79,10 +82,11 @@ class DataTable extends Component {
       data: propsData,
       groupBy,
       onMore,
+      onSearch, // removing unknown DOM attributes
       resizeable,
       size,
       sortable,
-      onSearch, // removing unknown DOM attributes
+      theme,
       ...rest
     } = this.props;
     const {
@@ -103,7 +107,7 @@ class DataTable extends Component {
     }
 
     return (
-      <StyledDataTable {...rest}>
+      <StyledDataTable theme={theme} {...rest}>
         <Header
           columns={columns}
           filtering={filtering}
@@ -135,6 +139,7 @@ class DataTable extends Component {
             onMore={onMore}
             primaryProperty={primaryProperty}
             size={size}
+            theme={theme}
           />
         )}
         {showFooter && (
@@ -155,6 +160,6 @@ let DataTableDoc;
 if (process.env.NODE_ENV !== 'production') {
   DataTableDoc = require('./doc').doc(DataTable); // eslint-disable-line global-require
 }
-const DataTableWrapper = DataTableDoc || DataTable;
+const DataTableWrapper = compose(withTheme)(DataTableDoc || DataTable);
 
 export { DataTableWrapper as DataTable };

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -122,7 +122,7 @@ A description of the data. The order controls the column order.
       made available for the column. 'primary' indicates that this property
       should be used as the unique identifier, which gives the cell 'row' scope
       for accessibility. If 'primary' is not used for any column, and
-      'primaryKey' isn't specified either, then the first column will be used. Defaults to `[]`.
+      'primaryKey' isn't specified either, then the first column will be used.
 
 ```
 [{
@@ -156,7 +156,7 @@ A description of the data. The order controls the column order.
 
 **data**
 
-Array of data objects. Defaults to `[]`.
+Array of data objects.
 
 ```
 [{
@@ -374,4 +374,14 @@ Defaults to
 
 ```
 right
+```
+
+**dataTable.step**
+
+How many items to render at a time. Expects `number`.
+
+Defaults to
+
+```
+50
 ```

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -164,4 +164,9 @@ export const themeDoc = {
     type: 'string',
     defaultValue: 'right',
   },
+  'dataTable.step': {
+    description: `How many items to render at a time.`,
+    type: 'number',
+    defaultValue: 50,
+  },
 };

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -3648,7 +3648,7 @@ A description of the data. The order controls the column order.
       made available for the column. 'primary' indicates that this property
       should be used as the unique identifier, which gives the cell 'row' scope
       for accessibility. If 'primary' is not used for any column, and
-      'primaryKey' isn't specified either, then the first column will be used. Defaults to \`[]\`.
+      'primaryKey' isn't specified either, then the first column will be used.
 
 \`\`\`
 [{
@@ -3682,7 +3682,7 @@ A description of the data. The order controls the column order.
 
 **data**
 
-Array of data objects. Defaults to \`[]\`.
+Array of data objects.
 
 \`\`\`
 [{
@@ -3900,6 +3900,16 @@ Defaults to
 
 \`\`\`
 right
+\`\`\`
+
+**dataTable.step**
+
+How many items to render at a time. Expects \`number\`.
+
+Defaults to
+
+\`\`\`
+50
 \`\`\`
 ",
   "Diagram": "## Diagram

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1615,7 +1615,218 @@ vertical",
     "usage": "import { Collapsible } from 'grommet';
 <Collapsible open={true}>test</Collapsible>",
   },
-  "DataTable": [Function],
+  "DataTable": Object {
+    "availableAt": Array [
+      Object {
+        "badge": "https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png",
+        "label": "Storybook",
+        "url": "https://storybook.grommet.io/?selectedKind=DataTable&full=0&addons=0&stories=1&panelRight=0",
+      },
+      Object {
+        "badge": "https://codesandbox.io/static/img/play-codesandbox.svg",
+        "label": "CodeSandbox",
+        "url": "https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=datatable&module=%2Fsrc%2FDataTable.js",
+      },
+    ],
+    "description": "A data driven table.",
+    "intrinsicElement": "table",
+    "name": "DataTable",
+    "properties": Array [
+      Object {
+        "description": "Custom title to be used by screen readers.",
+        "format": "string",
+        "name": "a11yTitle",
+      },
+      Object {
+        "description": "How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.",
+        "format": "start
+center
+end
+stretch",
+        "name": "alignSelf",
+      },
+      Object {
+        "description": "The name of the area to place
+    this inside a parent Grid.",
+        "format": "string",
+        "name": "gridArea",
+      },
+      Object {
+        "description": "The amount of margin around the component. An object can
+      be specified to distinguish horizontal margin, vertical margin, and
+      margin on a particular side.",
+        "format": "none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string",
+        "name": "margin",
+      },
+      Object {
+        "defaultValue": Array [],
+        "description": "A description of the data. The order controls the column order.
+      'property' indicates which property in the data objects to associate
+      the column with. 'header' indicates what to display in the column
+      header. 'render' allows for custom rendering of body cells. Use 'render'
+      for custom formatting for things like currency and date or to
+      display rich content like Meters. 'align' indicates how the cells in
+      the column are aligned. 'aggregate' indicates how the data in the
+      column should be aggregated. This only applies to a footer or groupBy
+      context. 'footer' indicates what should be shown in the footer for
+      the column. 'search' indicates whether a search filter should be
+      made available for the column. 'primary' indicates that this property
+      should be used as the unique identifier, which gives the cell 'row' scope
+      for accessibility. If 'primary' is not used for any column, and
+      'primaryKey' isn't specified either, then the first column will be used.",
+        "format": "[{
+  align: 
+    center
+    start
+    end,
+  aggregate: 
+    avg
+    max
+    min
+    sum,
+  footer: 
+    node
+    {
+      aggregate: boolean
+    },
+  header: 
+    string
+    node
+    {
+      aggregate: boolean
+    },
+  primary: boolean,
+  property: string,
+  render: function,
+  search: boolean,
+  sortable: boolean
+}]",
+        "name": "columns",
+      },
+      Object {
+        "defaultValue": Array [],
+        "description": "Array of data objects.",
+        "format": "[{
+
+}]",
+        "name": "data",
+      },
+      Object {
+        "description": "Property to group data by.",
+        "format": "string",
+        "name": "groupBy",
+      },
+      Object {
+        "description": "Use this to indicate that 'data' doesn't contain all that it could.
+      It will be called when all of the data rows have been rendered.
+      This might be used when the total number of items that could be retrieved
+      is more than you'd want to load into the browser. 'onMore' allows you
+      to lazily fetch more from the server only when needed. This cannot
+      be combined with properties that expect all data to be present in the
+      browser, such as columns.search, sortable, groupBy, or columns.aggregate.",
+        "format": "function",
+        "name": "onMore",
+      },
+      Object {
+        "description": "When supplied, and when at least one column has 'search' enabled,
+      this function will be called with an object with keys for property
+      names and values which are the search text strings. This is typically
+      employed so a back-end can be used to search through the data.",
+        "format": "function",
+        "name": "onSearch",
+      },
+      Object {
+        "description": "When supplied, indicates the property for a data object to use to
+      get a unique identifier. See also the 'columns.primary' description.
+      Use this property when the columns approach will not work for your
+      data set.",
+        "format": "string",
+        "name": "primaryKey",
+      },
+      Object {
+        "description": "Whether to allow the user to resize column widths.",
+        "format": "boolean",
+        "name": "resizeable",
+      },
+      Object {
+        "description": "The height of the table body. If set, the table body will have a fixed
+      height and the rows will be scrollable within it. In order to preserve
+      header and footer cell alignment, all cells will have the same
+      width. This cannot be used in combination with 'resizeable'.",
+        "format": "small
+medium
+large
+xlarge
+string",
+        "name": "size",
+      },
+      Object {
+        "description": "Whether to allow the user to sort columns.",
+        "format": "boolean",
+        "name": "sortable",
+      },
+    ],
+    "usage": "import { DataTable } from 'grommet';
+<DataTable />",
+  },
   "Diagram": Object {
     "availableAt": Array [
       Object {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -475,6 +475,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           side: 'right',
         },
       },
+      step: 50,
     },
     diagram: {
       // extend: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
DataTable - add step support for onMore loading
#### Where should the reviewer start?
doc.js
#### What testing has been done on this PR?
logs
#### How should this be manually tested?
datatable
#### Any background context you want to provide?

#### What are the relevant issues?
#3063 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yep, done
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible 