### PR TITLE
Fix grid-gap

### DIFF
--- a/src/js/components/Grid/StyledGrid.js
+++ b/src/js/components/Grid/StyledGrid.js
@@ -69,23 +69,23 @@ const justifyContentStyle = css`
 
 const gapStyle = props => {
   if (typeof props.gap === 'string') {
-    const gapSize = props.theme.global.edgeSize[props.gap];
+    const gapSize = props.theme.global.edgeSize[props.gap] || props.gap;
     return `grid-gap: ${gapSize} ${gapSize};`;
   }
   if (props.gap.row && props.gap.column) {
     return `
-      grid-row-gap: ${props.theme.global.edgeSize[props.gap.row]};
-      grid-column-gap: ${props.theme.global.edgeSize[props.gap.column]};
+      grid-row-gap: ${props.theme.global.edgeSize[props.gap.row] || props.gap.row};
+      grid-column-gap: ${props.theme.global.edgeSize[props.gap.column] || props.gap.column};
     `;
   }
   if (props.gap.row) {
     return `
-      grid-row-gap: ${props.theme.global.edgeSize[props.gap.row]};
+      grid-row-gap: ${props.theme.global.edgeSize[props.gap.row] || props.gap.row};
     `;
   }
   if (props.gap.column) {
     return `
-      grid-column-gap: ${props.theme.global.edgeSize[props.gap.column]};
+      grid-column-gap: ${props.theme.global.edgeSize[props.gap.column] || props.gap.column};
     `;
   }
   return '';


### PR DESCRIPTION
Update gap property of grid to allow css sizes.
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
If grid-gap prop is not a known size, interpret it as css.

#### Any background context you want to provide?
See https://v2.grommet.io/grid -> "any css size" for gap

#### What are the relevant issues?
Didn't open an issue, but can if needed

#### Do the grommet docs need to be updated?
No, this PR adjusts the implementation to the doc

#### Should this PR be mentioned in the release notes?
Maybe? <Shimi> Yes, it should.

#### Is this change backwards compatible or is it a breaking change?
I'd argue it's backwards compatible, as it fixes a bug.
