### PR TITLE
fix(Paragraph): Removes console warning for passing `fill` to `p`

### DIFF
--- a/src/js/components/Paragraph/Paragraph.js
+++ b/src/js/components/Paragraph/Paragraph.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { StyledParagraph } from './StyledParagraph';
 
-const Paragraph = ({ color, ...rest }) => (
-  <StyledParagraph colorProp={color} {...rest} />
+const Paragraph = ({ color, fill, ...rest }) => (
+  <StyledParagraph colorProp={color} fillProp={fill} {...rest} />
 );
 
 let ParagraphDoc;

--- a/src/js/components/Paragraph/StyledParagraph.js
+++ b/src/js/components/Paragraph/StyledParagraph.js
@@ -13,7 +13,7 @@ const sizeStyle = props => {
   return css`
     font-size: ${data.size};
     line-height: ${data.height};
-    max-width: ${props.fill ? 'none' : data.maxWidth};
+    max-width: ${props.fillProp ? 'none' : data.maxWidth};
   `;
 };
 

--- a/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.js.snap
+++ b/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.js.snap
@@ -175,11 +175,9 @@ exports[`Paragraph size renders 1`] = `
   />
   <p
     className="c6"
-    fill={true}
   />
   <p
     className="c2"
-    fill={false}
   />
 </div>
 `;


### PR DESCRIPTION
#### What does this PR do?
In #3222, we added the `fill` property. Styled Components passes all properties through to their DOM children. However, because `fill` isn't in react's `camelCase` format, React assumes this must be a native DOM property and throws a warning ("Received `true` for a non-boolean
attribute `fill`.)

The fix means consuming the `fill` prop on `Paragraph` and converting it to `fillProp` when calling the `StyledParagraph` object. This is similar to the fix we use for `color` / `colorProp`.

#### Where should the reviewer start?
Paragraph & StyledParagraph

#### What testing has been done on this PR?
Relaunched Storybook, checked console, checked tests.

#### How should this be manually tested?
Storybook => Paragraph

#### What are the relevant issues?
#3222 

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards Compatible

**DCO In Commit Log**