### PR TITLE
Video - removing html prop types from controls

### DIFF
--- a/src/js/components/Video/index.d.ts
+++ b/src/js/components/Video/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Omit } from "../../utils";
 
 export interface VideoProps {
   a11yTitle?: string;
@@ -12,6 +13,6 @@ export interface VideoProps {
   mute?: boolean;
 }
 
-declare const Video: React.ComponentClass<VideoProps & JSX.IntrinsicElements['video']>;
+declare const Video: React.ComponentClass<VideoProps & JSX.IntrinsicElements['video'] & Omit<JSX.IntrinsicElements['video'], 'controls'>>;
 
 export { Video };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
removes the default types of HTML video controls, so grommet's custom types will be accepted.
#### Where should the reviewer start?
index.d.ts

#### What are the relevant issues?
#3129 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible