### PR TITLE
Moved Margin to one file to clean up TS

### DIFF
--- a/src/js/components/Accordion/index.d.ts
+++ b/src/js/components/Accordion/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { MarginType } from "../../utils";
 
 export interface AccordionProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   activeIndex?: number | number[];
   animate?: boolean;
   children?: React.ReactNode;

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -1,11 +1,11 @@
 import * as React from "react";
-import { Omit, PolymorphicType } from "../../utils";
+import { Omit, PolymorphicType, MarginType } from "../../utils";
 
 export interface AnchorProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   color?: string | {dark?: string,light?: string};
   href?: string;
   icon?: JSX.Element;

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -1,12 +1,12 @@
 import * as React from "react";
-import { PolymorphicType } from "../../utils";
+import { PolymorphicType, MarginType } from "../../utils";
 
 
 export interface BoxProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   align?: "start" | "center" | "end" | "baseline" | "stretch";
   alignContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
   animation?: "fadeIn" | "fadeOut" | "jiggle" | "pulse" | "slideUp" | "slideDown" | "slideLeft" | "slideRight" | "zoomIn" | "zoomOut" | {type?: "fadeIn" | "fadeOut" | "jiggle" | "pulse" | "slideUp" | "slideDown" | "slideLeft" | "slideRight" | "zoomIn" | "zoomOut",delay?: number,duration?: number,size?: "xsmall" | "small" | "medium" | "large" | "xlarge"} | ("fadeIn" | "fadeOut" | "jiggle" | "pulse" | "slideUp" | "slideDown" | "slideLeft" | "slideRight" | "zoomIn" | "zoomOut" | {type?: "fadeIn" | "fadeOut" | "jiggle" | "pulse" | "slideUp" | "slideDown" | "slideLeft" | "slideRight" | "zoomIn" | "zoomOut",delay?: number,duration?: number,size?: "xsmall" | "small" | "medium" | "large" | "xlarge"})[];

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -1,11 +1,11 @@
 import * as React from "react";
-import { Omit, PolymorphicType } from "../../utils";
+import { Omit, PolymorphicType, MarginType } from "../../utils";
 
 export interface ButtonProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   active?: boolean;
   color?: string | {dark?: string,light?: string};
   disabled?: boolean;

--- a/src/js/components/Calendar/index.d.ts
+++ b/src/js/components/Calendar/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { MarginType } from "../../utils";
 
 export interface CalendarProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   animate?: boolean;
   bounds?: string[];
   date?: string;

--- a/src/js/components/Carousel/index.d.ts
+++ b/src/js/components/Carousel/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { MarginType } from "../../utils";
 
 export interface CarouselProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   fill?: boolean;
   play?: number;
   initialChild?: number;

--- a/src/js/components/Chart/index.d.ts
+++ b/src/js/components/Chart/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { MarginType } from "../../utils";
 
 export interface ChartProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   bounds?: number[][];
   color?: string | {color?: string,opacity?: "weak" | "medium" | "strong" | boolean};
   onClick?: ((...args: any[]) => any);

--- a/src/js/components/Clock/index.d.ts
+++ b/src/js/components/Clock/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { MarginType } from "../../utils";
 
 export interface ClockProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   hourLimit?: "12" | "24" | "12" | "24";
   onChange?: ((...args: any[]) => any);
   precision?: "hours" | "minutes" | "seconds";

--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { MarginType } from "../../utils";
 
 export interface DataTableProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   columns?: {align?: "center" | "start" | "end",aggregate?: "avg" | "max" | "min" | "sum",footer?: React.ReactNode | {aggregate?: boolean},header?: string | React.ReactNode | {aggregate?: boolean},primary?: boolean,property: string,render?: ((...args: any[]) => any),search?: boolean,sortable?: boolean}[];
   data?: {}[];
   groupBy?: string;

--- a/src/js/components/Distribution/index.d.ts
+++ b/src/js/components/Distribution/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { MarginType } from "../../utils";
 
 export interface DistributionProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   children?: ((...args: any[]) => any);
   fill?: boolean;
   gap?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -1,11 +1,11 @@
 import * as React from "react";
-import { PolymorphicType } from "../../utils";
+import { PolymorphicType, MarginType } from "../../utils";
 
 export interface GridProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   align?: "start" | "center" | "end" | "stretch";
   alignContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
   areas?: {name?: string,start?: number[],end?: number[]}[];

--- a/src/js/components/Heading/index.d.ts
+++ b/src/js/components/Heading/index.d.ts
@@ -1,12 +1,12 @@
 import * as React from "react";
-import { Omit, PolymorphicType } from "../../utils";
+import { Omit, PolymorphicType, MarginType } from "../../utils";
 
 export interface HeadingProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   as?: PolymorphicType;
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   color?: string | {dark?: string,light?: string};
   level?: "1" | "2" | "3" | "4" | "5" | "6" | 1 | 2 | 3 | 4 | 5 | 6;
   responsive?: boolean;

--- a/src/js/components/Image/index.d.ts
+++ b/src/js/components/Image/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { MarginType } from "../../utils";
 
 export interface ImageProps {
   a11yTitle?: string;
@@ -6,7 +7,7 @@ export interface ImageProps {
   fit?: "cover" | "contain";
   fallback?: string;
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   opacity?: "weak" | "medium" | "strong" | string | boolean;
 }
 

--- a/src/js/components/Layer/index.d.ts
+++ b/src/js/components/Layer/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { MarginType } from "../../utils";
 
 export interface LayerProps {
   animate?: boolean;
   animation?: "none" | "slide" | "fadeIn" | boolean;
   full?: boolean | "vertical" | "horizontal";
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | string} | string;
+  margin?: MarginType;
   modal?: boolean;
   onClickOutside?: ((...args: any[]) => any);
   onEsc?: ((...args: any[]) => any);

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -1,11 +1,12 @@
 import * as React from "react";
 import { DropProps } from "../Drop";
+import { MarginType } from "../../utils";
 
 export interface MenuProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   disabled?: boolean;
   dropAlign?: {top?: "top" | "bottom",bottom?: "top" | "bottom",left?: "right" | "left",right?: "right" | "left"};
   dropBackground?: string | {color?: string,opacity?: "weak" | "medium" | "strong" | boolean | number};

--- a/src/js/components/Meter/index.d.ts
+++ b/src/js/components/Meter/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { MarginType } from "../../utils";
 
 export interface MeterProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   background?: string | {color?: string,opacity?: "weak" | "medium" | "strong" | boolean};
   round?: boolean;
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | string;

--- a/src/js/components/Paragraph/index.d.ts
+++ b/src/js/components/Paragraph/index.d.ts
@@ -1,11 +1,11 @@
 import * as React from "react";
-import { Omit } from "../../utils";
+import { Omit, MarginType } from "../../utils";
 
 export interface ParagraphProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   color?: string | {dark?: string,light?: string};
   responsive?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;

--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -1,11 +1,12 @@
 import * as React from "react";
 import { DropProps } from "../Drop";
+import { MarginType } from "../../utils";
 
 export interface SelectProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | { bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string, horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string, left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string, right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string, top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string, vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string } | string;
+  margin?: MarginType;
   children?: ((...args: any[]) => any);
   closeOnChange?: boolean;
   disabled?: boolean | (number | string | object)[];

--- a/src/js/components/Stack/index.d.ts
+++ b/src/js/components/Stack/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { MarginType } from "../../utils";
 
 export interface StackProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   anchor?: "center" | "left" | "right" | "top" | "bottom" | "top-left" | "bottom-left" | "top-right" | "bottom-right";
   fill?: boolean;
   guidingChild?: number | "first" | "last";

--- a/src/js/components/Table/index.d.ts
+++ b/src/js/components/Table/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { MarginType } from "../../utils";
 
 export interface TableProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   caption?: string;
 }
 

--- a/src/js/components/Tabs/index.d.ts
+++ b/src/js/components/Tabs/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { MarginType } from "../../utils";
 
 export interface TabsProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   activeIndex?: number;
   children: React.ReactNode;
   flex?: "grow" | "shrink" | boolean;

--- a/src/js/components/Text/index.d.ts
+++ b/src/js/components/Text/index.d.ts
@@ -1,11 +1,11 @@
 import * as React from "react";
-import { Omit, PolymorphicType } from "../../utils";
+import { Omit, PolymorphicType, MarginType } from "../../utils";
 
 export interface TextProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   color?: string | {dark?: string,light?: string};
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
   tag?: PolymorphicType;

--- a/src/js/components/Video/index.d.ts
+++ b/src/js/components/Video/index.d.ts
@@ -1,11 +1,11 @@
 import * as React from "react";
-import { Omit } from "../../utils";
+import { Omit, MarginType } from "../../utils";
 
 export interface VideoProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   autoPlay?: boolean;
   controls?: "false" | "over" | "below";
   fit?: "cover" | "contain";

--- a/src/js/components/WorldMap/index.d.ts
+++ b/src/js/components/WorldMap/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { MarginType } from "../../utils";
 
 export interface WorldMapProps {
   a11yTitle?: string;
   alignSelf?: "start" | "center" | "end" | "stretch";
   gridArea?: string;
-  margin?: "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+  margin?: MarginType;
   color?: string | {dark?: string,light?: string};
   continents?: {color?: string | {dark?: string,light?: string},name: "Africa" | "Asia" | "Australia" | "Europe" | "North America" | "South America",onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any)}[];
   onSelectPlace?: ((...args: any[]) => any);

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -24,7 +24,6 @@ export interface DeepMerge {
   <T extends object, S extends object[]>(target: T, ...sources: S): T & S[number];
 }
 
-export type MarginType = "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 export type PolymorphicType = keyof JSX.IntrinsicElements | React.ComponentType<any>
 

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -35,5 +35,5 @@ declare const removeUndefined: <T extends object>(obj: T) => NonUndefinedProps<T
 
 export {isObject, deepFreeze, deepMerge, removeUndefined};
 
-//Extracting types for common properties among components
+// Extracting types for common properties among components
 export type MarginType = "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -24,6 +24,7 @@ export interface DeepMerge {
   <T extends object, S extends object[]>(target: T, ...sources: S): T & S[number];
 }
 
+export type MarginType = "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 export type PolymorphicType = keyof JSX.IntrinsicElements | React.ComponentType<any>
 

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -34,3 +34,6 @@ declare const deepMerge: DeepMerge;
 declare const removeUndefined: <T extends object>(obj: T) => NonUndefinedProps<T>;
 
 export {isObject, deepFreeze, deepMerge, removeUndefined};
+
+//Extracting types for common properties among components
+export type MarginType = "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR starts the clean up of the over use of type definitions 
This PR is taking care of the overlapping of Margin
#### Where should the reviewer start?
js/utils/index.d.ts
#### What testing has been done on this PR?
manually tested by branching out to a typescript project
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
relevant issue #3237
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backwards compatible