### PR TITLE
Adjust onClick TS definition for Anchor

### DIFF
--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -19,11 +19,12 @@ export interface AnchorProps {
   icon?: JSX.Element;
   label?: React.ReactNode;
   margin?: MarginType;
+  onClick?: ((event: React.MouseEvent<HTMLAnchorElement>) => void);
   reverse?: boolean;
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
   as?: PolymorphicType;
 }
 
-declare const Anchor: React.FC<AnchorProps & Omit<JSX.IntrinsicElements['a'], 'color'>>;
+declare const Anchor: React.FC<AnchorProps & Omit<JSX.IntrinsicElements['a'], 'color' | 'onClick'>>;
 
 export { Anchor };

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -19,12 +19,12 @@ export interface AnchorProps {
   icon?: JSX.Element;
   label?: React.ReactNode;
   margin?: MarginType;
-  onClick?: ((...args: any[]) => any);
+  onClick?: ((event: React.MouseEvent<HTMLAnchorElement>) => void);
   reverse?: boolean;
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
   as?: PolymorphicType;
 }
 
-declare const Anchor: React.FC<AnchorProps & Omit<JSX.IntrinsicElements['a'], 'color'>>;
+declare const Anchor: React.FC<AnchorProps & Omit<JSX.IntrinsicElements['a'], 'color' | 'onClick'>>;
 
 export { Anchor };

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -19,7 +19,6 @@ export interface AnchorProps {
   icon?: JSX.Element;
   label?: React.ReactNode;
   margin?: MarginType;
-  onClick?: ((event: React.MouseEvent<HTMLAnchorElement>) => void);
   reverse?: boolean;
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
   as?: PolymorphicType;

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -19,12 +19,11 @@ export interface AnchorProps {
   icon?: JSX.Element;
   label?: React.ReactNode;
   margin?: MarginType;
-  onClick?: ((event: React.MouseEvent<HTMLAnchorElement>) => void);
   reverse?: boolean;
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
   as?: PolymorphicType;
 }
 
-declare const Anchor: React.FC<AnchorProps & Omit<JSX.IntrinsicElements['a'], 'color' | 'onClick'>>;
+declare const Anchor: React.FC<AnchorProps & Omit<JSX.IntrinsicElements['a'], 'color'>>;
 
 export { Anchor };

--- a/src/js/components/Keyboard/Keyboard.js
+++ b/src/js/components/Keyboard/Keyboard.js
@@ -41,7 +41,7 @@ const Keyboard = ({ target, children, onKeyDown, ...restProps }) => {
         document.removeEventListener('keydown', onKeyDownHandler);
       }
     };
-  }, [onKeyDownHandler]);
+  }, [onKeyDownHandler, target]);
 
   return target === 'document'
     ? children

--- a/src/js/components/TextInput/stories/Custom.js
+++ b/src/js/components/TextInput/stories/Custom.js
@@ -86,7 +86,7 @@ const CustomSuggestionsTextInput = () => {
 
   useEffect(() => {
     forceUpdate();
-  }, []);
+  }, [forceUpdate]);
 
   const onChange = event => {
     const { value: newValue } = event.target;

--- a/src/js/contexts/AnnounceContext/announce-context.stories.js
+++ b/src/js/contexts/AnnounceContext/announce-context.stories.js
@@ -8,7 +8,7 @@ const Announcer = ({ announce, message, mode, role }) => {
   React.useEffect(() => {
     const timeout = 3000;
     announce(message, mode, timeout);
-  }, [message, mode]);
+  }, [announce, message, mode]);
 
   return (
     <Text align="center" role={role} aria-live={mode}>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adjusts the type definition for Anchor onClick type definition to `onClick?: ((event: React.MouseEvent<HTMLAnchorElement>) => void);`

#### Where should the reviewer start?
src/js/components/Anchor/index.d.ts

#### What testing has been done on this PR?
This has been tested on a local TS project with the following:
```
<Anchor icon={<Add />} href="https://v2.grommet.io/components" target="blank" onClick={(event) => console.log(event)}/>
```

#### How should this be manually tested?
With the above code in a local TS project.

#### Any background context you want to provide?
This type definition matches that of the intrinsic elements of anchor, but if we don't omit `onClick` from the intrinsic elements, then in a TS project, the type will appear duplicated which is not wanted:
```
onClick?: ((event: React.MouseEvent<HTMLAnchorElement>) => void) & (event: React.MouseEvent<HTMLAnchorElement>) => void) | undefined
```
To maintain clarity about what properties the Anchor component handles, I left our onClick handler in the interface and omitted the intrinsic property so that the declaration only appears once:
```
onClick?: ((event: React.MouseEvent<HTMLAnchorElement>) => void) | undefined
```

#### What are the relevant issues?
#3165 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, this is backwards compatible.