### PR TITLE
Added String to propTypes to be accepted for opacity.

### DIFF
--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -224,6 +224,7 @@ string
   image: string,
   position: string,
   opacity: 
+    string
     boolean
     number
     weak

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -81,6 +81,7 @@ export const doc = Box => {
         image: PropTypes.string,
         position: PropTypes.string,
         opacity: PropTypes.oneOfType([
+          PropTypes.string,
           PropTypes.bool,
           PropTypes.number,
           PropTypes.oneOf(['weak', 'medium', 'strong']),

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -812,6 +812,7 @@ string
   image: string,
   position: string,
   opacity: 
+    string
     boolean
     number
     weak

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -393,6 +393,7 @@ zoomOut
   image: string,
   position: string,
   opacity: 
+    string
     boolean
     number
     weak


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This adds to the proptypes for opacity in background
#### Where should the reviewer start?
Box/doc.js
#### What testing has been done on this PR?
Branched out grommet with this fix and testing using 
background={{color: 'green', opacity: '0.2'}}
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
closes #3236 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
already done
#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backwards compatible