### PR TITLE
Changed text color to use normalizeColor when background is dark

### DIFF
--- a/src/js/components/Button/stories/Custom.js
+++ b/src/js/components/Button/stories/Custom.js
@@ -39,11 +39,28 @@ const customTheme = {
   },
 };
 
+const coloredButton = {
+  button: {
+    border: {
+      color: 'accent-1',
+    },
+    color: { dark: 'accent-1', light: 'dark-2' },
+    primary: {
+      color: 'neutral-2',
+    },
+  },
+};
+
 const CustomTheme = () => (
   <>
     <Grommet theme={customTheme}>
       <Box align="center" pad="large">
         <Button label="custom theme" onClick={() => {}} primary />
+      </Box>
+    </Grommet>
+    <Grommet theme={coloredButton}>
+      <Box align="center" pad="large">
+        <Button as="span" label="theme on dark background" primary />
       </Box>
     </Grommet>
     <Grommet theme={grommet}>

--- a/src/js/utils/background.js
+++ b/src/js/utils/background.js
@@ -115,7 +115,10 @@ export const backgroundStyle = (backgroundArg, theme, textColorArg) => {
     if (color) {
       return css`
         background: ${color};
-        color: ${textColor[colorIsDark(color) ? 'dark' : 'light']};
+        color: ${normalizeColor(
+          textColor[colorIsDark(color) ? 'dark' : 'light'],
+          theme,
+        )};
       `;
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changes the text color to use normalizeColor when the theme uses a dark background. 
Currently, if you apply on the theme:
```
const customTheme = {
  button: {
    color: { dark: 'accent-1', light: 'dark-2' },
  },
```
The dark text color wouldn't be used as expected, because the string `accent-1` isn't normalized to actual CSS color (i.e. #6FFFB0)
But if you will try to use (which has the same colors as the above)
```
const customTheme = {
  button: {
    color: { dark: '#6FFFB0, light: 'dark-2' },
  },
```
This will work as expected, since the dark color is already provided in an acceptable CSS format.

This PR fixes the text color to work on both of the scenarios presented above.

#### Where should the reviewer start?
An example of this use case is added to Button/stories/Custom.js, the Button is primary hence should use the dark text color. (line #47 text color definition)

#### What testing has been done on this PR?
storybook 
#### How should this be manually tested?
storybook, chromatic
#### Any background context you want to provide?
@britt6612 raised this issue as she was working on #3026 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
nope
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backward compatible or is it a breaking change?
backward compatible 