### PR TITLE
types: Add missing CheckBox types

### DIFF
--- a/src/js/themes/index.d.ts
+++ b/src/js/themes/index.d.ts
@@ -314,10 +314,13 @@ export declare const generate: (baseSpacing?: number, scale?: number) => DeepRea
           width: string;
       };
       check: {
+          extend: string;
           radius: string;
           thickness: string;
       };
-      icon: {};
+      extend: string;
+      color: string | { dark: string; light: string; };
+      icon: { size: string; extend: string };
       icons: {};
       hover: {
           border: {
@@ -333,9 +336,13 @@ export declare const generate: (baseSpacing?: number, scale?: number) => DeepRea
               dark: string;
               light: string;
           };
+          background: {
+            dark: string;
+            light: string;
+          };
           radius: string;
           size: string;
-          knob: {};
+          knob: { extend: string };
       };
   };
   clock: {


### PR DESCRIPTION
Include types used in [StyledCheckBox](https://github.com/grommet/grommet/blob/master/src/js/components/CheckBox/StyledCheckBox.js)

Signed-off-by: Dimitrios Lytras <dnlytras@gmail.com>
Fixes: https://github.com/grommet/grommet/issues/3126
