### PR TITLE
Fix controlled opened state in Select

### DIFF
--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -1,4 +1,4 @@
-import React, { isValidElement, Component } from 'react';
+import React, { isValidElement, useState, useRef, useEffect } from 'react';
 import { compose } from 'recompose';
 import styled, { withTheme } from 'styled-components';
 
@@ -28,216 +28,203 @@ const StyledSelectDropButton = styled(DropButton)`
 StyledSelectDropButton.defaultProps = {};
 Object.setPrototypeOf(StyledSelectDropButton.defaultProps, defaultProps);
 
-class Select extends Component {
-  static defaultProps = {
-    closeOnChange: true,
-    dropAlign: { top: 'bottom', left: 'left' },
-    messages: { multiple: 'multiple' },
-  };
+const Select = props => {
+  const {
+    a11yTitle,
+    alignSelf,
+    children,
+    closeOnChange,
+    disabled,
+    dropAlign,
+    dropProps,
+    dropTarget,
+    forwardRef,
+    gridArea,
+    id,
+    icon,
+    labelKey,
+    margin,
+    messages,
+    onChange,
+    onClose,
+    onOpen,
+    open: propOpen,
+    options,
+    placeholder,
+    plain,
+    selected,
+    size,
+    theme,
+    value,
+    valueLabel,
+    ...rest
+  } = props;
+  const inputRef = useRef();
+  const [open, setOpen] = useState(propOpen);
+  useEffect(() => {
+    setOpen(propOpen);
+  }, [propOpen]);
 
-  inputRef = React.createRef();
-
-  constructor(props) {
-    super(props);
-
-    this.state = { open: props.open };
-  }
-
-  onOpen = () => {
-    const { onOpen } = this.props;
-    this.setState({ open: true }, () => {
-      if (onOpen) {
-        onOpen();
-      }
-    });
-  };
-
-  onClose = () => {
-    const { onClose } = this.props;
-    this.setState({ open: false }, () => {
-      if (onClose) {
-        onClose();
-      }
-    });
-  };
-
-  render() {
-    const {
-      a11yTitle,
-      alignSelf,
-      children,
-      closeOnChange,
-      disabled,
-      dropAlign,
-      dropProps,
-      dropTarget,
-      forwardRef,
-      gridArea,
-      id,
-      icon,
-      labelKey,
-      margin,
-      messages,
-      onChange,
-      onClose,
-      options,
-      placeholder,
-      plain,
-      selected,
-      size,
-      theme,
-      value,
-      valueLabel,
-      ...rest
-    } = this.props;
-    const { open } = this.state;
-
-    delete rest.onSearch;
-
-    const onSelectChange = (event, ...args) => {
-      if (closeOnChange) {
-        this.onClose();
-      }
-      if (onChange) {
-        onChange({ ...event, target: this.inputRef.current }, ...args);
-      }
-    };
-
-    let SelectIcon;
-    switch (icon) {
-      case false:
-        break;
-      case true:
-      case undefined:
-        SelectIcon = theme.select.icons.down;
-        break;
-      default:
-        SelectIcon = icon;
+  const onRequestOpen = () => {
+    setOpen(true);
+    if (onOpen) {
+      onOpen();
     }
-    let selectValue;
-    let inputValue = '';
-    if (valueLabel) {
-      selectValue = valueLabel;
-    } else if (Array.isArray(value)) {
-      if (value.length > 1) {
-        if (React.isValidElement(value[0])) {
-          selectValue = value;
-        } else {
-          inputValue = messages.multiple;
-        }
-      } else if (value.length === 1) {
-        if (React.isValidElement(value[0])) {
-          [selectValue] = value;
-        } else if (labelKey && typeof value[0] === 'object') {
-          if (typeof labelKey === 'function') {
-            inputValue = labelKey(value[0]);
-          } else {
-            inputValue = value[0][labelKey];
-          }
-        } else {
-          [inputValue] = value;
-        }
+  };
+
+  const onRequestClose = () => {
+    setOpen(false);
+    if (onClose) {
+      onClose();
+    }
+  };
+
+  const onSelectChange = (event, ...args) => {
+    if (closeOnChange) {
+      onRequestClose();
+    }
+    if (onChange) {
+      onChange({ ...event, target: inputRef.current }, ...args);
+    }
+  };
+
+  let SelectIcon;
+  switch (icon) {
+    case false:
+      break;
+    case true:
+    case undefined:
+      SelectIcon = theme.select.icons.down;
+      break;
+    default:
+      SelectIcon = icon;
+  }
+  let selectValue;
+  let inputValue = '';
+  if (valueLabel) {
+    selectValue = valueLabel;
+  } else if (Array.isArray(value)) {
+    if (value.length > 1) {
+      if (React.isValidElement(value[0])) {
+        selectValue = value;
       } else {
-        inputValue = '';
+        inputValue = messages.multiple;
       }
-    } else if (labelKey && typeof value === 'object') {
-      if (typeof labelKey === 'function') {
-        inputValue = labelKey(value);
-      } else {
-        inputValue = value[labelKey];
-      }
-    } else if (React.isValidElement(value)) {
-      selectValue = value; // deprecated in favor of valueLabel
-    } else if (selected !== undefined) {
-      if (Array.isArray(selected)) {
-        if (selected.length > 1) {
-          inputValue = messages.multiple;
-        } else if (selected.length === 1) {
-          inputValue = options[selected[0]];
+    } else if (value.length === 1) {
+      if (React.isValidElement(value[0])) {
+        [selectValue] = value;
+      } else if (labelKey && typeof value[0] === 'object') {
+        if (typeof labelKey === 'function') {
+          inputValue = labelKey(value[0]);
+        } else {
+          inputValue = value[0][labelKey];
         }
       } else {
-        inputValue = options[selected];
+        [inputValue] = value;
       }
     } else {
-      inputValue = value;
+      inputValue = '';
     }
+  } else if (labelKey && typeof value === 'object') {
+    if (typeof labelKey === 'function') {
+      inputValue = labelKey(value);
+    } else {
+      inputValue = value[labelKey];
+    }
+  } else if (React.isValidElement(value)) {
+    selectValue = value; // deprecated in favor of valueLabel
+  } else if (selected !== undefined) {
+    if (Array.isArray(selected)) {
+      if (selected.length > 1) {
+        inputValue = messages.multiple;
+      } else if (selected.length === 1) {
+        inputValue = options[selected[0]];
+      }
+    } else {
+      inputValue = options[selected];
+    }
+  } else {
+    inputValue = value;
+  }
 
-    // const dark = theme.select.background ? colorIsDark(theme.select.background) : theme.dark;
-    const iconColor = normalizeColor(
-      theme.select.icons.color || 'control',
-      theme,
-    );
+  // const dark = theme.select.background ? colorIsDark(theme.select.background) : theme.dark;
+  const iconColor = normalizeColor(
+    theme.select.icons.color || 'control',
+    theme,
+  );
 
-    return (
-      <Keyboard onDown={this.onOpen} onUp={this.onOpen}>
-        <StyledSelectDropButton
-          ref={forwardRef}
-          id={id}
-          disabled={disabled === true || undefined}
-          dropAlign={dropAlign}
-          dropTarget={dropTarget}
-          open={open}
-          alignSelf={alignSelf}
-          gridArea={gridArea}
-          margin={margin}
-          onOpen={this.onOpen}
-          onClose={this.onClose}
-          dropContent={
-            <SelectContainer {...this.props} onChange={onSelectChange} />
-          }
-          plain={plain}
-          dropProps={{ ...dropProps }}
+  delete rest.onSearch;
+
+  return (
+    <Keyboard onDown={onRequestOpen} onUp={onRequestOpen}>
+      <StyledSelectDropButton
+        ref={forwardRef}
+        id={id}
+        disabled={disabled === true || undefined}
+        dropAlign={dropAlign}
+        dropTarget={dropTarget}
+        open={open}
+        alignSelf={alignSelf}
+        gridArea={gridArea}
+        margin={margin}
+        onOpen={onRequestOpen}
+        onClose={onRequestClose}
+        dropContent={<SelectContainer {...props} onChange={onSelectChange} />}
+        plain={plain}
+        dropProps={{ ...dropProps }}
+      >
+        <Box
+          align="center"
+          direction="row"
+          justify="between"
+          background={theme.select.background}
         >
-          <Box
-            align="center"
-            direction="row"
-            justify="between"
-            background={theme.select.background}
-          >
-            <Box direction="row" flex basis="auto">
-              {selectValue || (
-                <SelectTextInput
-                  a11yTitle={
-                    a11yTitle &&
-                    `${a11yTitle}${
-                      typeof value === 'string' ? `, ${value}` : ''
-                    }`
-                  }
-                  id={id ? `${id}__input` : undefined}
-                  ref={this.inputRef}
-                  {...rest}
-                  tabIndex="-1"
-                  type="text"
-                  placeholder={placeholder}
-                  plain
-                  readOnly
-                  value={inputValue}
-                  size={size}
-                  onClick={disabled === true ? undefined : this.onOpen}
-                />
-              )}
-            </Box>
-            {SelectIcon && (
-              <Box
-                margin={theme.select.icons.margin}
-                flex={false}
-                style={{ minWidth: 'auto' }}
-              >
-                {isValidElement(SelectIcon) ? (
-                  SelectIcon
-                ) : (
-                  <SelectIcon color={iconColor} size={size} />
-                )}
-              </Box>
+          <Box direction="row" flex basis="auto">
+            {selectValue || (
+              <SelectTextInput
+                a11yTitle={
+                  a11yTitle &&
+                  `${a11yTitle}${typeof value === 'string' ? `, ${value}` : ''}`
+                }
+                id={id ? `${id}__input` : undefined}
+                ref={inputRef}
+                {...rest}
+                tabIndex="-1"
+                type="text"
+                placeholder={placeholder}
+                plain
+                readOnly
+                value={inputValue}
+                size={size}
+                onClick={disabled === true ? undefined : onRequestOpen}
+              />
             )}
           </Box>
-        </StyledSelectDropButton>
-      </Keyboard>
-    );
-  }
-}
+          {SelectIcon && (
+            <Box
+              margin={theme.select.icons.margin}
+              flex={false}
+              style={{ minWidth: 'auto' }}
+            >
+              {isValidElement(SelectIcon) ? (
+                SelectIcon
+              ) : (
+                <SelectIcon color={iconColor} size={size} />
+              )}
+            </Box>
+          )}
+        </Box>
+      </StyledSelectDropButton>
+    </Keyboard>
+  );
+};
 
-Object.setPrototypeOf(Select.defaultProps, defaultProps);
+Select.defaultProps = {
+  closeOnChange: true,
+  dropAlign: { top: 'bottom', left: 'left' },
+  messages: { multiple: 'multiple' },
+  ...defaultProps,
+};
 
 let SelectDoc;
 if (process.env.NODE_ENV !== 'production') {

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -815,7 +815,7 @@ exports[`Select complex options and children 3`] = `
 <div
   class="c0 c1"
   id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -1927,7 +1927,7 @@ exports[`Select empty results search 1`] = `
 <div
   class="c0 c1"
   id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -2253,7 +2253,7 @@ exports[`Select large drop container height 1`] = `
 <div
   class="c0 c1"
   id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -2587,7 +2587,7 @@ exports[`Select medium drop container height 1`] = `
 <div
   class="c0 c1"
   id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -3511,7 +3511,7 @@ exports[`Select multiple values 3`] = `
 <div
   class="c0 c1"
   id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -4338,7 +4338,7 @@ exports[`Select opens 3`] = `
 <div
   class="c0 c1"
   id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -5960,7 +5960,7 @@ exports[`Select search 2`] = `
 <div
   class="c0 c1"
   id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -7742,7 +7742,7 @@ exports[`Select small drop container height 1`] = `
 <div
   class="c0 c1"
   id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div

--- a/src/js/components/Select/stories/Controlled.js
+++ b/src/js/components/Select/stories/Controlled.js
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { Box, Grommet, Select, Button } from 'grommet';
+import { grommet } from 'grommet/themes';
+
+class SimpleSelect extends Component {
+  state = {
+    options: ['one', 'two'],
+    value: '',
+    open: false,
+  };
+
+  render() {
+    const { theme, ...rest } = this.props;
+    const { options, value, open } = this.state;
+    return (
+      <Grommet full theme={theme || grommet}>
+        <Box fill align="center" justify="start" pad="large" gap="small">
+          <Button
+            onClick={() => this.setState({ open: !open })}
+            label="Control the select"
+          />
+          <Select
+            id="select"
+            name="select"
+            placeholder="Select"
+            open={open}
+            value={value}
+            options={options}
+            onChange={({ option }) => this.setState({ value: option })}
+            {...rest}
+          />
+        </Box>
+      </Grommet>
+    );
+  }
+}
+
+storiesOf('Select', module).add('Controlled', () => <SimpleSelect />);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes the controlled open state of the Select.

#### Where should the reviewer start?

There were two solutions to the problem.

1. Use componentDidUpdate

```
componentDidUpdate(prevProps) {
  const { open: nextOpen } = this.props;
  if (prevProps.open !== nextOpen) {
    this.setState({ open: nextOpen });
  }
}
```
Eslint doesn't like setting the state in this lifecycle method though and while i didn't look for why i am assuming it has its reasons

2. Turn the component into a function with hooks and useEffect to update the state based on the prop change. 

I opted for solution 2. Most of the code is intact. important parts are happening at the top of the changes were the useEffect and useState calls are. 

There is some noise in snapshots the styling got re-ordered but the styles are normally without a change.
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
Added a storybook example
#### Any background context you want to provide?

#### What are the relevant issues?
#3103 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
no