### PR TITLE
Add initialActiveIndex to Carousel

### DIFF
--- a/src/js/components/Carousel/Carousel.js
+++ b/src/js/components/Carousel/Carousel.js
@@ -15,7 +15,7 @@ import { withFocus } from '../hocs';
 class Carousel extends Component {
   constructor(p) {
     super(p);
-    this.state = { activeIndex: p.initialActiveIndex };
+    this.state = { activeIndex: p.initialChild };
   }
 
   componentDidMount() {
@@ -197,7 +197,7 @@ class Carousel extends Component {
 }
 
 Carousel.defaultProps = {
-  initialActiveIndex: 0,
+  initialChild: 0,
 };
 Object.setPrototypeOf(Carousel.defaultProps, defaultProps);
 

--- a/src/js/components/Carousel/Carousel.js
+++ b/src/js/components/Carousel/Carousel.js
@@ -13,7 +13,10 @@ import { Stack } from '../Stack';
 import { withFocus } from '../hocs';
 
 class Carousel extends Component {
-  state = { activeIndex: 0 };
+  constructor(p) {
+    super(p);
+    this.state = { activeIndex: p.initialActiveIndex };
+  }
 
   componentDidMount() {
     const { play } = this.props;
@@ -150,12 +153,15 @@ class Carousel extends Component {
             <Button
               fill="vertical"
               icon={
-                <PreviousIcon color={
-                  normalizeColor(
-                    previousIconDisabled ? theme.carousel.disabled.icons.color : theme.carousel.icons.color,
-                    theme
+                <PreviousIcon
+                  color={normalizeColor(
+                    previousIconDisabled
+                      ? theme.carousel.disabled.icons.color
+                      : theme.carousel.icons.color,
+                    theme,
                   )}
-                />}
+                />
+              }
               plain
               disabled={previousIconDisabled}
               onClick={onLeft}
@@ -169,12 +175,15 @@ class Carousel extends Component {
             <Button
               fill="vertical"
               icon={
-                <NextIcon color={
-                  normalizeColor(
-                    nextIconDisabled ? theme.carousel.disabled.icons.color : theme.carousel.icons.color,
-                    theme
+                <NextIcon
+                  color={normalizeColor(
+                    nextIconDisabled
+                      ? theme.carousel.disabled.icons.color
+                      : theme.carousel.icons.color,
+                    theme,
                   )}
-                />}
+                />
+              }
               plain
               disabled={nextIconDisabled}
               onClick={onRight}
@@ -187,7 +196,9 @@ class Carousel extends Component {
   }
 }
 
-Carousel.defaultProps = {};
+Carousel.defaultProps = {
+  initialActiveIndex: 0,
+};
 Object.setPrototypeOf(Carousel.defaultProps, defaultProps);
 
 let CarouselDoc;

--- a/src/js/components/Carousel/README.md
+++ b/src/js/components/Carousel/README.md
@@ -127,6 +127,15 @@ If specified, the number of
 ```
 number
 ```
+
+**initialActiveIndex**
+
+If specified, the index of
+      the first element to be shown.
+
+```
+number
+```
   
 ## Intrinsic element
 

--- a/src/js/components/Carousel/README.md
+++ b/src/js/components/Carousel/README.md
@@ -128,10 +128,10 @@ If specified, the number of
 number
 ```
 
-**initialActiveIndex**
+**initialChild**
 
 If specified, the index of
-      the first element to be shown.
+      the first element to be shown. Defaults to 0.
 
 ```
 number

--- a/src/js/components/Carousel/__tests__/Carousel-test.js
+++ b/src/js/components/Carousel/__tests__/Carousel-test.js
@@ -23,6 +23,19 @@ describe('Carousel', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  test('basic with `initialActiveIndex: 1`', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Carousel initialActiveIndex={1}>
+          <Image src="//v2.grommet.io/assets/IMG_4245.jpg" />
+          <Image src="//v2.grommet.io/assets/IMG_4210.jpg" />
+        </Carousel>
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   test('navigate', () => {
     const { getByTestId, container } = render(
       <Grommet>

--- a/src/js/components/Carousel/__tests__/Carousel-test.js
+++ b/src/js/components/Carousel/__tests__/Carousel-test.js
@@ -23,10 +23,10 @@ describe('Carousel', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  test('basic with `initialActiveIndex: 1`', () => {
+  test('basic with `initialChild: 1`', () => {
     const component = renderer.create(
       <Grommet>
-        <Carousel initialActiveIndex={1}>
+        <Carousel initialChild={1}>
           <Image src="//v2.grommet.io/assets/IMG_4245.jpg" />
           <Image src="//v2.grommet.io/assets/IMG_4210.jpg" />
         </Carousel>

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -508,6 +508,514 @@ exports[`Carousel basic 1`] = `
 </div>
 `;
 
+exports[`Carousel basic with \`initialActiveIndex: 1\` 1`] = `
+.c9 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c9 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c9 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c9 *[stroke*="#"],
+.c9 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*="#"],
+.c9 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c13 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c13 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c13 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+  overflow: hidden;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+  opacity: 1;
+  -webkit-animation: iyuEas 1s 0s forwards;
+  animation: iyuEas 1s 0s forwards;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0px;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  padding: 0px;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 0px;
+}
+
+.c14 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+  height: 100%;
+  line-height: 0;
+}
+
+.c12 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  height: 100%;
+  line-height: 0;
+}
+
+.c8:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #444444;
+  color: #000000;
+}
+
+.c1 {
+  position: relative;
+}
+
+.c5 {
+  position: relative;
+  display: block;
+}
+
+.c2 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    padding: 0px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <div
+          className="c4"
+        >
+          <img
+            className=""
+            src="//v2.grommet.io/assets/IMG_4245.jpg"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c3"
+      >
+        <div
+          className="c6"
+        >
+          <img
+            className=""
+            src="//v2.grommet.io/assets/IMG_4210.jpg"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className="c2"
+    >
+      <div
+        className="c7"
+        tabIndex="0"
+      >
+        <button
+          className="c8"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseOut={[Function]}
+          onMouseOver={[Function]}
+          type="button"
+        >
+          <svg
+            aria-label="Previous"
+            className="c9"
+            viewBox="0 0 24 24"
+          >
+            <polyline
+              fill="none"
+              points="7 2 17 12 7 22"
+              stroke="#000"
+              strokeWidth="2"
+              transform="matrix(-1 0 0 1 24 0)"
+            />
+          </svg>
+        </button>
+        <div
+          className="c10"
+        >
+          <div
+            className="c11"
+          >
+            <button
+              className="c12"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              <svg
+                aria-label="Subtract"
+                className="c9"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M2,12 L22,12"
+                  fill="none"
+                  stroke="#000"
+                  strokeWidth="2"
+                />
+              </svg>
+            </button>
+            <button
+              className="c12"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              <svg
+                aria-label="Subtract"
+                className="c13"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M2,12 L22,12"
+                  fill="none"
+                  stroke="#000"
+                  strokeWidth="2"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <button
+          className="c14"
+          disabled={true}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseOut={[Function]}
+          onMouseOver={[Function]}
+          type="button"
+        >
+          <svg
+            aria-label="Next"
+            className="c9"
+            viewBox="0 0 24 24"
+          >
+            <polyline
+              fill="none"
+              points="7 2 17 12 7 22"
+              stroke="#000"
+              strokeWidth="2"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Carousel navigate 1`] = `
 .c9 {
   display: inline-block;

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -508,7 +508,7 @@ exports[`Carousel basic 1`] = `
 </div>
 `;
 
-exports[`Carousel basic with \`initialActiveIndex: 1\` 1`] = `
+exports[`Carousel basic with \`initialChild: 1\` 1`] = `
 .c9 {
   display: inline-block;
   -webkit-flex: 0 0 auto;

--- a/src/js/components/Carousel/carousel.stories.js
+++ b/src/js/components/Carousel/carousel.stories.js
@@ -4,10 +4,10 @@ import { Attraction, Car, TreeOption } from 'grommet-icons';
 
 import { Grommet, Box, Carousel } from 'grommet';
 
-const SimpleCarousel = () => (
+const SimpleCarousel = ({ initialActiveIndex }) => (
   <Grommet>
     <Box align="center" pad="large">
-      <Carousel>
+      <Carousel initialActiveIndex={initialActiveIndex}>
         <Box pad="xlarge" background="accent-1">
           <Attraction size="xlarge" />
         </Box>
@@ -23,3 +23,7 @@ const SimpleCarousel = () => (
 );
 
 storiesOf('Carousel', module).add('Simple Carousel', () => <SimpleCarousel />);
+storiesOf('Carousel', module).add(
+  'Simple Carousel With `initialActiveIndex: 1`',
+  () => <SimpleCarousel initialActiveIndex={1} />,
+);

--- a/src/js/components/Carousel/carousel.stories.js
+++ b/src/js/components/Carousel/carousel.stories.js
@@ -4,10 +4,10 @@ import { Attraction, Car, TreeOption } from 'grommet-icons';
 
 import { Grommet, Box, Carousel } from 'grommet';
 
-const SimpleCarousel = ({ initialActiveIndex }) => (
+const SimpleCarousel = ({ initialChild }) => (
   <Grommet>
     <Box align="center" pad="large">
-      <Carousel initialActiveIndex={initialActiveIndex}>
+      <Carousel initialChild={initialChild}>
         <Box pad="xlarge" background="accent-1">
           <Attraction size="xlarge" />
         </Box>
@@ -23,7 +23,6 @@ const SimpleCarousel = ({ initialActiveIndex }) => (
 );
 
 storiesOf('Carousel', module).add('Simple Carousel', () => <SimpleCarousel />);
-storiesOf('Carousel', module).add(
-  'Simple Carousel With `initialActiveIndex: 1`',
-  () => <SimpleCarousel initialActiveIndex={1} />,
-);
+storiesOf('Carousel', module).add('Carousel With `initialChild`', () => (
+  <SimpleCarousel initialChild={1} />
+));

--- a/src/js/components/Carousel/doc.js
+++ b/src/js/components/Carousel/doc.js
@@ -23,6 +23,8 @@ export const doc = Carousel => {
     play: PropTypes.number.description(`If specified, the number of
       milliseconds between automatically transitioning to the next child. It
       will loop through all children indefinitely.`),
+    initialActiveIndex: PropTypes.number.description(`If specified, the index of
+      the first element to be shown.`),
   };
 
   return DocumentedCarousel;

--- a/src/js/components/Carousel/doc.js
+++ b/src/js/components/Carousel/doc.js
@@ -23,8 +23,8 @@ export const doc = Carousel => {
     play: PropTypes.number.description(`If specified, the number of
       milliseconds between automatically transitioning to the next child. It
       will loop through all children indefinitely.`),
-    initialActiveIndex: PropTypes.number.description(`If specified, the index of
-      the first element to be shown.`),
+    initialChild: PropTypes.number.description(`If specified, the index of
+      the first element to be shown. Defaults to 0.`),
   };
 
   return DocumentedCarousel;

--- a/src/js/components/Carousel/index.d.ts
+++ b/src/js/components/Carousel/index.d.ts
@@ -7,6 +7,7 @@ export interface CarouselProps {
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   fill?: boolean;
   play?: number;
+  initialActiveIndex?: number;
 }
 
 declare const Carousel: React.ComponentClass<CarouselProps & JSX.IntrinsicElements['div']>;

--- a/src/js/components/Carousel/index.d.ts
+++ b/src/js/components/Carousel/index.d.ts
@@ -7,7 +7,7 @@ export interface CarouselProps {
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   fill?: boolean;
   play?: number;
-  initialActiveIndex?: number;
+  initialChild?: number;
 }
 
 declare const Carousel: React.ComponentClass<CarouselProps & JSX.IntrinsicElements['div']>;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -2435,10 +2435,10 @@ If specified, the number of
 number
 \`\`\`
 
-**initialActiveIndex**
+**initialChild**
 
 If specified, the index of
-      the first element to be shown.
+      the first element to be shown. Defaults to 0.
 
 \`\`\`
 number

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -2434,6 +2434,15 @@ If specified, the number of
 \`\`\`
 number
 \`\`\`
+
+**initialActiveIndex**
+
+If specified, the index of
+      the first element to be shown.
+
+\`\`\`
+number
+\`\`\`
   
 ## Intrinsic element
 

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1291,6 +1291,12 @@ string",
         "format": "number",
         "name": "play",
       },
+      Object {
+        "description": "If specified, the index of
+      the first element to be shown.",
+        "format": "number",
+        "name": "initialActiveIndex",
+      },
     ],
     "usage": "import { Carousel } from 'grommet';
 <Carousel />",

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1293,9 +1293,9 @@ string",
       },
       Object {
         "description": "If specified, the index of
-      the first element to be shown.",
+      the first element to be shown. Defaults to 0.",
         "format": "number",
-        "name": "initialActiveIndex",
+        "name": "initialChild",
       },
     ],
     "usage": "import { Carousel } from 'grommet';


### PR DESCRIPTION
Signed-off-by: Luis Deschamps Rudge <luis@luisrudge.net>

#### What does this PR do?
Adds `initialActiveIndex` prop to the `Carousel` component. This allows the developer to set what's the first image being shown in the Carousel.

#### Where should the reviewer start?
Carousel.js

#### What testing has been done on this PR?
Unit test + storybook

#### How should this be manually tested?
Storybook

#### Any background context you want to provide?
Super useful for scenarios that you have a lot of thumbnails and you want to open a Carousel with the active item being the item that was just clicked (today, it always starts from scratch).

#### What are the relevant issues?
#3199 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes (I think I already did?)

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible