### PR TITLE
Remove onClick and leave intrinsic for Anchor

### DIFF
--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -19,7 +19,6 @@ export interface AnchorProps {
   icon?: JSX.Element;
   label?: React.ReactNode;
   margin?: MarginType;
-  onClick?: ((...args: any[]) => any);
   reverse?: boolean;
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string;
   as?: PolymorphicType;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR removes the type definition for Anchor onClick type definition and just leaves the definition from the intrinsic elements since we are not adding any new/different behavior.

#### Where should the reviewer start?
src/js/components/Anchor/index.d.ts

#### What testing has been done on this PR?
This has been tested on a local TS project with the following:
```
      <Anchor icon={<Add />} href="https://v2.grommet.io/components" target="blank" onClick={(event) => console.log(event)}/>
```

#### How should this be manually tested?
With the above code in a local TS project.

#### Any background context you want to provide?
We are not adding any new/different behavior to the onClick handler from what the intrinsic element already provides, so we should remove it.

#### What are the relevant issues?
#3165 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, this is backwards compatible.