### PR TITLE
Adjust onSelectPlace type definition

### DIFF
--- a/src/js/components/WorldMap/index.d.ts
+++ b/src/js/components/WorldMap/index.d.ts
@@ -9,7 +9,7 @@ export interface WorldMapProps {
   gridArea?: GridAreaType;
   hoverColor?: string | {dark?: string,light?: string};
   margin?: MarginType;
-  onSelectPlace?: ((...args: any[]) => any);
+  onSelectPlace?: ((place: number[]) => void);
   places?: {color?: string | {dark?: string,light?: string},name?: string,location: number[],onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any)}[];
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This changes the TS definition for onSelectPlace prop from ((...args): any => any) to ((place: number[]) => void).

#### Where should the reviewer start?
src/js/components/WorldMap/index.d.ts

#### What testing has been done on this PR?
Testing has been done in a local TS project. The pattern for WorldMap from the grommet storybook was copied into the local project, and the type definitions were checked. First, I logged the value of the "place" parameter to confirm that is was, in fact, an array of numbers ([latitude, longitude]). Then, I tried breaking it by providing the function with different types such as a string to be sure it would flag this error.

#### How should this be manually tested?
In a project with TS added.

#### Any background context you want to provide?
When TS definitions are "any", it defeats its purpose. In this case, the argument received is an array of numbers (latitude and longitude) for the place coordinates. Therefore, a number array is the prop type. Void is the return type because the function doesn't return anything or get assigned to a variable.

#### What are the relevant issues?
Issue #3165 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.