### PR TITLE
Fix IE and Edge compatibility issue for diagram component 

### DIFF
--- a/src/js/components/Diagram/Diagram.js
+++ b/src/js/components/Diagram/Diagram.js
@@ -129,17 +129,17 @@ class Diagram extends Component {
           const toRect = toElement.getBoundingClientRect();
           // There is no x and y when unit testing.
           const fromPoint = [
-            fromRect.x - containerRect.x || 0,
-            fromRect.y - containerRect.y || 0,
+            fromRect.left - containerRect.left || 0,
+            fromRect.top - containerRect.top || 0,
           ];
           const toPoint = [
-            toRect.x - containerRect.x || 0,
-            toRect.y - containerRect.y || 0,
+            toRect.left - containerRect.left || 0,
+            toRect.top - containerRect.top || 0,
           ];
           if (anchor === 'vertical') {
             fromPoint[0] += fromRect.width / 2;
             toPoint[0] += toRect.width / 2;
-            if (fromRect.y < toRect.y) {
+            if (fromRect.top < toRect.top) {
               fromPoint[1] += fromRect.height;
             } else {
               toPoint[1] += toRect.height;
@@ -147,7 +147,7 @@ class Diagram extends Component {
           } else if (anchor === 'horizontal') {
             fromPoint[1] += fromRect.height / 2;
             toPoint[1] += toRect.height / 2;
-            if (fromRect.x < toRect.x) {
+            if (fromRect.left < toRect.left) {
               fromPoint[0] += fromRect.width;
             } else {
               toPoint[0] += toRect.width;
@@ -203,7 +203,10 @@ class Diagram extends Component {
                 // eslint-disable-next-line react/no-array-index-key
                 key={index}
                 {...cleanedRest}
-                stroke={normalizeColor(color || theme.diagram.line.color, theme)}
+                stroke={normalizeColor(
+                  color || theme.diagram.line.color,
+                  theme,
+                )}
                 strokeWidth={strokeWidth}
                 strokeLinecap={round ? 'round' : 'butt'}
                 strokeLinejoin={round ? 'round' : 'miter'}


### PR DESCRIPTION
Fixes IE and Edge compatibility issue for diagram component by replacing rect co-ordinates suitable for IE & Edge browsers.

#### What does this PR do?
Fix IE and Edge compatibility issue for diagram component 

#### Where should the reviewer start?
Diagram.js

#### What testing has been done on this PR?
Storybook

#### How should this be manually tested?
Storybook

#### Any background context you want to provide?
#### What are the relevant issues?
#2952 

#### Screenshots (if appropriate)
#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
backwards compatible