### PR TITLE
Add an option to show a checkmark when Checkbox toggled

### DIFF
--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -123,7 +123,7 @@ export interface ThemeType {
         borderSize?: BreakpointBorderSize;
         edgeSize?: BreakpointEdgeSize;
         size?: BreakpointSize;
-      };
+      } | undefined;
     };
     deviceBreakpoints?: {
       phone?: string;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds an opt-in checkmark when the Checkbox (in toggle mode) is checked.

#### What testing has been done on this PR?
Tested on storybook and ran the existing tests

#### How should this be manually tested?
Check the added storybook page

#### Any background context you want to provide?
Depending on the knob color, it is not always clear whether a toggle
is on or off. This just adds additional context.

#### Screenshots (if appropriate)
When toggle icon color is passed (otherwise it is transparent):
![Screen Shot 2019-09-26 at 1 17 40 PM](https://user-images.githubusercontent.com/4820812/65684644-635c8200-e060-11e9-8fd1-dc5ce0c98f2c.png)

#### Do the grommet docs need to be updated?
Yes

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
It is backwards compatible