### PR TITLE
Allow up/down arrows to navigate within MaskedInput.

### DIFF
--- a/src/js/components/MaskedInput/MaskedInput.js
+++ b/src/js/components/MaskedInput/MaskedInput.js
@@ -314,7 +314,7 @@ class MaskedInput extends Component {
       ...rest
     } = this.props;
     const theme = this.context || propsTheme;
-    const { activeMaskIndex, showDrop } = this.state;
+    const { activeMaskIndex, activeOptionIndex, showDrop } = this.state;
 
     return (
       <StyledMaskedInputContainer plain={plain}>
@@ -369,6 +369,7 @@ class MaskedInput extends Component {
                       this.setState({ activeOptionIndex: index })
                     }
                     onFocus={() => {}}
+                    active={index === activeOptionIndex}
                     hoverIndicator="background"
                   >
                     <Box pad={{ horizontal: 'small', vertical: 'xsmall' }}>

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -113,6 +113,9 @@ exports[`MaskedInput applies custom global.hover theme to options 2`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  background-color: rgba(221,221,221,0.4);
+  color: #444444;
+  color: #000000;
 }
 
 .c0:hover {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Allows users to use up/down arrow keys to navigate within a masked input.

#### Where should the reviewer start?
js/components/MaskedInput/MaskedInput.js

#### What testing has been done on this PR?
Testing has been done in Storybook to ensure changes function correctly.

#### How should this be manually tested?
Storybook can be used as visual reference to make sure the keyboard can be used to achieve expected interactions.

#### Any background context you want to provide?
Previously, when arrow keys were used, the background color of the active option would not change, so the user would not know which element of the drop was selected.

#### What are the relevant issues?
Issue #3225

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Yes, it is backwards compatible.