### PR TITLE
Changed MaskedInput to improve focus management

### DIFF
--- a/src/js/components/MaskedInput/MaskedInput.js
+++ b/src/js/components/MaskedInput/MaskedInput.js
@@ -188,10 +188,12 @@ class MaskedInput extends Component {
     const { onBlur } = this.props;
     clearTimeout(this.blurTimeout);
     this.blurTimeout = setTimeout(() => {
+      const { showDrop } = this.state;
       if (
-        !this.dropRef.current ||
-        !this.dropRef.current.contains ||
-        !this.dropRef.current.contains(document.activeElement)
+        showDrop &&
+        this.dropRef.current &&
+        document.activeElement !== this.inputRef.current &&
+        !this.dropRef.current.parentNode.contains(document.activeElement)
       ) {
         this.setState({ activeMaskIndex: undefined, showDrop: false });
       }
@@ -245,7 +247,6 @@ class MaskedInput extends Component {
       index += 1;
     }
     const nextValue = nextValueParts.map(part => part.part).join('');
-
     this.setValue(nextValue);
     // restore focus to input
     this.inputRef.current.focus();

--- a/src/js/components/MaskedInput/README.md
+++ b/src/js/components/MaskedInput/README.md
@@ -55,7 +55,10 @@ Describes the structure of the mask. If a regexp is provided, it should
     number
     [number],
   fixed: string,
-  options: [string],
+  options: [
+  string
+  number
+],
   regexp: 
     {
 

--- a/src/js/components/MaskedInput/doc.js
+++ b/src/js/components/MaskedInput/doc.js
@@ -28,7 +28,9 @@ export const doc = MaskedInput => {
           PropTypes.arrayOf(PropTypes.number),
         ]),
         fixed: PropTypes.string,
-        options: PropTypes.arrayOf(PropTypes.string),
+        options: PropTypes.arrayOf(
+          PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        ),
         regexp: PropTypes.shape({}), // RegExp
       }),
     ).description(

--- a/src/js/components/MaskedInput/index.d.ts
+++ b/src/js/components/MaskedInput/index.d.ts
@@ -8,7 +8,7 @@ export interface MaskedInputProps {
   mask?: Array<{
     length?: number | number[];
     fixed?: string;
-    options?: string[];
+    options?: string[] | number[];
     regexp?: {};
     placeholder?: string;
   }>;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -6500,7 +6500,10 @@ Describes the structure of the mask. If a regexp is provided, it should
     number
     [number],
   fixed: string,
-  options: [string],
+  options: [
+  string
+  number
+],
   regexp: 
     {
 

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2025,7 +2025,10 @@ function",
     number
     [number],
   fixed: string,
-  options: [string],
+  options: [
+  string
+  number
+],
   regexp: 
     {
 


### PR DESCRIPTION
#### What does this PR do?

Changed MaskedInput to improve focus management.
These changes do a better job of detecting when focus is lost. Previously, the component would think it had lost focus when in fact the focus was on the Drop container.

Also, allow mask options to be numbers.

#### Where should the reviewer start?

MaskedInput.js

#### What testing has been done on this PR?

storybook with Safari, Firefox, and Chrome.

#### How should this be manually tested?

 same

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
