### PR TITLE
fix(DataTable): make search field accept regexp special charactors

### DIFF
--- a/src/js/components/DataTable/Searcher.js
+++ b/src/js/components/DataTable/Searcher.js
@@ -41,7 +41,7 @@ class Searcher extends Component {
         <Keyboard onEsc={() => onFiltering(undefined)}>
           <Box flex pad={{ horizontal: 'small' }}>
             <TextInput
-              data-testid={`searcher-input-${property}`}
+              name={`search-${property}`}
               ref={this.inputRef}
               value={filters[property]}
               onChange={event => onFilter(property, event.target.value)}
@@ -60,7 +60,7 @@ class Searcher extends Component {
           </Box>
         ) : null}
         <Button
-          data-testid={`searcher-on-filtering-${property}`}
+          a11yTitle={`focus-search-${property}`}
           icon={
             <FormSearch
               color={normalizeColor(

--- a/src/js/components/DataTable/Searcher.js
+++ b/src/js/components/DataTable/Searcher.js
@@ -41,6 +41,7 @@ class Searcher extends Component {
         <Keyboard onEsc={() => onFiltering(undefined)}>
           <Box flex pad={{ horizontal: 'small' }}>
             <TextInput
+              data-testid={`searcher-input-${property}`}
               ref={this.inputRef}
               value={filters[property]}
               onChange={event => onFilter(property, event.target.value)}
@@ -59,6 +60,7 @@ class Searcher extends Component {
           </Box>
         ) : null}
         <Button
+          data-testid={`searcher-on-filtering-${property}`}
           icon={
             <FormSearch
               color={normalizeColor(

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -89,7 +89,7 @@ describe('DataTable', () => {
   });
 
   test('search', () => {
-    const { container, getByTestId } = render(
+    const { container } = render(
       <Grommet>
         <DataTable
           columns={[{ property: 'a', header: 'A', search: true }]}
@@ -98,8 +98,8 @@ describe('DataTable', () => {
       </Grommet>,
     );
     expect(container.firstChild).toMatchSnapshot();
-    fireEvent.click(getByTestId('searcher-on-filtering-a'), {});
-    fireEvent.change(getByTestId('searcher-input-a'), {
+    fireEvent.click(container.querySelector('[aria-label="focus-search-a"]'));
+    fireEvent.change(container.querySelector('[name="search-a"]'), {
       target: { value: '[' },
     });
     expect(container.firstChild).toMatchSnapshot();

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -88,6 +88,23 @@ describe('DataTable', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('search', () => {
+    const { container, getByTestId } = render(
+      <Grommet>
+        <DataTable
+          columns={[{ property: 'a', header: 'A', search: true }]}
+          data={[{ a: 'Alpha' }, { a: 'beta' }, { a: '[]' }]}
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+    fireEvent.click(getByTestId('searcher-on-filtering-a'), {});
+    fireEvent.change(getByTestId('searcher-input-a'), {
+      target: { value: '[' },
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('resizeable', () => {
     const component = renderer.create(
       <Grommet>

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2619,8 +2619,8 @@ exports[`DataTable search 1`] = `
               </span>
             </div>
             <button
+              aria-label="focus-search-a"
               class="c8"
-              data-testid="searcher-on-filtering-a"
               type="button"
             >
               <svg
@@ -2817,7 +2817,7 @@ exports[`DataTable search 2`] = `
                 <input
                   autocomplete="off"
                   class="c2"
-                  data-testid="searcher-input-a"
+                  name="search-a"
                   value="["
                 />
               </div>

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2330,6 +2330,590 @@ exports[`DataTable resizeable 1`] = `
 </div>
 `;
 
+exports[`DataTable search 1`] = `
+.c9 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: rgba(0,0,0,0.33);
+  stroke: rgba(0,0,0,0.33);
+}
+
+.c9 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c9 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c9 *[stroke*="#"],
+.c9 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*="#"],
+.c9 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  vertical-align: bottom;
+}
+
+.c10 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+}
+
+.c3 {
+  height: 100%;
+}
+
+.c2 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c7 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c12 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c8:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #444444;
+  color: #000000;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  height: 100%;
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c2 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class="c3"
+      >
+        <th
+          class="c4"
+          scope="col"
+        >
+          <div
+            class="c5"
+          >
+            <div
+              class="c6"
+            >
+              <span
+                class="c7"
+              >
+                A
+              </span>
+            </div>
+            <button
+              class="c8"
+              data-testid="searcher-on-filtering-a"
+              type="button"
+            >
+              <svg
+                aria-label="FormSearch"
+                class="c9"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M13.8,13.8 L18,18 L13.8,13.8 Z M10.5,15 C12.9852814,15 15,12.9852814 15,10.5 C15,8.01471863 12.9852814,6 10.5,6 C8.01471863,6 6,8.01471863 6,10.5 C6,12.9852814 8.01471863,15 10.5,15 Z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class=""
+    >
+      <tr
+        class="c3"
+      >
+        <th
+          class="c10"
+          scope="row"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              Alpha
+            </span>
+          </div>
+        </th>
+      </tr>
+      <tr
+        class="c3"
+      >
+        <th
+          class="c10"
+          scope="row"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              beta
+            </span>
+          </div>
+        </th>
+      </tr>
+      <tr
+        class="c3"
+      >
+        <th
+          class="c10"
+          scope="row"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              []
+            </span>
+          </div>
+        </th>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable search 2`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 eUfLDp"
+>
+  <table
+    class="StyledDataTable-xrlyjm-0 tpKnu StyledTable-sc-1m3u5g-6 fGUmP"
+  >
+    <thead
+      class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 bAIczD StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
+    >
+      <tr
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 ezpFws StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+      >
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hNAgVv"
+          scope="col"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 jPmsAr"
+          >
+            <div
+              class="StyledBox-sc-13pk1d4-0 lgPVDc"
+            >
+              <span
+                class="StyledText-sc-1sadyjn-0 fWSbXS"
+              >
+                A
+              </span>
+            </div>
+            .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c2 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  padding: 11px;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  width: 100%;
+}
+
+.c2::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c2::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c2::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c2:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c2::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c1 {
+  position: relative;
+  width: 100%;
+}
+
+@media only screen and (max-width:768px) {
+  .c0 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c0 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+<div
+              class="c0"
+            >
+              <div
+                class="c1"
+              >
+                <input
+                  autocomplete="off"
+                  class="c2"
+                  data-testid="searcher-input-a"
+                  value="["
+                />
+              </div>
+            </div>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="StyledDataTable__StyledDataTableBody-xrlyjm-2 hbZQKY StyledTable__StyledTableBody-sc-1m3u5g-3 dwInxx"
+    >
+      .c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+}
+
+.c0 {
+  height: 100%;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+<tr
+        class="c0"
+      >
+        <th
+          class="c1"
+          scope="row"
+        >
+          <div
+            class="c2"
+          >
+            <span
+              class="c3"
+            >
+              []
+            </span>
+          </div>
+        </th>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`DataTable sort 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/DataTable/buildState.js
+++ b/src/js/components/DataTable/buildState.js
@@ -40,6 +40,9 @@ const findPrimary = (nextProps, prevState, nextState) => {
   return { ...nextState, primaryProperty };
 };
 
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+const escapeRegExp = input => input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const filter = (nextProps, prevState, nextState) => {
   const { columns, onSearch } = nextProps;
   const { data, filters } = nextState;
@@ -58,7 +61,7 @@ const filter = (nextProps, prevState, nextState) => {
       // don't do filtering if the caller has supplied onSearch
       if (nextFilters[column.property] && column.search && !onSearch) {
         regexps[column.property] = new RegExp(
-          nextFilters[column.property],
+          escapeRegExp(nextFilters[column.property]),
           'i',
         );
       }


### PR DESCRIPTION
`DataTable` provides user input with `RegExp` constructor directly.  But we should escape user input.

#### What does this PR do?

`DataTable`'s bug fix 

#### Where should the reviewer start?

`buildState.js`

#### What testing has been done on this PR?

snapshot

#### How should this be manually tested?

storybook

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

backward compatible
