### PR TITLE
Add plain prop to formfield

### DIFF
--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -124,9 +124,9 @@ class FormFieldContent extends Component {
 
     let abut;
     let outerStyle = style;
+    let borderColor;
 
     if (!plain && border) {
-      let borderColor;
       if (focus && !normalizedError) {
         borderColor = 'focus';
       } else if (normalizedError) {

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -97,6 +97,7 @@ class FormFieldContent extends Component {
       label,
       name,
       pad,
+      plain,
       required,
       style,
       theme,
@@ -121,18 +122,19 @@ class FormFieldContent extends Component {
       contents = <Box {...formField.content}>{contents}</Box>;
     }
 
-    let borderColor;
-    if (focus && !normalizedError) {
-      borderColor = 'focus';
-    } else if (normalizedError) {
-      borderColor = (border && border.error.color) || 'status-critical';
-    } else {
-      borderColor = (border && border.color) || 'border';
-    }
     let abut;
     let outerStyle = style;
 
-    if (border) {
+    if (!plain && border) {
+      let borderColor;
+      if (focus && !normalizedError) {
+        borderColor = 'focus';
+      } else if (normalizedError) {
+        borderColor = border.error.color || 'status-critical';
+      } else {
+        borderColor = border.color || 'border';
+      }
+
       const normalizedChildren = children
         ? Children.map(children, child => {
             if (child) {
@@ -189,7 +191,7 @@ class FormFieldContent extends Component {
       <FormFieldBox
         className={className}
         border={
-          border && border.position === 'outer'
+          !plain && border && border.position === 'outer'
             ? { ...border, color: borderColor }
             : undefined
         }

--- a/src/js/components/FormField/README.md
+++ b/src/js/components/FormField/README.md
@@ -74,6 +74,14 @@ Whether to add padding to align with the padding of TextInput.
 boolean
 ```
 
+**plain**
+
+Whether to render a border around the form field and handle  the focus indicator
+
+```
+boolean
+```
+
 **required**
 
 Whether the field is required.

--- a/src/js/components/FormField/__tests__/FormField-test.js
+++ b/src/js/components/FormField/__tests__/FormField-test.js
@@ -54,6 +54,16 @@ test('renders error', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('renders plain', () => {
+  const component = renderer.create(
+    <Grommet>
+      <FormField plain />
+    </Grommet>,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('renders htmlFor', () => {
   const component = renderer.create(
     <Grommet>

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -642,3 +642,52 @@ exports[`renders label 1`] = `
   </div>
 </div>
 `;
+
+exports[`renders plain 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding: 0px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  />
+</div>
+`;

--- a/src/js/components/FormField/doc.js
+++ b/src/js/components/FormField/doc.js
@@ -42,6 +42,9 @@ export const doc = FormField => {
     pad: PropTypes.bool.description(
       'Whether to add padding to align with the padding of TextInput.',
     ),
+    plain: PropTypes.bool.description(
+      'Whether to render a border around the form field and handle  the focus indicator',
+    ),
     required: PropTypes.bool.description('Whether the field is required.'),
     validate: PropTypes.oneOfType([
       PropTypes.shape({

--- a/src/js/components/FormField/index.d.ts
+++ b/src/js/components/FormField/index.d.ts
@@ -8,6 +8,7 @@ export interface FormFieldProps {
   label?: string | React.ReactNode;
   name?: string;
   pad?: boolean;
+  plain?: boolean;
   // Although Placeholder is not a prop within FormField we Omit the HTML placeholder attribute and replaced with following.
   placeholder?: PlaceHolderType
   required?: boolean;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4853,6 +4853,14 @@ Whether to add padding to align with the padding of TextInput.
 boolean
 \`\`\`
 
+**plain**
+
+Whether to render a border around the form field and handle  the focus indicator
+
+\`\`\`
+boolean
+\`\`\`
+
 **required**
 
 Whether the field is required.

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1969,6 +1969,11 @@ node",
         "name": "pad",
       },
       Object {
+        "description": "Whether to render a border around the form field and handle  the focus indicator",
+        "format": "boolean",
+        "name": "plain",
+      },
+      Object {
         "description": "Whether the field is required.",
         "format": "boolean",
         "name": "required",


### PR DESCRIPTION
Fix: #2975

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
adds plain prop to the formfield component

#### Where should the reviewer start?

formfield

#### What testing has been done on this PR?

added a snapshot and tested manually on storybook

#### How should this be manually tested?

pass plain prop to one of the formfield story

#### Any background context you want to provide?

#### What are the relevant issues?
Fix: #2975
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
compat