### PR TITLE
Distribution - Added docs and typescript support for basis prop

### DIFF
--- a/src/js/all/stories/typescript/AllComponents.tsx
+++ b/src/js/all/stories/typescript/AllComponents.tsx
@@ -14,6 +14,7 @@ import {
   CheckBox,
   Clock,
   DataTable,
+  Distribution,
   FormField,
   Grid,
   Heading,
@@ -157,7 +158,7 @@ const Components = () => {
       />
     </Box>,
     <Box key="visualize" gap="small">
-      {/* <Distribution
+      <Distribution
         basis="small"
         values={[
           { value: 50, color: 'light-3' },
@@ -172,7 +173,7 @@ const Components = () => {
             <Text size="large">{value.value}</Text>
           </Box>
         )}
-      </Distribution> */}
+      </Distribution>
       <Stack>
         <Box>
           <Box direction="row">

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -4,6 +4,7 @@ import {
   AlignContentType, 
   AlignSelfType,
   BackgroundType,
+  BasisType,
   ElevationType,
   FillType,
   GapType, 
@@ -27,7 +28,7 @@ export interface BoxProps {
   alignContent?: AlignContentType;
   animation?: "fadeIn" | "fadeOut" | "jiggle" | "pulse" | "slideUp" | "slideDown" | "slideLeft" | "slideRight" | "zoomIn" | "zoomOut" | {type?: "fadeIn" | "fadeOut" | "jiggle" | "pulse" | "slideUp" | "slideDown" | "slideLeft" | "slideRight" | "zoomIn" | "zoomOut",delay?: number,duration?: number,size?: "xsmall" | "small" | "medium" | "large" | "xlarge"} | ("fadeIn" | "fadeOut" | "jiggle" | "pulse" | "slideUp" | "slideDown" | "slideLeft" | "slideRight" | "zoomIn" | "zoomOut" | {type?: "fadeIn" | "fadeOut" | "jiggle" | "pulse" | "slideUp" | "slideDown" | "slideLeft" | "slideRight" | "zoomIn" | "zoomOut",delay?: number,duration?: number,size?: "xsmall" | "small" | "medium" | "large" | "xlarge"})[];
   background?: BackgroundType;
-  basis?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "auto" | string;
+  basis?: BasisType;
   border?: boolean | SideType | {color?: ColorType, side?: SideType, size?: SizeType, style?: StyleType} | ({color?: ColorType, side?: SideType, size?: SizeType, style?: StyleType})[];
   direction?: "row" | "column" | "row-responsive" | 'row-reverse' | 'column-reverse';
   elevation?: ElevationType;

--- a/src/js/components/Distribution/README.md
+++ b/src/js/components/Distribution/README.md
@@ -111,6 +111,29 @@ xlarge
 string
 ```
 
+**basis**
+
+A fixed or relative size along its container's main axis.
+
+```
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+xxlarge
+full
+1/2
+1/3
+2/3
+1/4
+2/4
+3/4
+auto
+string
+```
+
 **children**
 
 Function that will be called when each value is rendered. Defaults to `function children(value) {

--- a/src/js/components/Distribution/doc.js
+++ b/src/js/components/Distribution/doc.js
@@ -17,6 +17,26 @@ export const doc = Distribution => {
 
   DocumentedDistribution.propTypes = {
     ...genericProps,
+    basis: PropTypes.oneOfType([
+      PropTypes.oneOf([
+        'xxsmall',
+        'xsmall',
+        'small',
+        'medium',
+        'large',
+        'xlarge',
+        'xxlarge',
+        'full',
+        '1/2',
+        '1/3',
+        '2/3',
+        '1/4',
+        '2/4',
+        '3/4',
+        'auto',
+      ]),
+      PropTypes.string,
+    ]).description("A fixed or relative size along its container's main axis."),
     children: PropTypes.func.description(
       'Function that will be called when each value is rendered.',
     ),

--- a/src/js/components/Distribution/index.d.ts
+++ b/src/js/components/Distribution/index.d.ts
@@ -1,9 +1,17 @@
 import * as React from "react";
-import { A11yTitleType, AlignSelfType, GapType, GridAreaType, MarginType } from "../../utils";
+import { 
+  A11yTitleType, 
+  AlignSelfType, 
+  BasisType, 
+  GapType, 
+  GridAreaType, 
+  MarginType 
+} from "../../utils";
 
 export interface DistributionProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
+  basis?: BasisType;
   gridArea?: GridAreaType;
   margin?: MarginType;
   children?: ((...args: any[]) => any);

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4698,6 +4698,29 @@ xlarge
 string
 \`\`\`
 
+**basis**
+
+A fixed or relative size along its container's main axis.
+
+\`\`\`
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+xxlarge
+full
+1/2
+1/3
+2/3
+1/4
+2/4
+3/4
+auto
+string
+\`\`\`
+
 **children**
 
 Function that will be called when each value is rendered. Defaults to \`function children(value) {

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -40,6 +40,7 @@ export type AlignContentType = "start" | "center" | "end" | "between" | "around"
 export type AlignSelfType = "start" | "center" | "end" | "stretch";
 export type AnimateType = boolean;
 export type BackgroundType = string | {color?: string,dark?: boolean | string,image?: string,position?: string,opacity?: "weak" | "medium" | "strong" | number | boolean,repeat?: "no-repeat" | "repeat" | string,size?: "cover" | "contain" | string,light?: string};
+export type BasisType = "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "auto" | string;
 export type ColorType = string | {dark?: string,light?: string};
 export type ElevationType = "none" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
 export type FillType = "horizontal" | "vertical" | boolean;


### PR DESCRIPTION
While working on AllComponents.tsx, I noticed the `basis` prop is missing from the typescript interface definition as well from the docs.
According to https://github.com/grommet/grommet/blob/27e372be78c559e114ecaf541d399b336872f910/src/js/components/Distribution/Distribution.js#L44
the `basis` value is derived from props, hence needs to be documented as a prop along with its typings.
This PR is addressing both missing docs and typescripts, and the ts compilation of AllComponents.tsx is passing as expected.

