### PR TITLE
Update type definitions for Functional Components

### DIFF
--- a/src/js/components/CheckBox/index.d.ts
+++ b/src/js/components/CheckBox/index.d.ts
@@ -12,6 +12,6 @@ export interface CheckBoxProps {
   indeterminate?: boolean;
 }
 
-declare const CheckBox: React.ComponentClass<CheckBoxProps & JSX.IntrinsicElements['input']>;
+declare const CheckBox: React.FC<CheckBoxProps & JSX.IntrinsicElements['input']>;
 
 export { CheckBox };

--- a/src/js/components/Keyboard/index.d.ts
+++ b/src/js/components/Keyboard/index.d.ts
@@ -17,6 +17,6 @@ export interface KeyboardProps {
   onUp?: KeyboardType;
 }
 
-declare const Keyboard: React.ComponentClass<KeyboardProps>;
+declare const Keyboard: React.FC<KeyboardProps>;
 
 export { Keyboard };

--- a/src/js/components/RangeInput/index.d.ts
+++ b/src/js/components/RangeInput/index.d.ts
@@ -10,6 +10,6 @@ export interface RangeInputProps {
   value?: number | string;
 }
 
-declare const RangeInput: React.ComponentClass<RangeInputProps & JSX.IntrinsicElements['input']>;
+declare const RangeInput: React.FC<RangeInputProps & JSX.IntrinsicElements['input']>;
 
 export { RangeInput };

--- a/src/js/components/SkipLinks/index.d.ts
+++ b/src/js/components/SkipLinks/index.d.ts
@@ -5,6 +5,6 @@ export interface SkipLinksProps {
   messages?: {skipTo?: string};
 }
 
-declare const SkipLinks: React.ComponentClass<SkipLinksProps>;
+declare const SkipLinks: React.FC<SkipLinksProps>;
 
 export { SkipLinks };

--- a/src/js/components/Stack/index.d.ts
+++ b/src/js/components/Stack/index.d.ts
@@ -12,6 +12,6 @@ export interface StackProps {
   margin?: MarginType;
 }
 
-declare const Stack: React.ComponentClass<StackProps & JSX.IntrinsicElements['div']>;
+declare const Stack: React.FC<StackProps & JSX.IntrinsicElements['div']>;
 
 export { Stack };

--- a/src/js/components/TextArea/index.d.ts
+++ b/src/js/components/TextArea/index.d.ts
@@ -13,6 +13,6 @@ export interface TextAreaProps {
   value?: string;
 }
 
-declare const TextArea: React.ComponentClass<TextAreaProps & JSX.IntrinsicElements['textarea']>;
+declare const TextArea: React.FC<TextAreaProps & JSX.IntrinsicElements['textarea']>;
 
 export { TextArea };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR updates the type definitions for components that have been refactored to hooks for Hacktober Fest. Before the changes were made, there were some components that had been refactored to hooks but their type definitions still said `React.ComponentClass`. This changes those to say `React.FC`.

#### Where should the reviewer start?
Any of the index.d.ts files listed in files changed.

#### What testing has been done on this PR?
These changes have been tested in a local typescript project. While the components that had mismatched type definitions were not being flagged in the editor, some where not rendering onto the screen. Once their type definitions were updated, the components all work as expected.

#### How should this be manually tested?
In a local typescript project, use any of the components whose types have been updated in the PR. There should be no flags in the editor, and the components should render to the screen.

#### Any background context you want to provide?
Some components had been refactored to hooks, but their type definitions had not been updated.

#### What are the relevant issues?
#3394 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, it's backwards compatible.