### PR TITLE
fix: fix focus behavior of Layer in presence of focusable contents

### DIFF
--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -37,9 +37,19 @@ class LayerContainer extends Component {
     const { position } = this.props;
     if (position !== 'hidden') {
       this.makeLayerVisible();
-      // once layer is open we set the focus in the hidden
-      // anchor so that you can start tabbing inside the layer
-      if (this.anchorRef.current) {
+      // Once layer is open we make sure it has focus so that you
+      // can start tabbing inside the layer. If the caller put focus
+      // on an element already, we honor that. Otherwise, we put
+      // the focus in the hidden anchor.
+      let element = document.activeElement;
+      while (element) {
+        if (element === this.containerRef.current) {
+          // already have focus inside the container
+          break;
+        }
+        element = element.parentElement;
+      }
+      if (!element && this.anchorRef.current) {
         this.anchorRef.current.focus();
       }
     }

--- a/src/js/components/Layer/__tests__/Layer-test.js
+++ b/src/js/components/Layer/__tests__/Layer-test.js
@@ -212,4 +212,38 @@ describe('Layer', () => {
     ref.current.componentDidMount();
     expect(queryByTestId(document, 'test-layer-container')).toMatchSnapshot();
   });
+
+  test('focus on layer', () => {
+    /* eslint-disable jsx-a11y/no-autofocus */
+    render(
+      <Grommet>
+        <Layer data-testid="focus-layer-test">
+          <input />
+        </Layer>
+        <input autoFocus />
+      </Grommet>,
+    );
+    /* eslint-disable jsx-a11y/no-autofocus */
+
+    const layerNode = getByTestId(document, 'focus-layer-test');
+    expect(layerNode).toMatchSnapshot();
+    expect(document.activeElement.nodeName).toBe('A');
+  });
+
+  test('not steal focus from an autofocus focusable element', () => {
+    /* eslint-disable jsx-a11y/no-autofocus */
+    render(
+      <Grommet>
+        <Layer data-testid="focus-layer-input-test">
+          <input autoFocus data-testid="focus-input" />
+          <button type="button">Button</button>
+        </Layer>
+      </Grommet>,
+    );
+    /* eslint-disable jsx-a11y/no-autofocus */
+    const layerNode = getByTestId(document, 'focus-layer-input-test');
+    const inputNode = getByTestId(document, 'focus-input');
+    expect(layerNode).toMatchSnapshot();
+    expect(document.activeElement).toBe(inputNode);
+  });
 });

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -223,6 +223,81 @@ exports[`Layer dark context 2`] = `
 }"
 `;
 
+exports[`Layer focus on layer 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-height: 48px;
+  background: #FFFFFF;
+  color: #444444;
+  outline: none;
+  pointer-events: all;
+  z-index: 15;
+  position: fixed;
+  max-height: calc(100% - 0px - 0px);
+  max-width: calc(100% - 0px - 0px);
+  border-radius: 4px;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
+  animation: bBMZdm 0.2s ease-in-out forwards;
+}
+
+.c1 {
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+@media only screen and (max-width:768px) {
+  .c0 {
+    position: relative;
+    max-height: none;
+    max-width: none;
+    border-radius: 0;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    -webkit-transform: none;
+    -ms-transform: none;
+    transform: none;
+    -webkit-animation: none;
+    animation: none;
+    height: 100vh;
+    width: 100vw;
+  }
+}
+
+<div
+  class="c0"
+  data-testid="focus-layer-test"
+>
+  <a
+    aria-hidden="true"
+    class="c1"
+    tabindex="-1"
+  />
+  <input />
+</div>
+`;
+
 exports[`Layer full false 1`] = `
 .c0 {
   font-size: 18px;
@@ -1677,6 +1752,88 @@ exports[`Layer non-modal 1`] = `
 `;
 
 exports[`Layer non-modal 2`] = `""`;
+
+exports[`Layer not steal focus from an autofocus focusable element 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-height: 48px;
+  background: #FFFFFF;
+  color: #444444;
+  outline: none;
+  pointer-events: all;
+  z-index: 15;
+  position: fixed;
+  max-height: calc(100% - 0px - 0px);
+  max-width: calc(100% - 0px - 0px);
+  border-radius: 4px;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+  -webkit-animation: bBMZdm 0.2s ease-in-out forwards;
+  animation: bBMZdm 0.2s ease-in-out forwards;
+}
+
+.c1 {
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+@media only screen and (max-width:768px) {
+  .c0 {
+    position: relative;
+    max-height: none;
+    max-width: none;
+    border-radius: 0;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    -webkit-transform: none;
+    -ms-transform: none;
+    transform: none;
+    -webkit-animation: none;
+    animation: none;
+    height: 100vh;
+    width: 100vw;
+  }
+}
+
+<div
+  class="c0"
+  data-testid="focus-layer-input-test"
+>
+  <a
+    aria-hidden="true"
+    class="c1"
+    tabindex="-1"
+  />
+  <input
+    data-testid="focus-input"
+  />
+  <button
+    type="button"
+  >
+    Button
+  </button>
+</div>
+`;
 
 exports[`Layer plain 1`] = `
 .c0 {


### PR DESCRIPTION
Fixes #3112

Signed-off-by: Priya Ranjan Singh <mail@priyaranjan.net>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR introduces conditions to check for already focused elements in contents of Layer and avoids stealing focus if there is any. In absence of any focused elements in contents of Layer, it continues to assign focus to the hidden anchor element.

#### Where should the reviewer start?
`src/js/components/Layer/LayerContainer.js` has changes in `componentDidMount` lifecycle.

#### What testing has been done on this PR?
In the `Form` story that renders `<FormLayer />`, placing an `autoFocus` to `<TextInput />` component. The component finally looks to be `<TextInput autoFocus />`. When layer container is visible, `TextInput` has focus. In absence of `autoFocus` prop, the hidden anchor continues to have the focus.

#### How should this be manually tested?
On this branch, if we add `autoFocus` prop in story https://storybook.grommet.io/?path=/story/layer--form, to the input element, we would see that it received the focus when Layer opens.

#### Any background context you want to provide?
This problem is observed initially with several open source modals. It is referred to as stealing autofocus.

#### What are the relevant issues?
#3112

#### Screenshots (if appropriate)
No

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Yes, the change is backwards compatible.
