### PR TITLE
Fix #2906 - Lazy load Layer container for successful use in SSR contexts

### DIFF
--- a/src/js/components/Layer/Layer.js
+++ b/src/js/components/Layer/Layer.js
@@ -14,9 +14,16 @@ class Layer extends Component {
     responsive: true,
   };
 
-  originalFocusedElement = document.activeElement;
+  state = {
+    islayerContainerAvailable: false,
+  };
 
-  layerContainer = getNewContainer();
+  componentDidMount() {
+    // ensure document is available
+    this.originalFocusedElement = document.activeElement;
+    this.layerContainer = getNewContainer();
+    this.setState({ islayerContainerAvailable: true });
+  }
 
   componentWillUnmount() {
     if (this.originalFocusedElement) {
@@ -38,10 +45,11 @@ class Layer extends Component {
   }
 
   render() {
-    return createPortal(
-      <LayerContainer {...this.props} />,
-      this.layerContainer,
-    );
+    const { islayerContainerAvailable } = this.state;
+
+    return islayerContainerAvailable
+      ? createPortal(<LayerContainer {...this.props} />, this.layerContainer)
+      : null;
   }
 }
 

--- a/src/js/components/Layer/__tests__/Layer-test.js
+++ b/src/js/components/Layer/__tests__/Layer-test.js
@@ -200,16 +200,16 @@ describe('Layer', () => {
     const ref = React.createRef();
     render(
       <Grommet>
-        <Layer data-testid="layer-container-test" ref={ref}>
-          My Test
+        <Layer data-testid="test-layer-container" ref={ref}>
+          Layer container is available
         </Layer>
       </Grommet>,
     );
 
-    ref.current.setState({ isLayerContainerAvailable: false });
-    expect(queryByTestId(document, 'my-test')).toBeNull();
+    ref.current.setState({ islayerContainerAvailable: false });
+    expect(queryByTestId(document, 'test-layer-container')).toBeNull();
 
     ref.current.componentDidMount();
-    expect(queryByTestId(document, 'my-test')).toMatchSnapshot();
+    expect(queryByTestId(document, 'test-layer-container')).toMatchSnapshot();
   });
 });

--- a/src/js/components/Layer/__tests__/Layer-test.js
+++ b/src/js/components/Layer/__tests__/Layer-test.js
@@ -195,4 +195,21 @@ describe('Layer', () => {
     expect(bodyNode).toMatchSnapshot();
     expect(queryByTestId(document, 'test-layer-node')).toBeNull();
   });
+
+  test('should be null prior to mounting, displayed after mount', () => {
+    const ref = React.createRef();
+    render(
+      <Grommet>
+        <Layer data-testid="layer-container-test" ref={ref}>
+          My Test
+        </Layer>
+      </Grommet>,
+    );
+
+    ref.current.setState({ isLayerContainerAvailable: false });
+    expect(queryByTestId(document, 'my-test')).toBeNull();
+
+    ref.current.componentDidMount();
+    expect(queryByTestId(document, 'my-test')).toMatchSnapshot();
+  });
 });

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -2477,3 +2477,5 @@ exports[`Layer position top 1`] = `
 `;
 
 exports[`Layer position top 2`] = `""`;
+
+exports[`Layer should be null prior to mounting, displayed after mount 1`] = `null`;

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -2478,4 +2478,77 @@ exports[`Layer position top 1`] = `
 
 exports[`Layer position top 2`] = `""`;
 
-exports[`Layer should be null prior to mounting, displayed after mount 1`] = `null`;
+exports[`Layer should be null prior to mounting, displayed after mount 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-height: 48px;
+  background: #FFFFFF;
+  color: #444444;
+  outline: none;
+  pointer-events: all;
+  z-index: 15;
+  position: fixed;
+  max-height: calc(100% - 0px - 0px);
+  max-width: calc(100% - 0px - 0px);
+  border-radius: 4px;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
+  animation: bBMZdm 0.2s ease-in-out forwards;
+}
+
+.c1 {
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+@media only screen and (max-width:768px) {
+  .c0 {
+    position: relative;
+    max-height: none;
+    max-width: none;
+    border-radius: 0;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    -webkit-transform: none;
+    -ms-transform: none;
+    transform: none;
+    -webkit-animation: none;
+    animation: none;
+    height: 100vh;
+    width: 100vw;
+  }
+}
+
+<div
+  class="c0"
+  data-testid="test-layer-container"
+>
+  <a
+    aria-hidden="true"
+    class="c1"
+    tabindex="-1"
+  />
+  Layer container is available
+</div>
+`;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Implements [recommended solution](https://github.com/grommet/grommet/issues/2906#issuecomment-472643372), ensuring that window.document is available before rendering the Layer container. This makes sure the Layer component will succeed in build processes for server side rendering contexts.

Waits for component mount, then accesses dependent document elements, then re-renders Layer component with document elements.

#### Where should the reviewer start?
src/js/components/Layer/Layer.js

- Added state for availability of `layerComponent`.
- Moved `originalFocusedElement` and `layerContainer` into `componentDidMount()`

#### What testing has been done on this PR?

1. Replicated [original issue](https://github.com/grommet/grommet/issues/2906) occurring during Gatsby build
2. Manual testing in Storybook
3. Passes unit tests
4. Performed successful `gatsby build`

#### How should this be manually tested?

#### Any background context you want to provide?
[original issue](https://github.com/grommet/grommet/issues/2906)

#### What are the relevant issues?
1. [#2906](https://github.com/grommet/grommet/issues/2906)
2. This solution might be applicable to Drop.js as well 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
