### PR TITLE
Changed onBlur type to match with react focusevent

### DIFF
--- a/src/js/components/MaskedInput/index.d.ts
+++ b/src/js/components/MaskedInput/index.d.ts
@@ -11,7 +11,7 @@ export interface MaskedInputProps {
   }>;
   name?: string;
   onChange?: ((...args: any[]) => any);
-  onBlur?: ((...args: any[]) => any);
+  onBlur?: ((event: React.FocusEvent) => any);
   plain?: boolean;
   size?: "small" | "medium" | "large" | "xlarge" | string;
   value?: string | number;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Update onBlur type to be more specific to the event 
#### Where should the reviewer start?
maskedInput/index.d.ts
#### What testing has been done on this PR?
manually 
#### How should this be manually tested?
write onBlur function in TS app 
#### Any background context you want to provide?
We are using ``` JSX.IntrinsicElements['input'] ``` this includes the 
HTML input elements so we just need to add the react event handling
of focus event
#### What are the relevant issues?
#3165 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible