### PR TITLE
Escape special characters for stories with regular expressions.

### DIFF
--- a/src/js/components/DataTable/stories/datatable.stories.js
+++ b/src/js/components/DataTable/stories/datatable.stories.js
@@ -222,12 +222,15 @@ const ServedDataTable = () => {
   const onSearch = search => {
     let nextData;
     if (search) {
+      // The function below escapes regular expression special characters
       const escapedText = text => {
         text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
         return new RegExp(escapedText, 'i');
       };
       const expressions = Object.keys(search).map(property => ({
         property,
+        // Create the regular expression with modified value which handles escaping special characters
+        // Without escaping special characters, errors will appear in the console
         exp: new RegExp(escapedText(search[property]), 'i'),
       }));
       nextData = DATA.filter(

--- a/src/js/components/DataTable/stories/datatable.stories.js
+++ b/src/js/components/DataTable/stories/datatable.stories.js
@@ -222,9 +222,13 @@ const ServedDataTable = () => {
   const onSearch = search => {
     let nextData;
     if (search) {
+      const escapedText = text => {
+        text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
+        return new RegExp(escapedText, 'i');
+      };
       const expressions = Object.keys(search).map(property => ({
         property,
-        exp: new RegExp(search[property], 'i'),
+        exp: new RegExp(escapedText(search[property]), 'i'),
       }));
       nextData = DATA.filter(
         d => !expressions.some(e => !e.exp.test(d[e.property])),

--- a/src/js/components/DataTable/stories/datatable.stories.js
+++ b/src/js/components/DataTable/stories/datatable.stories.js
@@ -222,7 +222,7 @@ const ServedDataTable = () => {
   const onSearch = search => {
     let nextData;
     if (search) {
-      // The function below escapes regular expression special characters
+      // The function below escapes regular expression special characters:  [ \ ^ $ . | ? * + ( )
       const escapedText = text => {
         text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
         return new RegExp(escapedText, 'i');

--- a/src/js/components/FormField/stories/TextInput.js
+++ b/src/js/components/FormField/stories/TextInput.js
@@ -14,7 +14,8 @@ class FormFieldTextInput extends Component {
     const {
       target: { value },
     } = event;
-    const exp = new RegExp(value, 'i');
+    const escapedText = value.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
+    const exp = new RegExp(escapedText, 'i');
     const suggestions = allSuggestions.filter(s => exp.test(s));
     this.setState({ value, suggestions });
   };

--- a/src/js/components/FormField/stories/TextInput.js
+++ b/src/js/components/FormField/stories/TextInput.js
@@ -14,7 +14,11 @@ class FormFieldTextInput extends Component {
     const {
       target: { value },
     } = event;
+    // The line below escapes regular expression special characters
     const escapedText = value.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
+
+    // Create the regular expression with modified value which handles escaping special characters
+    // Without escaping special characters, errors will appear in the console
     const exp = new RegExp(escapedText, 'i');
     const suggestions = allSuggestions.filter(s => exp.test(s));
     this.setState({ value, suggestions });

--- a/src/js/components/FormField/stories/TextInput.js
+++ b/src/js/components/FormField/stories/TextInput.js
@@ -14,7 +14,7 @@ class FormFieldTextInput extends Component {
     const {
       target: { value },
     } = event;
-    // The line below escapes regular expression special characters
+    // The line below escapes regular expression special characters:  [ \ ^ $ . | ? * + ( )
     const escapedText = value.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
 
     // Create the regular expression with modified value which handles escaping special characters

--- a/src/js/components/Select/stories/ObjectMultiple.js
+++ b/src/js/components/Select/stories/ObjectMultiple.js
@@ -42,7 +42,7 @@ class ObjectMultiSelect extends Component {
             }
             onClose={() => this.setState({ options: objectOptions })}
             onSearch={text => {
-              // The line below escapes regular expression special characters
+              // The line below escapes regular expression special characters:  [ \ ^ $ . | ? * + ( )
               const escapedText = text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
 
               // Create the regular expression with modified value which handles escaping special characters

--- a/src/js/components/Select/stories/ObjectMultiple.js
+++ b/src/js/components/Select/stories/ObjectMultiple.js
@@ -42,7 +42,8 @@ class ObjectMultiSelect extends Component {
             }
             onClose={() => this.setState({ options: objectOptions })}
             onSearch={text => {
-              const exp = new RegExp(text, 'i');
+              const escapedText = text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
+              const exp = new RegExp(escapedText, 'i');
               this.setState({
                 options: objectOptions.filter(o => exp.test(o.lab)),
               });

--- a/src/js/components/Select/stories/ObjectMultiple.js
+++ b/src/js/components/Select/stories/ObjectMultiple.js
@@ -42,7 +42,11 @@ class ObjectMultiSelect extends Component {
             }
             onClose={() => this.setState({ options: objectOptions })}
             onSearch={text => {
+              // The line below escapes regular expression special characters
               const escapedText = text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
+
+              // Create the regular expression with modified value which handles escaping special characters
+              // Without escaping special characters, errors will appear in the console
               const exp = new RegExp(escapedText, 'i');
               this.setState({
                 options: objectOptions.filter(o => exp.test(o.lab)),

--- a/src/js/components/Select/stories/Search.js
+++ b/src/js/components/Select/stories/Search.js
@@ -35,7 +35,7 @@ class SearchSelect extends Component {
             onChange={({ option }) => this.setState({ value: option })}
             onClose={() => this.setState({ options: defaultOptions })}
             onSearch={text => {
-              // The line below escapes regular expression special characters
+              // The line below escapes regular expression special characters:  [ \ ^ $ . | ? * + ( )
               const escapedText = text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
 
               // Create the regular expression with modified value which handles escaping special characters

--- a/src/js/components/Select/stories/Search.js
+++ b/src/js/components/Select/stories/Search.js
@@ -35,7 +35,8 @@ class SearchSelect extends Component {
             onChange={({ option }) => this.setState({ value: option })}
             onClose={() => this.setState({ options: defaultOptions })}
             onSearch={text => {
-              const exp = new RegExp(text, 'i');
+              const escapedText = text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
+              const exp = new RegExp(escapedText, 'i');
               this.setState({
                 options: defaultOptions.filter(o => exp.test(o)),
               });

--- a/src/js/components/Select/stories/Search.js
+++ b/src/js/components/Select/stories/Search.js
@@ -35,7 +35,11 @@ class SearchSelect extends Component {
             onChange={({ option }) => this.setState({ value: option })}
             onClose={() => this.setState({ options: defaultOptions })}
             onSearch={text => {
+              // The line below escapes regular expression special characters
               const escapedText = text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
+
+              // Create the regular expression with modified value which handles escaping special characters
+              // Without escaping special characters, errors will appear in the console
               const exp = new RegExp(escapedText, 'i');
               this.setState({
                 options: defaultOptions.filter(o => exp.test(o)),

--- a/src/js/components/Select/stories/SimpleMultiSelect.js
+++ b/src/js/components/Select/stories/SimpleMultiSelect.js
@@ -38,7 +38,8 @@ class SimpleMultiSelect extends Component {
             }
             onClose={() => this.setState({ options: defaultOptions })}
             onSearch={text => {
-              const exp = new RegExp(text, 'i');
+              const escapedText = text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
+              const exp = new RegExp(escapedText, 'i');
               this.setState({
                 options: defaultOptions.filter(o => exp.test(o)),
               });

--- a/src/js/components/Select/stories/SimpleMultiSelect.js
+++ b/src/js/components/Select/stories/SimpleMultiSelect.js
@@ -38,7 +38,7 @@ class SimpleMultiSelect extends Component {
             }
             onClose={() => this.setState({ options: defaultOptions })}
             onSearch={text => {
-              // The line below escapes regular expression special characters
+              // The line below escapes regular expression special characters:  [ \ ^ $ . | ? * + ( )
               const escapedText = text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
 
               // Create the regular expression with modified value which handles escaping special characters

--- a/src/js/components/Select/stories/SimpleMultiSelect.js
+++ b/src/js/components/Select/stories/SimpleMultiSelect.js
@@ -38,7 +38,11 @@ class SimpleMultiSelect extends Component {
             }
             onClose={() => this.setState({ options: defaultOptions })}
             onSearch={text => {
+              // The line below escapes regular expression special characters
               const escapedText = text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
+
+              // Create the regular expression with modified value which handles escaping special characters
+              // Without escaping special characters, errors will appear in the console
               const exp = new RegExp(escapedText, 'i');
               this.setState({
                 options: defaultOptions.filter(o => exp.test(o)),


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Escapes special characters that were printing errors to the console in stories that contain regular expressions.

#### Where should the reviewer start?
Any of the story files with changes.

#### What testing has been done on this PR?
Special characters were entered into the text input field of each changed file to ensure no errors were printed regarding invalid regular expressions.

#### How should this be manually tested?
Open the console while engaging with any of the changes stories, and enter any special characters for regular expressions ( [ \ ^ $ . | ? * + ( ) ).

#### Any background context you want to provide?
An error was appearing in the console if a user typed a character that was considered a "special character" by regular expressions.

#### What are the relevant issues?
None. This was just to test the recent release.

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
This change is backwards compatible.