### PR TITLE
Suggestions should have the same rendering when receiving Object[] of string[]

### DIFF
--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -297,9 +297,6 @@ class TextInput extends Component {
       <StyledSuggestions>
         <InfiniteScroll items={suggestions} step={theme.select.step}>
           {(suggestion, index) => {
-            const plain =
-              typeof suggestion === 'object' &&
-              typeof isValidElement(suggestion.label);
             return (
               <li key={`${stringLabel(suggestion)}-${index}`}>
                 <Button
@@ -313,13 +310,9 @@ class TextInput extends Component {
                     this.onClickSuggestion(suggestion, event);
                   }}
                 >
-                  {plain ? (
-                    renderLabel(suggestion)
-                  ) : (
-                    <Box align="start" pad="small">
-                      {renderLabel(suggestion)}
-                    </Box>
-                  )}
+                  <Box align="start" pad="small">
+                    {renderLabel(suggestion)}
+                  </Box>
                 </Button>
               </li>
             );


### PR DESCRIPTION

#### What does this PR do?
Makes suggestions rendering  consistent for TextInput when the input is an array of Objects or an array of strings and cleans up some code that is not needed
#### Where should the reviewer start?
All the changes were done in the renderSuggestions function. 

#### Screenshots (if appropriate)

Before the fix:
 - with array of object
![image](https://user-images.githubusercontent.com/1313388/65971863-339ae900-e469-11e9-8e56-92523de485d8.png)
 - with array of strings
![image](https://user-images.githubusercontent.com/1313388/65971925-4b726d00-e469-11e9-9404-4d8230f97321.png)

