### PR TITLE
AccordionPanel: Document icon color themeability

### DIFF
--- a/src/js/components/AccordionPanel/README.md
+++ b/src/js/components/AccordionPanel/README.md
@@ -48,6 +48,16 @@ Defaults to
 <FormUp />
 ```
 
+**accordion.icons.color**
+
+The icon color to use in the accordion. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+control
+```
+
 **accordion.icons.expand**
 
 The icon to use when the panel is collapsed. Expects `React.Element`.

--- a/src/js/components/AccordionPanel/doc.js
+++ b/src/js/components/AccordionPanel/doc.js
@@ -26,6 +26,11 @@ export const themeDoc = {
     type: 'React.Element',
     defaultValue: '<FormUp />',
   },
+  'accordion.icons.color': {
+    description: 'The icon color to use in the accordion.',
+    type: 'string | { dark: string, light: string }',
+    defaultValue: 'control',
+  },
   'accordion.icons.expand': {
     description: 'The icon to use when the panel is collapsed.',
     type: 'React.Element',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -235,6 +235,16 @@ Defaults to
 <FormDown />
 \`\`\`
 
+**accordion.icons.color**
+
+The icon color to use in the accordion. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+control
+\`\`\`
+
 **accordion.border.color**
 
 The border color to use in the accordion. Expects \`string | { dark: string, light: string }\`.

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -225,6 +225,16 @@ Defaults to
 <FormUp />
 \`\`\`
 
+**accordion.icons.color**
+
+The icon color to use in the accordion. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+control
+\`\`\`
+
 **accordion.icons.expand**
 
 The icon to use when the panel is collapsed. Expects \`React.Element\`.
@@ -233,16 +243,6 @@ Defaults to
 
 \`\`\`
 <FormDown />
-\`\`\`
-
-**accordion.icons.color**
-
-The icon color to use in the accordion. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-control
 \`\`\`
 
 **accordion.border.color**


### PR DESCRIPTION
Signed-off-by: Lucian <lucian.buzzo@gmail.com>

The color of the icon used in an `AccordionPanel` can be themed, but this is undocumented, see https://github.com/grommet/grommet/blob/master/src/js/components/AccordionPanel/AccordionPanel.js#L74

#### What does this PR do?

This PR adds the documentation for the icon color theme prop.

#### Where should the reviewer start?

This is a fairly small change, so it should be easy to review.

#### What testing has been done on this PR?

The docs were regenerated and manually checked.

#### How should this be manually tested?

Generate the docs and check that the output makes sense and doesn't contain any typos

#### Any background context you want to provide?

N/A

#### What are the relevant issues?

Possibly https://github.com/grommet/grommet/issues/2690

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

This PR updates the docs already, but I imagine the site will need to be updated

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

This is a backwards compatible change
