### PR TITLE
Fix prop type for 'replace' in DataTable to be bool and not a func

### DIFF
--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -358,7 +358,7 @@ Whether to replace previously rendered items with a generic spacing
       replaced.
 
 ```
-function
+boolean
 ```
 
 **onClickRow**

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -139,7 +139,7 @@ export const doc = DataTable => {
       browser, such as columns.search, sortable, groupBy, or 
       columns.aggregate.`,
     ),
-    replace: PropTypes.func.description(
+    replace: PropTypes.bool.description(
       `Whether to replace previously rendered items with a generic spacing
       element when they have scrolled out of view. This is more performant but
       means that in-page searching will not find elements that have been

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4144,7 +4144,7 @@ Whether to replace previously rendered items with a generic spacing
       replaced.
 
 \`\`\`
-function
+boolean
 \`\`\`
 
 **onClickRow**


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixing an error that showed in the logs for `DataTable` `replace` prop
```
console.error node_modules/prop-types/checkPropTypes.js:20
    Warning: Failed prop type: Invalid prop `replace` of type `boolean` supplied to `DataTable`, expected `function`.
        in DataTable
```
#### Where should the reviewer start?
`src/js/components/DataTable/doc.js `
#### What testing has been done on this PR?
Running `yarn test` before the fix and running `yarn test` after the fix
#### How should this be manually tested?
Running `yarn test`
#### Any background context you want to provide?
N/A
#### What are the relevant issues?
N/A
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/14626506/65980767-0af8fc00-e435-11e9-8495-1cb636616165.png)

#### Do the grommet docs need to be updated?
Yes
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible