### PR TITLE
Dependency removal of 'grommet-styles'

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@testing-library/react": "^9.1.3",
     "css": "^2.2.3",
     "grommet-icons": "^4.2.0",
-    "grommet-styles": "^0.2.0",
     "hoist-non-react-statics": "^3.2.0",
     "markdown-to-jsx": "^6.9.1",
     "polished": "^3.4.1",

--- a/src/js/components/Grommet/Grommet.js
+++ b/src/js/components/Grommet/Grommet.js
@@ -1,9 +1,13 @@
 import React, { Component } from 'react';
 import { createGlobalStyle } from 'styled-components';
 
-import { colorIsDark } from 'grommet-styles';
 import { ResponsiveContext, ThemeContext } from '../../contexts';
-import { deepMerge, getBreakpoint, getDeviceBreakpoint } from '../../utils';
+import {
+  colorIsDark,
+  deepMerge,
+  getBreakpoint,
+  getDeviceBreakpoint,
+} from '../../utils';
 import { base as baseTheme } from '../../themes';
 import { StyledGrommet } from './StyledGrommet';
 

--- a/src/js/components/Select/StyledSelect.js
+++ b/src/js/components/Select/StyledSelect.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { sizeStyle } from 'grommet-styles';
+import { sizeStyle } from '../../utils';
 
 export const StyledContainer = styled.div`
   /* IE11 hack to get drop contents to not overflow */

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -1,7 +1,6 @@
 import React, { Component, isValidElement } from 'react';
 import { compose } from 'recompose';
 import styled, { withTheme } from 'styled-components';
-import { sizeStyle } from 'grommet-styles';
 
 import { defaultProps } from '../../default-props';
 
@@ -11,6 +10,7 @@ import { Drop } from '../Drop';
 import { InfiniteScroll } from '../InfiniteScroll';
 import { Keyboard } from '../Keyboard';
 import { withAnnounce, withFocus, withForwardRef } from '../hocs';
+import { sizeStyle } from '../../utils';
 
 import {
   StyledTextInput,

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -265,3 +265,7 @@ export const disabledStyle = componentStyle => css`
     componentStyle || props.theme.global.control.disabled.opacity};
   cursor: default;
 `;
+
+export const sizeStyle = (name, value, theme) => css`
+  ${name}: ${theme.global.size[value] || value};
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3238,7 +3238,7 @@ browserslist@^4.6.0, browserslist@^4.8.0:
     electron-to-chromium "^1.3.322"
     node-releases "^1.1.42"
 
-bser@^2.0.0:
+bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
   integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
@@ -5212,11 +5212,11 @@ faye-websocket@~0.11.1:
     websocket-driver ">=0.5.1"
 
 fb-watchman@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
-  integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.1.tgz#fc84fb39d2709cf3ff6d743706157bb5708a8a85"
+  integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
-    bser "^2.0.0"
+    bser "2.1.1"
 
 fbjs@^0.8.0, fbjs@^0.8.1:
   version "0.8.17"
@@ -8921,9 +8921,9 @@ postcss-value-parser@^4.0.2:
   integrity sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==
 
 postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.23, postcss@^7.0.5, postcss@^7.0.6:
-  version "7.0.23"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.23.tgz#9f9759fad661b15964f3cfc3140f66f1e05eadc1"
-  integrity sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==
+  version "7.0.24"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.24.tgz#972c3c5be431b32e40caefe6c81b5a19117704c2"
+  integrity sha512-Xl0XvdNWg+CblAXzNvbSOUvgJXwSjmbAKORqyw9V2AlHrm1js2gFw9y3jibBAhpKZi8b5JzJCVh/FyzPsTtgTA==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"


### PR DESCRIPTION
Grommet currently uses external package for some of its utility functionalities, util functions as:
* `colorIsDark(...)`
* `sizeStyle(...)`

This PR is removing the dependency of the package by:
* Relying on the already existing util function of `colorIsDark(...)` from utils package. (functions are operating/implemented in the same way)
* Added it's own `sizeStyle(...)` function to styles.js, and removing the dependency of the external util function.

