### PR TITLE
Remove FocusedContainer from DropContainer

### DIFF
--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 
 import { defaultProps } from '../../default-props';
 import { ThemeContext } from '../../contexts';
-import { FocusedContainer } from '../FocusedContainer';
+
 import {
   backgroundIsDark,
   findScrollParents,
@@ -255,6 +255,7 @@ class DropContainer extends Component {
     const { onEsc } = this.props;
     event.stopPropagation();
     if (onEsc) {
+      preventLayerClose(event);
       onEsc(event);
     }
   };
@@ -325,15 +326,13 @@ class DropContainer extends Component {
     }
 
     return (
-      <FocusedContainer onKeyDown={onEsc && preventLayerClose}>
-        <Keyboard
-          onEsc={onEsc && this.onEsc}
-          onKeyDown={onKeyDown}
-          target="document"
-        >
-          {content}
-        </Keyboard>
-      </FocusedContainer>
+      <Keyboard
+        onEsc={onEsc && this.onEsc}
+        onKeyDown={onKeyDown}
+        target="document"
+      >
+        {content}
+      </Keyboard>
     );
   }
 }

--- a/src/js/components/Drop/stories/Tooltip.js
+++ b/src/js/components/Drop/stories/Tooltip.js
@@ -19,8 +19,8 @@ class TooltipDrop extends Component {
             ref={this.ref}
             onMouseOver={() => this.setState({ over: true })}
             onMouseOut={() => this.setState({ over: false })}
-            onFocus={() => {}}
-            onBlur={() => {}}
+            onFocus={() => this.setState({ over: true })}
+            onBlur={() => this.setState({ over: false })}
           />
           {this.ref.current && over && (
             <Drop align={{ left: 'right' }} target={this.ref.current} plain>

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -965,7 +965,6 @@ exports[`MaskedInput option via mouse 4`] = `
     id="item"
     name="item"
     placeholder="!"
-    tabindex="-1"
     value=""
   />
 </div>


### PR DESCRIPTION
Signed-off-by: Sarah Allen <sarah@zooniverse.org>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This removes `FocusedContainer` from `DropContainer` to fix #2660

#### Where should the reviewer start?
The `DropContainer`. Note the `preventLayerClose` function is moved into the class's `onEsc` handler itself.

#### What testing has been done on this PR?
I've updated the snapshots. There were a few snapshot failures that look completely unrelated. The only one that makes sense to have errored is the `MaskedInput` since it uses `Drop`, so I'm not sure why the others were mismatched.

#### How should this be manually tested?
You can inspect the Drop's Tooltip story to see that the target button no longer is getting a `tabIndex` of -1.
#### Any background context you want to provide?
I have a set of buttons with tooltips. The wrapper `FocusedContainer` was breaking keyboard accessibility of these set of buttons once I tabbed to the first one because it adds a `tabIndex` of -1.

#### What are the relevant issues?
#2660 

#### Screenshots (if appropriate)
Current behavior where `tabIndex` of -1 is added to the target:
![Screen Shot 2019-05-06 at 11 22 42 AM](https://user-images.githubusercontent.com/5016731/57240014-26311e00-6ff3-11e9-8eb7-cab8b1c67427.png)

The updated behavior in this branch where the target no longer gets a `tabIndex` of -1:
![Screen Shot 2019-05-06 at 11 22 55 AM](https://user-images.githubusercontent.com/5016731/57240049-39dc8480-6ff3-11e9-8510-ed10ecc8487f.png)


#### Do the grommet docs need to be updated?
No, this was undocumented behavior previously.

#### Should this PR be mentioned in the release notes?
Yes, it should be noted as a keyboard accessibility bug fix.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible