### PR TITLE
Removed padding with a plain menu

### DIFF
--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -123,7 +123,7 @@ class Menu extends Component {
         direction="row"
         justify={justifyContent}
         align="center"
-        pad="small"
+        pad={plain ? "none": "small"}
         gap={label && icon !== false ? 'small' : undefined}
       >
         <Text size={size}>{label}</Text>


### PR DESCRIPTION
What does this PR do?
This PR fixes the issue with padding when a menu component is set to plain

Where should the reviewer start?
src/js/components/components/Menu/Menu.js

What testing has been done on this PR?
I did a quick test (Google Chrome), with plain set to true and with no plain property set. The extra padding has disappeared in the former case.

How should this be manually tested?
Set plain={true} for a menu component and see the decrease in the height and width of the box around the component.

Any background context you want to provide?
I needed to have a thin header on my page, but the menu component does not allow it as it is surrounded with a Box with fixed 'small' padding.

What are the relevant issues?
No

Screenshots (if appropriate)
Do the grommet docs need to be updated?
No. The plain property implies that no extra padding and extra margins should stay when this property is set to true.

Should this PR be mentioned in the release notes?
No.

Is this change backward compatible or is it a breaking change?
Yes, backward compatible.