### PR TITLE
TS - Clean up textAlign

### DIFF
--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -14,6 +14,7 @@ export interface GridProps {
   align?: "start" | "center" | "end" | "stretch";
   alignContent?: AlignContentType;
   areas?: {name?: string,start?: number[],end?: number[]}[];
+  as?: PolymorphicType;
   columns?: ("xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | string | string[])[] | "xsmall" | "small" | "medium" | "large" | "xlarge" | {count?: "fit" | "fill" | number,size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | string | string[]} | string;
   fill?: "horizontal" | "vertical" | boolean;
   gap?: "small" | "medium" | "large" | "none" | {row?: "small" | "medium" | "large" | "none" | string,column?: "small" | "medium" | "large" | "none" | string} | string;
@@ -23,7 +24,6 @@ export interface GridProps {
   margin?: MarginType;
   rows?: ("xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | string | string[])[] | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   tag?: PolymorphicType;
-  as?: PolymorphicType;
 }
 
 declare const Grid: React.FC<GridProps & JSX.IntrinsicElements['div']>;

--- a/src/js/components/Heading/index.d.ts
+++ b/src/js/components/Heading/index.d.ts
@@ -14,10 +14,10 @@ export interface HeadingProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
   as?: PolymorphicType;
-  gridArea?: GridAreaType;
-  margin?: MarginType;
   color?: ColorType;
+  gridArea?: GridAreaType;
   level?: "1" | "2" | "3" | "4" | "5" | "6" | 1 | 2 | 3 | 4 | 5 | 6;
+  margin?: MarginType;
   responsive?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | string;
   textAlign?: TextAlignType;

--- a/src/js/components/Heading/index.d.ts
+++ b/src/js/components/Heading/index.d.ts
@@ -6,7 +6,8 @@ import {
   GridAreaType,
   MarginType,
   Omit,
-  PolymorphicType
+  PolymorphicType,
+  TextAlignType
 } from "../../utils";
 
 export interface HeadingProps {
@@ -19,7 +20,7 @@ export interface HeadingProps {
   level?: "1" | "2" | "3" | "4" | "5" | "6" | 1 | 2 | 3 | 4 | 5 | 6;
   responsive?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | string;
-  textAlign?: "start" | "center" | "end";
+  textAlign?: TextAlignType;
   truncate?: boolean;
 }
 

--- a/src/js/components/MaskedInput/index.d.ts
+++ b/src/js/components/MaskedInput/index.d.ts
@@ -2,9 +2,6 @@ import * as React from "react";
 
 export interface MaskedInputProps {
   id?: string;
-  name?: string;
-  onChange?: ((...args: any[]) => any);
-  onBlur?: ((...args: any[]) => any);
   mask?: Array<{
     length?: number | number[];
     fixed?: string;
@@ -12,6 +9,9 @@ export interface MaskedInputProps {
     regexp?: {};
     placeholder?: string;
   }>;
+  name?: string;
+  onChange?: ((...args: any[]) => any);
+  onBlur?: ((...args: any[]) => any);
   plain?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | string;
   value?: string | number;

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -11,9 +11,9 @@ export interface MenuProps {
   dropTarget?: object;
   dropProps?: DropProps;
   gridArea?: GridAreaType;
-  justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
   icon?: boolean | React.ReactNode;
   items: object[];
+  justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
   label?: string | React.ReactNode;
   margin?: MarginType;
   messages?: {closeMenu?: string,openMenu?: string};

--- a/src/js/components/Meter/index.d.ts
+++ b/src/js/components/Meter/index.d.ts
@@ -4,9 +4,9 @@ import { A11yTitleType, AlignSelfType, GridAreaType, MarginType } from "../../ut
 export interface MeterProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
+  background?: string | {color?: string,opacity?: "weak" | "medium" | "strong" | boolean};
   gridArea?: GridAreaType;
   margin?: MarginType;
-  background?: string | {color?: string,opacity?: "weak" | "medium" | "strong" | boolean};
   round?: boolean;
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | string;
   thickness?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;

--- a/src/js/components/Paragraph/index.d.ts
+++ b/src/js/components/Paragraph/index.d.ts
@@ -12,9 +12,9 @@ import {
 export interface ParagraphProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
+  color?: ColorType;
   gridArea?: GridAreaType;
   margin?: MarginType;
-  color?: ColorType;
   responsive?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
   textAlign?: TextAlignType;

--- a/src/js/components/Paragraph/index.d.ts
+++ b/src/js/components/Paragraph/index.d.ts
@@ -5,7 +5,8 @@ import {
   ColorType, 
   GridAreaType, 
   MarginType, 
-  Omit 
+  Omit,
+  TextAlignType
 } from "../../utils";
 
 export interface ParagraphProps {
@@ -16,7 +17,7 @@ export interface ParagraphProps {
   color?: ColorType;
   responsive?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
-  textAlign?: "start" | "center" | "end";
+  textAlign?: TextAlignType;
 }
 
 declare const Paragraph: React.FC<ParagraphProps & Omit<JSX.IntrinsicElements['p'], 'color'>>;

--- a/src/js/components/RoutedAnchor/index.d.ts
+++ b/src/js/components/RoutedAnchor/index.d.ts
@@ -3,8 +3,8 @@ import { AnchorProps } from "../Anchor";
 import { Omit } from "../../utils";
 
 export interface RoutedAnchorProps {
-  path: string;
   method?: "push" | "replace";
+  path: string;
 }
 
 declare const RoutedAnchor: React.ComponentClass<RoutedAnchorProps & Omit<AnchorProps, "href">>;

--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -6,7 +6,6 @@ export interface SelectProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
   gridArea?: GridAreaType;
-  margin?: MarginType;
   children?: ((...args: any[]) => any);
   closeOnChange?: boolean;
   disabled?: boolean | (number | string | object)[];
@@ -19,6 +18,7 @@ export interface SelectProps {
   icon?: boolean | ((...args: any[]) => any) | React.ReactNode;
   id?: string;
   labelKey?: string | ((...args: any[]) => any);
+  margin?: MarginType;
   messages?: { multiple?: string };
   multiple?: boolean;
   name?: string;

--- a/src/js/components/Stack/index.d.ts
+++ b/src/js/components/Stack/index.d.ts
@@ -4,12 +4,12 @@ import { A11yTitleType, AlignSelfType, GridAreaType, MarginType } from "../../ut
 export interface StackProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
-  gridArea?: GridAreaType;
-  margin?: MarginType;
   anchor?: "center" | "left" | "right" | "top" | "bottom" | "top-left" | "bottom-left" | "top-right" | "bottom-right";
   fill?: boolean;
+  gridArea?: GridAreaType;
   guidingChild?: number | "first" | "last";
   interactiveChild?: number | "first" | "last";
+  margin?: MarginType;
 }
 
 declare const Stack: React.ComponentClass<StackProps & JSX.IntrinsicElements['div']>;

--- a/src/js/components/Table/index.d.ts
+++ b/src/js/components/Table/index.d.ts
@@ -4,9 +4,9 @@ import { A11yTitleType, AlignSelfType, GridAreaType, MarginType } from "../../ut
 export interface TableProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
+  caption?: string;
   gridArea?: GridAreaType;
   margin?: MarginType;
-  caption?: string;
 }
 
 declare const Table: React.FC<TableProps & JSX.IntrinsicElements['table']>;

--- a/src/js/components/Tabs/index.d.ts
+++ b/src/js/components/Tabs/index.d.ts
@@ -3,13 +3,13 @@ import { A11yTitleType, AlignSelfType, GridAreaType, MarginType } from "../../ut
 
 export interface TabsProps {
   a11yTitle?: A11yTitleType;
-  alignSelf?: AlignSelfType;
-  gridArea?: GridAreaType;
-  margin?: MarginType;
   activeIndex?: number;
+  alignSelf?: AlignSelfType;
   children: React.ReactNode;
   flex?: "grow" | "shrink" | boolean;
+  gridArea?: GridAreaType;
   justify?: "start" | "center" | "end";
+  margin?: MarginType;
   messages?: {tabContents?: string};
   onActive?: ((...args: any[]) => any);
 }

--- a/src/js/components/Text/index.d.ts
+++ b/src/js/components/Text/index.d.ts
@@ -6,7 +6,8 @@ import {
   GridAreaType, 
   MarginType, 
   Omit, 
-  PolymorphicType 
+  PolymorphicType,
+  TextAlignType 
 } from "../../utils";
 
 export interface TextProps {
@@ -18,7 +19,7 @@ export interface TextProps {
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
   tag?: PolymorphicType;
   as?: PolymorphicType;
-  textAlign?: "start" | "center" | "end";
+  textAlign?: TextAlignType;
   truncate?: boolean;
   weight?: "normal" | "bold" | number;
   wordBreak?: "normal" | "break-all" | "keep-all" | "break-word";

--- a/src/js/components/Text/index.d.ts
+++ b/src/js/components/Text/index.d.ts
@@ -13,12 +13,12 @@ import {
 export interface TextProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
+  as?: PolymorphicType;
+  color?:  ColorType;
   gridArea?: GridAreaType,
   margin?: MarginType;
-  color?:  ColorType;
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
   tag?: PolymorphicType;
-  as?: PolymorphicType;
   textAlign?: TextAlignType;
   truncate?: boolean;
   weight?: "normal" | "bold" | number;

--- a/src/js/components/TextArea/index.d.ts
+++ b/src/js/components/TextArea/index.d.ts
@@ -1,16 +1,16 @@
 import * as React from "react";
 
 export interface TextAreaProps {
-  id?: string;
   fill?: boolean;
   focusIndicator?: boolean;
+  id?: string;
   name?: string;
   onChange?: ((...args: any[]) => any);
   placeholder?: string;
   plain?: boolean;
-  value?: string;
   resize?: "vertical" | "horizontal" | boolean;
   size?: "small" | "medium" | "large" | "xlarge" | string;
+  value?: string;
 }
 
 declare const TextArea: React.ComponentClass<TextAreaProps & JSX.IntrinsicElements['textarea']>;

--- a/src/js/components/TextInput/index.d.ts
+++ b/src/js/components/TextInput/index.d.ts
@@ -7,8 +7,8 @@ export interface TextInputProps {
   dropHeight?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   dropTarget?: object;
   dropProps?: DropProps;
-  id?: string;
   focusIndicator?: boolean;
+  id?: string;
   messages?: {enterSelect?: string,suggestionsCount?: string,suggestionsExist?: string,suggestionIsOpen?: string};
   name?: string;
   onSelect?: ((x: { target: React.RefObject<HTMLElement>['current'], suggestion: any }) => void);

--- a/src/js/components/Video/index.d.ts
+++ b/src/js/components/Video/index.d.ts
@@ -4,12 +4,12 @@ import { A11yTitleType, AlignSelfType, GridAreaType, MarginType, Omit } from "..
 export interface VideoProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
-  gridArea?: GridAreaType;
-  margin?: MarginType;
   autoPlay?: boolean;
   controls?: "false" | "over" | "below";
   fit?: "cover" | "contain";
+  gridArea?: GridAreaType;
   loop?: boolean;
+  margin?: MarginType;
   mute?: boolean;
 }
 

--- a/src/js/components/WorldMap/index.d.ts
+++ b/src/js/components/WorldMap/index.d.ts
@@ -4,13 +4,13 @@ import { A11yTitleType, AlignSelfType, GridAreaType, MarginType } from "../../ut
 export interface WorldMapProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
-  gridArea?: GridAreaType;
-  margin?: MarginType;
   color?: string | {dark?: string,light?: string};
   continents?: {color?: string | {dark?: string,light?: string},name: "Africa" | "Asia" | "Australia" | "Europe" | "North America" | "South America",onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any)}[];
+  gridArea?: GridAreaType;
+  hoverColor?: string | {dark?: string,light?: string};
+  margin?: MarginType;
   onSelectPlace?: ((...args: any[]) => any);
   places?: {color?: string | {dark?: string,light?: string},name?: string,location: number[],onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any)}[];
-  hoverColor?: string | {dark?: string,light?: string};
 }
 
 declare const WorldMap: React.ComponentClass<WorldMapProps & JSX.IntrinsicElements['svg']>;

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -42,3 +42,4 @@ export type ColorType = string | {dark?: string,light?: string};
 export type GridAreaType = string;
 export type MarginType = "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
 export type PlaceHolderType = string | JSX.Element | React.ReactNode;
+export type TextAlignType = "start" | "center" | "end";


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR cleans up the textAlign type definitions and puts all component ts prop types in alphabetical order.

#### Where should the reviewer start?
js/utils/index.d.ts

#### What testing has been done on this PR?
Manually tested by branching out to a typescript project.

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Issue #3237
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
