### PR TITLE
Select: Removed Text wrap if label is a function.

### DIFF
--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -255,11 +255,14 @@ class SelectContainer extends Component {
   };
 
   optionLabel = index => {
-    const { options, labelKey } = this.props;
+    const { options, labelKey, theme } = this.props;
     const option = options[index];
     let optionLabel;
+    let wrapInText = true;
     if (labelKey) {
       if (typeof labelKey === 'function') {
+        // we don't want to wrap in text if the caller is controlling the render
+        wrapInText = false;
         optionLabel = labelKey(option);
       } else {
         optionLabel = option[labelKey];
@@ -267,7 +270,11 @@ class SelectContainer extends Component {
     } else {
       optionLabel = option;
     }
-    return optionLabel;
+    return wrapInText ? (
+      <Text {...theme.select.options.text}>{optionLabel}</Text>
+    ) : (
+      optionLabel
+    );
   };
 
   optionValue = index => {
@@ -424,9 +431,7 @@ class SelectContainer extends Component {
                           {...theme.select.options.box}
                           selected={isSelected}
                         >
-                          <Text {...theme.select.options.text}>
-                            {this.optionLabel(index)}
-                          </Text>
+                          {this.optionLabel(index)}
                         </OptionBox>
                       )}
                     </SelectOption>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Removed select option container Text wrap if the label is a function.

#### Where should the reviewer start?

SelectContainer.

#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
open Select storybook examples and make nothing breaks.

#### Any background context you want to provide?
Text is a span and will not allow using a flexbox container to span over the entire option space.
IMHO if you are specifying how you want to render the Select option we cannot assuming it will be text.

#### What are the relevant issues?
no issue.
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
This is probably a small breaking change. I doubt it would affect users. If they are providing a custom option label render, they are probably using flexbox already.