### PR TITLE
fix: modify usage of props with true value

### DIFF
--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -10,7 +10,7 @@ You can provide a single function child that will be called with
 
 ```javascript
 import { Button } from 'grommet';
-<Button primary={true} label='Label' />
+<Button primary label='Label' />
 ```
 
 ## Properties
@@ -224,8 +224,8 @@ function
 
 **plain**
 
-Whether this is a plain button with no border or pad. 
-Non plain button will show both pad and border. 
+Whether this is a plain button with no border or pad.
+Non plain button will show both pad and border.
 The plain button has no border and unless the icon prop exist it has no pad as well.
 
 ```

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -18,7 +18,7 @@ export const doc = Button => {
     )
     .usage(
       `import { Button } from 'grommet';
-<Button primary={true} label='Label' />`,
+<Button primary label='Label' />`,
     )
     .intrinsicElement('button');
 
@@ -36,9 +36,11 @@ export const doc = Button => {
     fill: PropTypes.oneOfType([
       PropTypes.oneOf(['horizontal', 'vertical']),
       PropTypes.bool,
-    ]).description(
-      'Whether the button expands to fill all of the available width and/or height.',
-    ).defaultValue(false),
+    ])
+      .description(
+        'Whether the button expands to fill all of the available width and/or height.',
+      )
+      .defaultValue(false),
     focusIndicator: PropTypes.bool
       .description("Whether when 'plain' it should receive a focus outline.")
       .defaultValue(true),
@@ -83,8 +85,8 @@ causes the Button to be disabled.`,
     ),
     plain: PropTypes.bool
       .description(
-        `Whether this is a plain button with no border or pad. 
-Non plain button will show both pad and border. 
+        `Whether this is a plain button with no border or pad.
+Non plain button will show both pad and border.
 The plain button has no border and unless the icon prop exist it has no pad as well.`,
       )
       .defaultValue(false),

--- a/src/js/components/Collapsible/README.md
+++ b/src/js/components/Collapsible/README.md
@@ -5,7 +5,7 @@ Expand or collapse animation.
 
 ```javascript
 import { Collapsible } from 'grommet';
-<Collapsible open={true}>test</Collapsible>
+<Collapsible open>test</Collapsible>
 ```
 
 ## Properties

--- a/src/js/components/Collapsible/doc.js
+++ b/src/js/components/Collapsible/doc.js
@@ -5,7 +5,7 @@ export const doc = Collapsible => {
     .description('Expand or collapse animation.')
     .usage(
       `import { Collapsible } from 'grommet';
-<Collapsible open={true}>test</Collapsible>`,
+<Collapsible open>test</Collapsible>`,
     )
     .intrinsicElement('div');
 

--- a/src/js/components/RoutedAnchor/README.md
+++ b/src/js/components/RoutedAnchor/README.md
@@ -6,7 +6,7 @@ An Anchor with support for React Router.
 
 ```javascript
 import { RoutedAnchor } from 'grommet';
-<RoutedAnchor primary={true} path='/documentation' />
+<RoutedAnchor primary path='/documentation' />
 ```
 
 ## Properties

--- a/src/js/components/RoutedAnchor/doc.js
+++ b/src/js/components/RoutedAnchor/doc.js
@@ -7,7 +7,7 @@ export const doc = RoutedAnchor => {
     .availableAt(getAvailableAtBadge('RoutedAnchor'))
     .description('An Anchor with support for React Router.')
     .usage(
-      "import { RoutedAnchor } from 'grommet';\n<RoutedAnchor primary={true} path='/documentation' />",
+      "import { RoutedAnchor } from 'grommet';\n<RoutedAnchor primary path='/documentation' />",
     )
     .intrinsicElement('a');
   DocumentedRoutedAnchor.propTypes = { ...ROUTER_PROPS };

--- a/src/js/components/RoutedButton/README.md
+++ b/src/js/components/RoutedButton/README.md
@@ -6,7 +6,7 @@ A button with support for React Router.
 
 ```javascript
 import { RoutedButton } from 'grommet';
-<RoutedButton primary={true} path='/documentation' />
+<RoutedButton primary path='/documentation' />
 ```
 
 ## Properties

--- a/src/js/components/RoutedButton/doc.js
+++ b/src/js/components/RoutedButton/doc.js
@@ -8,7 +8,7 @@ export const doc = RoutedButton => {
     .description('A button with support for React Router.')
     .usage(
       `import { RoutedButton } from 'grommet';
-<RoutedButton primary={true} path='/documentation' />`,
+<RoutedButton primary path='/documentation' />`,
     )
     .intrinsicElement('button');
   DocumentedRoutedButton.propTypes = { ...ROUTER_PROPS };

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1364,7 +1364,7 @@ You can provide a single function child that will be called with
 
 \`\`\`javascript
 import { Button } from 'grommet';
-<Button primary={true} label='Label' />
+<Button primary label='Label' />
 \`\`\`
 
 ## Properties
@@ -1578,8 +1578,8 @@ function
 
 **plain**
 
-Whether this is a plain button with no border or pad. 
-Non plain button will show both pad and border. 
+Whether this is a plain button with no border or pad.
+Non plain button will show both pad and border.
 The plain button has no border and unless the icon prop exist it has no pad as well.
 
 \`\`\`
@@ -3465,7 +3465,7 @@ Expand or collapse animation.
 
 \`\`\`javascript
 import { Collapsible } from 'grommet';
-<Collapsible open={true}>test</Collapsible>
+<Collapsible open>test</Collapsible>
 \`\`\`
 
 ## Properties
@@ -7906,7 +7906,7 @@ An Anchor with support for React Router.
 
 \`\`\`javascript
 import { RoutedAnchor } from 'grommet';
-<RoutedAnchor primary={true} path='/documentation' />
+<RoutedAnchor primary path='/documentation' />
 \`\`\`
 
 ## Properties
@@ -7941,7 +7941,7 @@ A button with support for React Router.
 
 \`\`\`javascript
 import { RoutedButton } from 'grommet';
-<RoutedButton primary={true} path='/documentation' />
+<RoutedButton primary path='/documentation' />
 \`\`\`
 
 ## Properties

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -904,8 +904,8 @@ causes the Button to be disabled.",
       },
       Object {
         "defaultValue": false,
-        "description": "Whether this is a plain button with no border or pad. 
-Non plain button will show both pad and border. 
+        "description": "Whether this is a plain button with no border or pad.
+Non plain button will show both pad and border.
 The plain button has no border and unless the icon prop exist it has no pad as well.",
         "format": "boolean",
         "name": "plain",
@@ -939,7 +939,7 @@ function",
       },
     ],
     "usage": "import { Button } from 'grommet';
-<Button primary={true} label='Label' />",
+<Button primary label='Label' />",
   },
   "Calendar": Object {
     "availableAt": Array [
@@ -1613,7 +1613,7 @@ vertical",
       },
     ],
     "usage": "import { Collapsible } from 'grommet';
-<Collapsible open={true}>test</Collapsible>",
+<Collapsible open>test</Collapsible>",
   },
   "DataTable": [Function],
   "Diagram": Object {


### PR DESCRIPTION
Modified usage of props with true value as in priciple,
passing true value in props is not required & it is
enough to pass the prop with no defined value.

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
It modifies incorrect usage of `{true}`values in props.

#### Where should the reviewer start?
`src/js/components/Button/doc.js`: 21 where the first usage is corrected.

#### What testing has been done on this PR?
I ensured all tests continue to pass and a small change in snapshot has been updated.

#### How should this be manually tested?
After using `<Button primary label='Label' />` button should continue to be a primary button.

#### Any background context you want to provide?
None

#### What are the relevant issues?
The only benefit is improved code quality by simpler props representation in code.

#### Screenshots (if appropriate)
Non functional change.

#### Do the grommet docs need to be updated?
A small change as a part of this PR is in documentation as well to show usage of `primary` prop in `<Button />` component.

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Yes, it is backwards compatible.
