### PR TITLE
Adjust onClick TS definition for Button

### DIFF
--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -28,7 +28,7 @@ export interface ButtonProps {
   target?: "_self" | "_blank" | "_parent" | "_top";
   icon?: JSX.Element;
   label?: React.ReactNode;
-  onClick?: ((...args: any[]) => any);
+  onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void);
   plain?: boolean;
   primary?: boolean;
   reverse?: boolean;
@@ -36,6 +36,6 @@ export interface ButtonProps {
   as?: PolymorphicType;
 }
 
-declare const Button: React.FC<ButtonProps & Omit<JSX.IntrinsicElements['button'], 'color'>>;
+declare const Button: React.FC<ButtonProps & Omit<JSX.IntrinsicElements['button'], 'color' | 'onClick'>>;
 
 export { Button };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adjusts the type definition for Button onClick type definition to `onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void);`

#### Where should the reviewer start?
src/js/components/Button/index.d.ts

#### What testing has been done on this PR?
This has been tested on a local TS project with the following:
```
<Button label="Click Me!" onClick={() => alert('clicked!')} />
```

#### How should this be manually tested?
With the above code in a local TS project.

#### Any background context you want to provide?
This type definition matches that of the intrinsic elements of button, but if we don't omit `onClick` from the intrinsic elements, then in a TS project, the type will appear duplicated which is not wanted:
```
onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void) & (event: React.MouseEvent<HTMLButtonElement>) => void) | undefined
```
To maintain clarity about what properties the Button component handles, I left our onClick handler in the interface and omitted the intrinsic property so that the declaration only appears once:
```
onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void) | undefined
```

#### What are the relevant issues?
#3165 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, this is backwards compatible.