### PR TITLE
Fix type signature of MaskedInput

### DIFF
--- a/src/js/components/MaskedInput/index.d.ts
+++ b/src/js/components/MaskedInput/index.d.ts
@@ -16,6 +16,8 @@ export interface MaskedInputProps {
   value?: string | number;
 }
 
-declare const MaskedInput: React.ComponentClass<MaskedInputProps & JSX.IntrinsicElements['input']>;
+declare const MaskedInput: React.ComponentClass<
+    MaskedInputProps & Omit<JSX.IntrinsicElements['input'], 'size'>
+>;
 
 export { MaskedInput };


### PR DESCRIPTION
#### What does this PR do?

This fixes issue #3213.

#### Where should the reviewer start?

It's a one-liner so...

#### What testing has been done on this PR?

Let me know how you want to test this. I don't see `typescript` included as a dev dependency so I'm not sure how you are testing type definitions.

#### How should this be manually tested?

If you could reproduce the type error in #3213, then with this patch the error should be gone.

#### Any background context you want to provide?

`size: string & number` leads to an empty set.

#### What are the relevant issues?

#3213.

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

I don't see any documentation regarding types so probably not?

#### Should this PR be mentioned in the release notes?

Why not.

#### Is this change backwards compatible or is it a breaking change?

It makes `MaskedInput` from not usable with TypeScript to usable, so... "unbreaking" change?