### PR TITLE
Fix keyboard interactivity for Menu

### DIFF
--- a/src/js/components/Distribution/index.d.ts
+++ b/src/js/components/Distribution/index.d.ts
@@ -1,14 +1,14 @@
 import * as React from "react";
-import { A11yTitleType, AlignSelfType, GridAreaType, MarginType } from "../../utils";
+import { A11yTitleType, AlignSelfType, GapType, GridAreaType, MarginType } from "../../utils";
 
 export interface DistributionProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
-  gridArea?: GridAreaType;
-  margin?: MarginType;
   children?: ((...args: any[]) => any);
   fill?: boolean;
-  gap?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
+  gap?: GapType | "xsmall" | "xlarge";
+  gridArea?: GridAreaType;
+  margin?: MarginType;
   values: {value: number, color?: string | {dark?: string,light?: string}}[];
 }
 

--- a/src/js/components/DropButton/DropButton.js
+++ b/src/js/components/DropButton/DropButton.js
@@ -88,7 +88,6 @@ class DropButton extends Component {
       drop = (
         <Drop
           id={id ? `${id}__drop` : undefined}
-          restrictFocus
           align={dropAlign}
           target={dropTarget || (forwardRef || this.buttonRef).current}
           onClickOutside={this.onDropClose}

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -1968,7 +1968,267 @@ exports[`Select disabled 2`] = `
 `;
 
 exports[`Select empty results search 1`] = `
+<body>
+  <div />
+  .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0px;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  padding: 0px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding: 0px;
+}
+
 .c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c6 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  padding: 11px;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  width: 100%;
+  border: none;
+}
+
+.c6::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c6::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c6:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c4 {
+  position: relative;
+  width: 100%;
+}
+
+.c5 {
+  cursor: pointer;
+}
+
+.c0 {
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding: 0px;
+  }
+}
+
+<div>
+    <button
+      aria-label="Open Drop"
+      class="c0 c1"
+      id="test-select"
+      type="button"
+    >
+      <div
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          <div
+            class="c4"
+          >
+            <input
+              autocomplete="off"
+              class="c5 c6"
+              id="test-select__input"
+              placeholder="test select"
+              readonly=""
+              tabindex="-1"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="c7"
+          style="min-width: auto;"
+        >
+          <svg
+            aria-label="FormDown"
+            class="c8"
+            viewBox="0 0 24 24"
+          >
+            <polyline
+              fill="none"
+              points="18 9 12 15 6 9"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </div>
+      </div>
+    </button>
+  </div>
+  .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2283,63 +2543,332 @@ exports[`Select empty results search 1`] = `
   }
 }
 
-<div
-  class="c0 c1"
-  id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
-  tabindex="-1"
->
-  <div
-    class="c2 c3"
-    id="test-select__select-drop"
-  >
+<div>
     <div
-      class="c4"
+      aria-hidden="false"
     >
       <div
-        class="c5"
+        class="c0 c1"
+        id="test-select__drop"
+        style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+        tabindex="-1"
       >
-        <input
-          autocomplete="off"
-          class="c6"
-          type="search"
-          value=""
-        />
-      </div>
-    </div>
-    <div
-      class="c7 c8"
-      role="menubar"
-      tabindex="-1"
-    >
-      <div
-        class="c9"
-      >
-        <button
-          class="c10"
-          disabled=""
-          role="menuitem"
-          tabindex="-1"
-          type="button"
+        <div
+          class="c2 c3"
+          id="test-select__select-drop"
         >
           <div
-            class="c11"
+            class="c4"
           >
-            <span
-              class="c12"
+            <div
+              class="c5"
             >
-              no results
-            </span>
+              <input
+                autocomplete="off"
+                class="c6"
+                type="search"
+                value=""
+              />
+            </div>
           </div>
-        </button>
+          <div
+            class="c7 c8"
+            role="menubar"
+            tabindex="-1"
+          >
+            <div
+              class="c9"
+            >
+              <button
+                class="c10"
+                disabled=""
+                role="menuitem"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c11"
+                >
+                  <span
+                    class="c12"
+                  >
+                    no results
+                  </span>
+                </div>
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
-</div>
+</body>
 `;
 
 exports[`Select large drop container height 1`] = `
+<body>
+  <div />
+  .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 48px;
+  height: 48px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0px;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  padding: 0px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding: 0px;
+}
+
 .c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c6 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  padding: 11px;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  width: 100%;
+  font-size: 22px;
+  line-height: 28px;
+  border: none;
+}
+
+.c6::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c6::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c6:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c4 {
+  position: relative;
+  width: 100%;
+}
+
+.c5 {
+  cursor: pointer;
+}
+
+.c0 {
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding: 0px;
+  }
+}
+
+<div>
+    <button
+      aria-label="Open Drop"
+      class="c0 c1"
+      id="test-select"
+      type="button"
+    >
+      <div
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          <div
+            class="c4"
+          >
+            <input
+              autocomplete="off"
+              class="c5 c6"
+              id="test-select__input"
+              placeholder="test select"
+              readonly=""
+              tabindex="-1"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="c7"
+          style="min-width: auto;"
+        >
+          <svg
+            aria-label="FormDown"
+            class="c8"
+            viewBox="0 0 24 24"
+          >
+            <polyline
+              fill="none"
+              points="18 9 12 15 6 9"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </div>
+      </div>
+    </button>
+  </div>
+  .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2615,71 +3144,340 @@ exports[`Select large drop container height 1`] = `
   }
 }
 
-<div
-  class="c0 c1"
-  id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
-  tabindex="-1"
->
-  <div
-    class="c2 c3"
-    id="test-select__select-drop"
-  >
+<div>
     <div
-      class="c4 c5"
-      role="menubar"
-      tabindex="-1"
+      aria-hidden="false"
     >
       <div
-        class="c6"
+        class="c0 c1"
+        id="test-select__drop"
+        style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+        tabindex="-1"
       >
-        <button
-          class="c7"
-          role="menuitem"
-          tabindex="-1"
-          type="button"
+        <div
+          class="c2 c3"
+          id="test-select__select-drop"
         >
           <div
-            class="c8"
+            class="c4 c5"
+            role="menubar"
+            tabindex="-1"
           >
-            <span
-              class="c9"
+            <div
+              class="c6"
             >
-              one
-            </span>
-          </div>
-        </button>
-      </div>
-      <div
-        class="c6"
-      >
-        <button
-          class="c7"
-          role="menuitem"
-          tabindex="-1"
-          type="button"
-        >
-          <div
-            class="c8"
-          >
-            <span
-              class="c9"
+              <button
+                class="c7"
+                role="menuitem"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c8"
+                >
+                  <span
+                    class="c9"
+                  >
+                    one
+                  </span>
+                </div>
+              </button>
+            </div>
+            <div
+              class="c6"
             >
-              two
-            </span>
+              <button
+                class="c7"
+                role="menuitem"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c8"
+                >
+                  <span
+                    class="c9"
+                  >
+                    two
+                  </span>
+                </div>
+              </button>
+            </div>
+            <div
+              class="c10"
+            />
           </div>
-        </button>
+        </div>
       </div>
-      <div
-        class="c10"
-      />
     </div>
   </div>
-</div>
+</body>
 `;
 
 exports[`Select medium drop container height 1`] = `
+<body>
+  <div />
+  .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 48px;
+  height: 48px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0px;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  padding: 0px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding: 0px;
+}
+
 .c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c6 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  padding: 11px;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  width: 100%;
+  font-size: 22px;
+  line-height: 28px;
+  border: none;
+}
+
+.c6::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c6::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c6:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c4 {
+  position: relative;
+  width: 100%;
+}
+
+.c5 {
+  cursor: pointer;
+}
+
+.c0 {
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding: 0px;
+  }
+}
+
+<div>
+    <button
+      aria-label="Open Drop"
+      class="c0 c1"
+      id="test-select"
+      type="button"
+    >
+      <div
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          <div
+            class="c4"
+          >
+            <input
+              autocomplete="off"
+              class="c5 c6"
+              id="test-select__input"
+              placeholder="test select"
+              readonly=""
+              tabindex="-1"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="c7"
+          style="min-width: auto;"
+        >
+          <svg
+            aria-label="FormDown"
+            class="c8"
+            viewBox="0 0 24 24"
+          >
+            <polyline
+              fill="none"
+              points="18 9 12 15 6 9"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </div>
+      </div>
+    </button>
+  </div>
+  .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2955,67 +3753,74 @@ exports[`Select medium drop container height 1`] = `
   }
 }
 
-<div
-  class="c0 c1"
-  id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
-  tabindex="-1"
->
-  <div
-    class="c2 c3"
-    id="test-select__select-drop"
-  >
+<div>
     <div
-      class="c4 c5"
-      role="menubar"
-      tabindex="-1"
+      aria-hidden="false"
     >
       <div
-        class="c6"
+        class="c0 c1"
+        id="test-select__drop"
+        style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+        tabindex="-1"
       >
-        <button
-          class="c7"
-          role="menuitem"
-          tabindex="-1"
-          type="button"
+        <div
+          class="c2 c3"
+          id="test-select__select-drop"
         >
           <div
-            class="c8"
+            class="c4 c5"
+            role="menubar"
+            tabindex="-1"
           >
-            <span
-              class="c9"
+            <div
+              class="c6"
             >
-              one
-            </span>
-          </div>
-        </button>
-      </div>
-      <div
-        class="c6"
-      >
-        <button
-          class="c7"
-          role="menuitem"
-          tabindex="-1"
-          type="button"
-        >
-          <div
-            class="c8"
-          >
-            <span
-              class="c9"
+              <button
+                class="c7"
+                role="menuitem"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c8"
+                >
+                  <span
+                    class="c9"
+                  >
+                    one
+                  </span>
+                </div>
+              </button>
+            </div>
+            <div
+              class="c6"
             >
-              two
-            </span>
+              <button
+                class="c7"
+                role="menuitem"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c8"
+                >
+                  <span
+                    class="c9"
+                  >
+                    two
+                  </span>
+                </div>
+              </button>
+            </div>
+            <div
+              class="c10"
+            />
           </div>
-        </button>
+        </div>
       </div>
-      <div
-        class="c10"
-      />
     </div>
   </div>
-</div>
+</body>
 `;
 
 exports[`Select modifies select control style on open 1`] = `
@@ -8939,7 +9744,109 @@ exports[`Select size 1`] = `
 `;
 
 exports[`Select small drop container height 1`] = `
-.c1 {
+.c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 48px;
+  height: 48px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0px;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  padding: 0px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding: 0px;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8958,7 +9865,7 @@ exports[`Select small drop container height 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8975,7 +9882,7 @@ exports[`Select small drop container height 1`] = `
   padding: 0px;
 }
 
-.c5 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8996,7 +9903,7 @@ exports[`Select small drop container height 1`] = `
   overflow: auto;
 }
 
-.c6 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9016,7 +9923,7 @@ exports[`Select small drop container height 1`] = `
   padding: 0px;
 }
 
-.c8 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9037,7 +9944,7 @@ exports[`Select small drop container height 1`] = `
   padding: 12px;
 }
 
-.c10 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9058,7 +9965,7 @@ exports[`Select small drop container height 1`] = `
   padding: 0px;
 }
 
-.c7 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -9076,19 +9983,37 @@ exports[`Select small drop container height 1`] = `
   text-align: inherit;
 }
 
-.c7:hover {
+.c16 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c16:hover {
   background-color: rgba(221,221,221,0.4);
   color: #444444;
   color: #000000;
 }
 
-.c9 {
+.c18 {
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c0 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -9112,11 +10037,57 @@ exports[`Select small drop container height 1`] = `
   animation-delay: 0.01s;
 }
 
-.c2 {
-  max-height: 192px;
+.c6 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  padding: 11px;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  width: 100%;
+  font-size: 22px;
+  line-height: 28px;
+  border: none;
+}
+
+.c6::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c6::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c6:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6::-moz-focus-inner {
+  border: none;
+  outline: none;
 }
 
 .c4 {
+  position: relative;
+  width: 100%;
+}
+
+.c11 {
+  max-height: 192px;
+}
+
+.c13 {
   position: relative;
   -webkit-scroll-behavior: smooth;
   -moz-scroll-behavior: smooth;
@@ -9124,14 +10095,23 @@ exports[`Select small drop container height 1`] = `
   scroll-behavior: smooth;
 }
 
+.c5 {
+  cursor: pointer;
+}
+
+.c0 {
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+}
+
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -9149,55 +10129,92 @@ exports[`Select small drop container height 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
-    margin: 0px;
+  .c7 {
+    margin-left: 6px;
+    margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c7 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c10 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c10 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c12 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c12 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c15 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c15 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c17 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c17 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c19 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c19 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c9 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -9210,70 +10227,127 @@ exports[`Select small drop container height 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c11 {
     width: 100%;
   }
 }
 
-<div
-  class="c0 c1"
-  id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
-  tabindex="-1"
->
-  <div
-    class="c2 c3"
-    id="test-select__select-drop"
-  >
-    <div
-      class="c4 c5"
-      role="menubar"
-      tabindex="-1"
+<body>
+  <div />
+  <div>
+    <button
+      aria-label="Open Drop"
+      class="c0 c1"
+      id="test-select"
+      type="button"
     >
       <div
-        class="c6"
+        class="c2"
       >
-        <button
-          class="c7"
-          role="menuitem"
-          tabindex="-1"
-          type="button"
+        <div
+          class="c3"
         >
           <div
-            class="c8"
+            class="c4"
           >
-            <span
-              class="c9"
-            >
-              one
-            </span>
+            <input
+              autocomplete="off"
+              class="c5 c6"
+              id="test-select__input"
+              placeholder="test select"
+              readonly=""
+              tabindex="-1"
+              type="text"
+              value=""
+            />
           </div>
-        </button>
-      </div>
-      <div
-        class="c6"
-      >
-        <button
+        </div>
+        <div
           class="c7"
-          role="menuitem"
-          tabindex="-1"
-          type="button"
+          style="min-width: auto;"
+        >
+          <svg
+            aria-label="FormDown"
+            class="c8"
+            viewBox="0 0 24 24"
+          >
+            <polyline
+              fill="none"
+              points="18 9 12 15 6 9"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </div>
+      </div>
+    </button>
+  </div>
+  <div>
+    <div
+      aria-hidden="false"
+    >
+      <div
+        class="c9 c10"
+        id="test-select__drop"
+        style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+        tabindex="-1"
+      >
+        <div
+          class="c11 c12"
+          id="test-select__select-drop"
         >
           <div
-            class="c8"
+            class="c13 c14"
+            role="menubar"
+            tabindex="-1"
           >
-            <span
-              class="c9"
+            <div
+              class="c15"
             >
-              two
-            </span>
+              <button
+                class="c16"
+                role="menuitem"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c17"
+                >
+                  <span
+                    class="c18"
+                  >
+                    one
+                  </span>
+                </div>
+              </button>
+            </div>
+            <div
+              class="c15"
+            >
+              <button
+                class="c16"
+                role="menuitem"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c17"
+                >
+                  <span
+                    class="c18"
+                  >
+                    two
+                  </span>
+                </div>
+              </button>
+            </div>
+            <div
+              class="c19"
+            />
           </div>
-        </button>
+        </div>
       </div>
-      <div
-        class="c10"
-      />
     </div>
   </div>
-</div>
+</body>
 `;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changes functionality of Menu with keyboard interactions by removing restrictFocus from DropButton. Allows users to use up/down arrow keys to open/navigate through Menu component. With restrictFocus set to true, it puts the Drop in control of focus— meaning that "tab" must be used to advance to the next tabbable element within the focused component. In this case, that made tab the only way users could advance between menu items. By removing "restrictFocus", the menu doesn't become a modal that controls the focus, and because of this the arrow keys can be used to properly navigate the menu items.

#### Where should the reviewer start?
js/components/DropButton.js

#### What testing has been done on this PR?
Testing was done in storybook to ensure functionality of other components such as Select or DropButton were not affected.

#### How should this be manually tested?
Testing can be done using Storybook components by interacting with keyboard navigation in Menu, Select, and DropButton.

#### Any background context you want to provide?
Based on HTML behaviors, up and down arrows should allow users to open and navigate within a menu. However, the Menu component was not allowing this and was incorrectly requiring users to use tab within a menu.

#### What are the relevant issues?
Issue #3225 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
If users were previously using tab to navigate within a menu component, they will now need to use arrow keys. However, upon further investigation it appears that tab is the correct behavior. Therefore, this PR maybe should be disregarded as the existing grommet behavior seems to be correct.