### PR TITLE
fix: #2975:  plain prop in the FormField component which will remove the defa…

### DIFF
--- a/src/js/components/Distribution/README.md
+++ b/src/js/components/Distribution/README.md
@@ -114,10 +114,10 @@ string
 **children**
 
 Function that will be called when each value is rendered. Defaults to `function children(value) {
-    return _react.default.createElement(_Box.Box, {
+    return _react["default"].createElement(_Box.Box, {
       fill: true,
       border: true
-    }, _react.default.createElement(_Text.Text, null, value.value));
+    }, _react["default"].createElement(_Text.Text, null, value.value));
   }`.
 
 ```

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -103,6 +103,7 @@ class FormFieldContent extends Component {
       validate,
       onBlur,
       onFocus,
+      plain,
     } = this.props;
     const { formField } = theme;
     const { border } = formField;
@@ -126,7 +127,7 @@ class FormFieldContent extends Component {
       borderColor = 'focus';
     } else if (normalizedError) {
       borderColor = (border && border.error.color) || 'status-critical';
-    } else {
+    } else if (!plain) {
       borderColor = (border && border.color) || 'border';
     }
     let abut;
@@ -152,7 +153,7 @@ class FormFieldContent extends Component {
             this.childContainerRef = ref;
           }}
           border={
-            border.position === 'inner'
+            border.position === 'inner' && !plain
               ? {
                   ...border,
                   side: border.side || 'bottom',

--- a/src/js/components/FormField/formfield.stories.js
+++ b/src/js/components/FormField/formfield.stories.js
@@ -172,6 +172,23 @@ const CustomFormField = () => (
   </Grommet>
 );
 
+const CustomFormFieldWithPlainProp = props => (
+  <Grommet theme={grommet}>
+    <Box align="center" pad="large">
+      <Form>
+        <FormField
+          label="Label"
+          htmlFor="text-area"
+          plain
+          component={TextArea}
+          placeholder="placeholder"
+          {...props}
+        />
+      </Form>
+    </Box>
+  </Grommet>
+);
+
 storiesOf('FormField', module)
   .add('TextInput', () => <FormFieldTextInput />)
   .add('TextArea', () => <FormFieldTextArea />)
@@ -179,4 +196,7 @@ storiesOf('FormField', module)
   .add('CheckBox', () => <FormFieldCheckBox />)
   .add('Toggle', () => <FormFieldToggle />)
   .add('Help and error', () => <FormFieldHelpError />)
-  .add('Custom Theme', () => <CustomFormField />);
+  .add('Custom Theme', () => <CustomFormField />)
+  .add('Custom Form Filed with Plain Prop', () => (
+    <CustomFormFieldWithPlainProp />
+  ));

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4136,10 +4136,10 @@ string
 **children**
 
 Function that will be called when each value is rendered. Defaults to \`function children(value) {
-    return _react.default.createElement(_Box.Box, {
+    return _react[\\"default\\"].createElement(_Box.Box, {
       fill: true,
       border: true
-    }, _react.default.createElement(_Text.Text, null, value.value));
+    }, _react[\\"default\\"].createElement(_Text.Text, null, value.value));
   }\`.
 
 \`\`\`


### PR DESCRIPTION
…ult underline from the FormField

<!--- Provide a general summary of the PR in the Title above -->

#### plain prop in the FormField component which will remove the default underline from the FormField

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### https://github.com/grommet/grommet/issues/2975

#### Screenshots (if appropriate)


#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
yes it is backward compatible
