### PR TITLE
Signed-off-by: imad <imad.messelmani@live.com>

### DIFF
--- a/src/js/components/Grid/grid.stories.js
+++ b/src/js/components/Grid/grid.stories.js
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
 
-import { Grommet, Box, Button, Grid, Text } from 'grommet';
+import { Grommet, Box, Button, Grid, Text, Heading } from 'grommet';
 import { grommet } from 'grommet/themes';
+import { deepMerge } from 'grommet/utils';
 
 class AppGrid extends Component {
   state = { sidebar: true };
@@ -99,7 +100,193 @@ const NColumnGrid = () => (
   </Grommet>
 );
 
+// Two responsive grids
+//    - First one with known number of elements
+//    - Second one with unkown number of elements
+
+// set custom breakpoints so we can see the changes
+const customBreakpoints = deepMerge(grommet, {
+  global: {
+    breakpoints: {
+      small: {
+        value: 600,
+      },
+      medium: {
+        value: 900,
+      },
+      large: 3000,
+    },
+  },
+});
+
+// columns, rows and areas are for Grid with a known number of contents / boxes.
+
+// if size if small, we only 1 column
+// if size if medium, we only 2 column
+// if size if large or xlarge, we 3 three columns
+const columns = {
+  small: ['auto'],
+  medium: ['auto', 'auto'],
+  large: ['auto', 'auto', 'auto'],
+  xlarge: ['auto', 'auto', 'auto'],
+};
+
+// if size if small, we have 3 rows
+// if size if medium, we have 2 rows
+// if size if large or xlarge, we have 1 row
+const rows = {
+  small: ['xsmall', 'xsmall', 'xsmall'],
+  medium: ['xsmall', 'xsmall'],
+  large: ['xsmall'],
+  xlarge: ['xsmall'],
+};
+
+// set the different areas you need for every size
+const fixedGridAreas = {
+  small: [
+    { name: 'header', start: [0, 0], end: [0, 0] },
+    { name: 'test', start: [0, 1], end: [0, 1] },
+    { name: 'test1', start: [0, 2], end: [0, 2] },
+  ],
+  medium: [
+    { name: 'header', start: [0, 0], end: [1, 0] },
+    { name: 'test', start: [0, 1], end: [0, 1] },
+    { name: 'test1', start: [1, 1], end: [1, 1] },
+  ],
+  large: [
+    { name: 'header', start: [0, 0], end: [0, 0] },
+    { name: 'test', start: [1, 0], end: [1, 0] },
+    { name: 'test1', start: [2, 0], end: [2, 0] },
+  ],
+  xlarge: [
+    { name: 'header', start: [0, 0], end: [0, 0] },
+    { name: 'test', start: [1, 0], end: [1, 0] },
+    { name: 'test1', start: [2, 0], end: [2, 0] },
+  ],
+};
+
+// let's say this is returned from an API
+const animals = [
+  'dog',
+  'cat',
+  'pig',
+  'cow',
+  'giraffe',
+  'elephant',
+  'dinosaur',
+  'chicken',
+  'duck',
+  'tiger',
+  'lion',
+  'cheetah',
+];
+
+// Create box for each animal
+const listAnimalsBoxes = animals.map(animalName => (
+  <Box
+    elevation="large"
+    key={animalName}
+    background="light-3"
+    flex={false}
+    justify="center"
+    align="center"
+  >
+    <Heading level={2}>{animalName}</Heading>
+  </Box>
+));
+
+const ResponsiveContext = ({
+  children,
+  overrideColumns,
+  overrideRows,
+  areas,
+  ...props
+}) => (
+  <ResponsiveContext.Consumer>
+    {size => {
+      // take into consideration if not array is sent but a simple string
+      let columnsVal = columns;
+      if (columns) {
+        if (columns[size]) {
+          columnsVal = columns[size];
+        }
+      }
+
+      let rowsVal = rows;
+      if (rows) {
+        if (rows[size]) {
+          rowsVal = rows[size];
+        }
+      }
+
+      // also if areas is a simple array not an object of arrays for different sizes
+      let areasVal = areas;
+      if (areas && !Array.isArray(areas)) areasVal = areas[size];
+
+      return (
+        <Grid
+          {...props}
+          areas={!areasVal ? undefined : areasVal}
+          rows={!rowsVal ? size : rowsVal}
+          columns={!columnsVal ? size : columnsVal}
+        >
+          {children}
+        </Grid>
+      );
+    }}
+  </ResponsiveContext.Consumer>
+);
+
+const ResponsiveGrid = () => (
+  <Grommet theme={customBreakpoints}>
+    <Box>
+      <Heading level={2}>Resize me.</Heading>
+      <ResponsiveContext
+        rows={rows}
+        columns={columns}
+        gap="small"
+        areas={fixedGridAreas}
+        margin="medium"
+      >
+        <Box
+          gridArea="header"
+          background="neutral-2"
+          justify="center"
+          align="center"
+        >
+          <strong>Box 1</strong>
+        </Box>
+        <Box
+          gridArea="test"
+          background="neutral-3"
+          justify="center"
+          align="center"
+        >
+          <strong>Box 2</strong>
+        </Box>
+        <Box
+          gridArea="test1"
+          background="neutral-4"
+          justify="center"
+          align="center"
+        >
+          <strong>Box 3</strong>
+        </Box>
+      </ResponsiveContext>
+      <ResponsiveContext
+        gap="small"
+        margin="medium"
+        columns="medium"
+        rows="xsmall"
+      >
+        {listAnimalsBoxes}
+      </ResponsiveContext>
+    </Box>
+  </Grommet>
+);
+
 storiesOf('Grid', module)
   .add('App', () => <AppGrid />)
   .add('Percentages', () => <Percentages />)
-  .add('N-column layout', () => <NColumnGrid />);
+  .add('N-column layout', () => <NColumnGrid />)
+  .add('Responsive Grid', () => <ResponsiveGrid />);

--- a/src/js/components/Grid/grid.stories.js
+++ b/src/js/components/Grid/grid.stories.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
 
-import { Grommet, Box, Button, Grid, Text, Heading } from 'grommet';
+import { Grommet, Box, Button, Grid, Text, Heading, ResponsiveContext } from 'grommet';
 import { grommet } from 'grommet/themes';
 import { deepMerge } from 'grommet/utils';
 
@@ -195,7 +195,7 @@ const listAnimalsBoxes = animals.map(animalName => (
   </Box>
 ));
 
-const ResponsiveContext = ({
+const Responsive = ({
   children,
   overrideColumns,
   overrideRows,
@@ -241,7 +241,7 @@ const ResponsiveGrid = () => (
   <Grommet theme={customBreakpoints}>
     <Box>
       <Heading level={2}>Resize me.</Heading>
-      <ResponsiveContext
+      <Responsive
         rows={rows}
         columns={columns}
         gap="small"
@@ -272,15 +272,15 @@ const ResponsiveGrid = () => (
         >
           <strong>Box 3</strong>
         </Box>
-      </ResponsiveContext>
-      <ResponsiveContext
+      </Responsive>
+      <Responsive
         gap="small"
         margin="medium"
         columns="medium"
         rows="xsmall"
       >
         {listAnimalsBoxes}
-      </ResponsiveContext>
+      </Responsive>
     </Box>
   </Grommet>
 );


### PR DESCRIPTION
Add responsive Grid example to stories

#### What does this PR do?
This PR adds to stories an example of how to build two types of responsive Grids:

1. A grid with a known number of components, using areas,
2. A grid with an unknown number of components.

Both using ResponsiveContext.

#### What testing has been done on this PR?
`yarn test`

#### How should this be manually tested?
Check if the example got into stories and resize the screen to see if the Grids responses correctly:
1. For the first Grid with 3 elements:
    a. For size small, the three elements should be one on top of the other.
    b. For size medium, there should be one element on top, two elements underneath it taking 50% of the space each.
    c. For size large, the three elements should be inline.
2. For the Grid with an unknown number of elements, the boxes containing animal names should resize and/or got to the next line when reducing the screen size.

#### Working codesandbox for this:
https://codesandbox.io/s/grommet-responsive-grids-ji8zg
