### PR TITLE
Adjust Keyboard TS Definitions

### DIFF
--- a/src/js/components/Keyboard/index.d.ts
+++ b/src/js/components/Keyboard/index.d.ts
@@ -2,18 +2,18 @@ import * as React from "react";
 
 export interface KeyboardProps {
   target?: "component" | "document";
-  onBackspace?: ((...args: any[]) => any);
-  onComma?: ((...args: any[]) => any);
-  onDown?: ((...args: any[]) => any);
-  onEnter?: ((...args: any[]) => any);
-  onEsc?: ((...args: any[]) => any);
-  onKeyDown?: ((...args: any[]) => any);
-  onLeft?: ((...args: any[]) => any);
-  onRight?: ((...args: any[]) => any);
-  onShift?: ((...args: any[]) => any);
-  onSpace?: ((...args: any[]) => any);
-  onTab?: ((...args: any[]) => any);
-  onUp?: ((...args: any[]) => any);
+  onBackspace?: ((event: React.KeyboardEvent<HTMLElement>) => void);
+  onComma?: ((event: React.KeyboardEvent<HTMLElement>) => void);
+  onDown?: ((event: React.KeyboardEvent<HTMLElement>) => void);
+  onEnter?: ((event: React.KeyboardEvent<HTMLElement>) => void);
+  onEsc?: ((event: React.KeyboardEvent<HTMLElement>) => void);
+  onKeyDown?: ((event: React.KeyboardEvent<HTMLElement>) => void);
+  onLeft?: ((event: React.KeyboardEvent<HTMLElement>) => void);
+  onRight?: ((event: React.KeyboardEvent<HTMLElement>) => void);
+  onShift?: ((event: React.KeyboardEvent<HTMLElement>) => void);
+  onSpace?: ((event: React.KeyboardEvent<HTMLElement>) => void);
+  onTab?: ((event: React.KeyboardEvent<HTMLElement>) => void);
+  onUp?: ((event: React.KeyboardEvent<HTMLElement>) => void);
 }
 
 declare const Keyboard: React.ComponentClass<KeyboardProps>;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This changes the TS definitions for all Keyboard props from ((...args): any => any) to ((event: React.KeyboardEvent<HTMLElement>) => void).

#### Where should the reviewer start?
src/js/components/Keyboard/index.d.ts

#### What testing has been done on this PR?
Testing has been done in a local TS project. Keyboard was wrapped around content in a local TS file, and the type definitions were checked for the different keyboard interactions. First, I created a separate handler and defined the event type to match the TS definition. I expected there to be no errors, and there weren't. Then, I tried breaking it by providing the function with different types such as a string to be sure it would flag this error. It did.

#### How should this be manually tested?
In a project with TS added.

#### Any background context you want to provide?
When TS definitions are "any", it defeats its purpose. In this case, the event is a KeyboardEvent and this will happen on an HTML Element. Therefore, React.KeyboardEvent is the event type. Void is the return type because the function doesn't return anything or get assigned to a variable.

See React's documentation about Keyboard Events: https://reactjs.org/docs/events.html#keyboard-events

#### What are the relevant issues?
Issue #3165 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.