### PR TITLE
Create test for when user tabs through menu until it closes

### DIFF
--- a/src/js/components/Menu/__tests__/Menu-test.js
+++ b/src/js/components/Menu/__tests__/Menu-test.js
@@ -174,6 +174,45 @@ describe('Menu', () => {
     expect(document.getElementById('test-menu__drop')).toBeNull();
   });
 
+  test('tab through menu until it closes', () => {
+    const { getByLabelText, container } = render(
+      <Grommet>
+        <Menu
+          id="test-menu"
+          label="Test"
+          items={[{ label: 'Item 1' }, { label: 'Item 2' }]}
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+
+    // Pressing space opens drop
+    // First tab moves to first item
+    // Second tab moves to second item
+    // Third tab moves beyond last menu item and close menu
+    fireEvent.keyDown(getByLabelText('Open Menu'), {
+      key: 'Space',
+      keyCode: 32,
+      which: 32,
+    });
+    fireEvent.keyDown(document.activeElement.firstChild, {
+      key: 'Tab',
+      keyCode: 9,
+      which: 9,
+    });
+    fireEvent.keyDown(document.activeElement, {
+      key: 'Tab',
+      keyCode: 9,
+      which: 9,
+    });
+    fireEvent.keyDown(document.activeElement, {
+      key: 'Tab',
+      keyCode: 9,
+      which: 9,
+    });
+    expect(document.getElementById('test-menu__drop')).toBeNull();
+  });
+
   test('close on esc', () => {
     const { getByLabelText, container } = render(
       <Grommet>

--- a/src/js/components/Menu/__tests__/Menu-test.js
+++ b/src/js/components/Menu/__tests__/Menu-test.js
@@ -189,7 +189,7 @@ describe('Menu', () => {
     // Pressing space opens drop
     // First tab moves to first item
     // Second tab moves to second item
-    // Third tab moves beyond last menu item and close menu
+    // Third tab moves beyond last menu item and closes menu
     fireEvent.keyDown(getByLabelText('Open Menu'), {
       key: 'Space',
       keyCode: 32,

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -3073,6 +3073,155 @@ exports[`Menu select an item 1`] = `
 </div>
 `;
 
+exports[`Menu tab through menu until it closes 1`] = `
+.c5 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c5 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c5 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c5 *[stroke*="#"],
+.c5 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c5 *[fill-rule],
+.c5 *[FILL-RULE],
+.c5 *[fill*="#"],
+.c5 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  padding: 12px;
+}
+
+.c4 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 12px;
+}
+
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 6px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <button
+    aria-label="Open Menu"
+    class="c1"
+    id="test-menu"
+    type="button"
+  >
+    <div
+      class="c2"
+    >
+      <span
+        class="c3"
+      >
+        Test
+      </span>
+      <div
+        class="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        class="c5"
+        viewBox="0 0 24 24"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          stroke-width="2"
+        />
+      </svg>
+    </div>
+  </button>
+</div>
+`;
+
 exports[`Menu with dropAlign renders 1`] = `
 .c5 {
   display: inline-block;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR creates a new test for when a user tabs through all menu items until the menu closes.

#### Where should the reviewer start?
src/js/components/Menu/__tests__/Menu-test.js

#### What testing has been done on this PR?
Jest's debug feature was used to view the DOM structure before the menu opens, when the menu opens, and when the menu was expected to be closed again. Also, the test utilizes the `    expect(document.getElementById('test-menu__drop')).toBeNull();` to confirm that the menu has closed.

#### How should this be manually tested?

#### Any background context you want to provide?
This behavior (tabbing through menu until it closes) was not reflected in any of the tests, so it needed to be added.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, it is backwards compatible.