### PR TITLE
Changed circleci to accommodate chromatic changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,14 @@ jobs:
       - run:
           name: Running chromatic test
           command: yarn chromatic test --app-code=9q99in2ygnh --exit-zero-on-changes
+  chromatic-accept:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/grommet-ci
+      - run:
+          name: Running chromatic test
+          command: yarn chromatic test --app-code=9q99in2ygnh --exit-zero-on-changes --auto-accept-changes
   build:
     <<: *defaults
     steps:
@@ -119,6 +127,16 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore:
+                - master
+      - chromatic-accept:
+          requires:
+            - checkout
+          filters:
+            branches:
+              only:
+                - master
       - build:
           requires:
             - checkout


### PR DESCRIPTION
This PR is a complete solution for https://github.com/grommet/grommet/pull/3512

Since we only need to run `--auto-accept-changes` (that accepts the chromatic changes) on the master branch, I've created a new job of `chromatic-accept` that will run only on master after a PR is merged, hence will automatically accept the changes on master so the baseline will be updated.

The solution offered on #3512 will run `--auto-accept-changes` for every feature branch and make the changes hard to catch.
With this PR solution, the job of chromatic will run as usual for feature branches, but the job that will run on the master branch will be chromatic-accept that will accept changes on master and fix the changed snapshots on the baseline.

I'll be merging this PR to make sure the behavior I'm anticipating is accurate in action.
 