### PR TITLE
Added disabled prop to anchor

### DIFF
--- a/src/js/components/Anchor/README.md
+++ b/src/js/components/Anchor/README.md
@@ -123,6 +123,14 @@ string
 }
 ```
 
+**disabled**
+
+Whether the button is disabled.
+
+```
+boolean
+```
+
 **href**
 
 Hyperlink reference to place in the anchor.

--- a/src/js/components/Anchor/README.md
+++ b/src/js/components/Anchor/README.md
@@ -125,7 +125,7 @@ string
 
 **disabled**
 
-Whether the button is disabled.
+Whether the anchor is disabled.
 
 ```
 boolean

--- a/src/js/components/Anchor/anchor.stories.js
+++ b/src/js/components/Anchor/anchor.stories.js
@@ -42,6 +42,15 @@ storiesOf('Anchor', module)
       </Box>
     </Grommet>
   ))
+  .add('Disabled', () => (
+    <Grommet theme={grommet}>
+      <Box align="center" pad="large">
+        <Box margin="small">
+          <Anchor disabled label="Disabled Anchor" />
+        </Box>
+      </Box>
+    </Grommet>
+  ))
   .add('Inline', () => (
     <Grommet theme={grommet}>
       <Box align="center" pad="large">

--- a/src/js/components/Anchor/doc.js
+++ b/src/js/components/Anchor/doc.js
@@ -30,7 +30,7 @@ or just use children.`,
       'Label color and icon color, if not specified on the icon.',
     ),
     disabled: PropTypes.bool
-      .description('Whether the button is disabled.')
+      .description('Whether the anchor is disabled.')
       .defaultValue(false),
     href: PropTypes.string.description(
       'Hyperlink reference to place in the anchor.',

--- a/src/js/components/Anchor/doc.js
+++ b/src/js/components/Anchor/doc.js
@@ -29,6 +29,9 @@ or just use children.`,
     color: colorPropType.description(
       'Label color and icon color, if not specified on the icon.',
     ),
+    disabled: PropTypes.bool
+      .description('Whether the button is disabled.')
+      .defaultValue(false),
     href: PropTypes.string.description(
       'Hyperlink reference to place in the anchor.',
     ),

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -5,6 +5,7 @@ export interface AnchorProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
   gridArea?: string;
+  disabled?: boolean;
   margin?: MarginType;
   color?: ColorType;
   href?: string;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -390,6 +390,14 @@ string
 }
 \`\`\`
 
+**disabled**
+
+Whether the button is disabled.
+
+\`\`\`
+boolean
+\`\`\`
+
 **href**
 
 Hyperlink reference to place in the anchor.

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -392,7 +392,7 @@ string
 
 **disabled**
 
-Whether the button is disabled.
+Whether the anchor is disabled.
 
 \`\`\`
 boolean

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -135,6 +135,12 @@ string",
         "name": "color",
       },
       Object {
+        "defaultValue": false,
+        "description": "Whether the button is disabled.",
+        "format": "boolean",
+        "name": "disabled",
+      },
+      Object {
         "description": "Hyperlink reference to place in the anchor.",
         "format": "string",
         "name": "href",

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -136,7 +136,7 @@ string",
       },
       Object {
         "defaultValue": false,
-        "description": "Whether the button is disabled.",
+        "description": "Whether the anchor is disabled.",
         "format": "boolean",
         "name": "disabled",
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds to the anchor docs that allows for the disabled property 
also added in the disabled property to TS file
#### Where should the reviewer start?
Anchor/doc.js
#### What testing has been done on this PR?
manually tested by branching out to a typescript project
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
closes issue #3242 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
auto
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible