### PR TITLE
Addit omit for placeholder in Formfield to work with TS

### DIFF
--- a/src/js/components/FormField/README.md
+++ b/src/js/components/FormField/README.md
@@ -74,6 +74,14 @@ Whether to add padding to align with the padding of TextInput.
 boolean
 ```
 
+**placeholder**
+
+Provides a hint that describes the expected value of the input field
+
+```
+node
+```
+
 **required**
 
 Whether the field is required.

--- a/src/js/components/FormField/doc.js
+++ b/src/js/components/FormField/doc.js
@@ -42,6 +42,9 @@ export const doc = FormField => {
     pad: PropTypes.bool.description(
       'Whether to add padding to align with the padding of TextInput.',
     ),
+    placeholder: PropTypes.node.description(
+      'Provides a hint that describes the expected value of the input field',
+    ),
     required: PropTypes.bool.description('Whether the field is required.'),
     validate: PropTypes.oneOfType([
       PropTypes.shape({

--- a/src/js/components/FormField/index.d.ts
+++ b/src/js/components/FormField/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Omit } from "../../utils";
 
 export interface FormFieldProps {
   error?: string | React.ReactNode;
@@ -7,11 +8,12 @@ export interface FormFieldProps {
   label?: string | React.ReactNode;
   name?: string;
   pad?: boolean;
+  placeholder?: React.ReactNode;
   required?: boolean;
   component?: any;
   validate?: {regexp?: object,message?: string} | ((...args: any[]) => any);
 }
 
-declare const FormField: React.ComponentClass<FormFieldProps & JSX.IntrinsicElements['input']>;
+declare const FormField: React.ComponentClass<FormFieldProps & Omit<JSX.IntrinsicElements['input'], 'placeholder'>>;
 
 export { FormField };

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4824,6 +4824,14 @@ Whether to add padding to align with the padding of TextInput.
 boolean
 \`\`\`
 
+**placeholder**
+
+Provides a hint that describes the expected value of the input field
+
+\`\`\`
+node
+\`\`\`
+
 **required**
 
 Whether the field is required.

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1954,6 +1954,11 @@ node",
         "name": "pad",
       },
       Object {
+        "description": "Provides a hint that describes the expected value of the input field",
+        "format": "node",
+        "name": "placeholder",
+      },
+      Object {
         "description": "Whether the field is required.",
         "format": "boolean",
         "name": "required",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR Omits Placeholder so that it can use the React.ReactNode for TS 
#### Where should the reviewer start?
docs/FormField/index.d.ts
#### What testing has been done on this PR?
I branched out grommet with these fixes and created a react app with passing in
  <FormField label="hello" placeholder={<Text>barry</Text>}
to test for the error
#### How should this be manually tested?

#### Any background context you want to provide?
The placeholder is a HTML attribute so it was only accepting a string in which we needed to Omit and use the React.ReactNode 
#### What are the relevant issues?
closes #3205 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
already did
#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backwards compatible