### PR TITLE
TS - ColorType clean up

### DIFF
--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -1,12 +1,12 @@
 import * as React from "react";
-import { Omit, PolymorphicType } from "../../utils";
+import { Omit, PolymorphicType, ColorType } from "../../utils";
 
 export interface AnchorProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
-  color?: string | {dark?: string,light?: string};
+  color?: ColorType;
   href?: string;
   icon?: JSX.Element;
   label?: React.ReactNode;

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { ColorType, Omit, PolymorphicType, MarginType } from "../../utils";
 
-
 export interface AnchorProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Omit, PolymorphicType } from "../../utils";
+import { Omit, PolymorphicType, ColorType } from "../../utils";
 
 export interface ButtonProps {
   a11yTitle?: string;
@@ -7,7 +7,7 @@ export interface ButtonProps {
   gridArea?: string;
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
   active?: boolean;
-  color?: string | {dark?: string,light?: string};
+  color?: ColorType;
   disabled?: boolean;
   fill?: "horizontal" | "vertical" | boolean;
   focusIndicator?: boolean;

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { ColorType, Omit, PolymorphicType, MarginType } from "../../utils";
 
-
 export interface ButtonProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";

--- a/src/js/components/Heading/index.d.ts
+++ b/src/js/components/Heading/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Omit, PolymorphicType } from "../../utils";
+import { Omit, PolymorphicType, ColorType } from "../../utils";
 
 export interface HeadingProps {
   a11yTitle?: string;
@@ -7,7 +7,7 @@ export interface HeadingProps {
   as?: PolymorphicType;
   gridArea?: string;
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
-  color?: string | {dark?: string,light?: string};
+  color?: ColorType;
   level?: "1" | "2" | "3" | "4" | "5" | "6" | 1 | 2 | 3 | 4 | 5 | 6;
   responsive?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | string;

--- a/src/js/components/Paragraph/index.d.ts
+++ b/src/js/components/Paragraph/index.d.ts
@@ -1,12 +1,12 @@
 import * as React from "react";
-import { Omit } from "../../utils";
+import { Omit, ColorType } from "../../utils";
 
 export interface ParagraphProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
-  color?: string | {dark?: string,light?: string};
+  color?: ColorType;
   responsive?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
   textAlign?: "start" | "center" | "end";

--- a/src/js/components/RangeSelector/index.d.ts
+++ b/src/js/components/RangeSelector/index.d.ts
@@ -1,8 +1,8 @@
 import * as React from "react";
-import { Omit } from "../../utils";
+import { Omit, ColorType } from "../../utils";
 
 export interface RangeSelectorProps {
-  color?: string | {dark?: string,light?: string};
+  color?: ColorType;
   direction?: "horizontal" | "vertical";
   invert?: boolean;
   max?: number;

--- a/src/js/components/Text/index.d.ts
+++ b/src/js/components/Text/index.d.ts
@@ -1,12 +1,12 @@
 import * as React from "react";
-import { Omit, PolymorphicType } from "../../utils";
+import { Omit, PolymorphicType, ColorType } from "../../utils";
 
 export interface TextProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
   margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
-  color?: string | {dark?: string,light?: string};
+  color?: ColorType;
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
   tag?: PolymorphicType;
   as?: PolymorphicType;

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -26,6 +26,7 @@ export interface DeepMerge {
 
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 export type PolymorphicType = keyof JSX.IntrinsicElements | React.ComponentType<any>
+export type ColorType = string | {dark?: string,light?: string}
 
 declare const isObject: (item:any) => boolean;
 declare const deepFreeze: DeepFreeze;

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -27,7 +27,6 @@ export interface DeepMerge {
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 export type PolymorphicType = keyof JSX.IntrinsicElements | React.ComponentType<any>
 
-
 declare const isObject: (item:any) => boolean;
 declare const deepFreeze: DeepFreeze;
 declare const deepMerge: DeepMerge;

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -26,7 +26,7 @@ export interface DeepMerge {
 
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 export type PolymorphicType = keyof JSX.IntrinsicElements | React.ComponentType<any>
-export type ColorType = string | {dark?: string,light?: string}
+
 
 declare const isObject: (item:any) => boolean;
 declare const deepFreeze: DeepFreeze;
@@ -34,3 +34,6 @@ declare const deepMerge: DeepMerge;
 declare const removeUndefined: <T extends object>(obj: T) => NonUndefinedProps<T>;
 
 export {isObject, deepFreeze, deepMerge, removeUndefined};
+
+//Extracting types for common properties among components
+export type ColorType = string | {dark?: string,light?: string}


### PR DESCRIPTION

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR starts the clean up of the over use of type definitions 
#### Where should the reviewer start?
js/utils/index.d.ts
#### What testing has been done on this PR?
manually tested by branching out to a typescript project
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
relevant issue #3237
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backwards compatible