### PR TITLE
Changed Heading to fix an issue with arbitrary size

### DIFF
--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -806,7 +806,7 @@ exports[`Accordion change active index 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 1
             </h4>
@@ -850,7 +850,7 @@ exports[`Accordion change active index 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 2
             </h4>
@@ -1302,7 +1302,7 @@ exports[`Accordion change to second Panel 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 1
             </h4>
@@ -1353,7 +1353,7 @@ exports[`Accordion change to second Panel 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 2
             </h4>
@@ -1825,7 +1825,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 1
             </h4>
@@ -1869,7 +1869,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 2
             </h4>
@@ -3250,7 +3250,7 @@ exports[`Accordion multiple panels 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 1
             </h4>
@@ -3294,7 +3294,7 @@ exports[`Accordion multiple panels 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 2
             </h4>
@@ -3387,7 +3387,7 @@ exports[`Accordion multiple panels 3`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 1
             </h4>
@@ -3468,7 +3468,7 @@ exports[`Accordion multiple panels 3`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 2
             </h4>
@@ -3527,7 +3527,7 @@ exports[`Accordion multiple panels 4`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 1
             </h4>
@@ -3574,7 +3574,7 @@ exports[`Accordion multiple panels 4`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 2
             </h4>
@@ -3664,7 +3664,7 @@ exports[`Accordion multiple panels 5`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 1
             </h4>
@@ -3742,7 +3742,7 @@ exports[`Accordion multiple panels 5`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 2
             </h4>
@@ -4241,7 +4241,7 @@ exports[`Accordion set on hover 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 iOLzha"
+              class="StyledHeading-sc-1rdh4aw-0 StelQ"
             >
               Panel 1
             </h4>
@@ -4292,7 +4292,7 @@ exports[`Accordion set on hover 2`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 2
             </h4>
@@ -4355,7 +4355,7 @@ exports[`Accordion set on hover 3`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 iOLzha"
+              class="StyledHeading-sc-1rdh4aw-0 StelQ"
             >
               Panel 1
             </h4>
@@ -4406,7 +4406,7 @@ exports[`Accordion set on hover 3`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 iOLzha"
+              class="StyledHeading-sc-1rdh4aw-0 StelQ"
             >
               Panel 2
             </h4>
@@ -4469,7 +4469,7 @@ exports[`Accordion set on hover 4`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 1
             </h4>
@@ -4520,7 +4520,7 @@ exports[`Accordion set on hover 4`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 iOLzha"
+              class="StyledHeading-sc-1rdh4aw-0 StelQ"
             >
               Panel 2
             </h4>
@@ -4583,7 +4583,7 @@ exports[`Accordion set on hover 5`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 1
             </h4>
@@ -4634,7 +4634,7 @@ exports[`Accordion set on hover 5`] = `
             class="StyledBox-sc-13pk1d4-0 kFoGJP"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 hlZfma"
+              class="StyledHeading-sc-1rdh4aw-0 dOVRRX"
             >
               Panel 2
             </h4>

--- a/src/js/components/Heading/StyledHeading.js
+++ b/src/js/components/Heading/StyledHeading.js
@@ -16,6 +16,7 @@ const sizeStyle = props => {
         font-size: ${data.size};
         line-height: ${data.height};
         max-width: ${data.maxWidth};
+        font-weight: ${levelStyle.font.weight || headingTheme.weight};
       ` :
       css`
         font-size: ${size};

--- a/src/js/components/Heading/StyledHeading.js
+++ b/src/js/components/Heading/StyledHeading.js
@@ -17,7 +17,7 @@ const sizeStyle = props => {
         line-height: ${data ? data.height : 'normal'};
         max-width: ${data ? data.maxWidth : levelStyle.medium.maxWidth};
         font-weight: ${levelStyle.font.weight || headingTheme.weight};
-      `
+      `,
     ];
     if (props.responsive && headingTheme.responsiveBreakpoint) {
       const breakpoint =

--- a/src/js/components/Heading/StyledHeading.js
+++ b/src/js/components/Heading/StyledHeading.js
@@ -30,16 +30,18 @@ const sizeStyle = props => {
       if (breakpoint) {
         const responsiveData =
           headingTheme.level[Math.min(props.level + 1, 4)][size];
-        styles.push(
-          breakpointStyle(
-            breakpoint,
-            `
-          font-size: ${responsiveData.size};
-          line-height: ${responsiveData.height};
-          max-width: ${responsiveData.maxWidth};
-        `,
-          ),
-        );
+        if(responsiveData) {
+          styles.push(
+            breakpointStyle(
+              breakpoint,
+              `
+            font-size: ${responsiveData.size};
+            line-height: ${responsiveData.height};
+            max-width: ${responsiveData.maxWidth};
+          `,
+            ),
+          );
+        }
       }
     }
     return styles;

--- a/src/js/components/Heading/StyledHeading.js
+++ b/src/js/components/Heading/StyledHeading.js
@@ -12,18 +12,12 @@ const sizeStyle = props => {
     const data = levelStyle[size];
     const styles =  
     [
-      data ? css`
-        font-size: ${data.size};
-        line-height: ${data.height};
-        max-width: ${data.maxWidth};
-        font-weight: ${levelStyle.font.weight || headingTheme.weight};
-      ` :
       css`
-        font-size: ${size};
-        line-height: normal;
-        max-width: ${levelStyle.medium.maxWidth}
+        font-size: ${data ? data.size : size};
+        line-height: ${data ? data.height : 'normal'};
+        max-width: ${data ? data.maxWidth : levelStyle.medium.maxWidth};
         font-weight: ${levelStyle.font.weight || headingTheme.weight};
-      `,
+      `
     ];
     if (props.responsive && headingTheme.responsiveBreakpoint) {
       const breakpoint =

--- a/src/js/components/Heading/StyledHeading.js
+++ b/src/js/components/Heading/StyledHeading.js
@@ -10,11 +10,17 @@ const sizeStyle = props => {
   const levelStyle = headingTheme.level[props.level];
   if (levelStyle) {
     const data = levelStyle[size];
-    const styles = [
-      css`
+    const styles =  
+    [
+      data ? css`
         font-size: ${data.size};
         line-height: ${data.height};
         max-width: ${data.maxWidth};
+      ` :
+      css`
+        font-size: ${size};
+        line-height: normal;
+        max-width: ${levelStyle.medium.maxWidth}
         font-weight: ${levelStyle.font.weight || headingTheme.weight};
       `,
     ];

--- a/src/js/components/Heading/__tests__/Heading-test.js
+++ b/src/js/components/Heading/__tests__/Heading-test.js
@@ -51,6 +51,7 @@ test('Heading size renders', () => {
       <Heading level={4} size="medium" />
       <Heading level={4} size="large" />
       <Heading level={4} size="xlarge" />
+      <Heading level={1} size="77px" />
     </Grommet>,
   );
   const tree = component.toJSON();

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -480,7 +480,8 @@ exports[`Heading size renders 1`] = `
 .c12 {
   font-size: 77px;
   line-height: normal;
-  max-width: 1200px font-weight:600;
+  max-width: 1200px;
+  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -477,6 +477,12 @@ exports[`Heading size renders 1`] = `
   font-weight: 600;
 }
 
+.c12 {
+  font-size: 77px;
+  line-height: normal;
+  max-width: 1200px font-weight:600;
+}
+
 @media only screen and (max-width:768px) {
   .c2 {
     font-size: 34px;
@@ -631,6 +637,10 @@ exports[`Heading size renders 1`] = `
   <h4
     className="c11"
     size="xlarge"
+  />
+  <h1
+    className="c12"
+    size="77px"
   />
 </div>
 `;

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -15,6 +15,7 @@ exports[`Heading color renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
   color: #7D4CDB;
 }
 
@@ -50,24 +51,28 @@ exports[`Heading level renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
 }
 
 .c2 {
   font-size: 34px;
   line-height: 40px;
   max-width: 816px;
+  font-weight: 600;
 }
 
 .c3 {
   font-size: 26px;
   line-height: 32px;
   max-width: 624px;
+  font-weight: 600;
 }
 
 .c4 {
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
+  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {
@@ -148,6 +153,7 @@ exports[`Heading margin renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
 }
 
 .c2 {
@@ -155,6 +161,7 @@ exports[`Heading margin renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
 }
 
 .c3 {
@@ -162,6 +169,7 @@ exports[`Heading margin renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
 }
 
 .c4 {
@@ -169,6 +177,7 @@ exports[`Heading margin renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
 }
 
 .c5 {
@@ -176,6 +185,7 @@ exports[`Heading margin renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
 }
 
 .c6 {
@@ -183,6 +193,7 @@ exports[`Heading margin renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
 }
 
 .c7 {
@@ -190,6 +201,7 @@ exports[`Heading margin renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
 }
 
 .c8 {
@@ -197,6 +209,7 @@ exports[`Heading margin renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {
@@ -356,6 +369,7 @@ exports[`Heading renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {
@@ -390,66 +404,77 @@ exports[`Heading size renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
 }
 
 .c1 {
   font-size: 34px;
   line-height: 40px;
   max-width: 816px;
+  font-weight: 600;
 }
 
 .c8 {
   font-size: 26px;
   line-height: 32px;
   max-width: 624px;
+  font-weight: 600;
 }
 
 .c11 {
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
+  font-weight: 600;
 }
 
 .c3 {
   font-size: 82px;
   line-height: 88px;
   max-width: 1968px;
+  font-weight: 600;
 }
 
 .c4 {
   font-size: 114px;
   line-height: 120px;
   max-width: 2736px;
+  font-weight: 600;
 }
 
 .c5 {
   font-size: 26px;
   line-height: 32px;
   max-width: 624px;
+  font-weight: 600;
 }
 
 .c6 {
   font-size: 66px;
   line-height: 72px;
   max-width: 1584px;
+  font-weight: 600;
 }
 
 .c7 {
   font-size: 22px;
   line-height: 28px;
   max-width: 528px;
+  font-weight: 600;
 }
 
 .c9 {
   font-size: 34px;
   line-height: 40px;
   max-width: 816px;
+  font-weight: 600;
 }
 
 .c10 {
   font-size: 42px;
   line-height: 48px;
   max-width: 1008px;
+  font-weight: 600;
 }
 
 .c12 {
@@ -635,6 +660,7 @@ exports[`Heading textAlign renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
   text-align: left;
 }
 
@@ -642,6 +668,7 @@ exports[`Heading textAlign renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
   text-align: center;
 }
 
@@ -649,6 +676,7 @@ exports[`Heading textAlign renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
   text-align: right;
 }
 
@@ -706,12 +734,14 @@ exports[`Heading truncate renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
 }
 
 .c2 {
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -765,6 +795,7 @@ exports[`Theme based font family renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
 }
 
 .c2 {
@@ -772,6 +803,7 @@ exports[`Theme based font family renders 1`] = `
   font-size: 34px;
   line-height: 40px;
   max-width: 816px;
+  font-weight: 600;
 }
 
 .c3 {
@@ -779,6 +811,7 @@ exports[`Theme based font family renders 1`] = `
   font-size: 26px;
   line-height: 32px;
   max-width: 624px;
+  font-weight: 600;
 }
 
 .c4 {
@@ -786,6 +819,7 @@ exports[`Theme based font family renders 1`] = `
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
+  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {
@@ -849,28 +883,40 @@ exports[`Theme based font weight renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
 .c1 {
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 700;
 }
 
 .c2 {
   font-size: 34px;
   line-height: 40px;
   max-width: 816px;
+  font-weight: 400;
 }
 
 .c3 {
   font-size: 26px;
   line-height: 32px;
   max-width: 624px;
+  font-weight: 200;
 }
 
-.c4 {
-  font-size: 18px;
-  line-height: 24px;
-  max-width: 432px;
+@media only screen and (max-width:768px) {
+  .c4 {
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
+  }
 }
 
 @media only screen and (max-width:768px) {
@@ -891,14 +937,6 @@ exports[`Theme based font weight renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c3 {
-    font-size: 18px;
-    line-height: 24px;
-    max-width: 432px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c4 {
     font-size: 18px;
     line-height: 24px;
     max-width: 432px;
@@ -938,12 +976,14 @@ exports[`responsive renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
 }
 
 .c2 {
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
+  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -15,7 +15,6 @@ exports[`Heading color renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
   color: #7D4CDB;
 }
 
@@ -51,28 +50,24 @@ exports[`Heading level renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
 }
 
 .c2 {
   font-size: 34px;
   line-height: 40px;
   max-width: 816px;
-  font-weight: 600;
 }
 
 .c3 {
   font-size: 26px;
   line-height: 32px;
   max-width: 624px;
-  font-weight: 600;
 }
 
 .c4 {
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
-  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {
@@ -153,7 +148,6 @@ exports[`Heading margin renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
 }
 
 .c2 {
@@ -161,7 +155,6 @@ exports[`Heading margin renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
 }
 
 .c3 {
@@ -169,7 +162,6 @@ exports[`Heading margin renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
 }
 
 .c4 {
@@ -177,7 +169,6 @@ exports[`Heading margin renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
 }
 
 .c5 {
@@ -185,7 +176,6 @@ exports[`Heading margin renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
 }
 
 .c6 {
@@ -193,7 +183,6 @@ exports[`Heading margin renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
 }
 
 .c7 {
@@ -201,7 +190,6 @@ exports[`Heading margin renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
 }
 
 .c8 {
@@ -209,7 +197,6 @@ exports[`Heading margin renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {
@@ -369,7 +356,6 @@ exports[`Heading renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {
@@ -404,77 +390,66 @@ exports[`Heading size renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
 }
 
 .c1 {
   font-size: 34px;
   line-height: 40px;
   max-width: 816px;
-  font-weight: 600;
 }
 
 .c8 {
   font-size: 26px;
   line-height: 32px;
   max-width: 624px;
-  font-weight: 600;
 }
 
 .c11 {
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
-  font-weight: 600;
 }
 
 .c3 {
   font-size: 82px;
   line-height: 88px;
   max-width: 1968px;
-  font-weight: 600;
 }
 
 .c4 {
   font-size: 114px;
   line-height: 120px;
   max-width: 2736px;
-  font-weight: 600;
 }
 
 .c5 {
   font-size: 26px;
   line-height: 32px;
   max-width: 624px;
-  font-weight: 600;
 }
 
 .c6 {
   font-size: 66px;
   line-height: 72px;
   max-width: 1584px;
-  font-weight: 600;
 }
 
 .c7 {
   font-size: 22px;
   line-height: 28px;
   max-width: 528px;
-  font-weight: 600;
 }
 
 .c9 {
   font-size: 34px;
   line-height: 40px;
   max-width: 816px;
-  font-weight: 600;
 }
 
 .c10 {
   font-size: 42px;
   line-height: 48px;
   max-width: 1008px;
-  font-weight: 600;
 }
 
 .c12 {
@@ -660,7 +635,6 @@ exports[`Heading textAlign renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
   text-align: left;
 }
 
@@ -668,7 +642,6 @@ exports[`Heading textAlign renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
   text-align: center;
 }
 
@@ -676,7 +649,6 @@ exports[`Heading textAlign renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
   text-align: right;
 }
 
@@ -734,14 +706,12 @@ exports[`Heading truncate renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
 }
 
 .c2 {
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -795,7 +765,6 @@ exports[`Theme based font family renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
 }
 
 .c2 {
@@ -803,7 +772,6 @@ exports[`Theme based font family renders 1`] = `
   font-size: 34px;
   line-height: 40px;
   max-width: 816px;
-  font-weight: 600;
 }
 
 .c3 {
@@ -811,7 +779,6 @@ exports[`Theme based font family renders 1`] = `
   font-size: 26px;
   line-height: 32px;
   max-width: 624px;
-  font-weight: 600;
 }
 
 .c4 {
@@ -819,7 +786,6 @@ exports[`Theme based font family renders 1`] = `
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
-  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {
@@ -883,40 +849,28 @@ exports[`Theme based font weight renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c4 {
-  font-size: 18px;
-  line-height: 24px;
-  max-width: 432px;
-  font-weight: 600;
-}
-
 .c1 {
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 700;
 }
 
 .c2 {
   font-size: 34px;
   line-height: 40px;
   max-width: 816px;
-  font-weight: 400;
 }
 
 .c3 {
   font-size: 26px;
   line-height: 32px;
   max-width: 624px;
-  font-weight: 200;
 }
 
-@media only screen and (max-width:768px) {
-  .c4 {
-    font-size: 18px;
-    line-height: 24px;
-    max-width: 432px;
-  }
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
 }
 
 @media only screen and (max-width:768px) {
@@ -937,6 +891,14 @@ exports[`Theme based font weight renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c3 {
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
     font-size: 18px;
     line-height: 24px;
     max-width: 432px;
@@ -976,14 +938,12 @@ exports[`responsive renders 1`] = `
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
 }
 
 .c2 {
   font-size: 50px;
   line-height: 56px;
   max-width: 1200px;
-  font-weight: 600;
 }
 
 @media only screen and (max-width:768px) {


### PR DESCRIPTION
### What does this PR do?
Changed Heading to fix an issue with arbitrary size

### Where should the reviewer start?
StyledHeading.js

### What testing has been done on this PR?
storybook

### How should this be manually tested?
storybook

### Any background context you want to provide?
What are the relevant issues?
#3091 

### Do the grommet docs need to be updated?
no

### Should this PR be mentioned in the release notes?
yes

### Is this change backwards compatible or is it a breaking change?
backwards compatible

### Potential issues
`max-width: ${levelStyle.medium.maxWidth}`
If a custom theme has been defined and that theme doesn't have a `levelStyle` for `medium`, this will result in an error. Alternatives: Note set any `maxWidth` or define a standard `maxWidth` to be used when `medium` is not available

### Notes
I tried to stick to https://github.com/grommet/grommet/issues/2435 / https://github.com/grommet/grommet/pull/2436