### PR TITLE
Fix for Issue 3137 - Making all event.target props available

### DIFF
--- a/src/js/components/MaskedInput/MaskedInput.js
+++ b/src/js/components/MaskedInput/MaskedInput.js
@@ -200,7 +200,7 @@ class MaskedInput extends Component {
 
   // This could be due to a paste or as the user is typing.
   onChange = event => {
-    const { onChange, mask } = this.props;
+    const { onChange, mask, ...props } = this.props;
     const {
       target: { value },
     } = event;
@@ -208,12 +208,12 @@ class MaskedInput extends Component {
     const valueParts = parseValue(mask, value);
     const nextValue = valueParts.map(part => part.part).join('');
     if (onChange) {
-      onChange({ target: { ...event.target, value: nextValue } });
+      onChange({ target: { ...props, value: nextValue } });
     }
   };
 
   onOption = option => () => {
-    const { onChange, mask } = this.props;
+    const { onChange, mask, ...props } = this.props;
     const { activeMaskIndex, valueParts } = this.state;
     const nextValueParts = [...valueParts];
     nextValueParts[activeMaskIndex] = { part: option };
@@ -227,7 +227,8 @@ class MaskedInput extends Component {
     // restore focus to input
     this.inputRef.current.focus();
     if (onChange) {
-      onChange({ target: { value: nextValue } });
+      // onChange({ target: { value: nextValue } })
+      onChange({ target: { ...props, value: nextValue } });
     }
   };
 

--- a/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
+++ b/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
@@ -84,7 +84,9 @@ describe('MaskedInput', () => {
       fireEvent.click(getByText(document, 'aa'));
       expect(container.firstChild).toMatchSnapshot();
       expect(onChange).toBeCalledWith(
-        expect.objectContaining({ target: { value: 'aa!' } }),
+        expect.objectContaining({
+          target: expect.objectContaining({ value: 'aa!' }),
+        }),
       );
       done();
     }, 500);
@@ -122,7 +124,9 @@ describe('MaskedInput', () => {
       fireEvent.keyDown(input, { keyCode: 38 }); // up
       fireEvent.keyDown(input, { keyCode: 13 }); // enter
       expect(onChange).toBeCalledWith(
-        expect.objectContaining({ target: { value: 'aa!' } }),
+        expect.objectContaining({
+          target: expect.objectContaining({ value: 'aa!' }),
+        }),
       );
       done();
     }, 300);
@@ -158,6 +162,101 @@ describe('MaskedInput', () => {
       fireEvent.keyDown(input, { keyCode: 13 }); // enter
       expect(onChange).not.toBeCalled();
       expect(container.firstChild).toMatchSnapshot();
+      done();
+    }, 300);
+  });
+
+  test('event target props are available option via mouse', done => {
+    const onChange = jest.fn();
+    const { getByTestId, container } = render(
+      <MaskedInput
+        data-testid="test-event-target-select-by-mouse"
+        plain
+        size="large"
+        id="input-id"
+        name="input-name"
+        mask={[
+          {
+            length: [1, 2],
+            options: ['aa', 'bb'],
+            regexp: /^[ab][ab]$|^[ab]$/,
+          },
+          { fixed: '!' },
+        ]}
+        value=""
+        onChange={onChange}
+      />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+
+    fireEvent.focus(getByTestId('test-event-target-select-by-mouse'));
+
+    setTimeout(() => {
+      expectPortal('masked-input-drop__input-id').toMatchSnapshot();
+
+      fireEvent.click(getByText(document, 'aa'));
+      expect(container.firstChild).toMatchSnapshot();
+      expect(onChange).toBeCalledWith(
+        expect.objectContaining({
+          target: expect.objectContaining({
+            value: 'aa!',
+            id: 'input-id',
+            name: 'input-name',
+            size: 'large',
+            plain: true,
+            'data-testid': 'test-event-target-select-by-mouse',
+          }),
+        }),
+      );
+      done();
+    }, 500);
+  });
+
+  test('event target props are available option via keyboard', done => {
+    const onChange = jest.fn();
+    const { getByTestId, container } = render(
+      <MaskedInput
+        data-testid="test-event-target-select-by-keyboard"
+        id="input-id"
+        name="input-name"
+        size="medium"
+        mask={[
+          {
+            length: [1, 2],
+            options: ['aa', 'bb'],
+            regexp: /^[ab][ab]$|^[ab]$/,
+          },
+          { fixed: '!' },
+        ]}
+        value=""
+        onChange={onChange}
+      />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+
+    const input = getByTestId('test-event-target-select-by-keyboard');
+    fireEvent.focus(input);
+
+    setTimeout(() => {
+      // pressing enter here nothing will happen
+      fireEvent.keyDown(input, { keyCode: 13 }); // enter
+      fireEvent.keyDown(input, { keyCode: 40 }); // down
+      fireEvent.keyDown(input, { keyCode: 40 }); // down
+      fireEvent.keyDown(input, { keyCode: 38 }); // up
+      fireEvent.keyDown(input, { keyCode: 13 }); // enter
+      expect(onChange).toBeCalled();
+      expect(onChange).toBeCalledTimes(1);
+      expect(onChange).toBeCalledWith(
+        expect.objectContaining({
+          target: expect.objectContaining({
+            value: 'aa!',
+            id: 'input-id',
+            name: 'input-name',
+            size: 'medium',
+            'data-testid': 'test-event-target-select-by-keyboard',
+          }),
+        }),
+      );
       done();
     }, 300);
   });

--- a/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
+++ b/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
@@ -54,7 +54,7 @@ describe('MaskedInput', () => {
   });
 
   test('option via mouse', done => {
-    const onChange = jest.fn();
+    const onChange = jest.fn(event => event.target.value);
     const { getByTestId, container } = render(
       <MaskedInput
         data-testid="test-input"
@@ -75,7 +75,6 @@ describe('MaskedInput', () => {
       />,
     );
     expect(container.firstChild).toMatchSnapshot();
-
     fireEvent.focus(getByTestId('test-input'));
 
     setTimeout(() => {
@@ -83,17 +82,14 @@ describe('MaskedInput', () => {
 
       fireEvent.click(getByText(document, 'aa'));
       expect(container.firstChild).toMatchSnapshot();
-      expect(onChange).toBeCalledWith(
-        expect.objectContaining({
-          target: expect.objectContaining({ value: 'aa!' }),
-        }),
-      );
+      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveReturnedWith('aa!');
       done();
     }, 500);
   });
 
   test('option via keyboard', done => {
-    const onChange = jest.fn();
+    const onChange = jest.fn(event => event.target.value);
     const { getByTestId, container } = render(
       <MaskedInput
         data-testid="test-input"
@@ -123,11 +119,8 @@ describe('MaskedInput', () => {
       fireEvent.keyDown(input, { keyCode: 40 }); // down
       fireEvent.keyDown(input, { keyCode: 38 }); // up
       fireEvent.keyDown(input, { keyCode: 13 }); // enter
-      expect(onChange).toBeCalledWith(
-        expect.objectContaining({
-          target: expect.objectContaining({ value: 'aa!' }),
-        }),
-      );
+      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveReturnedWith('aa!');
       done();
     }, 300);
   });
@@ -167,7 +160,12 @@ describe('MaskedInput', () => {
   });
 
   test('event target props are available option via mouse', done => {
-    const onChange = jest.fn();
+    const onChangeMock = jest.fn(event => {
+      const {
+        target: { value, id, name },
+      } = event;
+      return { target: { id, value, name } };
+    });
     const { getByTestId, container } = render(
       <MaskedInput
         data-testid="test-event-target-select-by-mouse"
@@ -184,7 +182,7 @@ describe('MaskedInput', () => {
           { fixed: '!' },
         ]}
         value=""
-        onChange={onChange}
+        onChange={onChangeMock}
       />,
     );
     expect(container.firstChild).toMatchSnapshot();
@@ -196,15 +194,13 @@ describe('MaskedInput', () => {
 
       fireEvent.click(getByText(document, 'aa'));
       expect(container.firstChild).toMatchSnapshot();
-      expect(onChange).toBeCalledWith(
+      expect(onChangeMock).toHaveBeenCalled();
+      expect(onChangeMock).toHaveReturnedWith(
         expect.objectContaining({
           target: expect.objectContaining({
-            value: 'aa!',
             id: 'input-id',
             name: 'input-name',
-            size: 'large',
-            plain: true,
-            'data-testid': 'test-event-target-select-by-mouse',
+            value: 'aa!',
           }),
         }),
       );
@@ -213,7 +209,12 @@ describe('MaskedInput', () => {
   });
 
   test('event target props are available option via keyboard', done => {
-    const onChange = jest.fn();
+    const onChangeMock = jest.fn(event => {
+      const {
+        target: { value, id, name },
+      } = event;
+      return { target: { id, value, name } };
+    });
     const { getByTestId, container } = render(
       <MaskedInput
         data-testid="test-event-target-select-by-keyboard"
@@ -229,7 +230,7 @@ describe('MaskedInput', () => {
           { fixed: '!' },
         ]}
         value=""
-        onChange={onChange}
+        onChange={onChangeMock}
       />,
     );
     expect(container.firstChild).toMatchSnapshot();
@@ -240,20 +241,19 @@ describe('MaskedInput', () => {
     setTimeout(() => {
       // pressing enter here nothing will happen
       fireEvent.keyDown(input, { keyCode: 13 }); // enter
+      expect(onChangeMock).not.toBeCalled();
       fireEvent.keyDown(input, { keyCode: 40 }); // down
       fireEvent.keyDown(input, { keyCode: 40 }); // down
       fireEvent.keyDown(input, { keyCode: 38 }); // up
       fireEvent.keyDown(input, { keyCode: 13 }); // enter
-      expect(onChange).toBeCalled();
-      expect(onChange).toBeCalledTimes(1);
-      expect(onChange).toBeCalledWith(
+      expect(onChangeMock).toBeCalled();
+      expect(onChangeMock).toBeCalledTimes(1);
+      expect(onChangeMock).toHaveReturnedWith(
         expect.objectContaining({
           target: expect.objectContaining({
-            value: 'aa!',
             id: 'input-id',
             name: 'input-name',
-            size: 'medium',
-            'data-testid': 'test-event-target-select-by-keyboard',
+            value: 'aa!',
           }),
         }),
       );

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -57,6 +57,487 @@ exports[`MaskedInput basic 1`] = `
 </div>
 `;
 
+exports[`MaskedInput event target props are available option via keyboard 1`] = `
+.c1 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  padding: 11px;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  width: 100%;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c1::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c1::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c1:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+}
+
+<div
+  class="c0"
+>
+  <input
+    autocomplete="off"
+    class="c1"
+    data-testid="test-event-target-select-by-keyboard"
+    id="input-id"
+    name="input-name"
+    placeholder="!"
+    value=""
+  />
+</div>
+`;
+
+exports[`MaskedInput event target props are available option via mouse 1`] = `
+.c1 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  padding: 11px;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  width: 100%;
+  font-size: 22px;
+  line-height: 28px;
+  border: none;
+}
+
+.c1::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c1::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c1:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+}
+
+<div
+  class="c0"
+>
+  <input
+    autocomplete="off"
+    class="c1"
+    data-testid="test-event-target-select-by-mouse"
+    id="input-id"
+    name="input-name"
+    placeholder="!"
+    value=""
+  />
+</div>
+`;
+
+exports[`MaskedInput event target props are available option via mouse 2`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+  overflow: auto;
+  box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding: 0px;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  border-radius: 0px;
+  position: fixed;
+  z-index: 20;
+  outline: none;
+  background: #ffffff;
+  color: #444444;
+  opacity: 0;
+  -webkit-transform-origin: top left;
+  -ms-transform-origin: top left;
+  transform-origin: top left;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
+  -webkit-animation-delay: 0.01s;
+  animation-delay: 0.01s;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+<div
+  class="c0 c1"
+  id="masked-input-drop__input-id"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
+  tabindex="-1"
+>
+  <div
+    class="c2"
+  >
+    <div
+      class="c3"
+    >
+      <button
+        class="c4"
+        tabindex="-1"
+        type="button"
+      >
+        <div
+          class="c5"
+        >
+          aa
+        </div>
+      </button>
+    </div>
+    <div
+      class="c3"
+    >
+      <button
+        class="c4"
+        tabindex="-1"
+        type="button"
+      >
+        <div
+          class="c5"
+        >
+          bb
+        </div>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MaskedInput event target props are available option via mouse 3`] = `
+".fMpdhH {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+  overflow: auto;
+  box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
+}
+
+@media only screen and (max-width:768px) {
+  .IRSNj {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .IRSNj {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .jqGCfM {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .jqGCfM {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .hkPRCG {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .hkPRCG {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .hkPRCG {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .jyWdAg {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .jyWdAg {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .jyWdAg {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+.hEnyXU {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  border-radius: 0px;
+  position: fixed;
+  z-index: 20;
+  outline: none;
+  background: #ffffff;
+  color: #444444;
+  opacity: 0;
+  -webkit-transform-origin: top left;
+  -ms-transform-origin: top left;
+  transform-origin: top left;
+  -webkit-animation: jNdvGQ 0.1s forwards;
+  animation: jNdvGQ 0.1s forwards;
+  -webkit-animation-delay: 0.01s;
+  animation-delay: 0.01s;
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .hEnyXU {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}"
+`;
+
+exports[`MaskedInput event target props are available option via mouse 4`] = `
+<div
+  class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 kyyRCm"
+>
+  <input
+    autocomplete="off"
+    class="StyledMaskedInput-sc-99vkfa-0 bwgQpE"
+    data-testid="test-event-target-select-by-mouse"
+    id="input-id"
+    name="input-name"
+    placeholder="!"
+    tabindex="-1"
+    value=""
+  />
+</div>
+`;
+
 exports[`MaskedInput mask 1`] = `
 .c1 {
   box-sizing: border-box;


### PR DESCRIPTION
Signed-off-by: Matt Glissmann <mdglissmann@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Makes all MaskedInput component props available in event.target addressing [issue #3137](https://github.com/grommet/grommet/issues/3137).

#### Where should the reviewer start?
MaskedInput.js

#### What testing has been done on this PR?
- Local project utilizing modified MaskedInput component
- Unit tests written in MaskedInput-tests.js
  - NOTE: Original tests were checking for the event argument passed to a mock onChange function with Jest's `.toHaveBeenCalledWith()`. After changing the implementation, the `.toHaveBeenCalledWith()` failed because now passing a SyntheticEvent instead of the React value setter. I think we want to be spying on whether the new `setValue` method is being called, or more specifically the `dispatchEvent()`, but was unable to get this functional in the test implementation. The current tests mock an `onChange()` handler the developer would be able to implement and demonstrates that the `event.target` props are available. I'm not sure if this is sufficient and am open to alternative testing approaches. 

#### How should this be manually tested?
Add the following to your MaskedInput component and verify that the props are contained in event.target.
```
onChange={event => {
    console.table(event);
}}
```

#### Any background context you want to provide?

#### What are the relevant issues?
[issue #3137](https://github.com/grommet/grommet/issues/3137)

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
