### PR TITLE
Added stories for focus color customization

### DIFF
--- a/src/js/all/stories/Focus.js
+++ b/src/js/all/stories/Focus.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { deepMerge } from 'grommet/utils';
+
+import {
+  grommet,
+  Anchor,
+  Box,
+  Button,
+  Grommet,
+  Menu,
+  Text,
+  TextInput,
+} from 'grommet';
+
+const customFocus = deepMerge(grommet, {
+  global: {
+    colors: {
+      focus: 'neutral-3',
+    },
+  },
+});
+
+const CustomDefaultProps = () => (
+  <Grommet theme={customFocus}>
+    <Box pad="small" gap="medium" width="medium">
+      <Text>
+        Focus on the input components and notice the custom focus color
+      </Text>
+      <TextInput placeholder="hi" />
+      <Anchor href="">Anchor</Anchor>
+      <Menu
+        label="Menu"
+        items={[{ label: 'One', onClick: () => {} }, { label: 'Two' }]}
+      />
+      <Button label="Button" onClick={() => {}} />
+    </Box>
+  </Grommet>
+);
+
+storiesOf('Theme', module).add('Focus', () => <CustomDefaultProps />);

--- a/src/js/all/stories/typescript/Focus.tsx
+++ b/src/js/all/stories/typescript/Focus.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import isChromatic from 'storybook-chromatic/isChromatic';
+
+import { deepMerge } from 'grommet/utils';
+
+import {
+  grommet,
+  Anchor,
+  Box,
+  Button,
+  Grommet,
+  Menu,
+  Text,
+  TextInput,
+} from 'grommet';
+
+const customFocus = deepMerge(grommet, {
+  global: {
+    colors: {
+      focus: 'neutral-3',
+    },
+  },
+});
+
+const CustomFocusFC = () => (
+  <Grommet theme={customFocus}>
+    <Box pad="small" gap="medium" width="medium">
+      <Text>
+        Focus on the input components and notice the custom focus color
+      </Text>
+      <TextInput placeholder="hi" />
+      <Anchor href="">Anchor</Anchor>
+      <Menu
+        label="Menu"
+        items={[{ label: 'One', onClick: () => {} }, { label: 'Two' }]}
+      />
+      <Button label="Button" onClick={() => {}} />
+    </Box>
+  </Grommet>
+);
+
+if (!isChromatic()) {
+  storiesOf('TypeScript/Theme', module).add('Focus', () => <CustomFocusFC />);
+}


### PR DESCRIPTION
Following up on some slack requests for customization of Focus color via theme.
Added showcase support with typescript.
Tested on storybook.
@ANDRESROMEROH FYI