### PR TITLE
Add the possibility to specify Grid's areas prop as an array of rows

### DIFF
--- a/src/js/components/Grid/README.md
+++ b/src/js/components/Grid/README.md
@@ -139,7 +139,11 @@ stretch
 
 **areas**
 
-Area names and column,row coordinates.
+Grid areas.
+      If the value is an array of objects, it indicates the
+      area names and columns, row coordinates.
+      Otherwise an array of string arrays can be used to write
+      in a way similar to the gridArea css property.
 
 ```
 [{
@@ -147,6 +151,7 @@ Area names and column,row coordinates.
   start: [number],
   end: [number]
 }]
+[[string]]
 ```
 
 **columns**

--- a/src/js/components/Grid/StyledGrid.js
+++ b/src/js/components/Grid/StyledGrid.js
@@ -181,6 +181,14 @@ const areasStyle = props => {
   if (!Array.isArray(props.rowsProp) || !Array.isArray(props.columns)) {
     console.warn('Grid `areas` requires `rows` and `columns` to be arrays.');
   }
+  if (
+    Array.isArray(props.areas) &&
+    props.areas.every(area => Array.isArray(area))
+  ) {
+    return `grid-template-areas: ${props.areas
+      .map(area => `"${area.join(' ')}"`)
+      .join(' ')};`;
+  }
   const cells = props.rowsProp.map(() => props.columns.map(() => '.'));
   props.areas.forEach(area => {
     for (let row = area.start[1]; row <= area.end[1]; row += 1) {

--- a/src/js/components/Grid/__tests__/Grid-test.js
+++ b/src/js/components/Grid/__tests__/Grid-test.js
@@ -60,6 +60,24 @@ test('Grid areas renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('Grid areas renders when given an array of string arrays', () => {
+  const component = renderer.create(
+    <Grommet>
+      <Grid
+        rows={['xxsmall', 'medium', 'xsmall']}
+        columns={['3/4', '1/4']}
+        areas={[
+          ['header', 'header'],
+          ['sidebar', 'main'],
+          ['footer', 'footer'],
+        ]}
+      />
+    </Grommet>,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('Grid justify renders', () => {
   const component = renderer.create(
     <Grommet>

--- a/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
+++ b/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
@@ -176,6 +176,34 @@ exports[`Grid areas renders 1`] = `
 </div>
 `;
 
+exports[`Grid areas renders when given an array of string arrays 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "header header" "sidebar main" "footer footer";
+  grid-template-columns: 75% 25%;
+  grid-template-rows: 48px 384px 96px;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  />
+</div>
+`;
+
 exports[`Grid as renders 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -54,13 +54,22 @@ space in the column axis.`,
       'around',
       'stretch',
     ]).description('How to align the contents along the column axis.'),
-    areas: PropTypes.arrayOf(
-      PropTypes.shape({
-        name: PropTypes.string,
-        start: PropTypes.arrayOf(PropTypes.number),
-        end: PropTypes.arrayOf(PropTypes.number),
-      }),
-    ).description('Area names and column,row coordinates.'),
+    areas: PropTypes.oneOfType([
+      PropTypes.arrayOf(
+        PropTypes.shape({
+          name: PropTypes.string,
+          start: PropTypes.arrayOf(PropTypes.number),
+          end: PropTypes.arrayOf(PropTypes.number),
+        }),
+      ),
+      PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
+    ]).description(
+      `Grid areas.
+      If the value is an array of objects, it indicates the
+      area names and columns, row coordinates.
+      Otherwise an array of string arrays can be used to write
+      in a way similar to the gridArea css property.`,
+    ),
     columns: PropTypes.oneOfType([
       PropTypes.arrayOf(
         PropTypes.oneOfType([

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -8,7 +8,7 @@ export interface GridProps {
   margin?: MarginType;
   align?: "start" | "center" | "end" | "stretch";
   alignContent?: AlignContentType;
-  areas?: {name?: string,start?: number[],end?: number[]}[];
+  areas?: {name?: string,start?: number[],end?: number[]}[] | string[][];
   columns?: ("xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | string | string[])[] | "xsmall" | "small" | "medium" | "large" | "xlarge" | {count?: "fit" | "fill" | number,size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | string | string[]} | string;
   fill?: "horizontal" | "vertical" | boolean;
   gap?: "small" | "medium" | "large" | "none" | {row?: "small" | "medium" | "large" | "none" | string,column?: "small" | "medium" | "large" | "none" | string} | string;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5142,7 +5142,11 @@ stretch
 
 **areas**
 
-Area names and column,row coordinates.
+Grid areas.
+      If the value is an array of objects, it indicates the
+      area names and columns, row coordinates.
+      Otherwise an array of string arrays can be used to write
+      in a way similar to the gridArea css property.
 
 \`\`\`
 [{
@@ -5150,6 +5154,7 @@ Area names and column,row coordinates.
   start: [number],
   end: [number]
 }]
+[[string]]
 \`\`\`
 
 **columns**


### PR DESCRIPTION
#### What does this PR do?
Add the possibility to specify the Grid component's "areas" prop as an array of row, which allows for a format more similar the CSS property.

#### Where should the reviewer start?
StyledGrid.js

#### What testing has been done on this PR?
added a new snapshot that shows the new way of using areas props works.

#### How should this be manually tested?
snapshots

#### Any background context you want to provide?
I did not change the current test for the areas prop an preferred to add another one next to it. 
I noticed though that the current test renders [a weirdCSS value in the snapshot](https://github.com/a-peltier/grommet/blob/d2aa9c131601b7ce4177819ac8dfcf38a841d7f9/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap#L165) , maybe we should fix that too because it makes it harder to understand how the coordinates system works.

#### What are the relevant issues?
closes #2902 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes, and I would gladly improve my changes with the help of the maintainers, as english is not my native language

#### Should this PR be mentioned in the release notes?
yes

#### Is this change backwards compatible or is it a breaking change?
backwards compatible