### PR TITLE
Changed DropButton to allow caller to pass onClick

### DIFF
--- a/src/js/components/DropButton/DropButton.js
+++ b/src/js/components/DropButton/DropButton.js
@@ -55,12 +55,15 @@ class DropButton extends Component {
     });
   };
 
-  onToggle = () => {
-    const { onClose, onOpen } = this.props;
+  onToggle = event => {
+    const { onClick, onClose, onOpen } = this.props;
     const { show } = this.state;
     this.setState({ show: !show }, () =>
       show ? onClose && onClose() : onOpen && onOpen(),
     );
+    if (onClick) {
+      onClick(event);
+    }
   };
 
   render() {
@@ -103,8 +106,8 @@ class DropButton extends Component {
           id={id}
           ref={forwardRef || this.buttonRef}
           disabled={disabled}
-          onClick={this.onToggle}
           {...rest}
+          onClick={this.onToggle}
         />
         {drop}
       </React.Fragment>


### PR DESCRIPTION
#### What does this PR do?

Changed DropButton to allow caller to pass onClick

#### Where should the reviewer start?

DropButton.js

#### What testing has been done on this PR?

storybook
grommet-design

#### How should this be manually tested?

storybook

#### Any background context you want to provide?

grommet-design attaches a click handler to all components it renders to allow the user to select that component. Menu wasn't working because DropButton didn't honor the click handler passed.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
