### PR TITLE
Update README.md / Added standalone componnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ For Yarn users:
   $ yarn add grommet styled-components
 ```
 
+Install standalone components, or import for local code modifications:
+
+[bit.dev/grommet/grommet](https://bit.dev/grommet/grommet)
+
 There are more detailed instructions in the [Grommet Starter] app tutorial for
 new apps. For incorporating Grommet into an existing app, see the [Existing App]
 version.


### PR DESCRIPTION
Added a link to bit.dev/grommet/grommet for the installation of standalone components, in the micro-frontends/atomic-design spirit.
It also lets people import the components into their own projects for modifications when needed. Even though there are examples there too, I added it under "Installation" and not "Explore" since the real value is in the flexible distribution and consumption of standalone components.

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

It adds a link to the flexible consumption of standalone components.

#### Where should the reviewer start?
-

#### What testing has been done on this PR?
-

#### How should this be manually tested?
-

#### Any background context you want to provide?

Through bit.dev developers can export, distribute, consume and collaborate on standalone components: https://docs.bit.dev/docs/quick-start

#### What are the relevant issues?
-

#### Screenshots (if appropriate)
-

#### Do the grommet docs need to be updated?
no

#### Should this PR be mentioned in the release notes?
no

#### Is this change backwards compatible or is it a breaking change?
-
