### PR TITLE
TS Extraction: justifyContent & Elevation

### DIFF
--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -4,6 +4,7 @@ import {
   AlignContentType, 
   AlignSelfType,
   BackgroundType,
+  ElevationType,
   FillType,
   GapType, 
   GridAreaType, 
@@ -29,7 +30,7 @@ export interface BoxProps {
   basis?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "auto" | string;
   border?: boolean | SideType | {color?: ColorType, side?: SideType, size?: SizeType, style?: StyleType} | ({color?: ColorType, side?: SideType, size?: SizeType, style?: StyleType})[];
   direction?: "row" | "column" | "row-responsive" | 'row-reverse' | 'column-reverse';
-  elevation?: "none" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
+  elevation?: ElevationType;
   flex?: "grow" | "shrink" | boolean | {grow?: number,shrink?: number};
   fill?: FillType;
   gap?: GapType;

--- a/src/js/components/Drop/index.d.ts
+++ b/src/js/components/Drop/index.d.ts
@@ -1,9 +1,9 @@
 import * as React from "react";
-import { KeyboardType } from "../../utils";
+import { ElevationType, KeyboardType } from "../../utils";
 
 export interface DropProps {
   align?: {top?: "top" | "bottom",bottom?: "top" | "bottom",right?: "left" | "right",left?: "left" | "right"};
-  elevation?: "none" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
+  elevation?: ElevationType;
   onClickOutside?: ((...args: any[]) => any);
   onEsc?: KeyboardType;
   overflow?: "auto" | "hidden" | "scroll" | "visible" | {horizontal?: "auto" | "hidden" | "scroll" | "visible",vertical?: "auto" | "hidden" | "scroll" | "visible"} | string;

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -6,8 +6,9 @@ import {
   FillType,
   GapType, 
   GridAreaType, 
+  JustifyContentType, 
   MarginType, 
-  PolymorphicType, 
+  PolymorphicType,
 } from "../../utils";
 
 export interface GridProps {
@@ -22,7 +23,7 @@ export interface GridProps {
   gap?: GapType | {row?: GapType,column?: GapType};
   gridArea?: GridAreaType;
   justify?: "start" | "center" | "end" | "stretch";
-  justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
+  justifyContent?: JustifyContentType;
   margin?: MarginType;
   rows?: ("xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | string | string[])[] | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   tag?: PolymorphicType;

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { DropProps } from "../Drop";
-import { A11yTitleType, AlignSelfType, GridAreaType, JustifyContentType, MarginType} from "../../utils";
+import { A11yTitleType, AlignSelfType, GridAreaType, JustifyContentType, MarginType } from "../../utils";
 
 export interface MenuProps {
   a11yTitle?: A11yTitleType;

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { DropProps } from "../Drop";
-import { A11yTitleType, AlignSelfType, GridAreaType, MarginType } from "../../utils";
+import { A11yTitleType, AlignSelfType, GridAreaType, JustifyContentType, MarginType} from "../../utils";
 
 export interface MenuProps {
   a11yTitle?: A11yTitleType;
@@ -13,7 +13,7 @@ export interface MenuProps {
   gridArea?: GridAreaType;
   icon?: boolean | React.ReactNode;
   items: object[];
-  justifyContent?: "start" | "center" | "end" | "between" | "around" | "stretch";
+  justifyContent?: JustifyContentType;
   label?: string | React.ReactNode;
   margin?: MarginType;
   messages?: {closeMenu?: string,openMenu?: string};

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -41,6 +41,7 @@ export type AlignSelfType = "start" | "center" | "end" | "stretch";
 export type AnimateType = boolean;
 export type BackgroundType = string | {color?: string,dark?: boolean | string,image?: string,position?: string,opacity?: "weak" | "medium" | "strong" | number | boolean,repeat?: "no-repeat" | "repeat" | string,size?: "cover" | "contain" | string,light?: string};
 export type ColorType = string | {dark?: string,light?: string};
+export type ElevationType = "none" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
 export type FillType = "horizontal" | "vertical" | boolean;
 export type GapType = "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
 export type GridAreaType = string;

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -45,6 +45,7 @@ export type ElevationType = "none" | "xsmall" | "small" | "medium" | "large" | "
 export type FillType = "horizontal" | "vertical" | boolean;
 export type GapType = "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
 export type GridAreaType = string;
+export type JustifyContentType = "start" | "center" | "end" | "between" | "around" | "stretch";
 export type KeyboardType = ((event: React.KeyboardEvent<HTMLElement>) => void);
 export type MarginType = "none" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | {bottom?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,horizontal?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,left?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,right?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,top?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string,vertical?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string} | string;
 export type OpacityType = "weak" | "medium" | "strong" | string | true | false | number;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR extracts `elevation` and `justifyContent` into variables that can be used across various components.

#### Where should the reviewer start?
src/js/utils/index.d.ts

#### What testing has been done on this PR?
These changes have been tested in a local TS project on the components that have these properties to ensure it only accepts the types defined in the utils/index.d.ts file.

#### How should this be manually tested?
In a local TS project, use one of the components that has these props and put a value that matches the prop type (no flag should appear and the app should render) and then provide a value that doesn't match the prop type (should cause an error).

#### Any background context you want to provide?

#### What are the relevant issues?
#3237 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.