### PR TITLE
Add missing prop type `plain` for MaskedInput.

### DIFF
--- a/src/js/components/MaskedInput/index.d.ts
+++ b/src/js/components/MaskedInput/index.d.ts
@@ -12,7 +12,6 @@ export interface MaskedInputProps {
     regexp?: {};
     placeholder?: string;
   }>;
-  placeholder?: string | React.ReactNode | JSX.Element;
   plain?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | string;
   value?: string | number;

--- a/src/js/components/MaskedInput/index.d.ts
+++ b/src/js/components/MaskedInput/index.d.ts
@@ -12,6 +12,8 @@ export interface MaskedInputProps {
     regexp?: {};
     placeholder?: string;
   }>;
+  placeholder?: string | React.ReactNode | JSX.Element;
+  plain?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | string;
   value?: string | number;
 }

--- a/src/js/components/MaskedInput/index.d.ts
+++ b/src/js/components/MaskedInput/index.d.ts
@@ -19,7 +19,7 @@ export interface MaskedInputProps {
 }
 
 declare const MaskedInput: React.ComponentClass<
-    MaskedInputProps & Omit<JSX.IntrinsicElements['input'], 'size'>
+    MaskedInputProps & Omit<JSX.IntrinsicElements['input'], keyof MaskedInputProps>
 >;
 
 export { MaskedInput };


### PR DESCRIPTION
#### What does this PR do?

This mainly fixes issue #3218.

#### What testing has been done on this PR?

Only locally with my vscode intellisense.

#### How should this be manually tested?

Previously, specifying `plain` to `MaskedInput` would throw a type error, as shown in the screenshot provided in issue #3218.
Now the type error should no longer exist.

#### Any background context you want to provide?

Instead of using `'plain' | 'size'` in `Omit`, I decided to use `keyof MaskedInputProps` instead to get rid of any potential type collisions once and for all.

(Originally I thought `placeholder` was also missing its type, since I was cross-referencing the interface of TextInput, but then I realized it's used differently in `MaskedInput`. Please ignore the fact that some commits involves `placeholder`.)

#### What are the relevant issues?

#3218.

#### Do the grommet docs need to be updated?

https://v2.grommet.io/maskedinput should probably mention the option `plain`.

#### Should this PR be mentioned in the release notes?

Why not.

#### Is this change backwards compatible or is it a breaking change?

Should be compatible. It makes the option `plain` usable in TypeScript.