### PR TITLE
Fix Select with search issue (#3247)

### DIFF
--- a/src/js/components/Select/stories/CustomSearch.js
+++ b/src/js/components/Select/stories/CustomSearch.js
@@ -198,6 +198,9 @@ class CustomSearchSelect extends Component {
                   }, 500);
                 });
               }}
+              onClose={() =>
+                this.setState({ contentPartners: allContentPartners })
+              }
             >
               {this.renderOption}
             </Select>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
It fixes a bug (#3247) in a demo story: https://storybook.grommet.io/?path=/story/select--custom-search.

When you open Select, type a search query, click outside and then open Select again, a list of options for the query is shown, although the search input is empty.

The fix is done by reseting the list of matched options when Select gets closed (and resets).

#### Where should the reviewer start?
Try to reproduce the bug and then run my code, if necessary.

#### What testing has been done on this PR?
I'm just reseting the list of options on Select close.

#### How should this be manually tested?
Clone the forked repo, `yarn install`, `yarn storybook`, open http://localhost:9001/?path=/story/select--custom-search and compare the behavior with current one.

#### Any background context you want to provide?
Nope.

#### What are the relevant issues?
 #3247

#### Screenshots (if appropriate)
None.

#### Do the grommet docs need to be updated?
Nope.

#### Should this PR be mentioned in the release notes?
Nope.

#### Is this change backwards compatible or is it a breaking change?
It's fully compatible, only demo code was edited.
