### PR TITLE
Button: Extend typings to include the `target` property

### DIFF
--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -183,6 +183,17 @@ If specified, the button will behave like an anchor tag.
 string
 ```
 
+**target**
+
+Specifies where to display the URL defined in the href property.
+
+```
+_self
+_blank
+_parent
+_top
+```
+
 **icon**
 
 Icon element to place in the button.

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -62,6 +62,9 @@ with plain Buttons.`,
     href: PropTypes.string.description(
       'If specified, the button will behave like an anchor tag.',
     ),
+    target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']).description(
+      `Specifies where to display the URL defined in the href property.`,
+    ),
     icon: PropTypes.element.description('Icon element to place in the button.'),
     gap: PropTypes.oneOfType([
       PropTypes.oneOf([

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -14,6 +14,7 @@ export interface ButtonProps {
   gap?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   hoverIndicator?: boolean | string | "background" | {background?: boolean | string};
   href?: string;
+  target?: "_self" | "_blank" | "_parent" | "_top";
   icon?: JSX.Element;
   label?: React.ReactNode;
   onClick?: ((...args: any[]) => any);

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1537,6 +1537,17 @@ If specified, the button will behave like an anchor tag.
 string
 \`\`\`
 
+**target**
+
+Specifies where to display the URL defined in the href property.
+
+\`\`\`
+_self
+_blank
+_parent
+_top
+\`\`\`
+
 **icon**
 
 Icon element to place in the button.

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -875,6 +875,14 @@ background
         "name": "href",
       },
       Object {
+        "description": "Specifies where to display the URL defined in the href property.",
+        "format": "_self
+_blank
+_parent
+_top",
+        "name": "target",
+      },
+      Object {
         "description": "Icon element to place in the button.",
         "format": "element",
         "name": "icon",


### PR DESCRIPTION
We could alternatively turn this into a union type and make the `target` valid only when `href` is provided. Unfortunately this would require us to change the `export interface` to `export type`, which would be a breaking change for whoever currently inherits the ButtonProps interface.

Resolves: #3158
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Extends the typings of the Button component to support the `target` html property, so that it can be used when the `href` property is provided and an `<a>` in rendered.

#### Where should the reviewer start?

#### What testing has been done on this PR?

I linked that to my project with TS v3.5.1 and I was able to use the `target` property as expected.

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, but I think that I did my part

#### Should this PR be mentioned in the release notes?
Probably not.

#### Is this change backwards compatible or is it a breaking change?
It's backwards compatible.
