### PR TITLE
fix: modify implementation of parseMetricToNum mixin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,7 @@
     "fail": true,
     "afterEach": true,
     "beforeEach": true,
+    "afterAll": true,
     "MouseEvent": true,
     "requestAnimationFrame": true
   },

--- a/src/js/utils/__tests__/mixins-test.js
+++ b/src/js/utils/__tests__/mixins-test.js
@@ -1,0 +1,35 @@
+import { parseMetricToNum } from '../mixins';
+
+afterAll(() => {
+  jest.clearAllMocks();
+});
+
+describe('Mixins parseMetricToNum', () => {
+  global.console = {
+    warn: jest.fn(),
+  };
+
+  test('converts "12px" to 12', () => {
+    const warn = jest.spyOn(global.console, 'warn');
+    const number = parseMetricToNum('12px');
+
+    expect(number).toBe(12);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('converts "12.5px" to 12', () => {
+    const number = parseMetricToNum('12.5px');
+
+    expect(number).toBe(12.5);
+  });
+
+  test('converts "12px 20px" to 12 & warns about usage', () => {
+    const warn = jest.spyOn(global.console, 'warn');
+    const number = parseMetricToNum('12px 20px');
+
+    expect(number).toBe(12);
+    expect(warn).toHaveBeenCalledWith(
+      'Invalid single measurement value: "12px 20px"',
+    );
+  });
+});

--- a/src/js/utils/mixins.js
+++ b/src/js/utils/mixins.js
@@ -1,7 +1,11 @@
 import { css } from 'styled-components';
 
-export const parseMetricToNum = fontAsString =>
-  parseFloat(fontAsString.replace(/[^0-9/.]/g, ''), 10);
+export const parseMetricToNum = fontAsString => {
+  if (fontAsString.match(/\s/) && process.env.NODE_ENV !== 'production') {
+    console.warn(`Invalid single measurement value: "${fontAsString}"`);
+  }
+  return parseFloat(fontAsString.match(/\d+(\.\d+)?/), 10);
+};
 
 export const fontSize = (size, lineHeight) => css`
   font-size: ${props =>


### PR DESCRIPTION
The previous implementation of `parseMetricToNum` was it modifies "12px 20px" to 1220.
For "12px 20px", `fontAsString.replace(/[^0-9/.]/g, ''` removes all strings leaving "1220" and works what it was specified for.

The problem occurs when this function is used in `StyledTextInput` at [code that decides left padding](https://github.com/crashuniverse/grommet/blob/master/src/js/components/TextInput/StyledTextInput.js#L65). The user, while overriding theme variables for padding tries "12px 20px" imagining that css shorthand syntax is supported, [while documentation suggests only 1 value is supported](https://v2.grommet.io/textinput#global.input.padding). The side-effect is left padding becomes 1220px.

Fixes #3124

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
It modifies how `parseMetricToNum` works. The new regex `/\d+(\.\d+)?/` to extract value from string is:
```
/                         // start
 \d                       // a digit
   +                      // and its 0 or more occurrences
    (                     // start of an optional group to support 12.567px
      \.                  // decimal
       \d+                // more digits
          )?              // end of optional group
            /             // end
```
So now it just extracts the first match (no global regex) and "12px 20px" is still 12. The user's expectation can be managed by a console warning suggested by @oorestisime. It retains all the initial features of function.

#### Where should the reviewer start?
With a critical mindset to increase safety as this fn is used at several places and helping me understand how does `-20px` is used with these functions as I could not understand it. I wrote tests to support all occurrences of usage I saw in code.

#### What testing has been done on this PR?
Besides adding unit tests, while running storybook, I see the problem for `TextInput` by adding this code in `src/js/components/TextInput/stories/textinput.stories.js` line 88
```
const customTheme = deepMerge(grommet, {
  global: {
    input: {
      padding: '12px 20px', // breaks layout and left padding becomes 1220px
    }
  },
  textInput: {
```
When I change to my branch, the problem disappears and console has a warning.

#### How should this be manually tested?
Same as the previous point.

#### Any background context you want to provide?
#3124

#### What are the relevant issues?
#3124

#### Screenshots (if appropriate)
<img width="1438" alt="Screen Shot 2019-06-08 at 19 27 39" src="https://user-images.githubusercontent.com/540130/59150428-946a6580-8a23-11e9-8501-60f0f111f7ef.png">

#### Do the grommet docs need to be updated?
No. However while running tests, a small change is introduced possibly because of updates in libraries yesterday in `master`.

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Yes, it is backwards compatible.