### PR TITLE
fix(utils/colors): prevent opacity being ignored when equal to zero

### DIFF
--- a/src/js/utils/colors.js
+++ b/src/js/utils/colors.js
@@ -93,7 +93,7 @@ export const colorIsDark = color => {
 export const getRGBA = (color, opacity) => {
   if (color && canExtractRGBArray(color)) {
     const [red, green, blue] = getRGBArray(color);
-    return `rgba(${red}, ${green}, ${blue}, ${opacity || 1})`;
+    return `rgba(${red}, ${green}, ${blue}, ${typeof opacity === 'number' ? opacity : (opacity || 1)})`;
   }
   return undefined;
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR fixes the `opacity` param of `getRBGA` being ignored when using `0`

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

I discovered this issue when playing with a dynamic background opacity like below:
```jsx
const opacity = myDynamicValueBetweenZeroAndOne;
return <Box background={{ color: 'primary', opacity }} />
```
Had to change it to
```jsx
const opacity = `${myDynamicValueBetweenZeroAndOne * 100}%`;
return <Box background={{ color: 'primary', opacity  }} />
```

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
