### PR TITLE
modify theme property name to extend MaskedInput component

### DIFF
--- a/src/js/components/MaskedInput/StyledMaskedInput.js
+++ b/src/js/components/MaskedInput/StyledMaskedInput.js
@@ -28,7 +28,7 @@ export const StyledMaskedInput = styled.input`
   }
 
   ${props => props.focus && !props.plain && focusStyle};
-  ${props => props.theme.MaskedInput && props.theme.MaskedInput.extend};
+  ${props => props.theme.maskedInput && props.theme.maskedInput.extend};
 `;
 
 export const StyledMaskedInputContainer = styled.div`


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes https://github.com/grommet/grommet/issues/3134

#### Where should the reviewer start?
https://github.com/grommet/grommet/blob/master/src/js/themes/base.js#L613 happens to be the base theme that needs to be merged with a custom theme.

#### What testing has been done on this PR?
I used a custom theme at `<MaskedInput />`story of email. When applied the change, custom theme applies fine for extend property.

#### How should this be manually tested?
In `src/js/components/MaskedInput/stories/Email.js`, add:
```
// add
import { deepMerge } from "grommet/utils";
const customTheme = deepMerge(grommet, {
  maskedInput: {
    extend: () => `
      color: red,
    `
  },
});
// replace
<Grommet full theme={customTheme}>
```

#### Any background context you want to provide?
No

#### What are the relevant issues?
Probably IDE autocomplete got in the way and filled up component name MaskedInput while typing.

#### Screenshots (if appropriate)
No

#### Do the grommet docs need to be updated?
No, there is a no example of themed MaskedInput, if that is useful I can add one in coming week.

#### Should this PR be mentioned in the release notes?
Please use discretion, I am not sure because I have not seen release notes.

#### Is this change backwards compatible or is it a breaking change?
Yes, it is backward compatible.
