### PR TITLE
Use string method supported in ie11 (closes #3221)

### DIFF
--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -76,7 +76,7 @@ const StyledOverlay = styled.div`
 
 const getMargin = (margin, theme, position) => {
   const axis =
-    position.includes('top') || position.includes('bottom')
+    position.indexOf('top') !== -1 || position.indexOf('bottom') !== -1
       ? 'vertical'
       : 'horizontal';
   const marginValue = margin[position] || margin[axis] || margin;


### PR DESCRIPTION
Signed-off-by: Stéphane Klein <stephaneklein221@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

It fixes ie11 compatibilty for the layer component.

#### What testing has been done on this PR?

Automated tests.

#### What are the relevant issues?

#3221 

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

Not sure.

#### Is this change backwards compatible or is it a breaking change?

It's backwards compatible.
