### PR TITLE
fix: avoid Form state's race condition

### DIFF
--- a/src/js/components/Form/Form.js
+++ b/src/js/components/Form/Form.js
@@ -2,6 +2,29 @@ import React, { Component } from 'react';
 import { defaultProps } from '../../default-props';
 import { FormContext } from './FormContext';
 
+const updateReducer = (name, data, error, validations) => state => {
+  const { errors, touched, value } = state;
+  const nextValue = { ...value };
+  nextValue[name] = data;
+  const nextTouched = { ...touched };
+  nextTouched[name] = true;
+  const nextErrors = { ...errors };
+  if (errors[name]) {
+    const nextError =
+      error || (validations[name] && validations[name](data, nextValue));
+    if (nextError) {
+      nextErrors[name] = nextError;
+    } else {
+      delete nextErrors[name];
+    }
+  }
+  return {
+    value: nextValue,
+    errors: nextErrors,
+    touched: nextTouched,
+  };
+};
+
 const defaultMessages = {
   invalid: 'invalid',
   required: 'required',
@@ -88,35 +111,13 @@ class Form extends Component {
   };
 
   update = (name, data, error) => {
-    const { onChange } = this.props;
-    const { errors, touched, value } = this.state;
-    const nextValue = { ...value };
-    nextValue[name] = data;
-    const nextTouched = { ...touched };
-    nextTouched[name] = true;
-    const nextErrors = { ...errors };
-    if (errors[name]) {
-      const nextError =
-        error ||
-        (this.validations[name] && this.validations[name](data, nextValue));
-      if (nextError) {
-        nextErrors[name] = nextError;
-      } else {
-        delete nextErrors[name];
+    this.setState(updateReducer(name, data, error, this.validations), () => {
+      const { onChange } = this.props;
+      const { value } = this.state;
+      if (onChange) {
+        onChange(value);
       }
-    }
-    this.setState(
-      {
-        value: nextValue,
-        errors: nextErrors,
-        touched: nextTouched,
-      },
-      () => {
-        if (onChange) {
-          onChange(nextValue);
-        }
-      },
-    );
+    });
   };
 
   addValidation = (name, validate) => {

--- a/src/js/components/Form/__tests__/Form-test.js
+++ b/src/js/components/Form/__tests__/Form-test.js
@@ -144,18 +144,25 @@ describe('Form', () => {
     const onSubmit = jest.fn();
     const { getByText, queryByText } = render(
       <Grommet>
-        <Form onSubmit={onSubmit}>
+        {/* this test continues running forever if the whole event passed to onSubmit */}
+        <Form onSubmit={({ value }) => onSubmit({ value })}>
           <FormField
             name="test"
             required
             placeholder="test input"
             value="Initial value"
           />
+          <FormField name="test2" value="Initial value2" />
           <Button type="submit" primary label="Submit" />
         </Form>
       </Grommet>,
     );
     fireEvent.click(getByText('Submit'));
     expect(queryByText('required')).toBeNull();
+    expect(onSubmit).toBeCalledWith(
+      expect.objectContaining({
+        value: { test: 'Initial value', test2: 'Initial value2' },
+      }),
+    );
   });
 });


### PR DESCRIPTION
`Form#update` uses object syntax for `setState`. And initialization of `Form` has multiple `FormField`s with value makes subsequent `setState` calls. Thus I replaced object syntax with callback(updater) syntax.

ref: https://reactjs.org/docs/react-component.html#setstate

#### What does this PR do?

#### Where should the reviewer start?

Form.js

#### What testing has been done on this PR?

unit test

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

no
