### PR TITLE
Update Grid Gap documentation to include gap of xlarge and refactor gap in utils.

### DIFF
--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -2,7 +2,8 @@ import * as React from "react";
 import { 
   A11yTitleType, 
   AlignContentType, 
-  AlignSelfType, 
+  AlignSelfType,
+  GapType, 
   GridAreaType, 
   MarginType, 
   PolymorphicType, 
@@ -23,7 +24,7 @@ export interface BoxProps {
   elevation?: "none" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   flex?: "grow" | "shrink" | boolean | {grow?: number,shrink?: number};
   fill?: "horizontal" | "vertical" | boolean;
-  gap?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
+  gap?: GapType | "xxsmall" | "xsmall" | "xlarge";
   height?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
   justify?: "start" | "center" | "between" | "around" | "evenly" | "end";
   overflow?: "auto" | "hidden" | "scroll" | "visible" | {horizontal?: "auto" | "hidden" | "scroll" | "visible",vertical?: "auto" | "hidden" | "scroll" | "visible"} | string;

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -2,7 +2,8 @@ import * as React from "react";
 import { 
   A11yTitleType,
   AlignSelfType, 
-  ColorType, 
+  ColorType,
+  GapType, 
   GridAreaType, 
   MarginType, 
   Omit, 
@@ -19,7 +20,7 @@ export interface ButtonProps {
   disabled?: boolean;
   fill?: "horizontal" | "vertical" | boolean;
   focusIndicator?: boolean;
-  gap?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
+  gap?: GapType | "xxsmall" | "xsmall" | "xlarge";
   hoverIndicator?: boolean | string | "background" | {background?: boolean | string};
   href?: string;
   target?: "_self" | "_blank" | "_parent" | "_top";

--- a/src/js/components/Distribution/index.d.ts
+++ b/src/js/components/Distribution/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { A11yTitleType, AlignSelfType, GridAreaType, MarginType } from "../../utils";
+import { A11yTitleType, AlignSelfType, GapType, GridAreaType, MarginType } from "../../utils";
 
 export interface DistributionProps {
   a11yTitle?: A11yTitleType;
@@ -8,7 +8,7 @@ export interface DistributionProps {
   margin?: MarginType;
   children?: ((...args: any[]) => any);
   fill?: boolean;
-  gap?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
+  gap?: GapType | "xsmall" | "xlarge";
   values: {value: number, color?: string | {dark?: string,light?: string}}[];
 }
 

--- a/src/js/components/Grid/README.md
+++ b/src/js/components/Grid/README.md
@@ -247,18 +247,21 @@ Gap sizes between rows and/or columns.
 small
 medium
 large
+xlarge
 none
 {
   row: 
     small
     medium
     large
+    xlarge
     none
     string,
   column: 
     small
     medium
     large
+    xlarge
     none
     string
 }

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -19,7 +19,7 @@ const sizes = [
   'flex',
   'auto',
 ];
-const edgeSizes = ['small', 'medium', 'large', 'none'];
+const edgeSizes = ['small', 'medium', 'large', 'xlarge', 'none'];
 
 export const doc = Grid => {
   const DocumentedGrid = describe(Grid)

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -2,7 +2,8 @@ import * as React from "react";
 import { 
   A11yTitleType, 
   AlignContentType, 
-  AlignSelfType, 
+  AlignSelfType,
+  GapType, 
   GridAreaType, 
   MarginType, 
   PolymorphicType, 
@@ -16,7 +17,7 @@ export interface GridProps {
   areas?: {name?: string,start?: number[],end?: number[]}[];
   columns?: ("xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | string | string[])[] | "xsmall" | "small" | "medium" | "large" | "xlarge" | {count?: "fit" | "fill" | number,size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | string | string[]} | string;
   fill?: "horizontal" | "vertical" | boolean;
-  gap?: "small" | "medium" | "large" | "none" | {row?: "small" | "medium" | "large" | "none" | string,column?: "small" | "medium" | "large" | "none" | string} | string;
+  gap?: GapType | "none" | {row?: GapType | "none",column?: GapType | "none"};
   gridArea?: GridAreaType;
   justify?: "start" | "center" | "end" | "stretch";
   justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch";

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5260,18 +5260,21 @@ Gap sizes between rows and/or columns.
 small
 medium
 large
+xlarge
 none
 {
   row: 
     small
     medium
     large
+    xlarge
     none
     string,
   column: 
     small
     medium
     large
+    xlarge
     none
     string
 }

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -39,6 +39,7 @@ export type A11yTitleType = string;
 export type AlignContentType = "start" | "center" | "end" | "between" | "around" | "stretch";
 export type AlignSelfType = "start" | "center" | "end" | "stretch";
 export type ColorType = string | {dark?: string,light?: string};
+export type GapType = "small" | "medium" | "large" | string;
 export type GridAreaType = string;
 export type MarginType = "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
 export type PlaceHolderType = string | JSX.Element | React.ReactNode;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds missing documentation for "xlarge" to grid's gap property. Refactors overlapping grid gap styles to single GapType.

#### Where should the reviewer start?
js/utils/index.d.ts

#### What testing has been done on this PR?
Tested manually on local project.

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Issue #3237 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
