### PR TITLE
Changed Layer to un-animate on exit

### DIFF
--- a/src/js/components/Layer/Layer.js
+++ b/src/js/components/Layer/Layer.js
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom';
 import { getNewContainer } from '../../utils';
 
 import { LayerContainer } from './LayerContainer';
+import { animationDuration } from './StyledLayer';
 
 class Layer extends Component {
   static defaultProps = {
@@ -58,7 +59,7 @@ class Layer extends Component {
         // we add the id and query here so the unit tests work
         const clone = document.getElementById('layerClone');
         if (clone) document.body.removeChild(clone);
-      }, 200); // matches 0.2s in StyledLayer.getAnimationStyle()
+      }, animationDuration);
     }
   }
 

--- a/src/js/components/Layer/Layer.js
+++ b/src/js/components/Layer/Layer.js
@@ -54,7 +54,7 @@ class Layer extends Component {
       const clonedContainer = layerClone.querySelector(
         '[class^="StyledLayer__StyledContainer"]',
       );
-      clonedContainer.style = 'animation-direction: reverse';
+      clonedContainer.style.animationDirection = 'reverse';
       setTimeout(() => {
         // we add the id and query here so the unit tests work
         const clone = document.getElementById('layerClone');

--- a/src/js/components/Layer/Layer.js
+++ b/src/js/components/Layer/Layer.js
@@ -26,6 +26,7 @@ class Layer extends Component {
   }
 
   componentWillUnmount() {
+    const { animate, animation } = this.props;
     if (this.originalFocusedElement) {
       if (this.originalFocusedElement.focus) {
         // wait for the fixed positioning to come back to normal
@@ -41,7 +42,24 @@ class Layer extends Component {
         this.originalFocusedElement.parentNode.focus();
       }
     }
-    document.body.removeChild(this.layerContainer);
+
+    const activeAnimation = animation !== undefined ? animation : animate;
+    if (activeAnimation !== false) {
+      // undefined still has fadeIn
+      // animate out and remove later
+      const layerClone = this.layerContainer.cloneNode(true);
+      layerClone.id = 'layerClone';
+      document.body.appendChild(layerClone);
+      const clonedContainer = layerClone.querySelector(
+        '[class^="StyledLayer__StyledContainer"]',
+      );
+      clonedContainer.style = 'animation-direction: reverse';
+      setTimeout(() => {
+        // we add the id and query here so the unit tests work
+        const clone = document.getElementById('layerClone');
+        if (clone) document.body.removeChild(clone);
+      }, 200); // matches 0.2s in StyledLayer.getAnimationStyle()
+    }
   }
 
   render() {

--- a/src/js/components/Layer/Layer.js
+++ b/src/js/components/Layer/Layer.js
@@ -46,7 +46,7 @@ class Layer extends Component {
 
     const activeAnimation = animation !== undefined ? animation : animate;
     if (activeAnimation !== false) {
-      // undefined still has fadeIn
+      // undefined uses 'slide' as the default
       // animate out and remove later
       const layerClone = this.layerContainer.cloneNode(true);
       layerClone.id = 'layerClone';

--- a/src/js/components/Layer/README.md
+++ b/src/js/components/Layer/README.md
@@ -25,7 +25,7 @@ boolean
 
 **animation**
 
-Animation transition of the Layer content when it opens. Defaults to `slide`.
+Animation transition of the Layer content when it opens and closes. Defaults to `slide`.
 
 ```
 slide

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -197,6 +197,8 @@ const KEYFRAMES = {
   },
 };
 
+const animationDuration = 200;
+
 const getAnimationStyle = (props, position, full) => {
   let animation =
     props.animation !== undefined ? props.animation : props.animate;
@@ -209,7 +211,7 @@ const getAnimationStyle = (props, position, full) => {
   }
   return keys
     ? css`
-        animation: ${keys} 0.2s ease-in-out forwards;
+        animation: ${keys} ${animationDuration / 1000.0}s ease-in-out forwards;
       `
     : '';
 };
@@ -565,4 +567,4 @@ const StyledContainer = styled.div`
 StyledContainer.defaultProps = {};
 Object.setPrototypeOf(StyledContainer.defaultProps, defaultProps);
 
-export { StyledLayer, StyledOverlay, StyledContainer };
+export { animationDuration, StyledLayer, StyledOverlay, StyledContainer };

--- a/src/js/components/Layer/__tests__/Layer-test.js
+++ b/src/js/components/Layer/__tests__/Layer-test.js
@@ -183,7 +183,7 @@ describe('Layer', () => {
     expect(onEsc).toBeCalled();
   });
 
-  test('is accessible', () => {
+  test('is accessible', done => {
     /* eslint-disable jsx-a11y/tabindex-no-positive */
     render(
       <Grommet>
@@ -204,9 +204,13 @@ describe('Layer', () => {
     expect(layerNode).toMatchSnapshot();
 
     fireEvent.keyDown(inputNode, { key: 'Esc', keyCode: 27, which: 27 });
+    // because of de-animation, we test both the initial and delayed states
     bodyNode = getByTestId(document, 'test-body-node');
     expect(bodyNode).toMatchSnapshot();
-    expect(queryByTestId(document, 'test-layer-node')).toBeNull();
+    setTimeout(() => {
+      expect(queryByTestId(document, 'test-layer-node')).toBeNull();
+      done();
+    }, 300);
   });
 
   test('should be null prior to mounting, displayed after mount', () => {

--- a/src/js/components/Layer/doc.js
+++ b/src/js/components/Layer/doc.js
@@ -30,7 +30,9 @@ export const doc = Layer => {
       PropTypes.oneOf(['slide', 'fadeIn', 'none']),
       PropTypes.bool,
     ])
-      .description('Animation transition of the Layer content when it opens.')
+      .description(
+        'Animation transition of the Layer content when it opens and closes.',
+      )
       .defaultValue('slide'),
     full: PropTypes.oneOfType([
       PropTypes.bool,

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -6263,7 +6263,7 @@ boolean
 
 **animation**
 
-Animation transition of the Layer content when it opens. Defaults to \`slide\`.
+Animation transition of the Layer content when it opens and closes. Defaults to \`slide\`.
 
 \`\`\`
 slide


### PR DESCRIPTION
#### What does this PR do?

Changed Layer to un-animate on exit.

The trick in this is that it clones the DOM element before unmounting it, reverses the animation, and starts a timer to remove the clone when the animation ends.

#### Where should the reviewer start?

Layer.js

#### What testing has been done on this PR?

Center and Notification Layer stories on Safari, Chrome, and Firefox

#### How should this be manually tested?

more flavors and browsers

#### What are the relevant issues?

#2387 

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
