### PR TITLE
Changed Carousel to fix an issue with fill propagation

### DIFF
--- a/src/js/components/Carousel/Carousel.js
+++ b/src/js/components/Carousel/Carousel.js
@@ -128,8 +128,10 @@ class Carousel extends Component {
       }
 
       return (
-        <Box overflow="hidden">
-          <Box animation={animation}>{child}</Box>
+        <Box fill={fill} overflow="hidden">
+          <Box fill={fill} animation={animation}>
+            {child}
+          </Box>
         </Box>
       );
     });


### PR DESCRIPTION
#### What does this PR do?

Changed Carousel to fix an issue with `fill` propagation.
If Carousel is used in a large outer container with `fill`, the children should be given a full height context, so they can align however they want to.

#### Where should the reviewer start?

Carousel.js

#### What testing has been done on this PR?

Carousel with small images.

#### How should this be manually tested?

same

#### Any background context you want to provide?

I came across this when using a Carousel with small images that I wanted to have centered.

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

should be backwards compatible
