### PR TITLE
Changed MaskedInput to allow number value, like TextInput

### DIFF
--- a/src/js/components/MaskedInput/README.md
+++ b/src/js/components/MaskedInput/README.md
@@ -85,6 +85,7 @@ What text to put in the input. The caller should ensure that it
 
 ```
 string
+number
 ```
   
 ## Intrinsic element

--- a/src/js/components/MaskedInput/doc.js
+++ b/src/js/components/MaskedInput/doc.js
@@ -42,7 +42,10 @@ export const doc = MaskedInput => {
       PropTypes.oneOf(['small', 'medium', 'large', 'xlarge']),
       PropTypes.string,
     ]).description('The size of the text.'),
-    value: PropTypes.string.description(
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]).description(
       `What text to put in the input. The caller should ensure that it
       is initially valid with respect to the mask.`,
     ),

--- a/src/js/components/MaskedInput/index.d.ts
+++ b/src/js/components/MaskedInput/index.d.ts
@@ -13,7 +13,7 @@ export interface MaskedInputProps {
     placeholder?: string;
   }>;
   size?: "small" | "medium" | "large" | "xlarge" | string;
-  value?: string;
+  value?: string | number;
 }
 
 declare const MaskedInput: React.ComponentClass<MaskedInputProps & JSX.IntrinsicElements['input']>;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -6562,6 +6562,7 @@ What text to put in the input. The caller should ensure that it
 
 \`\`\`
 string
+number
 \`\`\`
   
 ## Intrinsic element

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2054,7 +2054,8 @@ string",
       Object {
         "description": "What text to put in the input. The caller should ensure that it
       is initially valid with respect to the mask.",
-        "format": "string",
+        "format": "string
+number",
         "name": "value",
       },
     ],


### PR DESCRIPTION
#### What does this PR do?

Changed MaskedInput to allow number value, like TextInput

#### Where should the reviewer start?

doc.js

#### What testing has been done on this PR?

grommet-theme-designer

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
