### PR TITLE
Fix type import for PlaceHolderType

### DIFF
--- a/src/js/components/TextInput/index.d.ts
+++ b/src/js/components/TextInput/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Omit, PlaceholderType, } from "../../utils";
+import { Omit, PlaceHolderType, } from "../../utils";
 import { DropProps } from "../Drop";
 
 export interface TextInputProps {


### PR DESCRIPTION
Typescript builds started failing due to a misspelled type import

Signed-off-by: Stevche Radevski <stevche@balena.io>
