### PR TITLE
Fixes #3359

### DIFF
--- a/src/js/components/Layer/Layer.js
+++ b/src/js/components/Layer/Layer.js
@@ -54,7 +54,7 @@ class Layer extends Component {
       const clonedContainer = layerClone.querySelector(
         '[class*="StyledLayer__StyledContainer"]',
       );
-      if (clonedContainer.style) {
+      if (clonedContainer && clonedContainer.style) {
         clonedContainer.style.animationDirection = 'reverse';
       }
       setTimeout(() => {

--- a/src/js/components/Layer/Layer.js
+++ b/src/js/components/Layer/Layer.js
@@ -54,7 +54,9 @@ class Layer extends Component {
       const clonedContainer = layerClone.querySelector(
         '[class*="StyledLayer__StyledContainer"]',
       );
-      clonedContainer.style.animationDirection = 'reverse';
+      if (clonedContainer.style) {
+        clonedContainer.style.animationDirection = 'reverse';
+      }
       setTimeout(() => {
         // we add the id and query here so the unit tests work
         const clone = document.getElementById('layerClone');


### PR DESCRIPTION
#### What does this PR do?

Fixes #3359.  

#### Where should the reviewer start?
Read the diff.

#### What testing has been done on this PR?
Verified that after applying this fix to my project, the issue is resolved.

#### How should this be manually tested?
Layer component regression tests.

#### Any background context you want to provide?
General background:
`querySelector` operates on a DOM element, not a React element. So in some cases a race condition can occur where the DOM element no longer exists because the component is no longer mounted.

Specific example:
Build a Single Page Application in React + Grommet + React Router, like

```jsx
<Route render={({ location }) => (
  <TransitionGroup>
    <CSSTransition
      timeout={100}
      key={location.key}
      exit={false}>
      <Switch location={location}>
        <Route exact path={'/a'}              render={(props) => <PageA {...props} />} />
        <Route exact path={'/b'}              render={(props) => <PageB {...props} />} />
      </Switch>
    </CSSTransition>
  </TransitionGroup>
)}/>
```

Include a Layer component in `<PageA/>`, go render the component and navigate to `<PageB/>`. Observe that an error occurs in PageA because it's no longer mounted, yet it's trying to manipulate the DOM.

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/3359

#### Should this PR be mentioned in the release notes?
Sure

#### Is this change backwards compatible or is it a breaking change?
I think so.
