### PR TITLE
fix: modfiy radiobuttongroup component to retain focus

### DIFF
--- a/src/js/components/RadioButton/StyledRadioButton.js
+++ b/src/js/components/RadioButton/StyledRadioButton.js
@@ -32,7 +32,6 @@ const StyledRadioButtonInput = styled.input`
   width: 0;
   height: 0;
   margin: 0;
-  ${props => !props.disabled && 'cursor: pointer;'};
 `;
 
 StyledRadioButtonInput.defaultProps = {};

--- a/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
+++ b/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
@@ -97,7 +97,6 @@ exports[`RadioButton checked renders 1`] = `
   width: 0;
   height: 0;
   margin: 0;
-  cursor: pointer;
 }
 
 .c6 {
@@ -535,7 +534,6 @@ exports[`RadioButton label renders 1`] = `
   width: 0;
   height: 0;
   margin: 0;
-  cursor: pointer;
 }
 
 @media only screen and (max-width:768px) {
@@ -723,7 +721,6 @@ exports[`RadioButton renders 1`] = `
   width: 0;
   height: 0;
   margin: 0;
-  cursor: pointer;
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/js/components/RadioButtonGroup/RadioButtonGroup.js
@@ -22,6 +22,14 @@ class RadioButtonGroup extends Component {
 
   optionRefs = [];
 
+  componentDidUpdate() {
+    const { focus, value } = this.state;
+    if (focus && value) {
+      const valueIndex = this.valueIndex();
+      this.optionRefs[valueIndex].focus();
+    }
+  }
+
   valueIndex = () => {
     const { options, value } = this.state;
     let result;
@@ -72,18 +80,22 @@ class RadioButtonGroup extends Component {
     // Chrome behaves differently in that focus is given to radio buttons
     // when the user selects one, unlike Safari and Firefox.
     setTimeout(() => {
-      const { focus } = this.state;
-      if (!focus) {
-        this.setState({ focus: true });
-      }
+      this.setState(state => {
+        if(!state.focus) {
+          return { focus: true };
+        }
+        return null;
+      });
     }, 1);
   };
 
   onBlur = () => {
-    const { focus } = this.state;
-    if (focus) {
-      this.setState({ focus: false });
-    }
+    this.setState(state => {
+      if(state.focus) {
+        return { focus: false };
+      }
+      return null;
+    });
   };
 
   render() {

--- a/src/js/components/RadioButtonGroup/__tests__/RadioButtonGroup-test.js
+++ b/src/js/components/RadioButtonGroup/__tests__/RadioButtonGroup-test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import 'jest-styled-components';
+import { render, getByTestId } from 'react-testing-library';
 
 import { Grommet } from '../../Grommet';
 import { RadioButtonGroup } from '..';
@@ -67,5 +68,31 @@ describe('RadioButtonGroup', () => {
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  test('retains focus on selecting a value when focused', () => {
+    jest.useFakeTimers();
+    const onChange = jest.fn();
+    render(
+      <Grommet>
+        <input />
+        <RadioButtonGroup
+          data-testid="test-radiogroup-node"
+          name="test"
+          options={[{ id: 'one', value: 'one' }, { id: 'two', value: 'two' }]}
+          onChange={onChange}
+          value="two"
+        />
+        <button type="button">Save</button>
+      </Grommet>,
+    );
+
+    const radioGroupNode = getByTestId(document, 'test-radiogroup-node');
+    expect(radioGroupNode).toMatchSnapshot();
+    const selectedRadioButton = document.getElementById('two');
+    selectedRadioButton.focus();
+    jest.runAllTimers();
+
+    expect(document.activeElement).toEqual(selectedRadioButton);
   });
 });

--- a/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
+++ b/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
@@ -170,7 +170,6 @@ exports[`RadioButtonGroup object options 1`] = `
   width: 0;
   height: 0;
   margin: 0;
-  cursor: pointer;
 }
 
 @media only screen and (max-width:768px) {
@@ -427,15 +426,6 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   border-color: #000000;
 }
 
-.c9 {
-  opacity: 0;
-  -moz-appearance: none;
-  width: 0;
-  height: 0;
-  margin: 0;
-  cursor: pointer;
-}
-
 .c5 {
   opacity: 0;
   -moz-appearance: none;
@@ -545,7 +535,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
       >
         <input
           checked={false}
-          className="c9"
+          className="c5"
           name="test"
           onBlur={[Function]}
           onFocus={[Function]}
@@ -711,7 +701,6 @@ exports[`RadioButtonGroup object options just value 1`] = `
   width: 0;
   height: 0;
   margin: 0;
-  cursor: pointer;
 }
 
 .c9 {
@@ -867,6 +856,295 @@ exports[`RadioButtonGroup object options just value 1`] = `
 </div>
 `;
 
+exports[`RadioButtonGroup retains focus on selecting a value when focused 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 0px;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin-right: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  height: 24px;
+  width: 24px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px #7D4CDB;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 0px;
+  border-radius: 100%;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  height: 24px;
+  width: 24px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px rgba(0,0,0,0.15);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 0px;
+  border-radius: 100%;
+}
+
+.c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  height: 12px;
+}
+
+.c1 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  cursor: pointer;
+}
+
+.c1:hover input:not([disabled]) + div,
+.c1:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c4 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+}
+
+.c8 {
+  box-sizing: border-box;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+}
+
+@media only screen and (max-width:768px) {
+  .c0 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c0 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    border: solid 2px #7D4CDB;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    border: solid 2px rgba(0,0,0,0.15);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    height: 6px;
+  }
+}
+
+<div
+  class="c0"
+  data-testid="test-radiogroup-node"
+  value="two"
+>
+  <label
+    class="c1 c2"
+    for="one"
+  >
+    <div
+      class="c3"
+    >
+      <input
+        class="c4"
+        id="one"
+        name="test"
+        type="radio"
+        value="one"
+      />
+      <div
+        class="c5"
+      />
+    </div>
+  </label>
+  <div
+    class="c6"
+  />
+  <label
+    class="c1 c2"
+    for="two"
+  >
+    <div
+      class="c3"
+    >
+      <input
+        checked=""
+        class="c4"
+        id="two"
+        name="test"
+        type="radio"
+        value="two"
+      />
+      <div
+        class="c7"
+      >
+        <svg
+          class="c8"
+          preserveAspectRatio="xMidYMid meet"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="6"
+          />
+        </svg>
+      </div>
+    </div>
+  </label>
+</div>
+`;
+
 exports[`RadioButtonGroup string options 1`] = `
 .c0 {
   font-size: 18px;
@@ -1017,7 +1295,6 @@ exports[`RadioButtonGroup string options 1`] = `
   width: 0;
   height: 0;
   margin: 0;
-  cursor: pointer;
 }
 
 .c7 {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
As onChange modifies state in parent component, the component itself refreshes and so loses focus on activeElement at moment. A new block of code in componentDidUpdate lifecycle keeps track of focused element using focus & value state variables. Now at every render when focus is lost, the method computes lost focus position based on state variables & applies it again.

#### Where should the reviewer start?
1. The gif attached below is original user interaction in reported bug with new behavior.
2. In [netlify hosted storybook for this PR](https://deploy-preview-3189--sad-tereshkova-173d07.netlify.com/?path=/story/radiobuttongroup--simple), focus follows the selection and is lost when clicked anywhere else in document.
3. `src/js/components/RadioButtonGroup/RadioButtonGroup.js` / `componentDidUpdate()`

#### What testing has been done on this PR?
Using [storybook's only story for this component](https://storybook.grommet.io/?path=/story/radiobuttongroup--simple), I made hidden checkboxes visible by commenting code for `StyledRadioButtonInput` and ensured the native radio button retains focus along with styled component. I found the behavior consistent on Firefox 69.01a, Chrome 75, Safari 12.0.3 (and Opera 58.0).

#### How should this be manually tested?
- Click 2nd value in [story in this PR (link included)](https://deploy-preview-3189--sad-tereshkova-173d07.netlify.com/?path=/story/radiobuttongroup--simple).
- Click at the top of page inside the iframe where story start so that the iframe has focus.
- Press Tab to focus selected radio button.
- Click outside to lose focus.

#### Any background context you want to provide?
`onFocus` modifies state variable `focus` making component render again and so focus is lost. This is visible when looked closely with hidden checkbox (0x0 input) visible.

#### What are the relevant issues?
#3115

#### Screenshots (if appropriate)
<img src="https://media.giphy.com/media/YRJE0KH1YFVuv4sR3E/giphy.gif" />

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Yes, it is backward compatible.
