### PR TITLE
Fixed FocusedContainer hook issue

### DIFF
--- a/src/js/components/FocusedContainer.js
+++ b/src/js/components/FocusedContainer.js
@@ -17,29 +17,29 @@ export const FocusedContainer = ({
   const [bodyOverflowStyle, setBodyOverflowStyle] = useState('');
   const ref = useRef(null);
 
-  const removeTrap = () => {
-    const child = ref.current;
-    getBodyChildElements()
-      .filter(isNotAncestorOf(child))
-      .forEach(makeNodeFocusable);
-    if (restrictScroll) {
-      document.body.style.overflow = bodyOverflowStyle;
-    }
-  };
-
-  const trapFocus = () => {
-    const child = ref.current;
-    getBodyChildElements()
-      .filter(isNotAncestorOf(child))
-      .forEach(makeNodeUnfocusable);
-
-    if (restrictScroll) {
-      setBodyOverflowStyle(document.body.style.overflow);
-      document.body.style.overflow = 'hidden';
-    }
-  };
-
   useEffect(() => {
+    const removeTrap = () => {
+      const child = ref.current;
+      getBodyChildElements()
+        .filter(isNotAncestorOf(child))
+        .forEach(makeNodeFocusable);
+      if (restrictScroll) {
+        document.body.style.overflow = bodyOverflowStyle;
+      }
+    };
+
+    const trapFocus = () => {
+      const child = ref.current;
+      getBodyChildElements()
+        .filter(isNotAncestorOf(child))
+        .forEach(makeNodeUnfocusable);
+
+      if (restrictScroll) {
+        setBodyOverflowStyle(document.body.style.overflow);
+        document.body.style.overflow = 'hidden';
+      }
+    };
+
     const timer = setTimeout(() => {
       if (!hidden) {
         trapFocus();
@@ -50,7 +50,7 @@ export const FocusedContainer = ({
       removeTrap();
       clearTimeout(timer);
     };
-  }, []);
+  }, [hidden, bodyOverflowStyle, restrictScroll]);
 
   return (
     <div ref={ref} aria-hidden={hidden} {...rest}>


### PR DESCRIPTION
#### What does this PR do?

Fixed FocusedContainer hook issue

#### What testing has been done on this PR?

storybook and unit

#### How should this be manually tested?

storybook

#### Any background context you want to provide?

We were seeing lint warnings without this:

/home/circleci/grommet-ci/src/js/components/FocusedContainer.js
  53:6  warning  React Hook useEffect has missing dependencies: 'hidden', 'removeTrap', and 'trapFocus'. Either include them or remove the dependency array  react-hooks/exhaustive-deps

#### What are the relevant issues?

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible