### PR TITLE
DataTable - add step prop for onMore loading

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -13,6 +13,7 @@ export const Body = ({
   onMore,
   primaryProperty,
   size,
+  step,
   theme,
   ...rest
 }) => (
@@ -20,12 +21,13 @@ export const Body = ({
     <InfiniteScroll
       items={data}
       onMore={onMore}
-      scrollableAncestor="window"
       renderMarker={marker => (
         <TableRow>
           <TableCell>{marker}</TableCell>
         </TableRow>
       )}
+      scrollableAncestor="window"
+      step={step}
     >
       {datum => (
         <StyledDataTableRow key={datum[primaryProperty]} size={size}>

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -11,6 +11,7 @@ class DataTable extends Component {
   static defaultProps = {
     columns: [],
     data: [],
+    step: 50,
   };
 
   state = {};
@@ -82,6 +83,7 @@ class DataTable extends Component {
       resizeable,
       size,
       sortable,
+      step,
       onSearch, // removing unknown DOM attributes
       ...rest
     } = this.props;
@@ -135,6 +137,7 @@ class DataTable extends Component {
             onMore={onMore}
             primaryProperty={primaryProperty}
             size={size}
+            step={step}
           />
         )}
         {showFooter && (

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -238,6 +238,14 @@ Whether to allow the user to sort columns.
 ```
 boolean
 ```
+
+**step**
+
+How many items to render at a time. Defaults to `50`.
+
+```
+number
+```
   
 ## Intrinsic element
 

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -93,6 +93,9 @@ export const doc = DataTable => {
     sortable: PropTypes.bool.description(
       'Whether to allow the user to sort columns.',
     ),
+    step: PropTypes.number
+      .description('How many items to render at a time.')
+      .defaultValue(50),
   };
 
   return DocumentedDataTable;

--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -14,6 +14,7 @@ export interface DataTableProps {
   resizeable?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | string;
   sortable?: boolean;
+  step?: number;
 }
 
 declare const DataTable: React.ComponentClass<DataTableProps & JSX.IntrinsicElements['table']>;

--- a/src/js/components/DataTable/stories/InfiniteScrollDataTable.js
+++ b/src/js/components/DataTable/stories/InfiniteScrollDataTable.js
@@ -1,0 +1,337 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { Grommet, Box, DataTable, Heading, Meter, Text } from 'grommet';
+import { grommet } from 'grommet/themes';
+
+const amountFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'NIS',
+  minimumFractionDigits: 2,
+});
+
+const columns = [
+  {
+    property: 'key',
+    header: 'Key',
+    primary: true,
+    footer: 'Total',
+  },
+  {
+    property: 'name',
+    header: <Text>Name with extra</Text>,
+    primary: true,
+    footer: 'Total',
+  },
+  {
+    property: 'location',
+    header: 'Location',
+  },
+  {
+    property: 'date',
+    header: 'Due',
+    render: datum =>
+      datum.date && new Date(datum.date).toLocaleDateString('en-US'),
+    align: 'end',
+  },
+  {
+    property: 'percent',
+    header: 'Percent Complete',
+    render: datum => (
+      <Box pad={{ vertical: 'xsmall' }} alignSelf="center">
+        <Meter
+          values={[
+            { value: datum.percent, color: `accent-${(datum.key % 4) + 1}` },
+          ]}
+          thickness="small"
+          size="xxsmall"
+          type="circle"
+        />
+      </Box>
+    ),
+  },
+  {
+    property: 'paid',
+    header: 'Paid',
+    render: datum => amountFormatter.format(datum.paid / 100),
+    align: 'end',
+    aggregate: 'sum',
+    footer: { aggregate: true },
+  },
+];
+
+const DATA = [
+  {
+    key: 1,
+    name: 'Ilana',
+    location: 'Bay Area',
+    date: '',
+    percent: 0,
+    paid: 0,
+  },
+  {
+    key: 2,
+    name: 'Oorestisime',
+    location: 'Paris',
+    date: '2019-06-10',
+    percent: 30,
+    paid: 1234,
+  },
+  {
+    key: 3,
+    name: 'Chris',
+    location: 'Bay Area',
+    date: '2019-06-09',
+    percent: 40,
+    paid: 2345,
+  },
+  {
+    key: 4,
+    name: 'Eric',
+    location: 'Bay Area',
+    date: '2019-06-11',
+    percent: 80,
+    paid: 3456,
+  },
+  {
+    key: 5,
+    name: 'Shimi',
+    location: 'Fort Collins',
+    date: '2019-06-10',
+    percent: 60,
+    paid: 1234,
+  },
+  {
+    key: 6,
+    name: 'Jet',
+    location: 'Bay Area',
+    date: '2019-06-09',
+    percent: 40,
+    paid: 3456,
+  },
+  {
+    key: 7,
+    name: 'Mike',
+    location: 'Boise',
+    date: '2019-06-11',
+    percent: 50,
+    paid: 1234,
+  },
+  {
+    key: 8,
+    name: 'Alex',
+    location: 'Hillsborough',
+    date: '2019-06-10',
+    percent: 10,
+    paid: 2345,
+  },
+  {
+    key: 9,
+    name: 'Alan',
+    location: '',
+    date: '',
+    percent: 0,
+    paid: 0,
+  },
+  {
+    key: 10,
+    name: 'Bryan',
+    location: 'Fort Collins',
+    date: '2019-06-10',
+    percent: 30,
+    paid: 1234,
+  },
+  {
+    key: 11,
+    name: 'Jens',
+    location: 'Fort Collins',
+    date: '2019-06-09',
+    percent: 40,
+    paid: 2345,
+  },
+  {
+    key: 12,
+    name: 'Dana',
+    location: 'Fort Collins',
+    date: '2019-06-11',
+    percent: 80,
+    paid: 3456,
+  },
+  {
+    key: 13,
+    name: 'Tracy',
+    location: 'Bay Area',
+    date: '2019-06-10',
+    percent: 60,
+    paid: 1234,
+  },
+  {
+    key: 14,
+    name: 'Greg',
+    location: 'Fort Collins',
+    date: '2019-06-09',
+    percent: 40,
+    paid: 3456,
+  },
+  {
+    key: 15,
+    name: 'Brittany',
+    location: 'Fort Collins',
+    date: '2019-06-11',
+    percent: 50,
+    paid: 1234,
+  },
+  {
+    key: 16,
+    name: 'Madhu',
+    location: 'Seattle',
+    date: '2019-06-10',
+    percent: 10,
+    paid: 2345,
+  },
+  {
+    key: 17,
+    name: 'Ian',
+    location: '',
+    date: '',
+    percent: 0,
+    paid: 0,
+  },
+  {
+    key: 18,
+    name: 'Cheri',
+    location: 'Fort Collins',
+    date: '2019-06-10',
+    percent: 30,
+    paid: 1234,
+  },
+  {
+    key: 19,
+    name: 'John',
+    location: 'Fort Collins',
+    date: '2019-06-09',
+    percent: 40,
+    paid: 2345,
+  },
+  {
+    key: 20,
+    name: 'Jens',
+    location: 'Fort Collins',
+    date: '2019-06-11',
+    percent: 80,
+    paid: 3456,
+  },
+  {
+    key: 21,
+    name: 'Greg',
+    location: 'Fort Collins',
+    date: '2019-06-10',
+    percent: 60,
+    paid: 1234,
+  },
+  {
+    key: 22,
+    name: 'Karen',
+    location: 'Fort Collins',
+    date: '2019-06-09',
+    percent: 40,
+    paid: 3456,
+  },
+  {
+    key: 23,
+    name: 'Michael',
+    location: 'Boise',
+    date: '2019-06-11',
+    percent: 50,
+    paid: 1234,
+  },
+  {
+    key: 24,
+    name: 'Tracy',
+    location: 'San Francisco',
+    date: '2019-06-10',
+    percent: 10,
+    paid: 2345,
+  },
+  {
+    key: 25,
+    name: 'Alex',
+    location: 'Hillsborough',
+    date: '2019-06-09',
+    percent: 40,
+    paid: 3456,
+  },
+  {
+    key: 26,
+    name: 'Brittany',
+    location: 'Fort Collins',
+    date: '2019-06-11',
+    percent: 50,
+    paid: 1234,
+  },
+  {
+    key: 27,
+    name: 'Madhu',
+    location: 'Seattle',
+    date: '2019-06-10',
+    percent: 10,
+    paid: 2345,
+  },
+  {
+    key: 28,
+    name: 'Ian',
+    location: '',
+    date: '',
+    percent: 0,
+    paid: 0,
+  },
+  {
+    key: 29,
+    name: 'Cheri',
+    location: 'Fort Collins',
+    date: '2019-06-10',
+    percent: 30,
+    paid: 1234,
+  },
+  {
+    key: 30,
+    name: 'John',
+    location: 'Fort Collins',
+    date: '2019-06-09',
+    percent: 40,
+    paid: 2345,
+  },
+];
+
+const InfiniteScrollDataTable = () => {
+  const step = 10;
+
+  const load = () => {
+    console.log(`InfiniteScroll fires onMore after loading ${step} items`);
+  };
+
+  return (
+    <Grommet theme={grommet}>
+      <Box align="center" pad="large">
+        <Heading level={3}>
+          <Box gap="small">
+            <strong>InfiniteScroll embedded in DataTable</strong>
+            <Text>
+              Scroll down to load more data, open console to see loading info
+            </Text>
+          </Box>
+        </Heading>
+        <DataTable
+          columns={columns}
+          data={DATA}
+          step={step}
+          onMore={() => load()}
+        />
+      </Box>
+    </Grommet>
+  );
+};
+
+storiesOf('DataTable', module).add('Infinitescroll', () => (
+  <InfiniteScrollDataTable />
+));

--- a/src/js/components/DataTable/stories/datatable.stories.js
+++ b/src/js/components/DataTable/stories/datatable.stories.js
@@ -130,7 +130,7 @@ const DATA = [
 const SimpleDataTable = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
-      <DataTable columns={columns} data={DATA} />
+      <DataTable columns={columns} data={DATA} step={10} />
     </Box>
   </Grommet>
 );
@@ -278,9 +278,9 @@ class ControlledDataTable extends Component {
 }
 
 storiesOf('DataTable', module)
-  .add('Simple DataTable', () => <SimpleDataTable />)
-  .add('Sized DataTable', () => <SizedDataTable />)
-  .add('Tunable DataTable', () => <TunableDataTable />)
-  .add('Grouped DataTable', () => <GroupedDataTable />)
-  .add('Served DataTable', () => <ServedDataTable />)
-  .add('Controlled DataTable', () => <ControlledDataTable />);
+  .add('Simple', () => <SimpleDataTable />)
+  .add('Sized', () => <SizedDataTable />)
+  .add('Tunable', () => <TunableDataTable />)
+  .add('Grouped', () => <GroupedDataTable />)
+  .add('Served', () => <ServedDataTable />)
+  .add('Controlled', () => <ControlledDataTable />);

--- a/src/js/components/Table/stories/InfiniteScrollInTable.js
+++ b/src/js/components/Table/stories/InfiniteScrollInTable.js
@@ -84,6 +84,6 @@ const InfiniteScrollInTable = () => {
   );
 };
 
-storiesOf('Table', module).add('InfiniteScrollInTable', () => (
+storiesOf('Table', module).add('InfiniteScroll', () => (
   <InfiniteScrollInTable />
 ));

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -3764,6 +3764,14 @@ Whether to allow the user to sort columns.
 \`\`\`
 boolean
 \`\`\`
+
+**step**
+
+How many items to render at a time. Defaults to \`50\`.
+
+\`\`\`
+number
+\`\`\`
   
 ## Intrinsic element
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
DataTable - add step prop for onMore loading

#### Where should the reviewer start?
doc.js
#### What testing has been done on this PR?
added a storybook example 
#### How should this be manually tested?
checkout the new story
#### Any background context you want to provide?
a second approach to https://github.com/grommet/grommet/pull/3074
#### What are the relevant issues?
#3063
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
yep
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible