### PR TITLE
MaskedInput - Event propagation onEsc

### DIFF
--- a/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
+++ b/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
@@ -2,6 +2,8 @@ import React from 'react';
 import 'jest-styled-components';
 import { cleanup, fireEvent, render } from 'react-testing-library';
 import { getByText } from 'dom-testing-library';
+import { Grommet } from '../../Grommet';
+import { Keyboard } from '../../Keyboard';
 
 import { createPortal, expectPortal } from '../../../utils/portal';
 
@@ -123,6 +125,30 @@ describe('MaskedInput', () => {
       expect(onChange).toHaveReturnedWith('aa!');
       done();
     }, 300);
+  });
+
+  test('Escape events should propagage if there is no drop', done => {
+    const callback = jest.fn();
+    const { getByTestId } = render(
+      <Grommet>
+        <Keyboard onEsc={callback}>
+          <MaskedInput data-testid="test-masked-input" id="item" name="item" />
+        </Keyboard>
+      </Grommet>,
+    );
+
+    fireEvent.change(getByTestId('test-masked-input'), {
+      target: { value: ' ' },
+    });
+    setTimeout(() => {
+      fireEvent.keyDown(getByTestId('test-masked-input'), {
+        key: 'Esc',
+        keyCode: 27,
+        which: 27,
+      });
+      expect(callback).toBeCalled();
+      done();
+    }, 50);
   });
 
   test('next and previous without options', done => {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR was attempting to fix #3216, but apparently, the functionality was already there. so I just added a corresponding test to the one that exists on TextInput.

#### Where should the reviewer start?
the test file.

#### Any background context you want to provide?

#### What are the relevant issues?
#3216
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backward compatible or is it a breaking change?
backward compatible