### PR TITLE
Prevent TextInput from stopping all escape events from propagating

### DIFF
--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -275,11 +275,14 @@ class TextInput extends Component {
   };
 
   onEsc = event => {
-    // we have to stop both synthetic events and native events
-    // drop and layer should not close by pressing esc on this input
-    event.stopPropagation();
-    event.nativeEvent.stopImmediatePropagation();
-    this.setState({ showDrop: false });
+    const { showDrop } = this.state;
+    if (showDrop) {
+      // we have to stop both synthetic events and native events
+      // drop and layer should not close by pressing esc on this input
+      event.stopPropagation();
+      event.nativeEvent.stopImmediatePropagation();
+      this.setState({ showDrop: false });
+    }
   };
 
   onTab = () => {

--- a/src/js/components/TextInput/__tests__/TextInput-test.js
+++ b/src/js/components/TextInput/__tests__/TextInput-test.js
@@ -7,6 +7,7 @@ import { createPortal, expectPortal } from '../../../utils/portal';
 
 import { Grommet } from '../../Grommet';
 import { TextInput } from '..';
+import { Keyboard } from '../../Keyboard';
 
 describe('TextInput', () => {
   beforeEach(createPortal);
@@ -108,6 +109,32 @@ describe('TextInput', () => {
         expect(container.firstChild).toMatchSnapshot();
         done();
       }, 50);
+    }, 50);
+  });
+
+  test('let escape events propagage if there are no suggestions', done => {
+    const callback = jest.fn();
+    const { getByTestId } = render(
+      <Grommet>
+        <Keyboard onEsc={callback}>
+          <TextInput
+            data-testid="test-input"
+            id="item"
+            name="item"
+          />
+        </Keyboard>
+      </Grommet>,
+    );
+
+    fireEvent.change(getByTestId('test-input'), { target: { value: ' ' } });
+    setTimeout(() => {
+      fireEvent.keyDown(getByTestId('test-input'), {
+        key: 'Esc',
+        keyCode: 27,
+        which: 27,
+      });
+      expect(callback).toBeCalled();
+      done();
     }, 50);
   });
 


### PR DESCRIPTION
#### What does this PR do?

`<TextInput/>` uses a `<Keyboard/>` to listen for keydowns on the escape key to close the suggestions drop. When that happens, it stops the event's propagation in order to prevent other things listening for the escape key from doing their thing, like layers who might close on escape. This is good if you are using suggestions on a `<TextInput/>`, but bad if you aren't. If you want to have the escape key trigger other behaviour from a `<TextInput/>` before this change, it's not possible because the event is always stopped from propagating.

This changes `<TextInput/>` to only stop the propagation of the event when the suggestions drop is actually open, and otherwise, let the event through.

I came across this issue when trying to use `TextInput` to power a cell in an Excel style datasheet component I am building in a Grommet app. I don't strictly have to use `TextInput`, but it'd be nice to be able to get all the same look and feel from the grommet theme for my cell's input, as well as the ability to use the suggestion system as it is intended if a given cell has suggested inputs. I encountered this issue specifically when trying to implement Excel style "modal" editing: the sheet can be in a selection mode where the arrow keys move the cell selection around the sheet, or the sheet can be in an editing mode where the arrow keys move the cursor around a text input for the cell. The escape key exits this editing mode to go back to selection mode in Excel, and I was trying to implement the same thing. I was unable to use a `<TextInput/>` because I couldn't listen for escape key events on it to switch the editing mode, and this PR fixes that. 

#### What testing has been done on this PR?

- Added a unit test 
- Tested manually in storybooks by wrapping a simple text input in a Keyboard and watching for escape events, and by wrapping a suggestions text input in a Keyboard and making sure no escape events propagated out when closing the suggestions drop

#### How should this be manually tested?

Try something like 

```jsx
    return (
      <Grommet full theme={grommet}>
        <Keyboard onEsc={(e) => console.log(e)}>
        <Box fill align="center" justify="start" pad="large">
          <Box width="medium">
            <TextInput
              value={value}
              dropProps={{ height: 'small' }}
              onChange={this.onChange}
              onSelect={this.onSelect}
              suggestions={suggestions}
            />
          </Box>
        </Box>
        </Keyboard>
      </Grommet>
    );
```

in a storybook and fiddle with the suggestions prop to see when events get logged to the console

#### Do the grommet docs need to be updated?

Don't think so

#### Should this PR be mentioned in the release notes?

Probably as it is a user facing behaviour change

#### Is this change backwards compatible or is it a breaking change?

It is not strictly backwards compatible in that layers might close when users press escape within an input now, but, I think that's actually more consistent with what users would expect. 