### PR TITLE
InfiniteScroll/DataTable: onMore function triggers based on step value as user scrolls

### DIFF
--- a/src/js/components/InfiniteScroll/InfiniteScroll.js
+++ b/src/js/components/InfiniteScroll/InfiniteScroll.js
@@ -180,7 +180,9 @@ class InfiniteScroll extends PureComponent {
         this.setState(
           { beginPage: nextBeginPage, endPage: nextEndPage },
           () => {
-            if (onMore && nextEndPage === lastPage) {
+            console.log(nextEndPage, endPage, lastPage);
+            // Trigger onMore function as nextEndPage value is incremented as user scrolls through
+            if (onMore && nextEndPage > endPage && endPage <= lastPage) {
               onMore();
             }
           },

--- a/src/js/components/InfiniteScroll/InfiniteScroll.js
+++ b/src/js/components/InfiniteScroll/InfiniteScroll.js
@@ -180,7 +180,6 @@ class InfiniteScroll extends PureComponent {
         this.setState(
           { beginPage: nextBeginPage, endPage: nextEndPage },
           () => {
-            console.log(nextEndPage, endPage, lastPage);
             // Trigger onMore function as nextEndPage value is incremented as user scrolls through
             if (onMore && nextEndPage > endPage && endPage <= lastPage) {
               onMore();


### PR DESCRIPTION
Fixed onMore function trigger condition for Infinite scroll & data table with Infinite scroll components

#### What does this PR do?
Fixes issue with onMore function not being called as part of InfiniteScroll component

#### Where should the reviewer start?
InfiniteScroll.js 

#### What testing has been done on this PR?
Storybook

#### How should this be manually tested?
Storybook

#### Any background context you want to provide?
#### What are the relevant issues?
#3106 

#### Screenshots (if appropriate)
#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
backward compatible