### PR TITLE
Fix comment in base theme

### DIFF
--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -226,7 +226,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
       font: {
         ...fontSizing(0),
-        // face: undefined,
+        // family: undefined,
       },
       hover: {
         background: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -226,6 +226,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
       font: {
         ...fontSizing(0),
+        // face: undefined,
         // family: undefined,
       },
       hover: {


### PR DESCRIPTION
There's a comment in the base theme which implies that the way to set the global font is to set a value for `theme.global.font.face`; this should actually be `theme.global.font.family`.

Tested by creating a new theme using `base` as a starting point, setting `theme.global.font.family`, and checking the result (which is [how the `grommet` theme does it](https://github.com/grommet/grommet/blob/master/src/js/themes/grommet.js#L11)).