### PR TITLE
Feat/data table/expanded group keys

### DIFF
--- a/src/js/components/Accordion/README.md
+++ b/src/js/components/Accordion/README.md
@@ -46,8 +46,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Anchor/README.md
+++ b/src/js/components/Anchor/README.md
@@ -47,8 +47,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -45,8 +45,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side. Defaults to `none`.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side. Defaults to `none`.
 
 ```
 none

--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -47,8 +47,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Calendar/README.md
+++ b/src/js/components/Calendar/README.md
@@ -45,8 +45,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Carousel/README.md
+++ b/src/js/components/Carousel/README.md
@@ -45,8 +45,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Chart/README.md
+++ b/src/js/components/Chart/README.md
@@ -43,8 +43,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Clock/README.md
+++ b/src/js/components/Clock/README.md
@@ -43,8 +43,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -47,16 +47,24 @@ class DataTable extends Component {
 
   onToggleGroup = groupValue => () => {
     const { groupState } = this.state;
+    const { groupBy } = this.props;
     const nextGroupState = { ...groupState };
     nextGroupState[groupValue] = {
       ...nextGroupState[groupValue],
       expanded: !nextGroupState[groupValue].expanded,
     };
     this.setState({ groupState: nextGroupState });
+    if (groupBy.onExpand) {
+      const expandedKeys = Object.keys(nextGroupState).filter(
+        k => nextGroupState[k].expanded,
+      );
+      groupBy.onExpand(expandedKeys);
+    }
   };
 
   onToggleGroups = () => {
     const { groupState } = this.state;
+    const { groupBy } = this.props;
     const expanded =
       Object.keys(groupState).filter(k => !groupState[k].expanded).length === 0;
     const nextGroupState = {};
@@ -64,6 +72,12 @@ class DataTable extends Component {
       nextGroupState[k] = { ...groupState[k], expanded: !expanded };
     });
     this.setState({ groupState: nextGroupState });
+    if (groupBy.onExpand) {
+      const expandedKeys = Object.keys(nextGroupState).filter(
+        k => nextGroupState[k].expanded,
+      );
+      groupBy.onExpand(expandedKeys);
+    }
   };
 
   onResize = property => width => {
@@ -125,7 +139,7 @@ class DataTable extends Component {
         {groups ? (
           <GroupedBody
             columns={columns}
-            groupBy={groupBy}
+            groupBy={groupBy.property ? groupBy.property : groupBy}
             groups={groups}
             groupState={groupState}
             primaryProperty={primaryProperty}

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -43,8 +43,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -166,10 +166,19 @@ Array of data objects. Defaults to `[]`.
 
 **groupBy**
 
-Property to group data by.
+Property to group data by. If object is specified
+      'property' is used to group data by, 'expand' accepts array of 
+       group keys that sets expanded groups and 'onExpand' is a function
+       that will be called after expand button is clicked with
+       an array of keys of expanded groups.
 
 ```
 string
+{
+  property: string,
+  expand: [string],
+  onExpand: function
+}
 ```
 
 **onMore**

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -204,4 +204,80 @@ describe('DataTable', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('groupBy property', () => {
+    const { container, getByText } = render(
+      <Grommet>
+        <DataTable
+          columns={[
+            { property: 'a', header: 'A' },
+            { property: 'b', header: 'B' },
+          ]}
+          data={[
+            { a: 'one', b: 1.1 },
+            { a: 'one', b: 1.2 },
+            { a: 'two', b: 2.1 },
+            { a: 'two', b: 2.2 },
+          ]}
+          groupBy={{ property: 'a' }}
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+
+    const headerCell = getByText('A');
+    fireEvent.click(headerCell, {});
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('groupBy expand', () => {
+    const { container } = render(
+      <Grommet>
+        <DataTable
+          columns={[
+            { property: 'a', header: 'A' },
+            { property: 'b', header: 'B' },
+          ]}
+          data={[
+            { a: 'one', b: 1.1 },
+            { a: 'one', b: 1.2 },
+            { a: 'two', b: 2.1 },
+            { a: 'two', b: 2.2 },
+          ]}
+          primaryKey="b"
+          groupBy={{ property: 'a', expand: ['one'] }}
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('groupBy onExpand', () => {
+    const onExpand = jest.fn(groupState => groupState);
+    const { getAllByLabelText } = render(
+      <Grommet>
+        <DataTable
+          columns={[
+            { property: 'a', header: 'A' },
+            { property: 'b', header: 'B' },
+          ]}
+          data={[
+            { a: 'one', b: 1.1 },
+            { a: 'one', b: 1.2 },
+            { a: 'two', b: 2.1 },
+            { a: 'two', b: 2.2 },
+          ]}
+          primaryKey="b"
+          groupBy={{ property: 'a', onExpand }}
+        />
+      </Grommet>,
+    );
+
+    const expandButtons = getAllByLabelText('expand');
+    fireEvent.click(expandButtons[1], {});
+
+    expect(onExpand).toBeCalled();
+    expect(onExpand.mock.results[0].value).toEqual(['one']);
+    expect(onExpand.mock.results[0].value).toMatchSnapshot();
+  });
 });

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -3338,7 +3338,7 @@ exports[`DataTable groupBy property 2`] = `
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 gFEOoP"
+              class="StyledBox-sc-13pk1d4-0 gBySSp"
             >
               <svg
                 aria-label="FormDown"
@@ -3360,7 +3360,7 @@ exports[`DataTable groupBy property 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 folWQp"
+            class="StyledBox-sc-13pk1d4-0 bWDcKd"
           >
             <span
               class="StyledText-sc-1sadyjn-0 fWSbXS"
@@ -3374,7 +3374,7 @@ exports[`DataTable groupBy property 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 folWQp"
+            class="StyledBox-sc-13pk1d4-0 bWDcKd"
           >
             <span
               class="StyledText-sc-1sadyjn-0 fWSbXS"
@@ -3400,7 +3400,7 @@ exports[`DataTable groupBy property 2`] = `
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 emftoK"
+              class="StyledBox-sc-13pk1d4-0 czUhVo"
             >
               <svg
                 aria-label="FormDown"
@@ -3422,7 +3422,7 @@ exports[`DataTable groupBy property 2`] = `
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eAAZJM"
+            class="StyledBox-sc-13pk1d4-0 gUuXiG"
           >
             <span
               class="StyledText-sc-1sadyjn-0 fWSbXS"
@@ -3435,7 +3435,7 @@ exports[`DataTable groupBy property 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eAAZJM"
+            class="StyledBox-sc-13pk1d4-0 gUuXiG"
           />
         </td>
       </tr>
@@ -3451,7 +3451,7 @@ exports[`DataTable groupBy property 2`] = `
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 emftoK"
+              class="StyledBox-sc-13pk1d4-0 czUhVo"
             >
               <svg
                 aria-label="FormDown"
@@ -3473,7 +3473,7 @@ exports[`DataTable groupBy property 2`] = `
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eAAZJM"
+            class="StyledBox-sc-13pk1d4-0 gUuXiG"
           >
             <span
               class="StyledText-sc-1sadyjn-0 fWSbXS"
@@ -3486,7 +3486,7 @@ exports[`DataTable groupBy property 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eAAZJM"
+            class="StyledBox-sc-13pk1d4-0 gUuXiG"
           />
         </td>
       </tr>

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2063,6 +2063,1438 @@ exports[`DataTable groupBy 2`] = `
 </div>
 `;
 
+exports[`DataTable groupBy expand 1`] = `
+.c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: rgba(0,0,0,0.33);
+  stroke: rgba(0,0,0,0.33);
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+  padding: 6px;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 6px;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+  padding: 6px;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  background: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 6px;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c9 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  vertical-align: bottom;
+}
+
+.c13 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+}
+
+.c5 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  width: 48px;
+  max-width: 48px;
+  overflow: hidden;
+  vertical-align: top;
+}
+
+.c17 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  width: 48px;
+  max-width: 48px;
+  overflow: hidden;
+  vertical-align: bottom;
+}
+
+.c4 {
+  height: 100%;
+}
+
+.c2 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c6 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c6:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #444444;
+  color: #000000;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  height: 100%;
+}
+
+.c3:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #444444;
+  color: #000000;
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c16 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c16 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c16 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c15 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c15 {
+    padding: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c12 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c12 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c12 {
+    padding: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c18 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c18 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c18 {
+    padding: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c19 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c19 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c19 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c19 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c2 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class="c3 c4"
+      >
+        <td
+          class="c5"
+        >
+          <button
+            aria-label="expand"
+            class="c6"
+            type="button"
+          >
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <polyline
+                  fill="none"
+                  points="18 9 12 15 6 9"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </button>
+        </td>
+        <th
+          class="c9"
+          scope="col"
+        >
+          <div
+            class="c10"
+          >
+            <span
+              class="c11"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c9"
+          scope="col"
+        >
+          <div
+            class="c10"
+          >
+            <span
+              class="c11"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class=""
+    >
+      <tr
+        class="c3 c4"
+      >
+        <td
+          class="c5"
+        >
+          <button
+            aria-label="collapse"
+            class="c6"
+            type="button"
+          >
+            <div
+              class="c12"
+            >
+              <svg
+                aria-label="FormUp"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <polyline
+                  fill="none"
+                  points="18 9 12 15 6 9"
+                  stroke="#000"
+                  stroke-width="2"
+                  transform="matrix(1 0 0 -1 0 24)"
+                />
+              </svg>
+            </div>
+          </button>
+        </td>
+        <th
+          class="c13"
+          scope="row"
+        >
+          <div
+            class="c14"
+          >
+            <span
+              class="c11"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c13"
+        >
+          <div
+            class="c14"
+          />
+        </td>
+      </tr>
+      <tr
+        class="c3 c4"
+      >
+        <td
+          class="c5"
+        >
+          <div
+            class="c15"
+          />
+        </td>
+        <td
+          class="c13"
+        >
+          <div
+            class="c16"
+          >
+            <span
+              class="c11"
+            >
+              one
+            </span>
+          </div>
+        </td>
+        <td
+          class="c13"
+        >
+          <div
+            class="c16"
+          >
+            <span
+              class="c11"
+            >
+              1.1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="c3 c4"
+      >
+        <td
+          class="c17"
+        >
+          <div
+            class="c18"
+          />
+        </td>
+        <td
+          class="c13"
+        >
+          <div
+            class="c19"
+          >
+            <span
+              class="c11"
+            >
+              one
+            </span>
+          </div>
+        </td>
+        <td
+          class="c13"
+        >
+          <div
+            class="c19"
+          >
+            <span
+              class="c11"
+            >
+              1.2
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="c3 c4"
+      >
+        <td
+          class="c5"
+        >
+          <button
+            aria-label="expand"
+            class="c6"
+            type="button"
+          >
+            <div
+              class="c15"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <polyline
+                  fill="none"
+                  points="18 9 12 15 6 9"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </button>
+        </td>
+        <th
+          class="c13"
+          scope="row"
+        >
+          <div
+            class="c16"
+          >
+            <span
+              class="c11"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c13"
+        >
+          <div
+            class="c16"
+          />
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable groupBy onExpand 1`] = `
+Array [
+  "one",
+]
+`;
+
+exports[`DataTable groupBy property 1`] = `
+.c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: rgba(0,0,0,0.33);
+  stroke: rgba(0,0,0,0.33);
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+  padding: 6px;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 6px;
+}
+
+.c9 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  vertical-align: bottom;
+}
+
+.c13 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+}
+
+.c5 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  width: 48px;
+  max-width: 48px;
+  overflow: hidden;
+  vertical-align: top;
+}
+
+.c4 {
+  height: 100%;
+}
+
+.c2 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c6 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c6:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #444444;
+  color: #000000;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  height: 100%;
+}
+
+.c3:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #444444;
+  color: #000000;
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c12 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c12 {
+    padding: 3px;
+  }
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c2 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class="c3 c4"
+      >
+        <td
+          class="c5"
+        >
+          <button
+            aria-label="expand"
+            class="c6"
+            type="button"
+          >
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <polyline
+                  fill="none"
+                  points="18 9 12 15 6 9"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </button>
+        </td>
+        <th
+          class="c9"
+          scope="col"
+        >
+          <div
+            class="c10"
+          >
+            <span
+              class="c11"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c9"
+          scope="col"
+        >
+          <div
+            class="c10"
+          >
+            <span
+              class="c11"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class=""
+    >
+      <tr
+        class="c3 c4"
+      >
+        <td
+          class="c5"
+        >
+          <button
+            aria-label="expand"
+            class="c6"
+            type="button"
+          >
+            <div
+              class="c12"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <polyline
+                  fill="none"
+                  points="18 9 12 15 6 9"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </button>
+        </td>
+        <th
+          class="c13"
+          scope="row"
+        >
+          <div
+            class="c14"
+          >
+            <span
+              class="c11"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c13"
+        >
+          <div
+            class="c14"
+          />
+        </td>
+      </tr>
+      <tr
+        class="c3 c4"
+      >
+        <td
+          class="c5"
+        >
+          <button
+            aria-label="expand"
+            class="c6"
+            type="button"
+          >
+            <div
+              class="c12"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <polyline
+                  fill="none"
+                  points="18 9 12 15 6 9"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </button>
+        </td>
+        <th
+          class="c13"
+          scope="row"
+        >
+          <div
+            class="c14"
+          >
+            <span
+              class="c11"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c13"
+        >
+          <div
+            class="c14"
+          />
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable groupBy property 2`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 eUfLDp"
+>
+  <table
+    class="StyledDataTable-xrlyjm-0 tpKnu StyledTable-sc-1m3u5g-6 fGUmP"
+  >
+    <thead
+      class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 gtdqEW StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
+    >
+      <tr
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 dBBtdf StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+      >
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezoiKY"
+        >
+          <button
+            aria-label="expand"
+            class="StyledButton-sc-323bzc-0 gSzznR"
+            type="button"
+          >
+            <div
+              class="StyledBox-sc-13pk1d4-0 gFEOoP"
+            >
+              <svg
+                aria-label="FormDown"
+                class="StyledIcon-ofa7kd-0 eoTmgW"
+                viewBox="0 0 24 24"
+              >
+                <polyline
+                  fill="none"
+                  points="18 9 12 15 6 9"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </button>
+        </td>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hNAgVv"
+          scope="col"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 folWQp"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fWSbXS"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hNAgVv"
+          scope="col"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 folWQp"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fWSbXS"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="StyledDataTable__StyledDataTableBody-xrlyjm-2 bFXxPv StyledTable__StyledTableBody-sc-1m3u5g-3 dwInxx"
+    >
+      <tr
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 dBBtdf StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+      >
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezoiKY"
+        >
+          <button
+            aria-label="expand"
+            class="StyledButton-sc-323bzc-0 gSzznR"
+            type="button"
+          >
+            <div
+              class="StyledBox-sc-13pk1d4-0 emftoK"
+            >
+              <svg
+                aria-label="FormDown"
+                class="StyledIcon-ofa7kd-0 eoTmgW"
+                viewBox="0 0 24 24"
+              >
+                <polyline
+                  fill="none"
+                  points="18 9 12 15 6 9"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </button>
+        </td>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
+          scope="row"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 eAAZJM"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fWSbXS"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 eAAZJM"
+          />
+        </td>
+      </tr>
+      <tr
+        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 dBBtdf StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+      >
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezoiKY"
+        >
+          <button
+            aria-label="expand"
+            class="StyledButton-sc-323bzc-0 gSzznR"
+            type="button"
+          >
+            <div
+              class="StyledBox-sc-13pk1d4-0 emftoK"
+            >
+              <svg
+                aria-label="FormDown"
+                class="StyledIcon-ofa7kd-0 eoTmgW"
+                viewBox="0 0 24 24"
+              >
+                <polyline
+                  fill="none"
+                  points="18 9 12 15 6 9"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </button>
+        </td>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
+          scope="row"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 eAAZJM"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fWSbXS"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ezepRo"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 eAAZJM"
+          />
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`DataTable paths 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/DataTable/buildState.js
+++ b/src/js/components/DataTable/buildState.js
@@ -152,22 +152,27 @@ const groupData = (nextProps, prevState, nextState) => {
 
   let groups;
   let groupState;
+  let expandedState;
   if (groupBy) {
     groups = [];
     groupState = {};
     const groupMap = {};
     data.forEach(datum => {
-      const groupValue = datumValue(datum, groupBy);
+      const groupByProperty = groupBy.property ? groupBy.property : groupBy;
+      const groupValue = datumValue(datum, groupByProperty);
       if (!groupMap[groupValue]) {
         const group = { data: [], datum: {}, key: groupValue };
-        group.datum[groupBy] = groupValue;
+        group.datum[groupByProperty] = groupValue;
         groups.push(group);
-        groupState[groupValue] = {
-          expanded:
+        if (groupBy.expand) {
+          expandedState = groupBy.expand.some(key => key === groupValue);
+        } else {
+          expandedState =
             prevState.groupState && prevState.groupState[groupValue]
               ? prevState.groupState[groupValue].expanded
-              : false,
-        };
+              : false;
+        }
+        groupState[groupValue] = { expanded: expandedState };
         groupMap[groupValue] = group;
       }
       groupMap[groupValue].data.push(datum);

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -56,7 +56,18 @@ export const doc = DataTable => {
     data: PropTypes.arrayOf(PropTypes.shape({})).description(
       'Array of data objects.',
     ),
-    groupBy: PropTypes.string.description('Property to group data by.'),
+    groupBy: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        property: PropTypes.string,
+        expand: PropTypes.arrayOf(PropTypes.string),
+        onExpand: PropTypes.func,
+      }),
+    ]).description(`Property to group data by. If object is specified
+      'property' is used to group data by, 'expand' accepts array of 
+       group keys that sets expanded groups and 'onExpand' is a function
+       that will be called after expand button is clicked with
+       an array of keys of expanded groups.`),
     onMore: PropTypes.func.description(
       `Use this to indicate that 'data' doesn't contain all that it could.
       It will be called when all of the data rows have been rendered.

--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -8,7 +8,7 @@ export interface DataTableProps {
   margin?: MarginType;
   columns?: {align?: "center" | "start" | "end",aggregate?: "avg" | "max" | "min" | "sum",footer?: React.ReactNode | {aggregate?: boolean},header?: string | React.ReactNode | {aggregate?: boolean},primary?: boolean,property: string,render?: ((...args: any[]) => any),search?: boolean,sortable?: boolean}[];
   data?: {}[];
-  groupBy?: string;
+  groupBy?: string | { property: string, expand: Array<string>, onExpand: ((...args: any[]) => any) };
   onMore?: ((...args: any[]) => any);
   onSearch?: ((...args: any[]) => any);
   primaryKey?: string;

--- a/src/js/components/DataTable/stories/datatable.stories.js
+++ b/src/js/components/DataTable/stories/datatable.stories.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, DataTable, Meter, Text, CheckBox } from 'grommet';
@@ -186,6 +186,29 @@ const GroupedDataTable = () => (
   </Grommet>
 );
 
+class ControlledGroupedDataTable extends Component {
+  state = { expandedGroups: [DATA[2].location] };
+
+  render() {
+    const { expandedGroups } = this.state;
+    return (
+      <Grommet theme={grommet}>
+        <DataTable
+          columns={groupColumns}
+          data={DATA}
+          groupBy={{
+            property: 'location',
+            expand: expandedGroups,
+            onExpand: groupState =>
+              this.setState({ expandedGroups: groupState }),
+          }}
+          sortable
+        />
+      </Grommet>
+    );
+  }
+}
+
 const ServedDataTable = () => {
   const [data2, setData2] = React.useState(DATA);
 
@@ -284,5 +307,6 @@ storiesOf('DataTable', module)
   .add('Sized', () => <SizedDataTable />)
   .add('Tunable', () => <TunableDataTable />)
   .add('Grouped', () => <GroupedDataTable />)
+  .add('Controlled grouped', () => <ControlledGroupedDataTable />)
   .add('Served', () => <ServedDataTable />)
   .add('Controlled', () => <ControlledDataTable />);

--- a/src/js/components/Distribution/README.md
+++ b/src/js/components/Distribution/README.md
@@ -47,8 +47,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/DropButton/README.md
+++ b/src/js/components/DropButton/README.md
@@ -47,8 +47,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -3,8 +3,8 @@ import React, { Children, cloneElement, Component } from 'react';
 import { compose } from 'recompose';
 import styled, { withTheme } from 'styled-components';
 
-import { defaultProps } from '../../default-props';
 import { parseMetricToNum } from '../../utils';
+import { defaultProps } from '../../default-props';
 import { Box } from '../Box';
 import { CheckBox } from '../CheckBox';
 import { Text } from '../Text';
@@ -104,6 +104,7 @@ class FormFieldContent extends Component {
       validate,
       onBlur,
       onFocus,
+      margin,
     } = this.props;
     const { formField } = theme;
     const { border } = formField;
@@ -131,6 +132,7 @@ class FormFieldContent extends Component {
       borderColor = (border && border.color) || 'border';
     }
     let abut;
+    let abutMargin;
     let outerStyle = style;
 
     if (border) {
@@ -171,15 +173,20 @@ class FormFieldContent extends Component {
         (border.side === 'all' || border.side === 'horizontal' || !border.side);
       if (abut) {
         // marginBottom is set to overlap adjacent fields
-        let marginBottom = '-1px';
-        if (border.size) {
-          marginBottom = `-${parseMetricToNum(
-            theme.global.borderSize[border.size],
-          )}px`;
+        abutMargin = { bottom: '-1px' };
+        if (margin) {
+          abutMargin = margin;
+        } else if (border.size) {
+          // if the user defines a margin, then the default margin below will be overriden
+          abutMargin = {
+            bottom: `-${parseMetricToNum(
+              theme.global.borderSize[border.size] || border.size,
+            )}px`,
+          };
         }
+
         outerStyle = {
           position: focus ? 'relative' : undefined,
-          marginBottom,
           zIndex: focus ? 10 : undefined,
           ...style,
         };
@@ -194,7 +201,7 @@ class FormFieldContent extends Component {
             ? { ...border, color: borderColor }
             : undefined
         }
-        margin={abut ? undefined : { ...formField.margin }}
+        margin={abut ? abutMargin : margin || { ...formField.margin }}
         style={outerStyle}
       >
         {(label && component !== CheckBox) || help ? (

--- a/src/js/components/FormField/README.md
+++ b/src/js/components/FormField/README.md
@@ -66,6 +66,73 @@ The name of the value data when in a Form and the name of
 string
 ```
 
+**margin**
+
+The amount of margin around the component. An object can
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **pad**
 
 Whether to add padding to align with the padding of TextInput.

--- a/src/js/components/FormField/__tests__/FormField-test.js
+++ b/src/js/components/FormField/__tests__/FormField-test.js
@@ -64,6 +64,82 @@ test('renders htmlFor', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('renders custom margin', () => {
+  const component = renderer.create(
+    <Grommet>
+      <FormField margin="medium" />
+    </Grommet>,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('forces empty margin', () => {
+  const component = renderer.create(
+    <Grommet>
+      <FormField margin="none" />
+    </Grommet>,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('renders abut correctly', () => {
+  const component = renderer.create(
+    <Grommet
+      theme={{
+        formField: {
+          border: {
+            color: 'border',
+            error: {
+              color: {
+                dark: 'white',
+                light: 'status-critical',
+              },
+            },
+            size: 'large',
+            position: 'outer',
+            side: 'all',
+          },
+          margin: { bottom: 'small' },
+        },
+      }}
+    >
+      <FormField htmlFor="test-id" />
+    </Grommet>,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('renders abut with forced margin', () => {
+  const component = renderer.create(
+    <Grommet
+      theme={{
+        formField: {
+          border: {
+            color: 'border',
+            error: {
+              color: {
+                dark: 'white',
+                light: 'status-critical',
+              },
+            },
+            size: 'large',
+            position: 'outer',
+            side: 'all',
+          },
+          margin: { bottom: 'small' },
+        },
+      }}
+    >
+      <FormField margin="medium" htmlFor="test-id" />
+    </Grommet>,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('renders custom formfield', () => {
   const component = renderer.create(
     <Grommet>

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -1,5 +1,94 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`forces empty margin 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding: 0px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    />
+  </div>
+</div>
+`;
+
 exports[`renders 1`] = `
 .c0 {
   font-size: 18px;
@@ -153,6 +242,196 @@ exports[`renders 1`] = `
 </div>
 `;
 
+exports[`renders abut correctly 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin-bottom: -12px;
+  border: solid 12px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin-bottom: -12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    border: solid 6px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding: 0px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+    style={
+      Object {
+        "position": undefined,
+        "zIndex": undefined,
+      }
+    }
+  >
+    <div
+      className="c2"
+    />
+  </div>
+</div>
+`;
+
+exports[`renders abut with forced margin 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 24px;
+  border: solid 12px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    border: solid 6px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding: 0px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+    style={
+      Object {
+        "position": undefined,
+        "zIndex": undefined,
+      }
+    }
+  >
+    <div
+      className="c2"
+    />
+  </div>
+</div>
+`;
+
 exports[`renders custom formfield 1`] = `
 .c0 {
   font-size: 18px;
@@ -241,6 +520,95 @@ exports[`renders custom formfield 1`] = `
   >
     <div
       className="c3"
+    />
+  </div>
+</div>
+`;
+
+exports[`renders custom margin 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 24px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0px;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding: 0px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
     />
   </div>
 </div>

--- a/src/js/components/FormField/doc.js
+++ b/src/js/components/FormField/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { getAvailableAtBadge } from '../../utils';
+import { getAvailableAtBadge, marginProp } from '../../utils';
 
 export const doc = FormField => {
   const DocumentedFormField = describe(FormField)
@@ -39,6 +39,7 @@ export const doc = FormField => {
       `The name of the value data when in a Form and the name of
       the input field.`,
     ),
+    margin: marginProp,
     pad: PropTypes.bool.description(
       'Whether to add padding to align with the padding of TextInput.',
     ),

--- a/src/js/components/FormField/index.d.ts
+++ b/src/js/components/FormField/index.d.ts
@@ -1,11 +1,12 @@
 import * as React from "react";
-import { Omit, PlaceHolderType } from "../../utils";
+import { Omit, PlaceHolderType, MarginType } from "../../utils";
 
 export interface FormFieldProps {
   error?: string | React.ReactNode;
   help?: string | React.ReactNode;
   htmlFor?: string;
   label?: string | React.ReactNode;
+  margin?: MarginType;
   name?: string;
   pad?: boolean;
   // Although Placeholder is not a prop within FormField we Omit the HTML placeholder attribute and replaced with following.

--- a/src/js/components/Grid/README.md
+++ b/src/js/components/Grid/README.md
@@ -48,8 +48,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Heading/README.md
+++ b/src/js/components/Heading/README.md
@@ -43,8 +43,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Image/README.md
+++ b/src/js/components/Image/README.md
@@ -43,8 +43,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Menu/README.md
+++ b/src/js/components/Menu/README.md
@@ -49,8 +49,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Meter/README.md
+++ b/src/js/components/Meter/README.md
@@ -43,8 +43,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Paragraph/README.md
+++ b/src/js/components/Paragraph/README.md
@@ -43,8 +43,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -43,8 +43,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Stack/README.md
+++ b/src/js/components/Stack/README.md
@@ -47,8 +47,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Table/README.md
+++ b/src/js/components/Table/README.md
@@ -43,8 +43,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Tabs/README.md
+++ b/src/js/components/Tabs/README.md
@@ -46,8 +46,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Text/README.md
+++ b/src/js/components/Text/README.md
@@ -43,8 +43,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/Video/README.md
+++ b/src/js/components/Video/README.md
@@ -43,8 +43,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/WorldMap/README.md
+++ b/src/js/components/WorldMap/README.md
@@ -43,8 +43,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 ```
 none

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -50,8 +50,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -314,8 +314,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -641,8 +641,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side. Defaults to \`none\`.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side. Defaults to \`none\`.
 
 \`\`\`
 none
@@ -1461,8 +1461,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -1987,8 +1987,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -2472,8 +2472,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -2718,8 +2718,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -3344,8 +3344,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -3739,8 +3739,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -4291,8 +4291,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -4660,8 +4660,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -4960,6 +4960,73 @@ The name of the value data when in a Form and the name of
 string
 \`\`\`
 
+**margin**
+
+The amount of margin around the component. An object can
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **pad**
 
 Whether to add padding to align with the padding of TextInput.
@@ -5186,8 +5253,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -5693,8 +5760,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -6013,8 +6080,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -6889,8 +6956,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -7190,8 +7257,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -7456,8 +7523,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -8406,8 +8473,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -9016,8 +9083,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -9335,8 +9402,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -9812,8 +9879,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -10083,8 +10150,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -10970,8 +11037,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none
@@ -11179,8 +11246,8 @@ string
 **margin**
 
 The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
 
 \`\`\`
 none

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -3862,10 +3862,19 @@ Array of data objects. Defaults to \`[]\`.
 
 **groupBy**
 
-Property to group data by.
+Property to group data by. If object is specified
+      'property' is used to group data by, 'expand' accepts array of 
+       group keys that sets expanded groups and 'onExpand' is a function
+       that will be called after expand button is clicked with
+       an array of keys of expanded groups.
 
 \`\`\`
 string
+{
+  property: string,
+  expand: [string],
+  onExpand: function
+}
 \`\`\`
 
 **onMore**

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -63,8 +63,8 @@ stretch",
       },
       Object {
         "description": "The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.",
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.",
         "format": "none
 xxsmall
 xsmall
@@ -233,8 +233,8 @@ stretch",
       Object {
         "defaultValue": "none",
         "description": "The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.",
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.",
         "format": "none
 xxsmall
 xsmall
@@ -804,8 +804,8 @@ stretch",
       },
       Object {
         "description": "The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.",
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.",
         "format": "none
 xxsmall
 xsmall
@@ -1058,8 +1058,8 @@ stretch",
       },
       Object {
         "description": "The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.",
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.",
         "format": "none
 xxsmall
 xsmall
@@ -1284,8 +1284,8 @@ stretch",
       },
       Object {
         "description": "The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.",
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.",
         "format": "none
 xxsmall
 xsmall
@@ -1415,8 +1415,8 @@ stretch",
       },
       Object {
         "description": "The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.",
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.",
         "format": "none
 xxsmall
 xsmall
@@ -1822,8 +1822,8 @@ stretch",
       },
       Object {
         "description": "The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.",
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.",
         "format": "none
 xxsmall
 xsmall
@@ -2025,6 +2025,70 @@ node",
         "name": "name",
       },
       Object {
+        "description": "The amount of margin around the component. An object can
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.",
+        "format": "none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string",
+        "name": "margin",
+      },
+      Object {
         "description": "Whether to add padding to align with the padding of TextInput.",
         "format": "boolean",
         "name": "pad",
@@ -2182,8 +2246,8 @@ stretch",
       },
       Object {
         "description": "The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.",
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.",
         "format": "none
 xxsmall
 xsmall
@@ -2697,8 +2761,8 @@ stretch",
       },
       Object {
         "description": "The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.",
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.",
         "format": "none
 xxsmall
 xsmall
@@ -3134,8 +3198,8 @@ stretch",
       },
       Object {
         "description": "The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.",
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.",
         "format": "none
 xxsmall
 xsmall
@@ -3522,8 +3586,8 @@ stretch",
       },
       Object {
         "description": "The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.",
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.",
         "format": "none
 xxsmall
 xsmall
@@ -3656,8 +3720,8 @@ stretch",
       },
       Object {
         "description": "The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.",
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.",
         "format": "none
 xxsmall
 xsmall

--- a/src/js/utils/prop-types.js
+++ b/src/js/utils/prop-types.js
@@ -29,6 +29,36 @@ const MARGIN_SIZES = [
   'xlarge',
 ];
 
+export const marginProp = PropTypes.oneOfType([
+  PropTypes.oneOf(['none', ...MARGIN_SIZES]),
+  PropTypes.shape({
+    bottom: PropTypes.oneOfType([
+      PropTypes.oneOf(MARGIN_SIZES),
+      PropTypes.string,
+    ]),
+    horizontal: PropTypes.oneOfType([
+      PropTypes.oneOf(MARGIN_SIZES),
+      PropTypes.string,
+    ]),
+    left: PropTypes.oneOfType([
+      PropTypes.oneOf(MARGIN_SIZES),
+      PropTypes.string,
+    ]),
+    right: PropTypes.oneOfType([
+      PropTypes.oneOf(MARGIN_SIZES),
+      PropTypes.string,
+    ]),
+    top: PropTypes.oneOfType([PropTypes.oneOf(MARGIN_SIZES), PropTypes.string]),
+    vertical: PropTypes.oneOfType([
+      PropTypes.oneOf(MARGIN_SIZES),
+      PropTypes.string,
+    ]),
+  }),
+  PropTypes.string,
+]).description(`The amount of margin around the component. An object can
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.`);
+
 export const genericProps = {
   a11yTitle: a11yTitlePropType,
   alignSelf: PropTypes.oneOf(['start', 'center', 'end', 'stretch'])
@@ -36,36 +66,5 @@ export const genericProps = {
       a Box or along the column axis when contained in a Grid.`),
   gridArea: PropTypes.string.description(`The name of the area to place
     this inside a parent Grid.`),
-  margin: PropTypes.oneOfType([
-    PropTypes.oneOf(['none', ...MARGIN_SIZES]),
-    PropTypes.shape({
-      bottom: PropTypes.oneOfType([
-        PropTypes.oneOf(MARGIN_SIZES),
-        PropTypes.string,
-      ]),
-      horizontal: PropTypes.oneOfType([
-        PropTypes.oneOf(MARGIN_SIZES),
-        PropTypes.string,
-      ]),
-      left: PropTypes.oneOfType([
-        PropTypes.oneOf(MARGIN_SIZES),
-        PropTypes.string,
-      ]),
-      right: PropTypes.oneOfType([
-        PropTypes.oneOf(MARGIN_SIZES),
-        PropTypes.string,
-      ]),
-      top: PropTypes.oneOfType([
-        PropTypes.oneOf(MARGIN_SIZES),
-        PropTypes.string,
-      ]),
-      vertical: PropTypes.oneOfType([
-        PropTypes.oneOf(MARGIN_SIZES),
-        PropTypes.string,
-      ]),
-    }),
-    PropTypes.string,
-  ]).description(`The amount of margin around the component. An object can
-      be specified to distinguish horizontal margin, vertical margin, and
-      margin on a particular side.`),
+  margin: marginProp,
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Added the ability to set expanded groups by default via expandedGroupKeys prop.
Added onToggle event handler that passes groupState
Resolves issue [#3302](https://github.com/grommet/grommet/issues/3302)

#### Where should the reviewer start?
DataTable/index.d.ts

#### What testing has been done on this PR?
Tested manually.
2 tests where added to DataTable-test

#### How should this be manually tested?
use the storybook

#### Any background context you want to provide?

#### What are the relevant issues?
[#3302](https://github.com/grommet/grommet/issues/3302)

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes

#### Should this PR be mentioned in the release notes?
yes

#### Is this change backwards compatible or is it a breaking change?
non-breaking
