### PR TITLE
Convert RadioButtonGroup story to hooks

### DIFF
--- a/src/js/components/RadioButtonGroup/radiobuttongroup.stories.js
+++ b/src/js/components/RadioButtonGroup/radiobuttongroup.stories.js
@@ -1,38 +1,30 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 
 import { Box, Grommet, RadioButtonGroup } from 'grommet';
 import { grommet } from 'grommet/themes';
 
-class SimpleRadioButtonGroup extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { value: props.value };
-  }
+const SimpleRadioButtonGroup = ({ value: initialValue, ...props }) => {
+  const [value, setValue] = useState(initialValue);
 
-  onChange = event => this.setState({ value: event.target.value });
-
-  render() {
-    const { value } = this.state;
-    return (
-      <Grommet theme={grommet}>
-        <Box align="center" pad="large">
-          <RadioButtonGroup
-            name="radio"
-            options={[
-              { label: 'Choice 1', value: 'c1' },
-              { label: 'Choice 2', value: 'c2' },
-              { label: 'Choice 3', value: 'c3' },
-            ]}
-            value={value}
-            onChange={this.onChange}
-            {...this.props}
-          />
-        </Box>
-      </Grommet>
-    );
-  }
-}
+  return (
+    <Grommet theme={grommet}>
+      <Box align="center" pad="large">
+        <RadioButtonGroup
+          name="radio"
+          options={[
+            { label: 'Choice 1', value: 'c1' },
+            { label: 'Choice 2', value: 'c2' },
+            { label: 'Choice 3', value: 'c3' },
+          ]}
+          value={value}
+          onChange={event => setValue(event.target.value)}
+          {...props}
+        />
+      </Box>
+    </Grommet>
+  );
+};
 
 storiesOf('RadioButtonGroup', module).add('Simple', () => (
   <SimpleRadioButtonGroup />


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
As requested in https://github.com/grommet/grommet/issues/3394 the story in RadioButtonGroup is converted to use the `useState` hook.

#### What does this PR do?
The story in RadioButtonGroup is converted to a functional component using the `useState` hook.

#### Where should the reviewer start?
Check the RadioButtonGroup story

#### What testing has been done on this PR?
Visual testing in storybooks

#### How should this be manually tested?
Visual testing in storybooks

#### Any background context you want to provide?
As requested in https://github.com/grommet/grommet/issues/3394

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/3394

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Yes