### PR TITLE
CircleCi - removing dependency from environment variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           at: ~/grommet-ci
       - run:
           name: Running chromatic test
-          command: yarn chromatic test --app-code=$CHROMATIC_APP_CODE --exit-zero-on-changes
+          command: yarn chromatic test --app-code=ok10hcbrw9o --exit-zero-on-changes
   build:
     <<: *defaults
     steps:


### PR DESCRIPTION
Currently, all PRs (except for my PRs) are breaking on the chroma job because the environment variables are not being fetched to the build process, for example:
<img width="1437" alt="Screen Shot 2019-10-03 at 3 26 49 PM" src="https://user-images.githubusercontent.com/6320236/66165604-560c3e00-e5f2-11e9-92eb-10cef3530c16.png">
Passed build: https://circleci.com/gh/grommet/grommet/6900?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
Failed to build: https://circleci.com/gh/grommet/grommet/6880
The passing build (in green) is able to fetch the environment variables, hence the build passes.
The failed build doesn't.

I'm still trying to investigate what may cause this behavior, I made an attempt to update the node container #3405 , and although it works for my PR it doesn't work on others (e.g I tried it on https://github.com/grommet/grommet/pull/3404 as well, but it was still failing)

Until I'll resolve this issue and understand why the environment variables can't be found, the app code will be placed on the config file, and although it is exposed, it cannot be used to read story data, it can only be used to create new builds, so users will still have read-only access to the chroma UI.