### PR TITLE
RadioButtonGroup key warning

### DIFF
--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -53,7 +53,7 @@ class Box extends Component {
             contents.push(
               <StyledBoxGap
                 // eslint-disable-next-line react/no-array-index-key
-                key={`styled-box-gap_${index}`}
+                key={`gap-${index}`}
                 gap={gap}
                 directionProp={direction}
                 responsive={responsive}

--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -53,7 +53,7 @@ class Box extends Component {
             contents.push(
               <StyledBoxGap
                 // eslint-disable-next-line react/no-array-index-key
-                key={index}
+                key={`styled-box-gap_${index}`}
                 gap={gap}
                 directionProp={direction}
                 responsive={responsive}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
fixing the index key used to be more explicit
#### Where should the reviewer start?
Box.js
#### What testing has been done on this PR?
```
      <Grommet theme={grommet}>
        <Box align="center" pad="large">
          <RadioButtonGroup
            name="radio"
            options={[{ label: '1', value: '1' }, { label: '2', value: '2' }]}
            value={value}
            onChange={this.onChange}
            {...this.props}
          />
        </Box>
      </Grommet>
```
#### How should this be manually tested?
run the markup code above on storybook 
#### Any background context you want to provide?
RadioButtonGroup is using the key index as well as the StyledBoxGap, hence it causes a key duplication.

this is the error:
```
react-dom.development.js:506 Warning: Encountered two children with the same key, `1`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
    in div (created by Context.Consumer)
    in StyledComponent (created by StyledBox)
    in StyledBox (created by Box)
    in Box (created by Box)
    in Box (created by Context.Consumer)
    in WithTheme(Box) (created by RadioButtonGroup)
    in Keyboard (created by RadioButtonGroup)
    in RadioButtonGroup (created by RadioButtonGroup)
    in RadioButtonGroup (created by SimpleRadioButtonGroup)
    in div (created by Context.Consumer)
    in StyledComponent (created by StyledBox)
    in StyledBox (created by Box)
    in Box (created by Box)
    in Box (created by Context.Consumer)
    in WithTheme(Box) (created by SimpleRadioButtonGroup)
    in div (created by Context.Consumer)
    in StyledComponent (created by StyledGrommet)
    in StyledGrommet (created by Grommet)
    in Grommet (created by SimpleRadioButtonGroup)
    in SimpleRadioButtonGroup
```
#### What are the relevant issues?
#3069 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible