### PR TITLE
Fix error showing in log for DataTable test

### DIFF
--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -427,7 +427,9 @@ string
     small
     medium
     large
-    xlarge,
+    xlarge
+}
+{
   header: custom,
   body: custom,
   footer: custom

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -6,14 +6,16 @@ const sizes = ['xxsmall', 'xsmall', 'small', 'medium', 'large', 'xlarge'];
 const sides = ['horizontal', 'vertical', 'top', 'bottom', 'left', 'right'];
 const parts = ['header', 'body', 'footer'];
 
-const padShape = {};
+const padShapeSides = {};
 sides.forEach(side => {
-  padShape[side] = PropTypes.oneOf(sizes);
+  padShapeSides[side] = PropTypes.oneOf(sizes);
 });
+
+const padShapeParts = {};
 parts.forEach(part => {
-  padShape[part] = {};
+  padShapeParts[part] = {};
   sides.forEach(side => {
-    padShape[part][side] = PropTypes.oneOf(sizes);
+    padShapeParts[part][side] = PropTypes.oneOf(sizes);
   });
 });
 
@@ -152,7 +154,8 @@ export const doc = DataTable => {
     pad: PropTypes.oneOfType([
       PropTypes.oneOf(sizes),
       PropTypes.string,
-      PropTypes.shape(padShape),
+      PropTypes.shape(padShapeSides),
+      PropTypes.shape(padShapeParts),
     ]).description(
       `Cell padding. You can set the padding per context by passing an
       object with keys for 'heading', 'body', and/or 'footer'.`,

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4165,7 +4165,9 @@ string
     small
     medium
     large
-    xlarge,
+    xlarge
+}
+{
   header: custom,
   body: custom,
   footer: custom


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixing the error showing in the log for `DataTable` test
```
  console.error node_modules/prop-types/checkPropTypes.js:20
    Warning: Failed prop type: checker is not a function
        in DataTable
```

#### Where should the reviewer start?
src/js/components/DataTable/doc.js
#### What testing has been done on this PR?
Running `yarn test` before this fix will yield the above error and after the fix the error disappear
#### How should this be manually tested?
Running `yarn test`
#### Any background context you want to provide?
N/A
#### What are the relevant issues?
N/A
#### Screenshots (if appropriate)
```
  console.error node_modules/prop-types/checkPropTypes.js:20
    Warning: Failed prop type: checker is not a function
        in DataTable
```
#### Do the grommet docs need to be updated?
Yes
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
backwards compatible