### PR TITLE
Ts themefix#3251

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -55,3 +55,4 @@ export * from './components/WorldMap';
 export * from './contexts/AnnounceContext';
 export * from './contexts/ResponsiveContext';
 export * from './contexts/ThemeContext';
+export * from './themes/index';

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -55,4 +55,4 @@ export * from './components/WorldMap';
 export * from './contexts/AnnounceContext';
 export * from './contexts/ResponsiveContext';
 export * from './contexts/ThemeContext';
-export * from './themes/index';
+export * from './themes/';


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes a TS error when importing themes from grommet
#### Where should the reviewer start?
js/index.d.ts
#### What testing has been done on this PR?
manually tested by branching out to a typescript project

#### How should this be manually tested?
Also switch between grommet and dark theme to test both 
```

import { Grommet, grommet, dark, } from "grommet";

function App() {
  return (
    <Grommet full theme={dark}>
    </Grommet>

```
#### Any background context you want to provide?

#### What are the relevant issues?
#3251 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible