### PR TITLE
Clock - fix digital clock on a  backward run

### DIFF
--- a/src/js/components/Clock/Clock.js
+++ b/src/js/components/Clock/Clock.js
@@ -52,7 +52,7 @@ class Clock extends Component {
   static getDerivedStateFromProps(nextProps, prevState) {
     const { hourLimit, time } = nextProps;
     const { elements } = prevState;
-    if (!elements || time) {
+    if (!elements) {
       const nextElements = parseTime(time, hourLimit);
       if (!elements) {
         return { elements: nextElements };

--- a/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
+++ b/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
@@ -422,7 +422,7 @@ exports[`Clock run 2`] = `
       class="StyledClock__StyledSecond-y4xw8s-2 isEYCz"
       stroke="#000000"
       stroke-linecap="round"
-      style="transform: rotate(204deg); transform-origin: 48px 48px;"
+      style="transform: rotate(210deg); transform-origin: 48px 48px;"
       x1="48"
       x2="48"
       y1="48"
@@ -461,7 +461,7 @@ exports[`Clock run 2`] = `
       class="StyledClock__StyledSecond-y4xw8s-2 isEYCz"
       stroke="#000000"
       stroke-linecap="round"
-      style="transform: rotate(204deg); transform-origin: 48px 48px;"
+      style="transform: rotate(198deg); transform-origin: 48px 48px;"
       x1="48"
       x2="48"
       y1="48"
@@ -529,7 +529,38 @@ exports[`Clock run 2`] = `
     <div
       class="StyledClock__StyledDigitalDigit-y4xw8s-4 hQDjOB"
     >
-      4
+      .c0 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0.8em;
+  text-align: center;
+  -webkit-animation: cAgbtO 0.5s forwards;
+  animation: cAgbtO 0.5s forwards;
+}
+
+<div
+        class="c0"
+        direction="up"
+      >
+        4
+      </div>
+      .c0 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0.8em;
+  text-align: center;
+  -webkit-animation: iowhYu 0.5s forwards;
+  animation: iowhYu 0.5s forwards;
+}
+
+<div
+        class="c0"
+        direction="up"
+      >
+        5
+      </div>
     </div>
   </div>
   <div
@@ -573,7 +604,38 @@ exports[`Clock run 2`] = `
     <div
       class="StyledClock__StyledDigitalDigit-y4xw8s-4 hQDjOB"
     >
-      4
+      .c0 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0.8em;
+  text-align: center;
+  -webkit-animation: cwBHYZ 0.5s forwards;
+  animation: cwBHYZ 0.5s forwards;
+}
+
+<div
+        class="c0"
+        direction="down"
+      >
+        4
+      </div>
+      .c0 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0.8em;
+  text-align: center;
+  -webkit-animation: jYyoao 0.5s forwards;
+  animation: jYyoao 0.5s forwards;
+}
+
+<div
+        class="c0"
+        direction="down"
+      >
+        3
+      </div>
     </div>
   </div>
 </div>

--- a/src/js/components/Clock/clock.stories.js
+++ b/src/js/components/Clock/clock.stories.js
@@ -30,10 +30,10 @@ const CustomThemeAnalogClock = {
   },
 };
 
-const DigitalClock = () => (
+const DigitalClock = ({ ...rest }) => (
   <Grommet theme={grommet}>
     <Box align="center" justify="start" pad="large">
-      <Clock type="digital" />
+      <Clock type="digital" {...rest} />
     </Box>
   </Grommet>
 );
@@ -56,5 +56,8 @@ const CustomAnalogClock = () => (
 
 storiesOf('Clock', module)
   .add('Digital', () => <DigitalClock />)
+  .add('Digital Backward', () => (
+    <DigitalClock time="T10:00:00" run="backward" />
+  ))
   .add('Analog', () => <AnalogClock />)
   .add('Custom Analog', () => <CustomAnalogClock />);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
backward run on Clock only worked when `time` prop was undefined.
when setting the `time` prop, the lifecycle method of `getDerivedStateFromProps` didn't set the state for the next elements due to a condition-dependent partially on the existence of the `time` prop. my proposal is to remove the `time` from the condition.
#### Where should the reviewer start?
Clock.js

#### What testing has been done on this PR?
added a story that shows the backward run works well.
#### How should this be manually tested?
storybook + snapshots.
#### Any background context you want to provide?
not sure why one of the snapshots changed, regardless of the additional test added. I'll appreciate a second look there.
#### What are the relevant issues?
closes #3246 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible