### PR TITLE
Anchor - deprecation warning

### DIFF
--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -40,6 +40,12 @@ class Anchor extends Component {
       ...rest
     } = this.props;
 
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        `The Anchor component will be deprecated in the upcoming releases. Please use grommet Link component instead. For more info refer to https://github.com/grommet/grommet/issues/3297.`,
+      );
+    }
+
     let coloredIcon = icon;
     if (icon && !icon.props.color) {
       coloredIcon = cloneElement(icon, {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Warns the user via console message that the Anchor component will be replaced with the name Link.
IMO this PR should be merged after PR #3299.

#### What testing has been done on this PR? 
yarn-test and storybook

#### How should this be manually tested?
can see the message on CircleCI log or go to storybook

#### Do the grommet docs need to be updated?
on a separate PR
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible