### PR TITLE
Make Storybook Example Titles Capitalization Consistent

### DIFF
--- a/src/js/components/Accordion/stories/Simple.js
+++ b/src/js/components/Accordion/stories/Simple.js
@@ -35,7 +35,7 @@ const SimpleAccordion = props => {
 
 storiesOf('Accordion', module)
   .add('Simple', () => <SimpleAccordion />)
-  .add('Dark no animation', () => (
+  .add('Dark, No Animation', () => (
     <SimpleAccordion animate={false} background="dark-2" />
   ))
   .add('Multiple', () => <SimpleAccordion multiple />);

--- a/src/js/components/Box/stories/Fixed.js
+++ b/src/js/components/Box/stories/Fixed.js
@@ -47,4 +47,4 @@ const FixedSizesBox = () => (
   </Grommet>
 );
 
-storiesOf('Box', module).add('Fixed sizes', () => <FixedSizesBox />);
+storiesOf('Box', module).add('Fixed Sizes', () => <FixedSizesBox />);

--- a/src/js/components/Box/stories/MinMax.js
+++ b/src/js/components/Box/stories/MinMax.js
@@ -206,4 +206,4 @@ const MinMaxSizesBox = () => (
   </Grommet>
 );
 
-storiesOf('Box', module).add('Min/Max sizes', () => <MinMaxSizesBox />);
+storiesOf('Box', module).add('Min/Max Sizes', () => <MinMaxSizesBox />);

--- a/src/js/components/Carousel/stories/Simple.js
+++ b/src/js/components/Carousel/stories/Simple.js
@@ -27,6 +27,4 @@ const SimpleCarousel = ({ initialChild, ...props }) => {
 storiesOf('Carousel', module)
   .add('Simple', () => <SimpleCarousel />)
   .add('Initial Child', () => <SimpleCarousel initialChild={1} />)
-  .add('Without Controls', () => (
-    <SimpleCarousel controls={false} play={1500} />
-  ));
+  .add('No Controls', () => <SimpleCarousel controls={false} play={1500} />);

--- a/src/js/components/CheckBox/stories/Indeterminate.js
+++ b/src/js/components/CheckBox/stories/Indeterminate.js
@@ -48,6 +48,6 @@ const IndeterminateCheckBox = () => {
   );
 };
 
-storiesOf('CheckBox', module).add('Interminate', () => (
+storiesOf('CheckBox', module).add('Indeterminate', () => (
   <IndeterminateCheckBox />
 ));

--- a/src/js/components/DataTable/stories/ControlledGrouped.js
+++ b/src/js/components/DataTable/stories/ControlledGrouped.js
@@ -32,6 +32,6 @@ const ControlledGroupedDataTable = () => {
   );
 };
 
-storiesOf('DataTable', module).add('Controlled grouped', () => (
+storiesOf('DataTable', module).add('Controlled and Grouped', () => (
   <ControlledGroupedDataTable />
 ));

--- a/src/js/components/Drop/stories/AllNotStretch.js
+++ b/src/js/components/Drop/stories/AllNotStretch.js
@@ -160,4 +160,4 @@ const AllDrops = () => (
   </Grommet>
 );
 
-storiesOf('Drop', module).add('All not stretch', () => <AllDrops />);
+storiesOf('Drop', module).add('All Positions', () => <AllDrops />);

--- a/src/js/components/Grid/stories/AreasPropAlternative.js
+++ b/src/js/components/Grid/stories/AreasPropAlternative.js
@@ -37,6 +37,6 @@ const GridAreasAlternative = () => {
   );
 };
 
-storiesOf('Grid', module).add('Areas prop alternative', () => (
+storiesOf('Grid', module).add('Areas Prop Alternative', () => (
   <GridAreasAlternative />
 ));

--- a/src/js/components/Grid/stories/NColumn.js
+++ b/src/js/components/Grid/stories/NColumn.js
@@ -23,4 +23,4 @@ const NColumnGrid = () => (
   </Grommet>
 );
 
-storiesOf('Grid', module).add('N-column layout', () => <NColumnGrid />);
+storiesOf('Grid', module).add('N-Column Layout', () => <NColumnGrid />);

--- a/src/js/components/InfiniteScroll/stories/Basics.js
+++ b/src/js/components/InfiniteScroll/stories/Basics.js
@@ -29,7 +29,7 @@ const SimpleInfiniteScroll = props => (
 
 storiesOf('InfiniteScroll', module)
   .add('Simple', () => <SimpleInfiniteScroll />)
-  .add('Show 118th item', () => <SimpleInfiniteScroll show={117} />)
+  .add('Show 118th Item', () => <SimpleInfiniteScroll show={117} />)
   .add('Marker', () => (
     <SimpleInfiniteScroll
       renderMarker={marker => (

--- a/src/js/components/RadioButton/radiobutton.stories.js
+++ b/src/js/components/RadioButton/radiobutton.stories.js
@@ -113,4 +113,4 @@ storiesOf('RadioButton', module)
   .add('Simple', () => <SimpleRadioButton />)
   .add('Disabled', () => <SimpleRadioButton disabled selected="c2" />)
   .add('Custom Theme', () => <CustomRadioButton />)
-  .add('Inside a Button Theme', () => <CheckBoxInsideButton />);
+  .add('Inside a Button', () => <CheckBoxInsideButton />);

--- a/src/js/components/Select/stories/LazyLoading.js
+++ b/src/js/components/Select/stories/LazyLoading.js
@@ -76,4 +76,4 @@ const LazyLoading = () => {
   );
 };
 
-storiesOf('Select', module).add('Lazy Loading options', () => <LazyLoading />);
+storiesOf('Select', module).add('Lazy Loading Options', () => <LazyLoading />);

--- a/src/js/components/Select/stories/ManyOptions.js
+++ b/src/js/components/Select/stories/ManyOptions.js
@@ -69,4 +69,4 @@ const ManyOptions = () => {
   );
 };
 
-storiesOf('Select', module).add('Lots of options', () => <ManyOptions />);
+storiesOf('Select', module).add('Lots of Options', () => <ManyOptions />);

--- a/src/js/components/TextArea/stories/Simple.js
+++ b/src/js/components/TextArea/stories/Simple.js
@@ -20,4 +20,4 @@ const SimpleTextArea = props => {
 
 storiesOf('TextArea', module)
   .add('Simple', () => <SimpleTextArea resize />)
-  .add('Non resizable', () => <SimpleTextArea resize={false} />);
+  .add('Non-Resizable', () => <SimpleTextArea resize={false} />);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR capitalizes storybook examples into 'Title Case' and renames some stories to clearer names.

#### Where should the reviewer start?
src/js/components/Accordion/stories/Simple.js

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?
There isn't consistency in how storybook examples were capitalized. This PR aims to establish a style guide that storybook examples should be in title case (first letter of each word capitalized).

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, this is backwards compatible.