### PR TITLE
Extract keyboard type to single variable.

### DIFF
--- a/src/js/components/Drop/index.d.ts
+++ b/src/js/components/Drop/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { KeyboardType } from "../../utils";
 
 export interface DropProps {
   align?: {top?: "top" | "bottom",bottom?: "top" | "bottom",right?: "left" | "right",left?: "left" | "right"};
   elevation?: "none" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   onClickOutside?: ((...args: any[]) => any);
-  onEsc?: ((...args: any[]) => any);
+  onEsc?: KeyboardType;
   overflow?: "auto" | "hidden" | "scroll" | "visible" | {horizontal?: "auto" | "hidden" | "scroll" | "visible",vertical?: "auto" | "hidden" | "scroll" | "visible"} | string;
   responsive?: boolean;
   restrictFocus?: boolean;

--- a/src/js/components/Keyboard/index.d.ts
+++ b/src/js/components/Keyboard/index.d.ts
@@ -1,19 +1,20 @@
 import * as React from "react";
+import { KeyboardType } from '../../utils';
 
 export interface KeyboardProps {
   target?: "component" | "document";
-  onBackspace?: ((event: React.KeyboardEvent<HTMLElement>) => void);
-  onComma?: ((event: React.KeyboardEvent<HTMLElement>) => void);
-  onDown?: ((event: React.KeyboardEvent<HTMLElement>) => void);
-  onEnter?: ((event: React.KeyboardEvent<HTMLElement>) => void);
-  onEsc?: ((event: React.KeyboardEvent<HTMLElement>) => void);
-  onKeyDown?: ((event: React.KeyboardEvent<HTMLElement>) => void);
-  onLeft?: ((event: React.KeyboardEvent<HTMLElement>) => void);
-  onRight?: ((event: React.KeyboardEvent<HTMLElement>) => void);
-  onShift?: ((event: React.KeyboardEvent<HTMLElement>) => void);
-  onSpace?: ((event: React.KeyboardEvent<HTMLElement>) => void);
-  onTab?: ((event: React.KeyboardEvent<HTMLElement>) => void);
-  onUp?: ((event: React.KeyboardEvent<HTMLElement>) => void);
+  onBackspace?: KeyboardType;
+  onComma?: KeyboardType;
+  onDown?: KeyboardType;
+  onEnter?: KeyboardType;
+  onEsc?: KeyboardType;
+  onKeyDown?: KeyboardType;
+  onLeft?: KeyboardType;
+  onRight?: KeyboardType;
+  onShift?: KeyboardType;
+  onSpace?: KeyboardType;
+  onTab?: KeyboardType;
+  onUp?: KeyboardType;
 }
 
 declare const Keyboard: React.ComponentClass<KeyboardProps>;

--- a/src/js/components/Layer/index.d.ts
+++ b/src/js/components/Layer/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { AnimateType, MarginType } from "../../utils";
+import { AnimateType, MarginType, KeyboardType } from "../../utils";
 
 export interface LayerProps {
   animate?: AnimateType;
@@ -8,7 +8,7 @@ export interface LayerProps {
   margin?: MarginType;
   modal?: boolean;
   onClickOutside?: ((...args: any[]) => any);
-  onEsc?: ((...args: any[]) => any);
+  onEsc?: KeyboardType;
   plain?: boolean;
   position?: "bottom" | "bottom-left" | "bottom-right" | "center" | "hidden" | "left" | "right" | "top" | "top-left" | "top-right";
   responsive?: boolean;

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -43,6 +43,7 @@ export type BackgroundType = string | {color?: string,dark?: boolean | string,im
 export type ColorType = string | {dark?: string,light?: string};
 export type GapType = "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
 export type GridAreaType = string;
+export type KeyboardType = ((event: React.KeyboardEvent<HTMLElement>) => void);
 export type MarginType = "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
 export type PlaceHolderType = string | JSX.Element | React.ReactNode;
 export type TextAlignType = "start" | "center" | "end";


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Extracts Keyboard type into singe variable. Previously, many lines were copy and pasted. This change places the definition in a single place which will makes any future adjustments for streamline.

#### Where should the reviewer start?
src/js/utils/index.d.ts

#### What testing has been done on this PR?
Testing has been done on local TS project.

#### How should this be manually tested?
On a project with TS enabled.

#### Any background context you want to provide?

#### What are the relevant issues?
Issue #3165 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.