### PR TITLE
Changed DataTable to allow columns properties to traverse data object properties

### DIFF
--- a/src/js/components/DataTable/Cell.js
+++ b/src/js/components/DataTable/Cell.js
@@ -7,6 +7,7 @@ import { defaultProps } from '../../default-props';
 
 import { TableCell } from '../TableCell';
 import { Text } from '../Text';
+import { datumValue } from './buildState';
 
 const Cell = ({
   column: { align, property, render },
@@ -19,8 +20,11 @@ const Cell = ({
   let content;
   if (render) {
     content = render(datum);
-  } else if (datum[property] !== undefined) {
-    content = datum[property];
+  } else {
+    const value = datumValue(datum, property);
+    if (value !== undefined) {
+      content = value;
+    }
   }
 
   if (typeof content === 'string' || typeof content === 'number') {

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -35,6 +35,22 @@ describe('DataTable', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  test('paths', () => {
+    const component = renderer.create(
+      <Grommet>
+        <DataTable
+          columns={[
+            { property: 'a', header: 'A' },
+            { property: 'b.c', header: 'B' },
+          ]}
+          data={[{ a: 'one', b: { c: 1 } }, { a: 'two', b: { c: 2 } }]}
+        />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   test('primaryKey', () => {
     const component = renderer.create(
       <Grommet>

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -1700,6 +1700,276 @@ exports[`DataTable groupBy 2`] = `
 </div>
 `;
 
+exports[`DataTable paths 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  vertical-align: bottom;
+}
+
+.c7 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+}
+
+.c3 {
+  height: 100%;
+}
+
+.c2 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  height: 100%;
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c2 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  className="c0"
+>
+  <table
+    className="c1 c2"
+  >
+    <thead
+      className=""
+    >
+      <tr
+        className="c3"
+      >
+        <th
+          className="c4"
+          scope="col"
+        >
+          <div
+            className="c5"
+          >
+            <span
+              className="c6"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          className="c4"
+          scope="col"
+        >
+          <div
+            className="c5"
+          >
+            <span
+              className="c6"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      className=""
+    >
+      <tr
+        className="c3"
+      >
+        <th
+          className="c7"
+          scope="row"
+        >
+          <div
+            className="c8"
+          >
+            <span
+              className="c9"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          className="c7"
+        >
+          <div
+            className="c8"
+          >
+            <span
+              className="c6"
+            >
+              1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        className="c3"
+      >
+        <th
+          className="c7"
+          scope="row"
+        >
+          <div
+            className="c8"
+          >
+            <span
+              className="c9"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          className="c7"
+        >
+          <div
+            className="c8"
+          >
+            <span
+              className="c6"
+            >
+              2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`DataTable primaryKey 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/DataTable/buildState.js
+++ b/src/js/components/DataTable/buildState.js
@@ -1,3 +1,14 @@
+export const datumValue = (datum, property) => {
+  const parts = property.split('.');
+  if (parts.length === 1) {
+    return datum[property];
+  }
+  if (!datum[parts[0]]) {
+    return undefined;
+  }
+  return datumValue(datum[parts[0]], parts.slice(1).join('.'));
+};
+
 const sumReducer = (accumulated, next) => accumulated + next;
 const minReducer = (accumulated, next) =>
   accumulated === undefined ? next : Math.min(accumulated, next);
@@ -13,11 +24,11 @@ const reducers = {
 const aggregateColumn = (column, data) => {
   let value;
   if (column.aggregate === 'avg') {
-    value = data.map(d => d[column.property]).reduce(sumReducer);
+    value = data.map(d => datumValue(d, column.property)).reduce(sumReducer);
     value /= data.length;
   } else {
     value = data
-      .map(d => d[column.property])
+      .map(d => datumValue(d, column.property))
       .reduce(reducers[column.aggregate], 0);
   }
   return value;
@@ -73,7 +84,7 @@ const filter = (nextProps, prevState, nextState) => {
     nextData = data.filter(
       datum =>
         !Object.keys(regexps).some(
-          property => !regexps[property].test(datum[property]),
+          property => !regexps[property].test(datumValue(datum, property)),
         ),
     );
   }
@@ -146,7 +157,7 @@ const groupData = (nextProps, prevState, nextState) => {
     groupState = {};
     const groupMap = {};
     data.forEach(datum => {
-      const groupValue = datum[groupBy];
+      const groupValue = datumValue(datum, groupBy);
       if (!groupMap[groupValue]) {
         const group = { data: [], datum: {}, key: groupValue };
         group.datum[groupBy] = groupValue;


### PR DESCRIPTION
#### What does this PR do?

Changed DataTable to allow columns properties to traverse data object properties.
For example, if a datum is `{ a: { b: 'hi' } }`, then you can do: `columns={[{ property: 'a.b' }]}`.

#### Where should the reviewer start?

buildState.js

#### What testing has been done on this PR?

Added unit test.
Used with new grommet-data in progress.

#### How should this be manually tested?

unit test

#### Any background context you want to provide?

This is part of some DataTable updates coming down the pipe, trickling in in smaller bits.

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
