### PR TITLE
Test

### DIFF
--- a/src/js/components/SkipLinks/__tests__/SkipLink-test.js
+++ b/src/js/components/SkipLinks/__tests__/SkipLink-test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import { cleanup, render, fireEvent } from '@testing-library/react';
+import { act, cleanup, render, fireEvent } from '@testing-library/react';
 
 import { Grommet, SkipLinks, SkipLink, SkipLinkTarget } from '../..';
 
@@ -40,7 +40,9 @@ describe('SkipLink', () => {
       .querySelector('a')
       .blur();
 
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
     expect(container.firstChild).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Clean up test warning on SkipLink-test caused by refactoring to hooks.

 ```
 PASS  src/js/components/SkipLinks/__tests__/SkipLink-test.js
  ● Console

    console.error node_modules/react-dom/cjs/react-dom.development.js:545
      Warning: An update to SkipLinks inside a test was not wrapped in act(...).
      
      When testing, code that causes React state updates should be wrapped into act(...):
      
      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */
      
      This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
          in SkipLinks
          in div (created by Context.Consumer)
          in StyledComponent (created by StyledGrommet)
          in StyledGrommet (created by Grommet)
          in Grommet
```