### PR TITLE
Changed Menu to pass more items properties through to Button

### DIFF
--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -185,14 +185,15 @@ class Menu extends Component {
                       }}
                       active={activeItemIndex === index}
                       hoverIndicator="background"
-                      disabled={item.disabled}
+                      {...{ ...item, icon: undefined, label: undefined }}
                       onClick={(...args) => {
-                        item.onClick(...args);
+                        if (item.onClick) {
+                          item.onClick(...args);
+                        }
                         if (item.close !== false) {
                           this.onDropClose();
                         }
                       }}
-                      href={item.href}
                     >
                       <Box align="start" pad="small" direction="row">
                         {item.icon}


### PR DESCRIPTION
#### What does this PR do?

Changed Menu to pass more items properties through to Button.
The documentation states that all properties of each object in `items` will be used to construct a Button for that item. Unfortunately, only a few hard coded properties were being passed. This change passes all properties of the items through to the Buttons.

#### Where should the reviewer start?

Menu.js

#### What testing has been done on this PR?

unit
grommet-designer

#### How should this be manually tested?

unit

#### Any background context you want to provide?

The impetus for this was to support a Download menu item where the Button needed a `download` property passed through.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
