### PR TITLE
Fix Edge RangeSelector Issue

### DIFF
--- a/src/js/components/RangeSelector/RangeSelector.js
+++ b/src/js/components/RangeSelector/RangeSelector.js
@@ -41,11 +41,12 @@ class RangeSelector extends Component {
     const rect = this.containerRef.current.getBoundingClientRect();
     let value;
     if (direction === 'vertical') {
-      const y = event.clientY - (rect.y || 0); // unit test resilience
+      // there is no x and y in unit testing
+      const y = event.clientY - (rect.top || 0); // unit test resilience
       const scaleY = rect.height / (max - min + 1) || 1; // unit test resilience
       value = Math.floor(y / scaleY) + min;
     } else {
-      const x = event.clientX - (rect.x || 0); // unit test resilience
+      const x = event.clientX - (rect.left || 0); // unit test resilience
       const scaleX = rect.width / (max - min + 1) || 1; // unit test resilience
       value = Math.floor(x / scaleX) + min;
     }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes the issue with dragging the range selector on Edge.

#### Where should the reviewer start?
src/js/components/RangeSelector/RangeSelector.js

#### What testing has been done on this PR?
These changes have been tested using Browserstack on Edge. First, I recreated the issue and saw that there was difficulty when dragging the ends of the range selector. The value jumped around in a way that was not accurate to my mouse motions. Then, after making changes, I tested again and saw that the range selector was behaving as expected (would move to the correct coordinates according to my mouse motion).

#### How should this be manually tested?
Using Microsoft Edge and the Grommet storybook example of "Thin".

#### Any background context you want to provide?
A similar fix was done on this issue: https://github.com/grommet/grommet/pull/3078/files
The values of x and y need to be switched to left and top, respectively.

#### What are the relevant issues?
Issue #3295 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.