### PR TITLE
DataTableVirtualisation Support

### DIFF
--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -337,7 +337,7 @@ exports[`Accordion AccordionPanel 1`] = `
       >
         <div
           aria-hidden={true}
-          className="c10 c1"
+          className="c1 c10"
           open={false}
         >
           Panel body 1
@@ -394,7 +394,7 @@ exports[`Accordion AccordionPanel 1`] = `
       >
         <div
           aria-hidden={true}
-          className="c10 c1"
+          className="c1 c10"
           open={false}
         >
           Panel body 2
@@ -1216,7 +1216,7 @@ exports[`Accordion change to second Panel 1`] = `
       >
         <div
           aria-hidden="true"
-          class="c10 c1"
+          class="c1 c10"
         >
           Panel body 1
         </div>
@@ -1267,7 +1267,7 @@ exports[`Accordion change to second Panel 1`] = `
       >
         <div
           aria-hidden="true"
-          class="c10 c1"
+          class="c1 c10"
         >
           Panel body 2
         </div>
@@ -1330,7 +1330,7 @@ exports[`Accordion change to second Panel 2`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 fWrrBh"
+          class="StyledBox-sc-13pk1d4-0 fWrrBh Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL"
         >
           Panel body 1
         </div>
@@ -1416,7 +1416,7 @@ exports[`Accordion change to second Panel 2`] = `
       >
         <div
           aria-hidden="false"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 dMYckW StyledBox-sc-13pk1d4-0 fWrrBh"
+          class="StyledBox-sc-13pk1d4-0 fWrrBh Collapsible__AnimatedBox-sc-15kniua-0 dMYckW"
           open=""
         >
           Panel body 2
@@ -2441,7 +2441,7 @@ exports[`Accordion complex title 1`] = `
         >
           <div
             aria-hidden={true}
-            className="c9 c2"
+            className="c2 c9"
             open={false}
           >
             Panel body 1
@@ -2492,7 +2492,7 @@ exports[`Accordion complex title 1`] = `
         >
           <div
             aria-hidden={true}
-            className="c9 c2"
+            className="c2 c9"
             open={false}
           >
             Panel body 2
@@ -2841,7 +2841,7 @@ exports[`Accordion custom accordion 1`] = `
       >
         <div
           aria-hidden={true}
-          className="c10 c1"
+          className="c1 c10"
           open={false}
         >
           Panel body 1
@@ -4155,7 +4155,7 @@ exports[`Accordion set on hover 1`] = `
       >
         <div
           aria-hidden="true"
-          class="c10 c1"
+          class="c1 c10"
         >
           Panel body 1
         </div>
@@ -4206,7 +4206,7 @@ exports[`Accordion set on hover 1`] = `
       >
         <div
           aria-hidden="true"
-          class="c10 c1"
+          class="c1 c10"
         >
           Panel body 2
         </div>
@@ -4269,7 +4269,7 @@ exports[`Accordion set on hover 2`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 fWrrBh"
+          class="StyledBox-sc-13pk1d4-0 fWrrBh Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL"
         >
           Panel body 1
         </div>
@@ -4320,7 +4320,7 @@ exports[`Accordion set on hover 2`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 fWrrBh"
+          class="StyledBox-sc-13pk1d4-0 fWrrBh Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL"
         >
           Panel body 2
         </div>
@@ -4383,7 +4383,7 @@ exports[`Accordion set on hover 3`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 fWrrBh"
+          class="StyledBox-sc-13pk1d4-0 fWrrBh Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL"
         >
           Panel body 1
         </div>
@@ -4434,7 +4434,7 @@ exports[`Accordion set on hover 3`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 fWrrBh"
+          class="StyledBox-sc-13pk1d4-0 fWrrBh Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL"
         >
           Panel body 2
         </div>
@@ -4497,7 +4497,7 @@ exports[`Accordion set on hover 4`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 fWrrBh"
+          class="StyledBox-sc-13pk1d4-0 fWrrBh Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL"
         >
           Panel body 1
         </div>
@@ -4548,7 +4548,7 @@ exports[`Accordion set on hover 4`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 fWrrBh"
+          class="StyledBox-sc-13pk1d4-0 fWrrBh Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL"
         >
           Panel body 2
         </div>
@@ -4611,7 +4611,7 @@ exports[`Accordion set on hover 5`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 fWrrBh"
+          class="StyledBox-sc-13pk1d4-0 fWrrBh Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL"
         >
           Panel body 1
         </div>
@@ -4662,7 +4662,7 @@ exports[`Accordion set on hover 5`] = `
       >
         <div
           aria-hidden="true"
-          class="Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL StyledBox-sc-13pk1d4-0 fWrrBh"
+          class="StyledBox-sc-13pk1d4-0 fWrrBh Collapsible__AnimatedBox-sc-15kniua-0 cHrNEL"
         >
           Panel body 2
         </div>

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -11,7 +11,7 @@ exports[`CheckBox checked renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -111,20 +111,20 @@ exports[`CheckBox checked renders 1`] = `
   background: #7D4CDB;
 }
 
-.c2 {
+.c3 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -168,7 +168,7 @@ exports[`CheckBox checked renders 1`] = `
       />
       <div
         checked={true}
-        className="c5"
+        className="c5 "
       >
         <svg
           checked={true}
@@ -198,7 +198,7 @@ exports[`CheckBox disabled renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -327,20 +327,20 @@ exports[`CheckBox disabled renders 1`] = `
   background: #7D4CDB;
 }
 
-.c2 {
+.c3 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -401,7 +401,7 @@ exports[`CheckBox disabled renders 1`] = `
         type="checkbox"
       />
       <div
-        className="c5"
+        className="c5 "
         disabled={true}
       />
     </div>
@@ -427,7 +427,7 @@ exports[`CheckBox disabled renders 1`] = `
       />
       <div
         checked={true}
-        className="c6"
+        className="c6 "
         disabled={true}
       >
         <svg
@@ -463,7 +463,7 @@ exports[`CheckBox indeterminate renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -588,20 +588,20 @@ exports[`CheckBox indeterminate renders 1`] = `
   background: #7D4CDB;
 }
 
-.c2 {
+.c3 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -653,7 +653,7 @@ exports[`CheckBox indeterminate renders 1`] = `
         type="checkbox"
       />
       <div
-        className="c5"
+        className="c5 "
       >
         <svg
           className="c6"
@@ -673,7 +673,7 @@ exports[`CheckBox indeterminate renders 1`] = `
     onClick={[Function]}
   >
     <div
-      className="c2 c7"
+      className="c7 c3"
     >
       <input
         className="c4"
@@ -682,7 +682,7 @@ exports[`CheckBox indeterminate renders 1`] = `
         type="checkbox"
       />
       <div
-        className="c5"
+        className="c5 "
       >
         <svg
           className="c6"
@@ -743,7 +743,7 @@ exports[`CheckBox label renders 1`] = `
   border-radius: 4px;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -806,7 +806,7 @@ exports[`CheckBox label renders 1`] = `
   background: #7D4CDB;
 }
 
-.c2 {
+.c3 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -831,13 +831,13 @@ exports[`CheckBox label renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -859,7 +859,7 @@ exports[`CheckBox label renders 1`] = `
         type="checkbox"
       />
       <div
-        className="c5"
+        className="c5 "
       />
     </div>
     <span>
@@ -880,7 +880,7 @@ exports[`CheckBox label renders 1`] = `
         type="checkbox"
       />
       <div
-        className="c5"
+        className="c5 "
       />
     </div>
     <div>
@@ -901,7 +901,7 @@ exports[`CheckBox renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -993,20 +993,20 @@ exports[`CheckBox renders 1`] = `
   background: #7D4CDB;
 }
 
-.c2 {
+.c3 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -1046,7 +1046,7 @@ exports[`CheckBox renders 1`] = `
         type="checkbox"
       />
       <div
-        className="c5"
+        className="c5 "
       />
     </div>
   </label>
@@ -1067,7 +1067,7 @@ exports[`CheckBox renders 1`] = `
         type="checkbox"
       />
       <div
-        className="c5"
+        className="c5 "
       />
     </div>
   </label>
@@ -1114,7 +1114,7 @@ exports[`CheckBox reverse renders 1`] = `
   border-radius: 4px;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1177,7 +1177,7 @@ exports[`CheckBox reverse renders 1`] = `
   background: #7D4CDB;
 }
 
-.c2 {
+.c3 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -1202,13 +1202,13 @@ exports[`CheckBox reverse renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin-left: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -1233,7 +1233,7 @@ exports[`CheckBox reverse renders 1`] = `
         type="checkbox"
       />
       <div
-        className="c5"
+        className="c5 "
       />
     </div>
   </label>
@@ -1251,7 +1251,7 @@ exports[`CheckBox toggle renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1365,20 +1365,20 @@ exports[`CheckBox toggle renders 1`] = `
   border-radius: 24px;
 }
 
-.c2 {
+.c3 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -1452,7 +1452,7 @@ exports[`CheckBox toggle renders 1`] = `
     onClick={[Function]}
   >
     <div
-      className="c2 c7"
+      className="c7 c3"
     >
       <input
         className="c4"

--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -18,6 +18,7 @@ const Body = ({
   data,
   forwardRef,
   onMore,
+  replace,
   onClickRow,
   pad,
   primaryProperty,
@@ -66,6 +67,7 @@ const Body = ({
         <InfiniteScroll
           items={data}
           onMore={onMore}
+          replace={replace}
           renderMarker={marker => (
             <TableRow>
               <TableCell>{marker}</TableCell>

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -107,6 +107,7 @@ class DataTable extends Component {
       data: propsData,
       groupBy,
       onMore,
+      replace,
       pad,
       resizeable,
       rowProps,
@@ -173,6 +174,7 @@ class DataTable extends Component {
             columns={columns}
             data={data}
             onMore={onMore}
+            replace={replace}
             onClickRow={onClickRow}
             pad={normalizeProp(pad, 'body')}
             primaryProperty={primaryProperty}

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -350,6 +350,17 @@ Use this to indicate that 'data' doesn't contain all that it could.
 function
 ```
 
+**replace**
+
+Whether to replace previously rendered items with a generic spacing
+      element when they have scrolled out of view. This is more performant but
+      means that in-page searching will not find elements that have been
+      replaced.
+
+```
+function
+```
+
 **onClickRow**
 
 When supplied, this function will be called with an event object that

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -58,7 +58,7 @@ exports[`DataTable aggregate 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
@@ -75,14 +75,14 @@ exports[`DataTable aggregate 1`] = `
   font-weight: bold;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -97,7 +97,7 @@ exports[`DataTable aggregate 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c4"
@@ -128,7 +128,7 @@ exports[`DataTable aggregate 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c6"
@@ -151,7 +151,7 @@ exports[`DataTable aggregate 1`] = `
         </td>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c6"
@@ -324,7 +324,7 @@ exports[`DataTable background 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
@@ -341,14 +341,14 @@ exports[`DataTable background 1`] = `
   font-weight: bold;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -363,7 +363,7 @@ exports[`DataTable background 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c4"
@@ -394,7 +394,7 @@ exports[`DataTable background 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c6"
@@ -417,7 +417,7 @@ exports[`DataTable background 1`] = `
         </td>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c6"
@@ -468,7 +468,7 @@ exports[`DataTable background 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c9"
@@ -499,7 +499,7 @@ exports[`DataTable background 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c6"
@@ -522,7 +522,7 @@ exports[`DataTable background 1`] = `
         </td>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c10"
@@ -573,7 +573,7 @@ exports[`DataTable background 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c4"
@@ -604,7 +604,7 @@ exports[`DataTable background 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c10"
@@ -627,7 +627,7 @@ exports[`DataTable background 1`] = `
         </td>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c10"
@@ -717,7 +717,7 @@ exports[`DataTable basic 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
@@ -734,14 +734,14 @@ exports[`DataTable basic 1`] = `
   font-weight: bold;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -756,7 +756,7 @@ exports[`DataTable basic 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c4"
@@ -787,7 +787,7 @@ exports[`DataTable basic 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c6"
@@ -810,7 +810,7 @@ exports[`DataTable basic 1`] = `
         </td>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c6"
@@ -984,7 +984,7 @@ exports[`DataTable border 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
@@ -1001,14 +1001,14 @@ exports[`DataTable border 1`] = `
   font-weight: bold;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -1023,7 +1023,7 @@ exports[`DataTable border 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c4"
@@ -1054,7 +1054,7 @@ exports[`DataTable border 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c6"
@@ -1077,7 +1077,7 @@ exports[`DataTable border 1`] = `
         </td>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c6"
@@ -1128,7 +1128,7 @@ exports[`DataTable border 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c9"
@@ -1159,7 +1159,7 @@ exports[`DataTable border 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c10"
@@ -1182,7 +1182,7 @@ exports[`DataTable border 1`] = `
         </td>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c10"
@@ -1233,7 +1233,7 @@ exports[`DataTable border 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c12"
@@ -1264,7 +1264,7 @@ exports[`DataTable border 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c13"
@@ -1287,7 +1287,7 @@ exports[`DataTable border 1`] = `
         </td>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c13"
@@ -1338,7 +1338,7 @@ exports[`DataTable border 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c9"
@@ -1369,7 +1369,7 @@ exports[`DataTable border 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c13"
@@ -1392,7 +1392,7 @@ exports[`DataTable border 1`] = `
         </td>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c13"
@@ -1482,7 +1482,7 @@ exports[`DataTable click 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
@@ -1499,7 +1499,7 @@ exports[`DataTable click 1`] = `
   font-weight: bold;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
@@ -1510,7 +1510,7 @@ exports[`DataTable click 1`] = `
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -1525,7 +1525,7 @@ exports[`DataTable click 1`] = `
       class=""
     >
       <tr
-        class="c3"
+        class="c3 "
       >
         <th
           class="c4"
@@ -1544,7 +1544,7 @@ exports[`DataTable click 1`] = `
       tabindex="0"
     >
       <tr
-        class="c6 c3"
+        class="c3 c6"
       >
         <th
           class="c7"
@@ -1558,7 +1558,7 @@ exports[`DataTable click 1`] = `
         </th>
       </tr>
       <tr
-        class="c6 c3"
+        class="c3 c6"
       >
         <th
           class="c7"
@@ -1581,13 +1581,13 @@ exports[`DataTable click 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 eUfLDp"
 >
   <table
-    class="StyledDataTable-xrlyjm-0 tpKnu StyledTable-sc-1m3u5g-6 fGUmP"
+    class="StyledTable-sc-1m3u5g-6 fGUmP StyledDataTable-xrlyjm-0 tpKnu"
   >
     <thead
-      class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 gtdqEW StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd StyledDataTable__StyledDataTableHeader-xrlyjm-3 gtdqEW"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV"
       >
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 jfWrbb"
@@ -1602,11 +1602,11 @@ exports[`DataTable click 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledDataTable__StyledDataTableBody-xrlyjm-2 bFXxPv StyledTable__StyledTableBody-sc-1m3u5g-3 dwInxx"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 dwInxx StyledDataTable__StyledDataTableBody-xrlyjm-2 bFXxPv"
       tabindex="0"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 epdvRE StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX StyledDataTable__StyledDataTableRow-xrlyjm-1 epdvRE"
       >
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 IXbyK"
@@ -1620,7 +1620,7 @@ exports[`DataTable click 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 epdvRE StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX StyledDataTable__StyledDataTableRow-xrlyjm-1 epdvRE"
       >
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 IXbyK"
@@ -1653,20 +1653,20 @@ exports[`DataTable empty 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -1681,7 +1681,7 @@ exports[`DataTable empty 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       />
     </thead>
     <tbody
@@ -1752,7 +1752,7 @@ exports[`DataTable footer 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
@@ -1769,14 +1769,14 @@ exports[`DataTable footer 1`] = `
   font-weight: bold;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -1791,7 +1791,7 @@ exports[`DataTable footer 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c4"
@@ -1822,7 +1822,7 @@ exports[`DataTable footer 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c6"
@@ -1845,7 +1845,7 @@ exports[`DataTable footer 1`] = `
         </td>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c6"
@@ -2049,7 +2049,7 @@ exports[`DataTable groupBy 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
@@ -2060,7 +2060,7 @@ exports[`DataTable groupBy 1`] = `
   line-height: 24px;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
@@ -2079,7 +2079,7 @@ exports[`DataTable groupBy 1`] = `
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -2094,7 +2094,7 @@ exports[`DataTable groupBy 1`] = `
       class=""
     >
       <tr
-        class="c3"
+        class="c3 "
       >
         <td
           class="c4"
@@ -2148,7 +2148,7 @@ exports[`DataTable groupBy 1`] = `
       class=""
     >
       <tr
-        class="c3"
+        class="c3 "
       >
         <td
           class="c10"
@@ -2191,7 +2191,7 @@ exports[`DataTable groupBy 1`] = `
         />
       </tr>
       <tr
-        class="c3"
+        class="c3 "
       >
         <td
           class="c10"
@@ -2243,13 +2243,13 @@ exports[`DataTable groupBy 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 eUfLDp"
 >
   <table
-    class="StyledDataTable-xrlyjm-0 tpKnu StyledTable-sc-1m3u5g-6 fGUmP"
+    class="StyledTable-sc-1m3u5g-6 fGUmP StyledDataTable-xrlyjm-0 tpKnu"
   >
     <thead
-      class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 gtdqEW StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd StyledDataTable__StyledDataTableHeader-xrlyjm-3 gtdqEW"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 fPACPW"
@@ -2300,10 +2300,10 @@ exports[`DataTable groupBy 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledDataTable__StyledDataTableBody-xrlyjm-2 bFXxPv StyledTable__StyledTableBody-sc-1m3u5g-3 dwInxx"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 dwInxx StyledDataTable__StyledDataTableBody-xrlyjm-2 bFXxPv"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 hufzGX"
@@ -2346,7 +2346,7 @@ exports[`DataTable groupBy 2`] = `
         />
       </tr>
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 hufzGX"
@@ -2564,7 +2564,7 @@ exports[`DataTable groupBy expand 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
@@ -2575,7 +2575,7 @@ exports[`DataTable groupBy expand 1`] = `
   line-height: 24px;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
@@ -2594,7 +2594,7 @@ exports[`DataTable groupBy expand 1`] = `
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -2609,7 +2609,7 @@ exports[`DataTable groupBy expand 1`] = `
       class=""
     >
       <tr
-        class="c3"
+        class="c3 "
       >
         <td
           class="c4"
@@ -2663,7 +2663,7 @@ exports[`DataTable groupBy expand 1`] = `
       class=""
     >
       <tr
-        class="c3"
+        class="c3 "
       >
         <td
           class="c10"
@@ -2707,7 +2707,7 @@ exports[`DataTable groupBy expand 1`] = `
         />
       </tr>
       <tr
-        class="c3"
+        class="c3 "
       >
         <td
           class="c10"
@@ -2736,7 +2736,7 @@ exports[`DataTable groupBy expand 1`] = `
         </td>
       </tr>
       <tr
-        class="c3"
+        class="c3 "
       >
         <td
           class="c12"
@@ -2765,7 +2765,7 @@ exports[`DataTable groupBy expand 1`] = `
         </td>
       </tr>
       <tr
-        class="c3"
+        class="c3 "
       >
         <td
           class="c10"
@@ -2975,7 +2975,7 @@ exports[`DataTable groupBy property 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
@@ -2986,7 +2986,7 @@ exports[`DataTable groupBy property 1`] = `
   line-height: 24px;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
@@ -3005,7 +3005,7 @@ exports[`DataTable groupBy property 1`] = `
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -3020,7 +3020,7 @@ exports[`DataTable groupBy property 1`] = `
       class=""
     >
       <tr
-        class="c3"
+        class="c3 "
       >
         <td
           class="c4"
@@ -3074,7 +3074,7 @@ exports[`DataTable groupBy property 1`] = `
       class=""
     >
       <tr
-        class="c3"
+        class="c3 "
       >
         <td
           class="c10"
@@ -3117,7 +3117,7 @@ exports[`DataTable groupBy property 1`] = `
         />
       </tr>
       <tr
-        class="c3"
+        class="c3 "
       >
         <td
           class="c10"
@@ -3169,13 +3169,13 @@ exports[`DataTable groupBy property 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 eUfLDp"
 >
   <table
-    class="StyledDataTable-xrlyjm-0 tpKnu StyledTable-sc-1m3u5g-6 fGUmP"
+    class="StyledTable-sc-1m3u5g-6 fGUmP StyledDataTable-xrlyjm-0 tpKnu"
   >
     <thead
-      class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 gtdqEW StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd StyledDataTable__StyledDataTableHeader-xrlyjm-3 gtdqEW"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 fPACPW"
@@ -3226,10 +3226,10 @@ exports[`DataTable groupBy property 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledDataTable__StyledDataTableBody-xrlyjm-2 bFXxPv StyledTable__StyledTableBody-sc-1m3u5g-3 dwInxx"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 dwInxx StyledDataTable__StyledDataTableBody-xrlyjm-2 bFXxPv"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 hufzGX"
@@ -3272,7 +3272,7 @@ exports[`DataTable groupBy property 2`] = `
         />
       </tr>
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV"
       >
         <td
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 hufzGX"
@@ -3426,7 +3426,7 @@ exports[`DataTable pad 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
@@ -3443,14 +3443,14 @@ exports[`DataTable pad 1`] = `
   font-weight: bold;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -3465,7 +3465,7 @@ exports[`DataTable pad 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c4"
@@ -3496,7 +3496,7 @@ exports[`DataTable pad 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c6"
@@ -3519,7 +3519,7 @@ exports[`DataTable pad 1`] = `
         </td>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c6"
@@ -3570,7 +3570,7 @@ exports[`DataTable pad 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c9"
@@ -3601,7 +3601,7 @@ exports[`DataTable pad 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c10"
@@ -3624,7 +3624,7 @@ exports[`DataTable pad 1`] = `
         </td>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c10"
@@ -3675,7 +3675,7 @@ exports[`DataTable pad 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c4"
@@ -3706,7 +3706,7 @@ exports[`DataTable pad 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c10"
@@ -3729,7 +3729,7 @@ exports[`DataTable pad 1`] = `
         </td>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c10"
@@ -3819,7 +3819,7 @@ exports[`DataTable paths 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
@@ -3836,14 +3836,14 @@ exports[`DataTable paths 1`] = `
   font-weight: bold;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -3858,7 +3858,7 @@ exports[`DataTable paths 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c4"
@@ -3889,7 +3889,7 @@ exports[`DataTable paths 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c6"
@@ -3912,7 +3912,7 @@ exports[`DataTable paths 1`] = `
         </td>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c6"
@@ -3982,7 +3982,7 @@ exports[`DataTable primaryKey 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
@@ -3999,14 +3999,14 @@ exports[`DataTable primaryKey 1`] = `
   font-weight: bold;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -4021,7 +4021,7 @@ exports[`DataTable primaryKey 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c4"
@@ -4052,7 +4052,7 @@ exports[`DataTable primaryKey 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <td
           className="c6"
@@ -4075,7 +4075,7 @@ exports[`DataTable primaryKey 1`] = `
         </th>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <td
           className="c6"
@@ -4135,7 +4135,7 @@ exports[`DataTable resizeable 1`] = `
   padding: 0px;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4196,7 +4196,7 @@ exports[`DataTable resizeable 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
@@ -4213,11 +4213,11 @@ exports[`DataTable resizeable 1`] = `
   font-weight: bold;
 }
 
-.c8 {
+.c9 {
   cursor: col-resize;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
@@ -4236,7 +4236,7 @@ exports[`DataTable resizeable 1`] = `
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -4251,7 +4251,7 @@ exports[`DataTable resizeable 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c4"
@@ -4314,7 +4314,7 @@ exports[`DataTable resizeable 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c10"
@@ -4337,7 +4337,7 @@ exports[`DataTable resizeable 1`] = `
         </td>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c10"
@@ -4435,7 +4435,7 @@ exports[`DataTable rowProps 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
@@ -4452,14 +4452,14 @@ exports[`DataTable rowProps 1`] = `
   font-weight: bold;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -4474,7 +4474,7 @@ exports[`DataTable rowProps 1`] = `
       className=""
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c4"
@@ -4505,7 +4505,7 @@ exports[`DataTable rowProps 1`] = `
       onKeyDown={[Function]}
     >
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c6"
@@ -4528,7 +4528,7 @@ exports[`DataTable rowProps 1`] = `
         </td>
       </tr>
       <tr
-        className="c3"
+        className="c3 "
       >
         <th
           className="c8"
@@ -4642,7 +4642,7 @@ exports[`DataTable search 1`] = `
   padding: 0px;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4729,7 +4729,7 @@ exports[`DataTable search 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
@@ -4746,11 +4746,11 @@ exports[`DataTable search 1`] = `
   font-weight: bold;
 }
 
-.c10 {
+.c11 {
   cursor: col-resize;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
@@ -4769,7 +4769,7 @@ exports[`DataTable search 1`] = `
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -4784,7 +4784,7 @@ exports[`DataTable search 1`] = `
       class=""
     >
       <tr
-        class="c3"
+        class="c3 "
       >
         <th
           class="c4"
@@ -4833,7 +4833,7 @@ exports[`DataTable search 1`] = `
       class=""
     >
       <tr
-        class="c3"
+        class="c3 "
       >
         <th
           class="c12"
@@ -4847,7 +4847,7 @@ exports[`DataTable search 1`] = `
         </th>
       </tr>
       <tr
-        class="c3"
+        class="c3 "
       >
         <th
           class="c12"
@@ -4861,7 +4861,7 @@ exports[`DataTable search 1`] = `
         </th>
       </tr>
       <tr
-        class="c3"
+        class="c3 "
       >
         <th
           class="c12"
@@ -4884,13 +4884,13 @@ exports[`DataTable search 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 eUfLDp"
 >
   <table
-    class="StyledDataTable-xrlyjm-0 tpKnu StyledTable-sc-1m3u5g-6 fGUmP"
+    class="StyledTable-sc-1m3u5g-6 fGUmP StyledDataTable-xrlyjm-0 tpKnu"
   >
     <thead
-      class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 gtdqEW StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd StyledDataTable__StyledDataTableHeader-xrlyjm-3 gtdqEW"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV"
       >
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 jfWrbb"
@@ -5037,14 +5037,14 @@ exports[`DataTable search 2`] = `
               class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iChEkS"
             />
             <div
-              class="Resizer__ResizerBox-sc-8l808w-0 hnOyDj StyledBox-sc-13pk1d4-0 keXFvx"
+              class="StyledBox-sc-13pk1d4-0 keXFvx Resizer__ResizerBox-sc-8l808w-0 hnOyDj"
             />
           </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="StyledDataTable__StyledDataTableBody-xrlyjm-2 bFXxPv StyledTable__StyledTableBody-sc-1m3u5g-3 dwInxx"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 dwInxx StyledDataTable__StyledDataTableBody-xrlyjm-2 bFXxPv"
     >
       .c1 {
   margin: 0;
@@ -5070,7 +5070,7 @@ exports[`DataTable search 2`] = `
 }
 
 <tr
-        class="c0"
+        class="c0 "
       >
         <th
           class="c1"
@@ -5171,7 +5171,7 @@ exports[`DataTable sort 1`] = `
   height: 100%;
 }
 
-.c2 {
+.c1 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
@@ -5188,7 +5188,7 @@ exports[`DataTable sort 1`] = `
   font-weight: bold;
 }
 
-.c1 {
+.c2 {
   border-spacing: 0;
   border-collapse: collapse;
   height: 100%;
@@ -5207,7 +5207,7 @@ exports[`DataTable sort 1`] = `
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-  .c2 {
+  .c1 {
     table-layout: fixed;
   }
 }
@@ -5222,7 +5222,7 @@ exports[`DataTable sort 1`] = `
       class=""
     >
       <tr
-        class="c3"
+        class="c3 "
       >
         <th
           class="c4"
@@ -5268,7 +5268,7 @@ exports[`DataTable sort 1`] = `
       class=""
     >
       <tr
-        class="c3"
+        class="c3 "
       >
         <th
           class="c8"
@@ -5291,7 +5291,7 @@ exports[`DataTable sort 1`] = `
         </td>
       </tr>
       <tr
-        class="c3"
+        class="c3 "
       >
         <th
           class="c8"
@@ -5314,7 +5314,7 @@ exports[`DataTable sort 1`] = `
         </td>
       </tr>
       <tr
-        class="c3"
+        class="c3 "
       >
         <th
           class="c8"
@@ -5346,13 +5346,13 @@ exports[`DataTable sort 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 eUfLDp"
 >
   <table
-    class="StyledDataTable-xrlyjm-0 tpKnu StyledTable-sc-1m3u5g-6 fGUmP"
+    class="StyledTable-sc-1m3u5g-6 fGUmP StyledDataTable-xrlyjm-0 tpKnu"
   >
     <thead
-      class="StyledDataTable__StyledDataTableHeader-xrlyjm-3 gtdqEW StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd"
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 dHaGyd StyledDataTable__StyledDataTableHeader-xrlyjm-3 gtdqEW"
     >
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV"
       >
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 jfWrbb"
@@ -5451,7 +5451,7 @@ exports[`DataTable sort 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledDataTable__StyledDataTableBody-xrlyjm-2 bFXxPv StyledTable__StyledTableBody-sc-1m3u5g-3 dwInxx"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 dwInxx StyledDataTable__StyledDataTableBody-xrlyjm-2 bFXxPv"
     >
       .c1 {
   margin: 0;
@@ -5482,7 +5482,7 @@ exports[`DataTable sort 2`] = `
 }
 
 <tr
-        class="c0"
+        class="c0 "
       >
         <th
           class="c1"
@@ -5505,7 +5505,7 @@ exports[`DataTable sort 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 kXgizX StyledDataTable__StyledDataTableRow-xrlyjm-1 jriIGV"
       >
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 IXbyK"
@@ -5556,7 +5556,7 @@ exports[`DataTable sort 2`] = `
 }
 
 <tr
-        class="c0"
+        class="c0 "
       >
         <th
           class="c1"

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -139,6 +139,12 @@ export const doc = DataTable => {
       browser, such as columns.search, sortable, groupBy, or 
       columns.aggregate.`,
     ),
+    replace: PropTypes.func.description(
+      `Whether to replace previously rendered items with a generic spacing
+      element when they have scrolled out of view. This is more performant but
+      means that in-page searching will not find elements that have been
+      replaced.`,
+    ),
     onClickRow: PropTypes.func.description(
       `When supplied, this function will be called with an event object that
       include a 'datum' property containing the data value associated with

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Drop align left left 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20,7 +20,7 @@ exports[`Drop align left left 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -45,19 +45,19 @@ exports[`Drop align left left 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -176,7 +176,7 @@ exports[`Drop align left left 2`] = `
 `;
 
 exports[`Drop align left right top bottom 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -195,7 +195,7 @@ exports[`Drop align left right top bottom 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -220,19 +220,19 @@ exports[`Drop align left right top bottom 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -325,7 +325,7 @@ exports[`Drop align left right top bottom 2`] = `
 `;
 
 exports[`Drop align right left top top 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -344,7 +344,7 @@ exports[`Drop align right left top top 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -369,19 +369,19 @@ exports[`Drop align right left top top 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -513,7 +513,7 @@ exports[`Drop align right left top top 2`] = `
 `;
 
 exports[`Drop align right right 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -532,7 +532,7 @@ exports[`Drop align right right 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -557,19 +557,19 @@ exports[`Drop align right right 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -701,7 +701,7 @@ exports[`Drop align right right 2`] = `
 `;
 
 exports[`Drop align right right bottom top 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -720,7 +720,7 @@ exports[`Drop align right right bottom top 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -745,19 +745,19 @@ exports[`Drop align right right bottom top 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -863,7 +863,7 @@ exports[`Drop align right right bottom top 2`] = `
 `;
 
 exports[`Drop align right right bottom top 3`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -882,7 +882,7 @@ exports[`Drop align right right bottom top 3`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -907,19 +907,19 @@ exports[`Drop align right right bottom top 3`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1051,7 +1051,7 @@ exports[`Drop align right right bottom top 4`] = `
 `;
 
 exports[`Drop basic 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1070,7 +1070,7 @@ exports[`Drop basic 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1095,19 +1095,19 @@ exports[`Drop basic 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1200,7 +1200,7 @@ exports[`Drop basic 2`] = `
 `;
 
 exports[`Drop close 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1219,7 +1219,7 @@ exports[`Drop close 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1244,19 +1244,19 @@ exports[`Drop close 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1388,7 +1388,7 @@ exports[`Drop close 2`] = `
 `;
 
 exports[`Drop default elevation renders 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1407,7 +1407,7 @@ exports[`Drop default elevation renders 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1432,19 +1432,19 @@ exports[`Drop default elevation renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1576,7 +1576,7 @@ exports[`Drop default elevation renders 2`] = `
 `;
 
 exports[`Drop invalid align 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1595,7 +1595,7 @@ exports[`Drop invalid align 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1620,19 +1620,19 @@ exports[`Drop invalid align 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1764,7 +1764,7 @@ exports[`Drop invalid align 2`] = `
 `;
 
 exports[`Drop invoke onClickOutside 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1783,7 +1783,7 @@ exports[`Drop invoke onClickOutside 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1808,19 +1808,19 @@ exports[`Drop invoke onClickOutside 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1952,7 +1952,7 @@ exports[`Drop invoke onClickOutside 2`] = `
 `;
 
 exports[`Drop no stretch 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1971,7 +1971,7 @@ exports[`Drop no stretch 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1996,19 +1996,19 @@ exports[`Drop no stretch 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2140,7 +2140,7 @@ exports[`Drop no stretch 2`] = `
 `;
 
 exports[`Drop plain renders 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2158,7 +2158,7 @@ exports[`Drop plain renders 1`] = `
   overflow: auto;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2181,19 +2181,19 @@ exports[`Drop plain renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2371,7 +2371,7 @@ exports[`Drop plain renders 2`] = `
 `;
 
 exports[`Drop props elevation renders 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2390,7 +2390,7 @@ exports[`Drop props elevation renders 1`] = `
   box-shadow: 0px 4px 8px rgba(0,0,0,0.20);
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2415,19 +2415,19 @@ exports[`Drop props elevation renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2583,7 +2583,7 @@ exports[`Drop props elevation renders 2`] = `
 `;
 
 exports[`Drop resize 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2602,7 +2602,7 @@ exports[`Drop resize 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2627,19 +2627,19 @@ exports[`Drop resize 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2771,7 +2771,7 @@ exports[`Drop resize 2`] = `
 `;
 
 exports[`Drop restrict focus 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2790,7 +2790,7 @@ exports[`Drop restrict focus 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2815,19 +2815,19 @@ exports[`Drop restrict focus 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2851,7 +2851,7 @@ exports[`Drop restrict focus 1`] = `
 
 exports[`Drop restrict focus 2`] = `
 <div
-  class="StyledDrop-sc-16s5rx8-0 hEnyXU StyledBox-sc-13pk1d4-0 fLlzie"
+  class="StyledBox-sc-13pk1d4-0 fLlzie StyledDrop-sc-16s5rx8-0 hEnyXU"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
   tabindex="-1"
@@ -2972,7 +2972,7 @@ exports[`Drop restrict focus 3`] = `
 exports[`Drop restrict focus 4`] = `<body />`;
 
 exports[`Drop theme elevation renders 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2991,7 +2991,7 @@ exports[`Drop theme elevation renders 1`] = `
   box-shadow: 0px 8px 16px rgba(0,0,0,0.20);
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3016,19 +3016,19 @@ exports[`Drop theme elevation renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
@@ -215,7 +215,7 @@ exports[`Form update 1`] = `
 >
   <form>
     <div
-      class="c1"
+      class="c1 "
     >
       <div
         class="c2"
@@ -234,7 +234,7 @@ exports[`Form update 1`] = `
       </div>
     </div>
     <div
-      class="c1"
+      class="c1 "
     >
       <div
         class="c2"
@@ -390,7 +390,7 @@ exports[`Form with field 1`] = `
     onSubmit={[Function]}
   >
     <div
-      className="c1"
+      className="c1 "
     >
       <div
         className="c2"

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -80,7 +80,7 @@ exports[`forces empty margin 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="c1 "
   >
     <div
       className="c2"
@@ -213,14 +213,14 @@ exports[`renders 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="c1 "
   >
     <div
       className="c2"
     />
   </div>
   <div
-    className="c1"
+    className="c1 "
   >
     <div
       className="c2"
@@ -322,7 +322,7 @@ exports[`renders abut correctly 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="c1 "
     style={
       Object {
         "position": undefined,
@@ -417,7 +417,7 @@ exports[`renders abut with forced margin 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="c1 "
     style={
       Object {
         "position": undefined,
@@ -443,7 +443,7 @@ exports[`renders custom formfield 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -478,18 +478,18 @@ exports[`renders custom formfield 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c2 {
   font-size: 40px;
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }
@@ -605,7 +605,7 @@ exports[`renders custom margin 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="c1 "
   >
     <div
       className="c2"
@@ -704,7 +704,7 @@ exports[`renders error 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="c1 "
   >
     <div
       className="c2"
@@ -805,7 +805,7 @@ exports[`renders help 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="c1 "
   >
     <span
       className="c2"
@@ -899,7 +899,7 @@ exports[`renders htmlFor 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="c1 "
   >
     <div
       className="c2"
@@ -997,7 +997,7 @@ exports[`renders label 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="c1 "
   >
     <label
       className="c2"

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -338,7 +338,7 @@ exports[`MaskedInput event target props are available option via mouse 1`] = `
 `;
 
 exports[`MaskedInput event target props are available option via mouse 2`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -438,7 +438,7 @@ exports[`MaskedInput event target props are available option via mouse 2`] = `
   color: #000000;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -507,7 +507,7 @@ exports[`MaskedInput event target props are available option via mouse 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -741,7 +741,7 @@ exports[`MaskedInput mask 1`] = `
 `;
 
 exports[`MaskedInput mask 2`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -841,7 +841,7 @@ exports[`MaskedInput mask 2`] = `
   color: #000000;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -910,7 +910,7 @@ exports[`MaskedInput mask 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1264,7 +1264,7 @@ exports[`MaskedInput option via mouse 1`] = `
 `;
 
 exports[`MaskedInput option via mouse 2`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1364,7 +1364,7 @@ exports[`MaskedInput option via mouse 2`] = `
   color: #000000;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1433,7 +1433,7 @@ exports[`MaskedInput option via mouse 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -319,7 +319,7 @@ exports[`Menu close by clicking outside 2`] = `
   padding: 12px;
 }
 
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -338,7 +338,7 @@ exports[`Menu close by clicking outside 2`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -471,7 +471,7 @@ exports[`Menu close by clicking outside 2`] = `
   line-height: 24px;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -495,7 +495,7 @@ exports[`Menu close by clicking outside 2`] = `
   animation-delay: 0.01s;
 }
 
-.c2 {
+.c3 {
   max-height: inherit;
 }
 
@@ -512,25 +512,25 @@ exports[`Menu close by clicking outside 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -572,7 +572,7 @@ exports[`Menu close by clicking outside 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -585,7 +585,7 @@ exports[`Menu close by clicking outside 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }
@@ -2374,7 +2374,7 @@ exports[`Menu open and close on click 3`] = `
   padding: 12px;
 }
 
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2393,7 +2393,7 @@ exports[`Menu open and close on click 3`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2526,7 +2526,7 @@ exports[`Menu open and close on click 3`] = `
   line-height: 24px;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2550,7 +2550,7 @@ exports[`Menu open and close on click 3`] = `
   animation-delay: 0.01s;
 }
 
-.c2 {
+.c3 {
   max-height: inherit;
 }
 
@@ -2567,25 +2567,25 @@ exports[`Menu open and close on click 3`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -2627,7 +2627,7 @@ exports[`Menu open and close on click 3`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2640,7 +2640,7 @@ exports[`Menu open and close on click 3`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }
@@ -3286,7 +3286,7 @@ exports[`Menu with dropAlign renders 2`] = `
   padding: 12px;
 }
 
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3305,7 +3305,7 @@ exports[`Menu with dropAlign renders 2`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3438,7 +3438,7 @@ exports[`Menu with dropAlign renders 2`] = `
   line-height: 24px;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3462,7 +3462,7 @@ exports[`Menu with dropAlign renders 2`] = `
   animation-delay: 0.01s;
 }
 
-.c2 {
+.c3 {
   max-height: inherit;
 }
 
@@ -3479,25 +3479,25 @@ exports[`Menu with dropAlign renders 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -3539,7 +3539,7 @@ exports[`Menu with dropAlign renders 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3552,7 +3552,7 @@ exports[`Menu with dropAlign renders 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }

--- a/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
+++ b/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
@@ -11,7 +11,7 @@ exports[`RadioButton checked renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -78,7 +78,7 @@ exports[`RadioButton checked renders 1`] = `
   border-radius: 100%;
 }
 
-.c1 {
+.c2 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -86,8 +86,8 @@ exports[`RadioButton checked renders 1`] = `
   cursor: pointer;
 }
 
-.c1:hover input:not([disabled]) + div,
-.c1:hover input:not([disabled]) + span {
+.c2:hover input:not([disabled]) + div,
+.c2:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
@@ -108,13 +108,13 @@ exports[`RadioButton checked renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }
@@ -157,7 +157,7 @@ exports[`RadioButton checked renders 1`] = `
     onClick={[Function]}
   >
     <div
-      className="c3"
+      className="c3 "
     >
       <input
         checked={true}
@@ -166,7 +166,7 @@ exports[`RadioButton checked renders 1`] = `
         type="radio"
       />
       <div
-        className="c5"
+        className="c5 "
       >
         <svg
           className="c6"
@@ -196,7 +196,7 @@ exports[`RadioButton disabled renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -292,7 +292,7 @@ exports[`RadioButton disabled renders 1`] = `
   border-radius: 100%;
 }
 
-.c1 {
+.c2 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -301,8 +301,8 @@ exports[`RadioButton disabled renders 1`] = `
   cursor: default;
 }
 
-.c1:hover input:not([disabled]) + div,
-.c1:hover input:not([disabled]) + span {
+.c2:hover input:not([disabled]) + div,
+.c2:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
@@ -322,13 +322,13 @@ exports[`RadioButton disabled renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }
@@ -390,7 +390,7 @@ exports[`RadioButton disabled renders 1`] = `
     onClick={[Function]}
   >
     <div
-      className="c3"
+      className="c3 "
     >
       <input
         className="c4"
@@ -399,7 +399,7 @@ exports[`RadioButton disabled renders 1`] = `
         type="radio"
       />
       <div
-        className="c5"
+        className="c5 "
       />
     </div>
   </label>
@@ -409,7 +409,7 @@ exports[`RadioButton disabled renders 1`] = `
     onClick={[Function]}
   >
     <div
-      className="c3"
+      className="c3 "
     >
       <input
         checked={true}
@@ -419,7 +419,7 @@ exports[`RadioButton disabled renders 1`] = `
         type="radio"
       />
       <div
-        className="c6"
+        className="c6 "
       >
         <svg
           className="c7"
@@ -449,7 +449,7 @@ exports[`RadioButton label renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -516,7 +516,7 @@ exports[`RadioButton label renders 1`] = `
   border-radius: 100%;
 }
 
-.c1 {
+.c2 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -524,8 +524,8 @@ exports[`RadioButton label renders 1`] = `
   cursor: pointer;
 }
 
-.c1:hover input:not([disabled]) + div,
-.c1:hover input:not([disabled]) + span {
+.c2:hover input:not([disabled]) + div,
+.c2:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
@@ -539,13 +539,13 @@ exports[`RadioButton label renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }
@@ -588,7 +588,7 @@ exports[`RadioButton label renders 1`] = `
     onClick={[Function]}
   >
     <div
-      className="c3"
+      className="c3 "
     >
       <input
         className="c4"
@@ -596,7 +596,7 @@ exports[`RadioButton label renders 1`] = `
         type="radio"
       />
       <div
-        className="c5"
+        className="c5 "
       />
     </div>
     <span>
@@ -608,7 +608,7 @@ exports[`RadioButton label renders 1`] = `
     onClick={[Function]}
   >
     <div
-      className="c3"
+      className="c3 "
     >
       <input
         className="c4"
@@ -616,7 +616,7 @@ exports[`RadioButton label renders 1`] = `
         type="radio"
       />
       <div
-        className="c5"
+        className="c5 "
       />
     </div>
     <div>
@@ -637,7 +637,7 @@ exports[`RadioButton renders 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -704,7 +704,7 @@ exports[`RadioButton renders 1`] = `
   border-radius: 100%;
 }
 
-.c1 {
+.c2 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -712,8 +712,8 @@ exports[`RadioButton renders 1`] = `
   cursor: pointer;
 }
 
-.c1:hover input:not([disabled]) + div,
-.c1:hover input:not([disabled]) + span {
+.c2:hover input:not([disabled]) + div,
+.c2:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
@@ -727,13 +727,13 @@ exports[`RadioButton renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }
@@ -776,7 +776,7 @@ exports[`RadioButton renders 1`] = `
     onClick={[Function]}
   >
     <div
-      className="c3"
+      className="c3 "
     >
       <input
         className="c4"
@@ -784,7 +784,7 @@ exports[`RadioButton renders 1`] = `
         type="radio"
       />
       <div
-        className="c5"
+        className="c5 "
       />
     </div>
   </label>
@@ -794,7 +794,7 @@ exports[`RadioButton renders 1`] = `
     onClick={[Function]}
   >
     <div
-      className="c3"
+      className="c3 "
     >
       <input
         className="c4"
@@ -803,7 +803,7 @@ exports[`RadioButton renders 1`] = `
         type="radio"
       />
       <div
-        className="c5"
+        className="c5 "
       />
     </div>
   </label>

--- a/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
+++ b/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
@@ -77,7 +77,7 @@ exports[`RadioButtonGroup object options 1`] = `
   padding: 0px;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -151,7 +151,7 @@ exports[`RadioButtonGroup object options 1`] = `
   height: 12px;
 }
 
-.c2 {
+.c3 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -159,8 +159,8 @@ exports[`RadioButtonGroup object options 1`] = `
   cursor: pointer;
 }
 
-.c2:hover input:not([disabled]) + div,
-.c2:hover input:not([disabled]) + span {
+.c3:hover input:not([disabled]) + div,
+.c3:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
@@ -186,13 +186,13 @@ exports[`RadioButtonGroup object options 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -245,7 +245,7 @@ exports[`RadioButtonGroup object options 1`] = `
       onClick={[Function]}
     >
       <div
-        className="c4"
+        className="c4 "
       >
         <input
           checked={false}
@@ -258,7 +258,7 @@ exports[`RadioButtonGroup object options 1`] = `
           value="one"
         />
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
       <span>
@@ -274,7 +274,7 @@ exports[`RadioButtonGroup object options 1`] = `
       onClick={[Function]}
     >
       <div
-        className="c4"
+        className="c4 "
       >
         <input
           checked={false}
@@ -287,7 +287,7 @@ exports[`RadioButtonGroup object options 1`] = `
           value="two"
         />
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
       <span>
@@ -326,7 +326,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   padding: 0px;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -413,7 +413,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   border-color: #000000;
 }
 
-.c2 {
+.c3 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -422,8 +422,8 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   cursor: default;
 }
 
-.c2:hover input:not([disabled]) + div,
-.c2:hover input:not([disabled]) + span {
+.c3:hover input:not([disabled]) + div,
+.c3:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
@@ -457,13 +457,13 @@ exports[`RadioButtonGroup object options disabled 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -516,7 +516,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
       onClick={[Function]}
     >
       <div
-        className="c4"
+        className="c4 "
       >
         <input
           checked={false}
@@ -529,7 +529,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
           value="one"
         />
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </label>
@@ -537,11 +537,11 @@ exports[`RadioButtonGroup object options disabled 1`] = `
       className="c7"
     />
     <label
-      className="c8 c3"
+      className="c2 c8"
       onClick={[Function]}
     >
       <div
-        className="c4"
+        className="c4 "
       >
         <input
           checked={false}
@@ -553,7 +553,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
           value="two"
         />
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </label>
@@ -589,7 +589,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
   padding: 0px;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -692,7 +692,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
   height: 12px;
 }
 
-.c2 {
+.c3 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -700,8 +700,8 @@ exports[`RadioButtonGroup object options just value 1`] = `
   cursor: pointer;
 }
 
-.c2:hover input:not([disabled]) + div,
-.c2:hover input:not([disabled]) + span {
+.c3:hover input:not([disabled]) + div,
+.c3:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
@@ -734,13 +734,13 @@ exports[`RadioButtonGroup object options just value 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -811,7 +811,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
       onClick={[Function]}
     >
       <div
-        className="c4"
+        className="c4 "
       >
         <input
           checked={false}
@@ -823,7 +823,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
           value="one"
         />
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </label>
@@ -835,7 +835,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
       onClick={[Function]}
     >
       <div
-        className="c4"
+        className="c4 "
       >
         <input
           checked={true}
@@ -847,7 +847,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
           value="two"
         />
         <div
-          className="c8"
+          className="c8 "
         >
           <svg
             className="c9"
@@ -895,7 +895,7 @@ exports[`RadioButtonGroup string options 1`] = `
   padding: 0px;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -998,7 +998,7 @@ exports[`RadioButtonGroup string options 1`] = `
   height: 12px;
 }
 
-.c2 {
+.c3 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1006,8 +1006,8 @@ exports[`RadioButtonGroup string options 1`] = `
   cursor: pointer;
 }
 
-.c2:hover input:not([disabled]) + div,
-.c2:hover input:not([disabled]) + span {
+.c3:hover input:not([disabled]) + div,
+.c3:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
@@ -1040,13 +1040,13 @@ exports[`RadioButtonGroup string options 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -1118,7 +1118,7 @@ exports[`RadioButtonGroup string options 1`] = `
       onClick={[Function]}
     >
       <div
-        className="c4"
+        className="c4 "
       >
         <input
           checked={true}
@@ -1131,7 +1131,7 @@ exports[`RadioButtonGroup string options 1`] = `
           value="one"
         />
         <div
-          className="c6"
+          className="c6 "
         >
           <svg
             className="c7"
@@ -1159,7 +1159,7 @@ exports[`RadioButtonGroup string options 1`] = `
       onClick={[Function]}
     >
       <div
-        className="c4"
+        className="c4 "
       >
         <input
           checked={false}
@@ -1172,7 +1172,7 @@ exports[`RadioButtonGroup string options 1`] = `
           value="two"
         />
         <div
-          className="c9"
+          className="c9 "
         />
       </div>
       <span>

--- a/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
+++ b/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
@@ -11,7 +11,7 @@ exports[`RangeSelector basic 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -144,7 +144,7 @@ exports[`RangeSelector basic 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c2 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -152,13 +152,13 @@ exports[`RangeSelector basic 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }
@@ -327,7 +327,7 @@ exports[`RangeSelector color 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -460,7 +460,7 @@ exports[`RangeSelector color 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c2 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -468,13 +468,13 @@ exports[`RangeSelector color 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }
@@ -643,7 +643,7 @@ exports[`RangeSelector direction 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -871,7 +871,7 @@ exports[`RangeSelector direction 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c2 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -879,13 +879,13 @@ exports[`RangeSelector direction 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }
@@ -1089,7 +1089,7 @@ exports[`RangeSelector direction 1`] = `
     />
   </div>
   <div
-    className="c1 c8"
+    className="c8 c2"
   >
     <div
       className="c8"
@@ -1189,7 +1189,7 @@ exports[`RangeSelector handle keyboard 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1322,7 +1322,7 @@ exports[`RangeSelector handle keyboard 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c2 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1330,13 +1330,13 @@ exports[`RangeSelector handle keyboard 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }
@@ -1464,7 +1464,7 @@ exports[`RangeSelector handle mouse 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1597,7 +1597,7 @@ exports[`RangeSelector handle mouse 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c2 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1605,13 +1605,13 @@ exports[`RangeSelector handle mouse 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }
@@ -1739,7 +1739,7 @@ exports[`RangeSelector invert 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1893,7 +1893,7 @@ exports[`RangeSelector invert 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c2 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1901,13 +1901,13 @@ exports[`RangeSelector invert 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }
@@ -2175,7 +2175,7 @@ exports[`RangeSelector max 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2308,7 +2308,7 @@ exports[`RangeSelector max 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c2 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -2316,13 +2316,13 @@ exports[`RangeSelector max 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }
@@ -2491,7 +2491,7 @@ exports[`RangeSelector min 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2624,7 +2624,7 @@ exports[`RangeSelector min 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c2 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -2632,13 +2632,13 @@ exports[`RangeSelector min 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }
@@ -2807,7 +2807,7 @@ exports[`RangeSelector opacity 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2981,7 +2981,7 @@ exports[`RangeSelector opacity 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c2 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -2989,13 +2989,13 @@ exports[`RangeSelector opacity 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }
@@ -3362,7 +3362,7 @@ exports[`RangeSelector round 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3661,7 +3661,7 @@ exports[`RangeSelector round 1`] = `
   border-radius: 100%;
 }
 
-.c1 {
+.c2 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -3669,13 +3669,13 @@ exports[`RangeSelector round 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }
@@ -4336,7 +4336,7 @@ exports[`RangeSelector size 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4469,7 +4469,7 @@ exports[`RangeSelector size 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c2 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -4477,13 +4477,13 @@ exports[`RangeSelector size 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }
@@ -5174,7 +5174,7 @@ exports[`RangeSelector step 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5307,7 +5307,7 @@ exports[`RangeSelector step 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c2 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -5315,13 +5315,13 @@ exports[`RangeSelector step 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c1 {
     padding: 0px;
   }
 }

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -103,7 +103,7 @@ exports[`Select applies custom global.hover theme to options 1`] = `
   padding: 0px;
 }
 
-.c2 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -121,7 +121,7 @@ exports[`Select applies custom global.hover theme to options 1`] = `
   text-align: inherit;
 }
 
-.c7 {
+.c6 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -139,23 +139,23 @@ exports[`Select applies custom global.hover theme to options 1`] = `
   border: none;
 }
 
-.c7::-webkit-search-decoration {
+.c6::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-webkit-input-placeholder {
+.c6::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c6::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c6:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-focus-inner {
+.c6::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -175,11 +175,11 @@ exports[`Select applies custom global.hover theme to options 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c6 {
+.c7 {
   cursor: pointer;
 }
 
-.c1 {
+.c2 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -348,7 +348,7 @@ exports[`Select applies custom global.hover theme to options 2`] = `
   type="button"
 >
   <div
-    class="c1"
+    class="c1 "
   >
     <span
       class="c2"
@@ -462,7 +462,7 @@ exports[`Select basic 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c0 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -480,7 +480,7 @@ exports[`Select basic 1`] = `
   text-align: inherit;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -498,23 +498,23 @@ exports[`Select basic 1`] = `
   border: none;
 }
 
-.c6::-webkit-search-decoration {
+.c5::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c6:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -524,11 +524,11 @@ exports[`Select basic 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c6 {
   cursor: pointer;
 }
 
-.c0 {
+.c1 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -734,7 +734,7 @@ exports[`Select complex options and children 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c0 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -752,7 +752,7 @@ exports[`Select complex options and children 1`] = `
   text-align: inherit;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -770,23 +770,23 @@ exports[`Select complex options and children 1`] = `
   border: none;
 }
 
-.c6::-webkit-search-decoration {
+.c5::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c6:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -796,11 +796,11 @@ exports[`Select complex options and children 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c6 {
   cursor: pointer;
 }
 
-.c0 {
+.c1 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -893,7 +893,7 @@ exports[`Select complex options and children 1`] = `
 exports[`Select complex options and children 2`] = `
 <button
   aria-label="Open Drop"
-  class="Select__StyledSelectDropButton-sc-17idtfo-1 fcNjcL StyledButton-sc-323bzc-0 jfbKsv"
+  class="StyledButton-sc-323bzc-0 jfbKsv Select__StyledSelectDropButton-sc-17idtfo-1 fcNjcL"
   id="test-select"
   type="button"
 >
@@ -908,7 +908,7 @@ exports[`Select complex options and children 2`] = `
       >
         <input
           autocomplete="off"
-          class="Select__SelectTextInput-sc-17idtfo-0 lmyIUy StyledTextInput-sc-1x30a0s-0 duvNfq"
+          class="StyledTextInput-sc-1x30a0s-0 duvNfq Select__SelectTextInput-sc-17idtfo-0 lmyIUy"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -940,7 +940,7 @@ exports[`Select complex options and children 2`] = `
 `;
 
 exports[`Select complex options and children 3`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -959,7 +959,7 @@ exports[`Select complex options and children 3`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -976,7 +976,7 @@ exports[`Select complex options and children 3`] = `
   padding: 0px;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1062,7 +1062,7 @@ exports[`Select complex options and children 3`] = `
   color: #000000;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1086,11 +1086,11 @@ exports[`Select complex options and children 3`] = `
   animation-delay: 0.01s;
 }
 
-.c2 {
+.c3 {
   max-height: inherit;
 }
 
-.c4 {
+.c5 {
   position: relative;
   -webkit-scroll-behavior: smooth;
   -moz-scroll-behavior: smooth;
@@ -1099,37 +1099,37 @@ exports[`Select complex options and children 3`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     padding: 0px;
   }
 }
@@ -1159,7 +1159,7 @@ exports[`Select complex options and children 3`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1172,7 +1172,7 @@ exports[`Select complex options and children 3`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }
@@ -1498,7 +1498,7 @@ exports[`Select deselect an option 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c0 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1516,7 +1516,7 @@ exports[`Select deselect an option 1`] = `
   text-align: inherit;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -1534,23 +1534,23 @@ exports[`Select deselect an option 1`] = `
   border: none;
 }
 
-.c6::-webkit-search-decoration {
+.c5::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c6:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -1560,11 +1560,11 @@ exports[`Select deselect an option 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c6 {
   cursor: pointer;
 }
 
-.c0 {
+.c1 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -1758,7 +1758,7 @@ exports[`Select disabled 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c0 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1778,7 +1778,7 @@ exports[`Select disabled 1`] = `
   cursor: default;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -1796,23 +1796,23 @@ exports[`Select disabled 1`] = `
   border: none;
 }
 
-.c6::-webkit-search-decoration {
+.c5::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c6:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -1822,11 +1822,11 @@ exports[`Select disabled 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c6 {
   cursor: pointer;
 }
 
-.c0 {
+.c1 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -1920,7 +1920,7 @@ exports[`Select disabled 1`] = `
 exports[`Select disabled 2`] = `
 <button
   aria-label="Open Drop"
-  class="Select__StyledSelectDropButton-sc-17idtfo-1 fcNjcL StyledButton-sc-323bzc-0 chnll"
+  class="StyledButton-sc-323bzc-0 chnll Select__StyledSelectDropButton-sc-17idtfo-1 fcNjcL"
   disabled=""
   id="test-select"
   type="button"
@@ -1936,7 +1936,7 @@ exports[`Select disabled 2`] = `
       >
         <input
           autocomplete="off"
-          class="Select__SelectTextInput-sc-17idtfo-0 lmyIUy StyledTextInput-sc-1x30a0s-0 duvNfq"
+          class="StyledTextInput-sc-1x30a0s-0 duvNfq Select__SelectTextInput-sc-17idtfo-0 lmyIUy"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -1968,7 +1968,7 @@ exports[`Select disabled 2`] = `
 `;
 
 exports[`Select empty results search 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1987,7 +1987,7 @@ exports[`Select empty results search 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2004,7 +2004,7 @@ exports[`Select empty results search 1`] = `
   padding: 0px;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2111,7 +2111,7 @@ exports[`Select empty results search 1`] = `
   line-height: 24px;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2180,11 +2180,11 @@ exports[`Select empty results search 1`] = `
   width: 100%;
 }
 
-.c2 {
+.c3 {
   max-height: inherit;
 }
 
-.c7 {
+.c8 {
   position: relative;
   -webkit-scroll-behavior: smooth;
   -moz-scroll-behavior: smooth;
@@ -2193,37 +2193,37 @@ exports[`Select empty results search 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     padding: 0px;
   }
 }
@@ -2265,7 +2265,7 @@ exports[`Select empty results search 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2278,7 +2278,7 @@ exports[`Select empty results search 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }
@@ -2323,7 +2323,7 @@ exports[`Select empty results search 1`] = `
           type="button"
         >
           <div
-            class="c11"
+            class="c11 "
           >
             <span
               class="c12"
@@ -2339,7 +2339,7 @@ exports[`Select empty results search 1`] = `
 `;
 
 exports[`Select large drop container height 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2358,7 +2358,7 @@ exports[`Select large drop container height 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2375,7 +2375,7 @@ exports[`Select large drop container height 1`] = `
   padding: 0px;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2488,7 +2488,7 @@ exports[`Select large drop container height 1`] = `
   line-height: 24px;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2512,11 +2512,11 @@ exports[`Select large drop container height 1`] = `
   animation-delay: 0.01s;
 }
 
-.c2 {
+.c3 {
   max-height: 768px;
 }
 
-.c4 {
+.c5 {
   position: relative;
   -webkit-scroll-behavior: smooth;
   -moz-scroll-behavior: smooth;
@@ -2525,37 +2525,37 @@ exports[`Select large drop container height 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     padding: 0px;
   }
 }
@@ -2597,7 +2597,7 @@ exports[`Select large drop container height 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2610,7 +2610,7 @@ exports[`Select large drop container height 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }
@@ -2640,7 +2640,7 @@ exports[`Select large drop container height 1`] = `
           type="button"
         >
           <div
-            class="c8"
+            class="c8 "
           >
             <span
               class="c9"
@@ -2660,7 +2660,7 @@ exports[`Select large drop container height 1`] = `
           type="button"
         >
           <div
-            class="c8"
+            class="c8 "
           >
             <span
               class="c9"
@@ -2679,7 +2679,7 @@ exports[`Select large drop container height 1`] = `
 `;
 
 exports[`Select medium drop container height 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2698,7 +2698,7 @@ exports[`Select medium drop container height 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2715,7 +2715,7 @@ exports[`Select medium drop container height 1`] = `
   padding: 0px;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2828,7 +2828,7 @@ exports[`Select medium drop container height 1`] = `
   line-height: 24px;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2852,11 +2852,11 @@ exports[`Select medium drop container height 1`] = `
   animation-delay: 0.01s;
 }
 
-.c2 {
+.c3 {
   max-height: 384px;
 }
 
-.c4 {
+.c5 {
   position: relative;
   -webkit-scroll-behavior: smooth;
   -moz-scroll-behavior: smooth;
@@ -2865,37 +2865,37 @@ exports[`Select medium drop container height 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     padding: 0px;
   }
 }
@@ -2937,7 +2937,7 @@ exports[`Select medium drop container height 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2950,7 +2950,7 @@ exports[`Select medium drop container height 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }
@@ -2980,7 +2980,7 @@ exports[`Select medium drop container height 1`] = `
           type="button"
         >
           <div
-            class="c8"
+            class="c8 "
           >
             <span
               class="c9"
@@ -3000,7 +3000,7 @@ exports[`Select medium drop container height 1`] = `
           type="button"
         >
           <div
-            class="c8"
+            class="c8 "
           >
             <span
               class="c9"
@@ -3121,7 +3121,7 @@ exports[`Select modifies select control style on open 1`] = `
   padding: 0px;
 }
 
-.c2 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3139,7 +3139,7 @@ exports[`Select modifies select control style on open 1`] = `
   text-align: inherit;
 }
 
-.c7 {
+.c6 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -3157,23 +3157,23 @@ exports[`Select modifies select control style on open 1`] = `
   border: none;
 }
 
-.c7::-webkit-search-decoration {
+.c6::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-webkit-input-placeholder {
+.c6::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c6::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c6:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-focus-inner {
+.c6::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -3193,11 +3193,11 @@ exports[`Select modifies select control style on open 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c6 {
+.c7 {
   cursor: pointer;
 }
 
-.c1 {
+.c2 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   background: purple;
@@ -3396,7 +3396,7 @@ exports[`Select multiple 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c0 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3414,7 +3414,7 @@ exports[`Select multiple 1`] = `
   text-align: inherit;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -3432,23 +3432,23 @@ exports[`Select multiple 1`] = `
   border: none;
 }
 
-.c6::-webkit-search-decoration {
+.c5::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c6:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -3458,11 +3458,11 @@ exports[`Select multiple 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c6 {
   cursor: pointer;
 }
 
-.c0 {
+.c1 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -3670,7 +3670,7 @@ exports[`Select multiple values 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c0 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3688,7 +3688,7 @@ exports[`Select multiple values 1`] = `
   text-align: inherit;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -3706,23 +3706,23 @@ exports[`Select multiple values 1`] = `
   border: none;
 }
 
-.c6::-webkit-search-decoration {
+.c5::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c6:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -3732,11 +3732,11 @@ exports[`Select multiple values 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c6 {
   cursor: pointer;
 }
 
-.c0 {
+.c1 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -3830,7 +3830,7 @@ exports[`Select multiple values 1`] = `
 exports[`Select multiple values 2`] = `
 <button
   aria-label="Open Drop"
-  class="Select__StyledSelectDropButton-sc-17idtfo-1 fcNjcL StyledButton-sc-323bzc-0 jfbKsv"
+  class="StyledButton-sc-323bzc-0 jfbKsv Select__StyledSelectDropButton-sc-17idtfo-1 fcNjcL"
   id="test-select"
   type="button"
 >
@@ -3845,7 +3845,7 @@ exports[`Select multiple values 2`] = `
       >
         <input
           autocomplete="off"
-          class="Select__SelectTextInput-sc-17idtfo-0 lmyIUy StyledTextInput-sc-1x30a0s-0 duvNfq"
+          class="StyledTextInput-sc-1x30a0s-0 duvNfq Select__SelectTextInput-sc-17idtfo-0 lmyIUy"
           id="test-select__input"
           multiple=""
           placeholder="test select"
@@ -3878,7 +3878,7 @@ exports[`Select multiple values 2`] = `
 `;
 
 exports[`Select multiple values 3`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3897,7 +3897,7 @@ exports[`Select multiple values 3`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3914,7 +3914,7 @@ exports[`Select multiple values 3`] = `
   padding: 0px;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3955,7 +3955,7 @@ exports[`Select multiple values 3`] = `
   padding: 0px;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4027,7 +4027,7 @@ exports[`Select multiple values 3`] = `
   line-height: 24px;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4051,11 +4051,11 @@ exports[`Select multiple values 3`] = `
   animation-delay: 0.01s;
 }
 
-.c2 {
+.c3 {
   max-height: inherit;
 }
 
-.c4 {
+.c5 {
   position: relative;
   -webkit-scroll-behavior: smooth;
   -moz-scroll-behavior: smooth;
@@ -4063,44 +4063,44 @@ exports[`Select multiple values 3`] = `
   scroll-behavior: smooth;
 }
 
-.c8 {
+.c9 {
   background: #7D4CDB;
   color: #f8f8f8;
   color: #FFFFFF;
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     padding: 0px;
   }
 }
@@ -4118,13 +4118,13 @@ exports[`Select multiple values 3`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c8 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c8 {
     padding: 6px;
   }
 }
@@ -4142,7 +4142,7 @@ exports[`Select multiple values 3`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -4155,7 +4155,7 @@ exports[`Select multiple values 3`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }
@@ -4505,7 +4505,7 @@ exports[`Select opens 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c0 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -4523,7 +4523,7 @@ exports[`Select opens 1`] = `
   text-align: inherit;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -4541,23 +4541,23 @@ exports[`Select opens 1`] = `
   border: none;
 }
 
-.c6::-webkit-search-decoration {
+.c5::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c6:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -4567,11 +4567,11 @@ exports[`Select opens 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c6 {
   cursor: pointer;
 }
 
-.c0 {
+.c1 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -4664,7 +4664,7 @@ exports[`Select opens 1`] = `
 exports[`Select opens 2`] = `
 <button
   aria-label="Open Drop"
-  class="Select__StyledSelectDropButton-sc-17idtfo-1 fcNjcL StyledButton-sc-323bzc-0 jfbKsv"
+  class="StyledButton-sc-323bzc-0 jfbKsv Select__StyledSelectDropButton-sc-17idtfo-1 fcNjcL"
   id="test-select"
   type="button"
 >
@@ -4679,7 +4679,7 @@ exports[`Select opens 2`] = `
       >
         <input
           autocomplete="off"
-          class="Select__SelectTextInput-sc-17idtfo-0 lmyIUy StyledTextInput-sc-1x30a0s-0 duvNfq"
+          class="StyledTextInput-sc-1x30a0s-0 duvNfq Select__SelectTextInput-sc-17idtfo-0 lmyIUy"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -4711,7 +4711,7 @@ exports[`Select opens 2`] = `
 `;
 
 exports[`Select opens 3`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4730,7 +4730,7 @@ exports[`Select opens 3`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4747,7 +4747,7 @@ exports[`Select opens 3`] = `
   padding: 0px;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4860,7 +4860,7 @@ exports[`Select opens 3`] = `
   line-height: 24px;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4884,11 +4884,11 @@ exports[`Select opens 3`] = `
   animation-delay: 0.01s;
 }
 
-.c2 {
+.c3 {
   max-height: inherit;
 }
 
-.c4 {
+.c5 {
   position: relative;
   -webkit-scroll-behavior: smooth;
   -moz-scroll-behavior: smooth;
@@ -4897,37 +4897,37 @@ exports[`Select opens 3`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     padding: 0px;
   }
 }
@@ -4969,7 +4969,7 @@ exports[`Select opens 3`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -4982,7 +4982,7 @@ exports[`Select opens 3`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }
@@ -5012,7 +5012,7 @@ exports[`Select opens 3`] = `
           type="button"
         >
           <div
-            class="c8"
+            class="c8 "
           >
             <span
               class="c9"
@@ -5032,7 +5032,7 @@ exports[`Select opens 3`] = `
           type="button"
         >
           <div
-            class="c8"
+            class="c8 "
           >
             <span
               class="c9"
@@ -5219,7 +5219,7 @@ exports[`Select opens 4`] = `
 
 exports[`Select opens 5`] = `
 <div
-  class="SelectContainer__OptionsBox-sc-1wi0ul8-0 eBHXEP StyledBox-sc-13pk1d4-0 cuJBzn"
+  class="StyledBox-sc-13pk1d4-0 cuJBzn SelectContainer__OptionsBox-sc-1wi0ul8-0 eBHXEP"
   role="menubar"
   tabindex="-1"
 >
@@ -5233,7 +5233,7 @@ exports[`Select opens 5`] = `
       type="button"
     >
       <div
-        class="SelectContainer__OptionBox-sc-1wi0ul8-1 ixLLDr StyledBox-sc-13pk1d4-0 jpkxgh"
+        class="StyledBox-sc-13pk1d4-0 jpkxgh SelectContainer__OptionBox-sc-1wi0ul8-1 ixLLDr"
       >
         <span
           class="StyledText-sc-1sadyjn-0 cVkhuq"
@@ -5253,7 +5253,7 @@ exports[`Select opens 5`] = `
       type="button"
     >
       <div
-        class="SelectContainer__OptionBox-sc-1wi0ul8-1 ixLLDr StyledBox-sc-13pk1d4-0 jpkxgh"
+        class="StyledBox-sc-13pk1d4-0 jpkxgh SelectContainer__OptionBox-sc-1wi0ul8-1 ixLLDr"
       >
         <span
           class="StyledText-sc-1sadyjn-0 cVkhuq"
@@ -5372,7 +5372,7 @@ exports[`Select renders custom icon 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c0 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5390,7 +5390,7 @@ exports[`Select renders custom icon 1`] = `
   text-align: inherit;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -5408,23 +5408,23 @@ exports[`Select renders custom icon 1`] = `
   border: none;
 }
 
-.c6::-webkit-search-decoration {
+.c5::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c6:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -5434,11 +5434,11 @@ exports[`Select renders custom icon 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c6 {
   cursor: pointer;
 }
 
-.c0 {
+.c1 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -5644,7 +5644,7 @@ exports[`Select renders default icon 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c0 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5662,7 +5662,7 @@ exports[`Select renders default icon 1`] = `
   text-align: inherit;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -5680,23 +5680,23 @@ exports[`Select renders default icon 1`] = `
   border: none;
 }
 
-.c6::-webkit-search-decoration {
+.c5::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c6:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -5706,11 +5706,11 @@ exports[`Select renders default icon 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c6 {
   cursor: pointer;
 }
 
-.c0 {
+.c1 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -5917,7 +5917,7 @@ exports[`Select renders styled select options backwards compatible with legacy
   padding: 0px;
 }
 
-.c2 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5935,7 +5935,7 @@ exports[`Select renders styled select options backwards compatible with legacy
   text-align: inherit;
 }
 
-.c7 {
+.c6 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -5953,23 +5953,23 @@ exports[`Select renders styled select options backwards compatible with legacy
   border: none;
 }
 
-.c7::-webkit-search-decoration {
+.c6::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-webkit-input-placeholder {
+.c6::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c6::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c6:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-focus-inner {
+.c6::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -5989,11 +5989,11 @@ exports[`Select renders styled select options backwards compatible with legacy
   -webkit-font-smoothing: antialiased;
 }
 
-.c6 {
+.c7 {
   cursor: pointer;
 }
 
-.c1 {
+.c2 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -6193,7 +6193,7 @@ exports[`Select renders styled select options combining select.options.box &&
   padding: 0px;
 }
 
-.c2 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6211,7 +6211,7 @@ exports[`Select renders styled select options combining select.options.box &&
   text-align: inherit;
 }
 
-.c7 {
+.c6 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -6229,23 +6229,23 @@ exports[`Select renders styled select options combining select.options.box &&
   border: none;
 }
 
-.c7::-webkit-search-decoration {
+.c6::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-webkit-input-placeholder {
+.c6::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c6::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c6:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-focus-inner {
+.c6::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -6265,11 +6265,11 @@ exports[`Select renders styled select options combining select.options.box &&
   -webkit-font-smoothing: antialiased;
 }
 
-.c6 {
+.c7 {
   cursor: pointer;
 }
 
-.c1 {
+.c2 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -6467,7 +6467,7 @@ exports[`Select renders styled select options using select.options.container 1`]
   padding: 0px;
 }
 
-.c2 {
+.c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6485,7 +6485,7 @@ exports[`Select renders styled select options using select.options.container 1`]
   text-align: inherit;
 }
 
-.c7 {
+.c6 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -6503,23 +6503,23 @@ exports[`Select renders styled select options using select.options.container 1`]
   border: none;
 }
 
-.c7::-webkit-search-decoration {
+.c6::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-webkit-input-placeholder {
+.c6::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c6::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c6:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-focus-inner {
+.c6::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -6539,11 +6539,11 @@ exports[`Select renders styled select options using select.options.container 1`]
   -webkit-font-smoothing: antialiased;
 }
 
-.c6 {
+.c7 {
   cursor: pointer;
 }
 
-.c1 {
+.c2 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -6686,7 +6686,7 @@ exports[`Select renders without icon 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c0 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6704,7 +6704,7 @@ exports[`Select renders without icon 1`] = `
   text-align: inherit;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -6722,23 +6722,23 @@ exports[`Select renders without icon 1`] = `
   border: none;
 }
 
-.c6::-webkit-search-decoration {
+.c5::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c6:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -6748,11 +6748,11 @@ exports[`Select renders without icon 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c6 {
   cursor: pointer;
 }
 
-.c0 {
+.c1 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -6924,7 +6924,7 @@ exports[`Select search 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c0 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6942,7 +6942,7 @@ exports[`Select search 1`] = `
   text-align: inherit;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -6960,23 +6960,23 @@ exports[`Select search 1`] = `
   border: none;
 }
 
-.c6::-webkit-search-decoration {
+.c5::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c6:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -6986,11 +6986,11 @@ exports[`Select search 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c6 {
   cursor: pointer;
 }
 
-.c0 {
+.c1 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -7081,7 +7081,7 @@ exports[`Select search 1`] = `
 `;
 
 exports[`Select search 2`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7100,7 +7100,7 @@ exports[`Select search 2`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7117,7 +7117,7 @@ exports[`Select search 2`] = `
   padding: 0px;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7250,7 +7250,7 @@ exports[`Select search 2`] = `
   line-height: 24px;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -7319,11 +7319,11 @@ exports[`Select search 2`] = `
   width: 100%;
 }
 
-.c2 {
+.c3 {
   max-height: inherit;
 }
 
-.c7 {
+.c8 {
   position: relative;
   -webkit-scroll-behavior: smooth;
   -moz-scroll-behavior: smooth;
@@ -7332,37 +7332,37 @@ exports[`Select search 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     padding: 0px;
   }
 }
@@ -7416,7 +7416,7 @@ exports[`Select search 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -7429,7 +7429,7 @@ exports[`Select search 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }
@@ -7473,7 +7473,7 @@ exports[`Select search 2`] = `
           type="button"
         >
           <div
-            class="c11"
+            class="c11 "
           >
             <span
               class="c12"
@@ -7493,7 +7493,7 @@ exports[`Select search 2`] = `
           type="button"
         >
           <div
-            class="c11"
+            class="c11 "
           >
             <span
               class="c12"
@@ -7793,7 +7793,7 @@ exports[`Select select an option 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c0 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -7811,7 +7811,7 @@ exports[`Select select an option 1`] = `
   text-align: inherit;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -7829,23 +7829,23 @@ exports[`Select select an option 1`] = `
   border: none;
 }
 
-.c6::-webkit-search-decoration {
+.c5::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c6:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -7855,11 +7855,11 @@ exports[`Select select an option 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c6 {
   cursor: pointer;
 }
 
-.c0 {
+.c1 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -8109,7 +8109,7 @@ exports[`Select select an option with complex options 1`] = `
 
 <button
   aria-label="Open Drop"
-  class="c0"
+  class="c0 "
   id="test-select"
   type="button"
 >
@@ -8247,7 +8247,7 @@ exports[`Select select an option with enter 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c0 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -8265,7 +8265,7 @@ exports[`Select select an option with enter 1`] = `
   text-align: inherit;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -8283,23 +8283,23 @@ exports[`Select select an option with enter 1`] = `
   border: none;
 }
 
-.c6::-webkit-search-decoration {
+.c5::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c6:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -8309,11 +8309,11 @@ exports[`Select select an option with enter 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c6 {
   cursor: pointer;
 }
 
-.c0 {
+.c1 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -8506,7 +8506,7 @@ exports[`Select select another option 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c0 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -8524,7 +8524,7 @@ exports[`Select select another option 1`] = `
   text-align: inherit;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -8542,23 +8542,23 @@ exports[`Select select another option 1`] = `
   border: none;
 }
 
-.c6::-webkit-search-decoration {
+.c5::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c6:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -8568,11 +8568,11 @@ exports[`Select select another option 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c6 {
   cursor: pointer;
 }
 
-.c0 {
+.c1 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -8766,7 +8766,7 @@ exports[`Select size 1`] = `
   padding: 0px;
 }
 
-.c1 {
+.c0 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -8784,7 +8784,7 @@ exports[`Select size 1`] = `
   text-align: inherit;
 }
 
-.c6 {
+.c5 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -8804,23 +8804,23 @@ exports[`Select size 1`] = `
   border: none;
 }
 
-.c6::-webkit-search-decoration {
+.c5::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c6:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border: none;
   outline: none;
 }
@@ -8830,11 +8830,11 @@ exports[`Select size 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c6 {
   cursor: pointer;
 }
 
-.c0 {
+.c1 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -8940,7 +8940,7 @@ exports[`Select size 1`] = `
 `;
 
 exports[`Select small drop container height 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8959,7 +8959,7 @@ exports[`Select small drop container height 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8976,7 +8976,7 @@ exports[`Select small drop container height 1`] = `
   padding: 0px;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9089,7 +9089,7 @@ exports[`Select small drop container height 1`] = `
   line-height: 24px;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -9113,11 +9113,11 @@ exports[`Select small drop container height 1`] = `
   animation-delay: 0.01s;
 }
 
-.c2 {
+.c3 {
   max-height: 192px;
 }
 
-.c4 {
+.c5 {
   position: relative;
   -webkit-scroll-behavior: smooth;
   -moz-scroll-behavior: smooth;
@@ -9126,37 +9126,37 @@ exports[`Select small drop container height 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c1 {
+  .c0 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     padding: 0px;
   }
 }
@@ -9198,7 +9198,7 @@ exports[`Select small drop container height 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -9211,7 +9211,7 @@ exports[`Select small drop container height 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }
@@ -9241,7 +9241,7 @@ exports[`Select small drop container height 1`] = `
           type="button"
         >
           <div
-            class="c8"
+            class="c8 "
           >
             <span
               class="c9"
@@ -9261,7 +9261,7 @@ exports[`Select small drop container height 1`] = `
           type="button"
         >
           <div
-            class="c8"
+            class="c8 "
           >
             <span
               class="c9"

--- a/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
+++ b/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SkipLink basic 1`] = `
-.c2 {
+.c1 {
   box-sizing: border-box;
   font-size: inherit;
   line-height: inherit;
@@ -13,7 +13,7 @@ exports[`SkipLink basic 1`] = `
   outline: none;
 }
 
-.c2:hover {
+.c1:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -28,7 +28,7 @@ exports[`SkipLink basic 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
+.c2 {
   width: 0;
   height: 0;
   overflow: hidden;
@@ -73,7 +73,7 @@ exports[`SkipLink basic 2`] = `
   <div>
     <a
       aria-hidden="true"
-      class="SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 buKRUY StyledAnchor-sc-1rp7lwl-0 jgeOSx"
+      class="StyledAnchor-sc-1rp7lwl-0 jgeOSx SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 buKRUY"
       id="main"
       tabindex="-1"
     />
@@ -86,7 +86,7 @@ exports[`SkipLink basic 2`] = `
   <footer>
     <a
       aria-hidden="true"
-      class="SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 buKRUY StyledAnchor-sc-1rp7lwl-0 jgeOSx"
+      class="StyledAnchor-sc-1rp7lwl-0 jgeOSx SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 buKRUY"
       id="footer"
       tabindex="-1"
     />
@@ -105,7 +105,7 @@ exports[`SkipLink basic 3`] = `
   <div>
     <a
       aria-hidden="true"
-      class="SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 buKRUY StyledAnchor-sc-1rp7lwl-0 jgeOSx"
+      class="StyledAnchor-sc-1rp7lwl-0 jgeOSx SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 buKRUY"
       id="main"
       tabindex="-1"
     />
@@ -118,7 +118,7 @@ exports[`SkipLink basic 3`] = `
   <footer>
     <a
       aria-hidden="true"
-      class="SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 buKRUY StyledAnchor-sc-1rp7lwl-0 jgeOSx"
+      class="StyledAnchor-sc-1rp7lwl-0 jgeOSx SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 buKRUY"
       id="footer"
       tabindex="-1"
     />

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -45,7 +45,7 @@ exports[`Tabs Tab 1`] = `
   flex-wrap: wrap;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -127,14 +127,14 @@ exports[`Tabs Tab 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c4 {
+.c5 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 3px;
   margin-bottom: 3px;
 }
 
-.c4:hover {
+.c5:hover {
   color: #000000;
 }
 
@@ -167,27 +167,27 @@ exports[`Tabs Tab 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     margin-left: 6px;
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     margin-top: 2px;
     margin-bottom: 2px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     border-bottom: solid 2px #000000;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     padding-bottom: 3px;
   }
 }
@@ -222,11 +222,11 @@ exports[`Tabs Tab 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="c1 "
     role="tablist"
   >
     <div
-      className="c2"
+      className="c2 "
     >
       <button
         aria-expanded={true}
@@ -263,7 +263,7 @@ exports[`Tabs Tab 1`] = `
         type="button"
       >
         <div
-          className="c4 c7"
+          className="c7 c5"
         >
           <span
             className="c8"
@@ -329,7 +329,7 @@ exports[`Tabs change to second tab 1`] = `
   flex-wrap: wrap;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -411,14 +411,14 @@ exports[`Tabs change to second tab 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c4 {
+.c5 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 3px;
   margin-bottom: 3px;
 }
 
-.c4:hover {
+.c5:hover {
   color: #000000;
 }
 
@@ -451,27 +451,27 @@ exports[`Tabs change to second tab 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     margin-left: 6px;
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     margin-top: 2px;
     margin-bottom: 2px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     border-bottom: solid 2px #000000;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     padding-bottom: 3px;
   }
 }
@@ -506,11 +506,11 @@ exports[`Tabs change to second tab 1`] = `
   class="c0"
 >
   <div
-    class="c1"
+    class="c1 "
     role="tablist"
   >
     <div
-      class="c2"
+      class="c2 "
     >
       <button
         aria-expanded="true"
@@ -537,7 +537,7 @@ exports[`Tabs change to second tab 1`] = `
         type="button"
       >
         <div
-          class="c4 c7"
+          class="c7 c5"
         >
           <span
             class="c8"
@@ -563,11 +563,11 @@ exports[`Tabs change to second tab 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 eUfLDp"
 >
   <div
-    class="StyledTabs-a4fwxl-2 jBsJwq StyledBox-sc-13pk1d4-0 fWrrBh"
+    class="StyledBox-sc-13pk1d4-0 fWrrBh StyledTabs-a4fwxl-2 jBsJwq"
     role="tablist"
   >
     <div
-      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 ckzykU"
+      class="StyledBox-sc-13pk1d4-0 ckzykU StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH"
     >
       <button
         aria-expanded="false"
@@ -577,7 +577,7 @@ exports[`Tabs change to second tab 2`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 kyubVG"
+          class="StyledBox-sc-13pk1d4-0 kyubVG StyledTab-sc-1nnwnsb-0 dGMZCN"
         >
           <span
             class="StyledText-sc-1sadyjn-0 eotKNI"
@@ -594,7 +594,7 @@ exports[`Tabs change to second tab 2`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 hAQvDd"
+          class="StyledBox-sc-13pk1d4-0 hAQvDd StyledTab-sc-1nnwnsb-0 dGMZCN"
         >
           <span
             class="StyledText-sc-1sadyjn-0 ikIgfp"
@@ -660,7 +660,7 @@ exports[`Tabs complex title 1`] = `
   flex-wrap: wrap;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -730,14 +730,14 @@ exports[`Tabs complex title 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c4 {
+.c5 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 3px;
   margin-bottom: 3px;
 }
 
-.c4:hover {
+.c5:hover {
   color: #000000;
 }
 
@@ -770,27 +770,27 @@ exports[`Tabs complex title 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     margin-left: 6px;
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     margin-top: 2px;
     margin-bottom: 2px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     border-bottom: solid 2px #000000;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     padding-bottom: 3px;
   }
 }
@@ -825,11 +825,11 @@ exports[`Tabs complex title 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="c1 "
     role="tablist"
   >
     <div
-      className="c2"
+      className="c2 "
     >
       <button
         aria-expanded={true}
@@ -864,7 +864,7 @@ exports[`Tabs complex title 1`] = `
         type="button"
       >
         <div
-          className="c4 c6"
+          className="c6 c5"
         >
           <div>
             Tab 2
@@ -928,7 +928,7 @@ exports[`Tabs no Tab 1`] = `
   flex-wrap: wrap;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -977,14 +977,14 @@ exports[`Tabs no Tab 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c4 {
+.c5 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 3px;
   margin-bottom: 3px;
 }
 
-.c4:hover {
+.c5:hover {
   color: #000000;
 }
 
@@ -1017,27 +1017,27 @@ exports[`Tabs no Tab 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     margin-left: 6px;
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     margin-top: 2px;
     margin-bottom: 2px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     border-bottom: solid 2px #000000;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     padding-bottom: 3px;
   }
 }
@@ -1046,11 +1046,11 @@ exports[`Tabs no Tab 1`] = `
   className="c0"
 >
   <div
-    className="c1"
+    className="c1 "
     role="tablist"
   >
     <div
-      className="c2"
+      className="c2 "
     >
       <button
         aria-expanded={true}
@@ -1123,7 +1123,7 @@ exports[`Tabs set on hover 1`] = `
   flex-wrap: wrap;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1205,14 +1205,14 @@ exports[`Tabs set on hover 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c4 {
+.c5 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 3px;
   margin-bottom: 3px;
 }
 
-.c4:hover {
+.c5:hover {
   color: #000000;
 }
 
@@ -1245,27 +1245,27 @@ exports[`Tabs set on hover 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     margin-left: 6px;
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     margin-top: 2px;
     margin-bottom: 2px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     border-bottom: solid 2px #000000;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c4 {
     padding-bottom: 3px;
   }
 }
@@ -1300,11 +1300,11 @@ exports[`Tabs set on hover 1`] = `
   class="c0"
 >
   <div
-    class="c1"
+    class="c1 "
     role="tablist"
   >
     <div
-      class="c2"
+      class="c2 "
     >
       <button
         aria-expanded="true"
@@ -1331,7 +1331,7 @@ exports[`Tabs set on hover 1`] = `
         type="button"
       >
         <div
-          class="c4 c7"
+          class="c7 c5"
         >
           <span
             class="c8"
@@ -1357,11 +1357,11 @@ exports[`Tabs set on hover 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 eUfLDp"
 >
   <div
-    class="StyledTabs-a4fwxl-2 jBsJwq StyledBox-sc-13pk1d4-0 fWrrBh"
+    class="StyledBox-sc-13pk1d4-0 fWrrBh StyledTabs-a4fwxl-2 jBsJwq"
     role="tablist"
   >
     <div
-      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 ckzykU"
+      class="StyledBox-sc-13pk1d4-0 ckzykU StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH"
     >
       <button
         aria-expanded="true"
@@ -1371,7 +1371,7 @@ exports[`Tabs set on hover 2`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 hAQvDd"
+          class="StyledBox-sc-13pk1d4-0 hAQvDd StyledTab-sc-1nnwnsb-0 dGMZCN"
         >
           <span
             class="StyledText-sc-1sadyjn-0 ikIgfp"
@@ -1388,7 +1388,7 @@ exports[`Tabs set on hover 2`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 kyubVG"
+          class="StyledBox-sc-13pk1d4-0 kyubVG StyledTab-sc-1nnwnsb-0 dGMZCN"
         >
           <span
             class="StyledText-sc-1sadyjn-0 eotKNI"
@@ -1414,11 +1414,11 @@ exports[`Tabs set on hover 3`] = `
   class="StyledGrommet-sc-19lkkz7-0 eUfLDp"
 >
   <div
-    class="StyledTabs-a4fwxl-2 jBsJwq StyledBox-sc-13pk1d4-0 fWrrBh"
+    class="StyledBox-sc-13pk1d4-0 fWrrBh StyledTabs-a4fwxl-2 jBsJwq"
     role="tablist"
   >
     <div
-      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 ckzykU"
+      class="StyledBox-sc-13pk1d4-0 ckzykU StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH"
     >
       <button
         aria-expanded="true"
@@ -1428,7 +1428,7 @@ exports[`Tabs set on hover 3`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 hAQvDd"
+          class="StyledBox-sc-13pk1d4-0 hAQvDd StyledTab-sc-1nnwnsb-0 dGMZCN"
         >
           <span
             class="StyledText-sc-1sadyjn-0 ikIgfp"
@@ -1445,7 +1445,7 @@ exports[`Tabs set on hover 3`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 hAQvDd"
+          class="StyledBox-sc-13pk1d4-0 hAQvDd StyledTab-sc-1nnwnsb-0 dGMZCN"
         >
           <span
             class="StyledText-sc-1sadyjn-0 gFggBx"
@@ -1471,11 +1471,11 @@ exports[`Tabs set on hover 4`] = `
   class="StyledGrommet-sc-19lkkz7-0 eUfLDp"
 >
   <div
-    class="StyledTabs-a4fwxl-2 jBsJwq StyledBox-sc-13pk1d4-0 fWrrBh"
+    class="StyledBox-sc-13pk1d4-0 fWrrBh StyledTabs-a4fwxl-2 jBsJwq"
     role="tablist"
   >
     <div
-      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 ckzykU"
+      class="StyledBox-sc-13pk1d4-0 ckzykU StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH"
     >
       <button
         aria-expanded="true"
@@ -1485,7 +1485,7 @@ exports[`Tabs set on hover 4`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 hAQvDd"
+          class="StyledBox-sc-13pk1d4-0 hAQvDd StyledTab-sc-1nnwnsb-0 dGMZCN"
         >
           <span
             class="StyledText-sc-1sadyjn-0 ikIgfp"
@@ -1502,7 +1502,7 @@ exports[`Tabs set on hover 4`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 hAQvDd"
+          class="StyledBox-sc-13pk1d4-0 hAQvDd StyledTab-sc-1nnwnsb-0 dGMZCN"
         >
           <span
             class="StyledText-sc-1sadyjn-0 gFggBx"
@@ -1528,11 +1528,11 @@ exports[`Tabs set on hover 5`] = `
   class="StyledGrommet-sc-19lkkz7-0 eUfLDp"
 >
   <div
-    class="StyledTabs-a4fwxl-2 jBsJwq StyledBox-sc-13pk1d4-0 fWrrBh"
+    class="StyledBox-sc-13pk1d4-0 fWrrBh StyledTabs-a4fwxl-2 jBsJwq"
     role="tablist"
   >
     <div
-      class="StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH StyledBox-sc-13pk1d4-0 ckzykU"
+      class="StyledBox-sc-13pk1d4-0 ckzykU StyledTabs__StyledTabsHeader-a4fwxl-0 cjlqAH"
     >
       <button
         aria-expanded="true"
@@ -1542,7 +1542,7 @@ exports[`Tabs set on hover 5`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 hAQvDd"
+          class="StyledBox-sc-13pk1d4-0 hAQvDd StyledTab-sc-1nnwnsb-0 dGMZCN"
         >
           <span
             class="StyledText-sc-1sadyjn-0 ikIgfp"
@@ -1559,7 +1559,7 @@ exports[`Tabs set on hover 5`] = `
         type="button"
       >
         <div
-          class="StyledTab-sc-1nnwnsb-0 dGMZCN StyledBox-sc-13pk1d4-0 kyubVG"
+          class="StyledBox-sc-13pk1d4-0 kyubVG StyledTab-sc-1nnwnsb-0 dGMZCN"
         >
           <span
             class="StyledText-sc-1sadyjn-0 eotKNI"

--- a/src/js/components/TextInput/README 2.md
+++ b/src/js/components/TextInput/README 2.md
@@ -1,0 +1,389 @@
+## TextInput
+A control to input a single line of text, with optional suggestions.
+
+[![](https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png)](https://storybook.grommet.io/?selectedKind=TextInput&full=0&addons=0&stories=1&panelRight=0) [![](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=textinput&module=%2Fsrc%2FTextInput.js)
+## Usage
+
+```javascript
+import { TextInput } from 'grommet';
+<TextInput id='item' name='item' />
+```
+
+## Properties
+
+**dropAlign**
+
+How to align the drop. Defaults to `{
+  "top": "bottom",
+  "left": "left"
+}`.
+
+```
+{
+  top: 
+    top
+    bottom,
+  bottom: 
+    top
+    bottom,
+  right: 
+    left
+    right,
+  left: 
+    left
+    right
+}
+```
+
+**dropHeight**
+
+The height of the drop container.
+
+```
+xsmall
+small
+medium
+large
+xlarge
+string
+```
+
+**dropTarget**
+
+Target where any suggestions drop will be aligned to. This should be
+      a React reference. Typically, this is not required as the drop will be
+      aligned to the TextInput itself by default.
+
+```
+object
+```
+
+**dropProps**
+
+Any valid Drop prop.
+
+```
+object
+```
+
+**id**
+
+The id attribute of the input.
+
+```
+string
+```
+
+**focusIndicator**
+
+Whether the plain text input should receive a focus outline.
+
+```
+boolean
+```
+
+**messages**
+
+Custom messages for TextInput. Used for accessibility by screen 
+        readers. Defaults to `{
+  "enterSelect": "(Press Enter to Select)",
+  "suggestionsCount": "suggestions available",
+  "suggestionsExist": "This input has suggestions use arrow keys to navigate",
+  "suggestionIsOpen": "Suggestions drop is open, continue to use arrow keys to navigate"
+}`.
+
+```
+{
+  enterSelect: string,
+  suggestionsCount: string,
+  suggestionsExist: string,
+  suggestionIsOpen: string
+}
+```
+
+**name**
+
+The name attribute of the input.
+
+```
+string
+```
+
+**onChange**
+
+Function that will be called when the user types in the input.
+
+```
+function
+```
+
+**onSelect**
+
+Function that will be called when the user selects a suggestion.
+The suggestion contains the object chosen from the supplied suggestions.
+
+```
+function
+```
+
+**onSuggestionsOpen**
+
+Function that will be called when the suggestions drop is opened.
+
+```
+function
+```
+
+**onSuggestionsClose**
+
+Function that will be called when the suggestions drop is closed.
+
+```
+function
+```
+
+**placeholder**
+
+Placeholder to use when no value is provided.
+
+```
+node
+```
+
+**plain**
+
+Whether this is a plain input with no border or padding.
+Only use this when the containing context provides sufficient affordance
+
+```
+boolean
+```
+
+**size**
+
+The size of the TextInput.
+
+```
+small
+medium
+large
+xlarge
+string
+```
+
+**suggestions**
+
+Suggestions to show. It is recommended to avoid showing too many
+suggestions and instead rely on the user to type more.
+
+```
+[
+  {
+    label: node,
+    value: any
+  }
+  string
+]
+```
+
+**value**
+
+What text to put in the input.
+
+```
+string
+number
+```
+  
+## Intrinsic element
+
+```
+input
+```
+## Theme
+  
+**global.colors.border**
+
+The color of the border. Expects `object`.
+
+Defaults to
+
+```
+[object Object]
+```
+
+**global.control.border.color**
+
+The border color. Expects `string`.
+
+Defaults to
+
+```
+border
+```
+
+**global.control.border.radius**
+
+The border radius. Expects `string`.
+
+Defaults to
+
+```
+4px
+```
+
+**global.control.border.width**
+
+The border width. Expects `string`.
+
+Defaults to
+
+```
+1px
+```
+
+**select.step**
+
+How many suggestions to render at a time. Expects `number`.
+
+Defaults to
+
+```
+20
+```
+
+**text**
+
+The possible sizes of the text in terms of its font-size and 
+    line-height. Expects `object`.
+
+Defaults to
+
+```
+{
+      xsmall: {
+        size: '12px',
+        height: '18px',
+       },
+      small: {
+        size: '14px',
+        height: '20px',
+       },
+      medium: {
+        size: '18px',
+        height: '24px',
+      },
+      large: {
+        size: '22px',
+        height: '28px',
+      },
+      xlarge: {
+        size: '26px',
+        height: '32px',
+      },
+      xxlarge: {
+        size: '34px',
+        height: '40px',
+      },
+    }
+```
+
+**textInput.extend**
+
+Any additional style for TextInput. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```
+
+**textInput.container.extend**
+
+Any additional style for TextInput container. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```
+
+**textInput.placeholder.extend**
+
+Any additional style for non-string placeholder inside TextInput. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```
+
+**textInput.suggestions.extend**
+
+Any additional style for TextInput suggestions. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```
+
+**textInput.disabled.opacity**
+
+The opacity when the textInput is disabled. Expects `number`.
+
+Defaults to
+
+```
+0.3
+```
+
+**global.focus.border.color**
+
+The color around the component when in focus. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+focus
+```
+
+**global.colors.placeholder**
+
+The placeholder color used for the component. Expects `string`.
+
+Defaults to
+
+```
+#AAAAAA
+```
+
+**global.control.disabled.opacity**
+
+The opacity when a component is disabled. Expects `number`.
+
+Defaults to
+
+```
+0.3
+```
+
+**global.input.weight**
+
+The font weight of the text entered. Expects `number`.
+
+Defaults to
+
+```
+600
+```
+
+**global.input.padding**
+
+The padding of the text. Expects `string`.
+
+Defaults to
+
+```
+12px
+```

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -129,7 +129,7 @@ exports[`TextInput close suggestion drop 1`] = `
 `;
 
 exports[`TextInput close suggestion drop 2`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -148,7 +148,7 @@ exports[`TextInput close suggestion drop 2`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -217,7 +217,7 @@ exports[`TextInput close suggestion drop 2`] = `
   color: #000000;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -249,18 +249,18 @@ exports[`TextInput close suggestion drop 2`] = `
   list-style-type: none;
 }
 
-.c2 {
+.c3 {
   max-height: inherit;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -278,7 +278,7 @@ exports[`TextInput close suggestion drop 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -291,7 +291,7 @@ exports[`TextInput close suggestion drop 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }
@@ -517,7 +517,7 @@ exports[`TextInput complex suggestions 1`] = `
 `;
 
 exports[`TextInput complex suggestions 2`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -536,7 +536,7 @@ exports[`TextInput complex suggestions 2`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -584,7 +584,7 @@ exports[`TextInput complex suggestions 2`] = `
   color: #000000;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -616,24 +616,24 @@ exports[`TextInput complex suggestions 2`] = `
   list-style-type: none;
 }
 
-.c2 {
+.c3 {
   max-height: inherit;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -646,7 +646,7 @@ exports[`TextInput complex suggestions 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }
@@ -923,7 +923,7 @@ exports[`TextInput handles next and previous without suggestion 2`] = `
 `;
 
 exports[`TextInput large drop height 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -942,7 +942,7 @@ exports[`TextInput large drop height 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1011,7 +1011,7 @@ exports[`TextInput large drop height 1`] = `
   color: #000000;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1043,18 +1043,18 @@ exports[`TextInput large drop height 1`] = `
   list-style-type: none;
 }
 
-.c2 {
+.c3 {
   max-height: 768px;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -1072,7 +1072,7 @@ exports[`TextInput large drop height 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1085,7 +1085,7 @@ exports[`TextInput large drop height 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }
@@ -1238,7 +1238,7 @@ exports[`TextInput large drop height 2`] = `
 `;
 
 exports[`TextInput medium drop height 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1257,7 +1257,7 @@ exports[`TextInput medium drop height 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1326,7 +1326,7 @@ exports[`TextInput medium drop height 1`] = `
   color: #000000;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1358,18 +1358,18 @@ exports[`TextInput medium drop height 1`] = `
   list-style-type: none;
 }
 
-.c2 {
+.c3 {
   max-height: 384px;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -1387,7 +1387,7 @@ exports[`TextInput medium drop height 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1400,7 +1400,7 @@ exports[`TextInput medium drop height 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }
@@ -1694,7 +1694,7 @@ exports[`TextInput select suggestion 1`] = `
 `;
 
 exports[`TextInput select suggestion 2`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1713,7 +1713,7 @@ exports[`TextInput select suggestion 2`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1782,7 +1782,7 @@ exports[`TextInput select suggestion 2`] = `
   color: #000000;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1814,18 +1814,18 @@ exports[`TextInput select suggestion 2`] = `
   list-style-type: none;
 }
 
-.c2 {
+.c3 {
   max-height: inherit;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -1843,7 +1843,7 @@ exports[`TextInput select suggestion 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1856,7 +1856,7 @@ exports[`TextInput select suggestion 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }
@@ -2010,7 +2010,7 @@ exports[`TextInput select suggestion 4`] = `
 `;
 
 exports[`TextInput small drop height 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2029,7 +2029,7 @@ exports[`TextInput small drop height 1`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2098,7 +2098,7 @@ exports[`TextInput small drop height 1`] = `
   color: #000000;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2130,18 +2130,18 @@ exports[`TextInput small drop height 1`] = `
   list-style-type: none;
 }
 
-.c2 {
+.c3 {
   max-height: 192px;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -2159,7 +2159,7 @@ exports[`TextInput small drop height 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2172,7 +2172,7 @@ exports[`TextInput small drop height 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }
@@ -2371,7 +2371,7 @@ exports[`TextInput suggestions 1`] = `
 `;
 
 exports[`TextInput suggestions 2`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2390,7 +2390,7 @@ exports[`TextInput suggestions 2`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2459,7 +2459,7 @@ exports[`TextInput suggestions 2`] = `
   color: #000000;
 }
 
-.c0 {
+.c1 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2491,18 +2491,18 @@ exports[`TextInput suggestions 2`] = `
   list-style-type: none;
 }
 
-.c2 {
+.c3 {
   max-height: inherit;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
@@ -2520,7 +2520,7 @@ exports[`TextInput suggestions 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c0 {
+  .c1 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2533,7 +2533,7 @@ exports[`TextInput suggestions 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c2 {
+  .c3 {
     width: 100%;
   }
 }

--- a/src/js/components/Video/README 2.md
+++ b/src/js/components/Video/README 2.md
@@ -1,0 +1,208 @@
+## Video
+A video player.
+
+[![](https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png)](https://storybook.grommet.io/?selectedKind=Video&full=0&addons=0&stories=1&panelRight=0) [![](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=video&module=%2Fsrc%2FVideo.js)
+## Usage
+
+```javascript
+import { Video } from 'grommet';
+<Video />
+```
+
+## Properties
+
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
+**autoPlay**
+
+Enables automatic playback of the video as soon as it is loaded.
+
+```
+boolean
+```
+
+**controls**
+
+Whether to show playback controls and where to place them. Defaults to `over`.
+
+```
+false
+over
+below
+```
+
+**fit**
+
+How the image fills its container.
+
+```
+cover
+contain
+```
+
+**loop**
+
+Enables continuous video looping.
+
+```
+boolean
+```
+
+**mute**
+
+Enables video muting. This option is best used with the autoPlay flag.
+
+```
+boolean
+```
+  
+## Intrinsic element
+
+```
+video
+```
+## Theme
+  
+**global.edgeSize.responsiveBreakpoint**
+
+The actual breakpoint to trigger changes in the video component layout. Expects `string`.
+
+Defaults to
+
+```
+small
+```
+
+**global.edgeSize.xsmall**
+
+The width of the video scrubber. Expects `object`.
+
+Defaults to
+
+```
+6px
+```
+
+**video.captions.background**
+
+The caption background color of the video  Expects `string`.
+
+Defaults to
+
+```
+rgba(0, 0, 0, 0.7)
+```
+
+**video.scrubber.color**
+
+The background color of the video scrubber. Expects `string`.
+
+Defaults to
+
+```
+light-4
+```
+
+**video.extend**
+
+Any additional style for Video. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4103,6 +4103,17 @@ Use this to indicate that 'data' doesn't contain all that it could.
 function
 \`\`\`
 
+**replace**
+
+Whether to replace previously rendered items with a generic spacing
+      element when they have scrolled out of view. This is more performant but
+      means that in-page searching will not find elements that have been
+      replaced.
+
+\`\`\`
+function
+\`\`\`
+
 **onClickRow**
 
 When supplied, this function will be called with an event object that


### PR DESCRIPTION
**Please note that we are using grommet heavily in our SRE tooling at Trading Technologies, and would appreciate it if this can be merged sooner rather than later. Many thanks.**

#### What does this PR do?
Expose the replace prop of the InfiniteScroll component from DataTable to allow for virtualisation of table rows

#### Where should the reviewer start?
Checking the prop is properly exposed

#### What testing has been done on this PR?
Testing has been done on our app with many thousands of rows, we observe in the dom that the replace functionality is working correctly

#### How should this be manually tested?
Create a DataTable with many rows, set `replace={true}` and scroll through whilst inspecting the DOM, note the number of rows rendered remains constant

#### Any background context you want to provide?
Very slow performance on large tables, virtualisation needed
#3111 

#### Do the grommet docs need to be updated?
Updated doc.js

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
