### PR TITLE
TS - Clean up align content issue3237

### DIFF
--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { PolymorphicType, MarginType } from "../../utils";
+import { AlignContentType, MarginType, PolymorphicType, } from "../../utils";
 
 
 export interface BoxProps {
@@ -8,7 +8,7 @@ export interface BoxProps {
   gridArea?: string;
   margin?: MarginType;
   align?: "start" | "center" | "end" | "baseline" | "stretch";
-  alignContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
+  alignContent?: AlignContentType;
   animation?: "fadeIn" | "fadeOut" | "jiggle" | "pulse" | "slideUp" | "slideDown" | "slideLeft" | "slideRight" | "zoomIn" | "zoomOut" | {type?: "fadeIn" | "fadeOut" | "jiggle" | "pulse" | "slideUp" | "slideDown" | "slideLeft" | "slideRight" | "zoomIn" | "zoomOut",delay?: number,duration?: number,size?: "xsmall" | "small" | "medium" | "large" | "xlarge"} | ("fadeIn" | "fadeOut" | "jiggle" | "pulse" | "slideUp" | "slideDown" | "slideLeft" | "slideRight" | "zoomIn" | "zoomOut" | {type?: "fadeIn" | "fadeOut" | "jiggle" | "pulse" | "slideUp" | "slideDown" | "slideLeft" | "slideRight" | "zoomIn" | "zoomOut",delay?: number,duration?: number,size?: "xsmall" | "small" | "medium" | "large" | "xlarge"})[];
   background?: string | {color?: string,dark?: boolean | string,image?: string,position?: string,opacity?: "weak" | "medium" | "strong" | number | boolean,repeat?: "no-repeat" | "repeat" | string,size?: "cover" | "contain" | string,light?: string};
   basis?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "auto" | string;

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { PolymorphicType, MarginType } from "../../utils";
+import { AlignContentType, MarginType, PolymorphicType, } from "../../utils";
 
 export interface GridProps {
   a11yTitle?: string;
@@ -7,7 +7,7 @@ export interface GridProps {
   gridArea?: string;
   margin?: MarginType;
   align?: "start" | "center" | "end" | "stretch";
-  alignContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
+  alignContent?: AlignContentType;
   areas?: {name?: string,start?: number[],end?: number[]}[];
   columns?: ("xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | string | string[])[] | "xsmall" | "small" | "medium" | "large" | "xlarge" | {count?: "fit" | "fill" | number,size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | string | string[]} | string;
   fill?: "horizontal" | "vertical" | boolean;

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -36,3 +36,4 @@ export {isObject, deepFreeze, deepMerge, removeUndefined};
 
 // Extracting types for common properties among components
 export type MarginType = "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
+export type AlignContentType = "start" | "center" | "end" | "between" | "around" | "stretch";


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR starts the clean up of the over use of type definitions with alignContent
#### Where should the reviewer start?
js/utils/index.d.ts
#### What testing has been done on this PR?
manually tested by branching out to a typescript project
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
relevant issue #3237
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backwards compatible
