### PR TITLE
[TS] Tab - omit the HTML attribute title type

### DIFF
--- a/src/js/components/Tab/README.md
+++ b/src/js/components/Tab/README.md
@@ -23,7 +23,6 @@ boolean
 The title of the tab.
 
 ```
-string
 node
 ```
   

--- a/src/js/components/Tab/doc.js
+++ b/src/js/components/Tab/doc.js
@@ -13,9 +13,7 @@ export const doc = Tab => {
     plain: PropTypes.bool
       .description('Whether this is a plain tab with no style.')
       .defaultValue(false),
-    title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).description(
-      'The title of the tab.',
-    ),
+    title: PropTypes.node.description('The title of the tab.'),
   };
 
   return DocumentedTab;

--- a/src/js/components/Tab/index.d.ts
+++ b/src/js/components/Tab/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { Omit } from "../../utils";
 
 export interface TabProps {
   plain?: boolean;
-  title?: string | React.ReactNode;
+  title?: React.ReactNode;
 }
 
-declare const Tab: React.ComponentClass<TabProps & JSX.IntrinsicElements['button']>;
+declare const Tab: React.ComponentClass<TabProps & Omit<JSX.IntrinsicElements['button'], 'title'>>;
 
 export { Tab };

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -8966,7 +8966,6 @@ boolean
 The title of the tab.
 
 \`\`\`
-string
 node
 \`\`\`
   

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2953,8 +2953,7 @@ function",
       },
       Object {
         "description": "The title of the tab.",
-        "format": "string
-node",
+        "format": "node",
         "name": "title",
       },
     ],


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes typescript issues

#### Where should the reviewer start?
/Tab/index.d.ts

#### What testing has been done on this PR?
I branched out grommet with these fixes and created a react app with passing in 
 <Tab title={<Text>Foo</Text>}><Text>Foo</Text></Tab>
to test for the error

#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant issues?
#3193 

#### Screenshots (if appropriate)
#### Do the grommet docs need to be updated?
done

#### Should this PR be mentioned in the release notes?
#### Is this change backwards compatible or is it a breaking change?
backwards compatible
