### PR TITLE
TS Cleanup GridArea

### DIFF
--- a/src/js/components/Accordion/index.d.ts
+++ b/src/js/components/Accordion/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { AlignSelfType, MarginType } from "../../utils";
+import { AlignSelfType, GridAreaType, MarginType } from "../../utils";
 
 export interface AccordionProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   activeIndex?: number | number[];
   animate?: boolean;

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -1,10 +1,17 @@
 import * as React from "react";
-import { AlignSelfType, ColorType, MarginType, Omit, PolymorphicType } from "../../utils";
+import { 
+  AlignSelfType, 
+  ColorType, 
+  GridAreaType, 
+  MarginType, 
+  Omit, 
+  PolymorphicType 
+} from "../../utils";
 
 export interface AnchorProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   color?: ColorType;
   href?: string;

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { AlignContentType, AlignSelfType, MarginType, PolymorphicType, } from "../../utils";
+import { AlignContentType, AlignSelfType, GridAreaType, MarginType, PolymorphicType, } from "../../utils";
 
 export interface BoxProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   align?: "start" | "center" | "end" | "baseline" | "stretch";
   alignContent?: AlignContentType;

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -1,10 +1,17 @@
 import * as React from "react";
-import { AlignSelfType, ColorType, MarginType, Omit, PolymorphicType} from "../../utils";
+import { 
+  AlignSelfType, 
+  ColorType, 
+  GridAreaType, 
+  MarginType, 
+  Omit, 
+  PolymorphicType
+} from "../../utils";
 
 export interface ButtonProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   active?: boolean;
   color?: ColorType;

--- a/src/js/components/Calendar/index.d.ts
+++ b/src/js/components/Calendar/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { AlignSelfType, MarginType } from "../../utils";
+import { AlignSelfType, GridAreaType, MarginType } from "../../utils";
 
 export interface CalendarProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   animate?: boolean;
   bounds?: string[];

--- a/src/js/components/Carousel/index.d.ts
+++ b/src/js/components/Carousel/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { AlignSelfType, MarginType } from "../../utils";
+import { AlignSelfType, GridAreaType, MarginType } from "../../utils";
 
 export interface CarouselProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   fill?: boolean;
   play?: number;

--- a/src/js/components/Chart/index.d.ts
+++ b/src/js/components/Chart/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { AlignSelfType, MarginType } from "../../utils";
+import { AlignSelfType, GridAreaType, MarginType } from "../../utils";
 
 export interface ChartProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   bounds?: number[][];
   color?: string | {color?: string,opacity?: "weak" | "medium" | "strong" | boolean};

--- a/src/js/components/Clock/index.d.ts
+++ b/src/js/components/Clock/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { AlignSelfType, MarginType } from "../../utils";
+import { AlignSelfType, GridAreaType, MarginType } from "../../utils";
 
 export interface ClockProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   hourLimit?: "12" | "24" | "12" | "24";
   onChange?: ((...args: any[]) => any);

--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { AlignSelfType, MarginType } from "../../utils";
+import { AlignSelfType, GridAreaType, MarginType } from "../../utils";
 
 export interface DataTableProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   columns?: {align?: "center" | "start" | "end",aggregate?: "avg" | "max" | "min" | "sum",footer?: React.ReactNode | {aggregate?: boolean},header?: string | React.ReactNode | {aggregate?: boolean},primary?: boolean,property: string,render?: ((...args: any[]) => any),search?: boolean,sortable?: boolean}[];
   data?: {}[];

--- a/src/js/components/Distribution/index.d.ts
+++ b/src/js/components/Distribution/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { AlignSelfType, MarginType } from "../../utils";
+import { AlignSelfType, GridAreaType, MarginType } from "../../utils";
 
 export interface DistributionProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   children?: ((...args: any[]) => any);
   fill?: boolean;

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { AlignContentType, AlignSelfType, MarginType, PolymorphicType, } from "../../utils";
+import { AlignContentType, AlignSelfType, GridAreaType, MarginType, PolymorphicType, } from "../../utils";
 
 export interface GridProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   align?: "start" | "center" | "end" | "stretch";
   alignContent?: AlignContentType;

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -11,16 +11,16 @@ import {
 export interface GridProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
-  gridArea?: GridAreaType;
-  margin?: MarginType;
   align?: "start" | "center" | "end" | "stretch";
   alignContent?: AlignContentType;
   areas?: {name?: string,start?: number[],end?: number[]}[];
   columns?: ("xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | string | string[])[] | "xsmall" | "small" | "medium" | "large" | "xlarge" | {count?: "fit" | "fill" | number,size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | string | string[]} | string;
   fill?: "horizontal" | "vertical" | boolean;
   gap?: "small" | "medium" | "large" | "none" | {row?: "small" | "medium" | "large" | "none" | string,column?: "small" | "medium" | "large" | "none" | string} | string;
+  gridArea?: GridAreaType;
   justify?: "start" | "center" | "end" | "stretch";
   justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
+  margin?: MarginType;
   rows?: ("xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | string | string[])[] | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   tag?: PolymorphicType;
   as?: PolymorphicType;

--- a/src/js/components/Heading/index.d.ts
+++ b/src/js/components/Heading/index.d.ts
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { 
   A11yTitleType,
-  AlignSelfType, 
-  ColorType, 
-  GridAreaType, 
-  MarginType, 
-  Omit, 
-  PolymorphicType 
+  AlignSelfType,
+  ColorType,
+  GridAreaType,
+  MarginType,
+  Omit,
+  PolymorphicType
 } from "../../utils";
 
 export interface HeadingProps {

--- a/src/js/components/Heading/index.d.ts
+++ b/src/js/components/Heading/index.d.ts
@@ -1,11 +1,18 @@
 import * as React from "react";
-import { AlignSelfType, ColorType, MarginType, Omit, PolymorphicType } from "../../utils";
+import { 
+  AlignSelfType, 
+  ColorType, 
+  GridAreaType, 
+  MarginType, 
+  Omit, 
+  PolymorphicType 
+} from "../../utils";
 
 export interface HeadingProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
   as?: PolymorphicType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   color?: ColorType;
   level?: "1" | "2" | "3" | "4" | "5" | "6" | 1 | 2 | 3 | 4 | 5 | 6;

--- a/src/js/components/Image/index.d.ts
+++ b/src/js/components/Image/index.d.ts
@@ -1,12 +1,12 @@
 import * as React from "react";
-import { AlignSelfType, MarginType } from "../../utils";
+import { AlignSelfType, GridAreaType, MarginType } from "../../utils";
 
 export interface ImageProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
   fit?: "cover" | "contain";
   fallback?: string;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   opacity?: "weak" | "medium" | "strong" | string | boolean;
 }

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -5,17 +5,17 @@ import { A11yTitleType, AlignSelfType, GridAreaType, MarginType } from "../../ut
 export interface MenuProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
-  gridArea?: GridAreaType;
-  margin?: MarginType;
   disabled?: boolean;
   dropAlign?: {top?: "top" | "bottom",bottom?: "top" | "bottom",left?: "right" | "left",right?: "right" | "left"};
   dropBackground?: string | {color?: string,opacity?: "weak" | "medium" | "strong" | boolean | number};
   dropTarget?: object;
   dropProps?: DropProps;
+  gridArea?: GridAreaType;
   justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
   icon?: boolean | React.ReactNode;
   items: object[];
   label?: string | React.ReactNode;
+  margin?: MarginType;
   messages?: {closeMenu?: string,openMenu?: string};
   open?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | string;

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { DropProps } from "../Drop";
-import { AlignSelfType, MarginType } from "../../utils";
+import { AlignSelfType, GridAreaType, MarginType } from "../../utils";
 
 export interface MenuProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   disabled?: boolean;
   dropAlign?: {top?: "top" | "bottom",bottom?: "top" | "bottom",left?: "right" | "left",right?: "right" | "left"};

--- a/src/js/components/Meter/index.d.ts
+++ b/src/js/components/Meter/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { AlignSelfType, MarginType } from "../../utils";
+import { AlignSelfType, GridAreaType, MarginType } from "../../utils";
 
 export interface MeterProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   background?: string | {color?: string,opacity?: "weak" | "medium" | "strong" | boolean};
   round?: boolean;

--- a/src/js/components/Paragraph/index.d.ts
+++ b/src/js/components/Paragraph/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { AlignSelfType, ColorType, MarginType, Omit } from "../../utils";
+import { AlignSelfType, ColorType, GridAreaType, MarginType, Omit } from "../../utils";
 
 export interface ParagraphProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   color?: ColorType;
   responsive?: boolean;

--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { DropProps } from "../Drop";
-import { AlignSelfType, MarginType } from "../../utils";
+import { AlignSelfType, GridAreaType, MarginType } from "../../utils";
 
 export interface SelectProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   children?: ((...args: any[]) => any);
   closeOnChange?: boolean;

--- a/src/js/components/Stack/index.d.ts
+++ b/src/js/components/Stack/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { AlignSelfType, MarginType } from "../../utils";
+import { AlignSelfType, GridAreaType, MarginType } from "../../utils";
 
 export interface StackProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   anchor?: "center" | "left" | "right" | "top" | "bottom" | "top-left" | "bottom-left" | "top-right" | "bottom-right";
   fill?: boolean;

--- a/src/js/components/Table/index.d.ts
+++ b/src/js/components/Table/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { AlignSelfType, MarginType } from "../../utils";
+import { AlignSelfType, GridAreaType, MarginType } from "../../utils";
 
 export interface TableProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   caption?: string;
 }

--- a/src/js/components/Tabs/index.d.ts
+++ b/src/js/components/Tabs/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { AlignSelfType, MarginType } from "../../utils";
+import { AlignSelfType, GridAreaType, MarginType } from "../../utils";
 
 export interface TabsProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   activeIndex?: number;
   children: React.ReactNode;

--- a/src/js/components/Text/index.d.ts
+++ b/src/js/components/Text/index.d.ts
@@ -1,10 +1,17 @@
 import * as React from "react";
-import { AlignSelfType, ColorType, MarginType, Omit, PolymorphicType } from "../../utils";
+import { 
+  AlignSelfType,
+  ColorType, 
+  GridAreaType, 
+  MarginType, 
+  Omit, 
+  PolymorphicType 
+} from "../../utils";
 
 export interface TextProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType,
   margin?: MarginType;
   color?:  ColorType;
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;

--- a/src/js/components/Video/index.d.ts
+++ b/src/js/components/Video/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { AlignSelfType, Omit, MarginType } from "../../utils";
+import { AlignSelfType, GridAreaType, MarginType, Omit } from "../../utils";
 
 export interface VideoProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   autoPlay?: boolean;
   controls?: "false" | "over" | "below";

--- a/src/js/components/WorldMap/index.d.ts
+++ b/src/js/components/WorldMap/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { AlignSelfType, MarginType } from "../../utils";
+import { AlignSelfType, GridAreaType, MarginType } from "../../utils";
 
 export interface WorldMapProps {
   a11yTitle?: string;
   alignSelf?: AlignSelfType;
-  gridArea?: string;
+  gridArea?: GridAreaType;
   margin?: MarginType;
   color?: string | {dark?: string,light?: string};
   continents?: {color?: string | {dark?: string,light?: string},name: "Africa" | "Asia" | "Australia" | "Europe" | "North America" | "South America",onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any)}[];

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -37,5 +37,6 @@ export {isObject, deepFreeze, deepMerge, removeUndefined};
 // Extracting types for common properties among components
 export type AlignContentType = "start" | "center" | "end" | "between" | "around" | "stretch";
 export type AlignSelfType = "start" | "center" | "end" | "stretch";
+export type GridAreaType = string;
 export type MarginType = "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
 export type ColorType = string | {dark?: string,light?: string}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR starts the clean up of the over use of type definitions 
This PR cleans up the GridArea
#### Where should the reviewer start?
js/utils/index.d.ts
#### What testing has been done on this PR?
manually tested by branching out to a typescript project
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
relevant issue #3237
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backwards compatible
