### PR TITLE
Make target optional for Drop typescript type

### DIFF
--- a/src/js/components/Drop/index.d.ts
+++ b/src/js/components/Drop/index.d.ts
@@ -9,7 +9,7 @@ export interface DropProps {
   responsive?: boolean;
   restrictFocus?: boolean;
   stretch?: boolean;
-  target: object;
+  target?: object;
   plain?: boolean;
 }
 


### PR DESCRIPTION
#### What does this PR do?
Drop `target` should not be a required prop. When using `Menu`, passing `dropProps` fail typescript validation when you don't provide `target`, as opposed to the documentation.

#### Where should the reviewer start?
N/A

#### What testing has been done on this PR?
Yes.

#### How should this be manually tested?
Use Menu with a typescript setup, and don't provide `target` for `dropProps`.

#### Any background context you want to provide?
No.

#### What are the relevant issues?
N/A

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/497957/57574638-ef1c9b80-743c-11e9-9054-36ee532497f8.png)


#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
I don't think so.

#### Is this change backwards compatible or is it a breaking change?
Yes.
