### PR TITLE
Text - add default size value

### DIFF
--- a/src/js/components/Text/README.md
+++ b/src/js/components/Text/README.md
@@ -124,7 +124,7 @@ string
 The font size and line height are primarily driven by the chosen tag. But, it can
 be adjusted via this size property. The tag should be set for semantic
 correctness and accessibility. This size property allows for stylistic
-adjustments.
+adjustments. Defaults to `medium`.
 
 ```
 xsmall

--- a/src/js/components/Text/doc.js
+++ b/src/js/components/Text/doc.js
@@ -32,12 +32,14 @@ export const doc = Text => {
         'xxlarge',
       ]),
       PropTypes.string,
-    ]).description(
-      `The font size and line height are primarily driven by the chosen tag. But, it can
+    ])
+      .description(
+        `The font size and line height are primarily driven by the chosen tag. But, it can
 be adjusted via this size property. The tag should be set for semantic
 correctness and accessibility. This size property allows for stylistic
 adjustments.`,
-    ),
+      )
+      .defaultValue('medium'),
     tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).description(
       `The DOM tag to use for the element. NOTE: This is deprecated in favor
          of indicating the DOM tag via the 'as' property.`,

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -9708,7 +9708,7 @@ string
 The font size and line height are primarily driven by the chosen tag. But, it can
 be adjusted via this size property. The tag should be set for semantic
 correctness and accessibility. This size property allows for stylistic
-adjustments.
+adjustments. Defaults to \`medium\`.
 
 \`\`\`
 xsmall


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
update the docs with the default value of size Text 
according to https://github.com/grommet/grommet/blob/f944d4a6ad7e3d9c84ffe2f135d461ffecdd331f/src/js/components/Text/StyledText.js#L7
#### Where should the reviewer start?
doc.js
#### What testing has been done on this PR?
verifying with StyledText
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards