### PR TITLE
Remove theme.global.graph and added theme.global.colors.graph-*

### DIFF
--- a/src/js/components/Chart/Chart.js
+++ b/src/js/components/Chart/Chart.js
@@ -327,12 +327,7 @@ const Chart = React.forwardRef(
       if (color && color.color) colorName = color.color;
       else if (color) colorName = color;
       else if (theme.chart && theme.chart.color) colorName = theme.chart.color;
-      else if (theme.global.graph && theme.global.graph.colors) {
-        const colors =
-          theme.global.graph.colors[theme.dark ? 'dark' : 'light'] ||
-          theme.global.graph.colors;
-        [colorName] = colors;
-      }
+      else colorName = 'graph-0';
     }
     const opacity =
       color && color.opacity ? theme.global.opacity[color.opacity] : undefined;

--- a/src/js/components/Chart/README.md
+++ b/src/js/components/Chart/README.md
@@ -299,7 +299,7 @@ Required. Array of value objects describing the data.
   
 **chart.color**
 
-Color of the Chart. Expects `string | (props) => {}`.
+Color of the Chart. Expects `string | {dark: string, light: string}`.
 
 Defaults to
 
@@ -319,7 +319,7 @@ undefined
 
 **global.colors**
 
-color options Expects `object`.
+Color options. Expects `object`.
 
 Defaults to
 
@@ -327,6 +327,7 @@ Defaults to
 {
       "accent-1": "#6FFFB0",
       "graph-0": "accent-1",
+      ...
     }
 ```
 
@@ -352,7 +353,7 @@ Defaults to
 
 **global.opacity**
 
-The opacity of the Chart stroke. Expects `string`.
+The opacity of the Chart stroke. Expects `object`.
 
 Defaults to
 

--- a/src/js/components/Chart/README.md
+++ b/src/js/components/Chart/README.md
@@ -297,6 +297,16 @@ Required. Array of value objects describing the data.
   
 ## Theme
   
+**chart.color**
+
+Color of the Chart. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+accent-1
+```
+
 **chart.extend**
 
 Any additional style for the Chart. Expects `string | (props) => {}`.
@@ -309,12 +319,15 @@ undefined
 
 **global.colors**
 
-color options used for Chart fill area. Expects `object`.
+color options Expects `object`.
 
 Defaults to
 
 ```
-accent-1
+{
+      "accent-1": "#6FFFB0",
+      "graph-0": "accent-1",
+    }
 ```
 
 **global.edgeSize**
@@ -337,16 +350,6 @@ Defaults to
     }
 ```
 
-**global.graph.colors**
-
-The color to use when not specified via color. Expects `[string] or { dark: [string], light: [string] }`.
-
-Defaults to
-
-```
-undefined
-```
-
 **global.opacity**
 
 The opacity of the Chart stroke. Expects `string`.
@@ -354,7 +357,11 @@ The opacity of the Chart stroke. Expects `string`.
 Defaults to
 
 ```
-undefined
+{
+      strong: 0.8,
+      medium: 0.4,
+      weak: 0.1,
+    }
 ```
 
 **global.size**

--- a/src/js/components/Chart/doc.js
+++ b/src/js/components/Chart/doc.js
@@ -176,15 +176,23 @@ const data = calcs(<values>, { coarseness: 5, steps: [1, 1] });`,
 };
 
 export const themeDoc = {
+  'chart.color': {
+    description: 'Color of the Chart.',
+    type: 'string | (props) => {}',
+    defaultValue: 'accent-1',
+  },
   'chart.extend': {
     description: 'Any additional style for the Chart.',
     type: 'string | (props) => {}',
     defaultValue: undefined,
   },
   'global.colors': {
-    description: 'color options used for Chart fill area.',
+    description: 'color options',
     type: 'object',
-    defaultValue: 'accent-1',
+    defaultValue: `{
+      "accent-1": "#6FFFB0",
+      "graph-0": "accent-1",
+    }`,
   },
   'global.edgeSize': {
     description: 'The possible sizes for the thickness in the Chart.',
@@ -201,14 +209,14 @@ export const themeDoc = {
         responsiveBreakpoint: 'small',
     }`,
   },
-  'global.graph.colors': {
-    description: 'The color to use when not specified via color.',
-    type: '[string] or { dark: [string], light: [string] }',
-  },
   'global.opacity': {
     description: 'The opacity of the Chart stroke.',
     type: 'string',
-    defaultValue: undefined,
+    defaultValue: `{
+      strong: 0.8,
+      medium: 0.4,
+      weak: 0.1,
+    }`,
   },
   'global.size': {
     description: 'The possible sizes for Chart width and height.',

--- a/src/js/components/Chart/doc.js
+++ b/src/js/components/Chart/doc.js
@@ -178,7 +178,7 @@ const data = calcs(<values>, { coarseness: 5, steps: [1, 1] });`,
 export const themeDoc = {
   'chart.color': {
     description: 'Color of the Chart.',
-    type: 'string | {dark: string, light: string},
+    type: 'string | {dark: string, light: string}',
     defaultValue: 'accent-1',
   },
   'chart.extend': {
@@ -187,11 +187,12 @@ export const themeDoc = {
     defaultValue: undefined,
   },
   'global.colors': {
-    description: 'color options',
+    description: 'Color options.',
     type: 'object',
     defaultValue: `{
       "accent-1": "#6FFFB0",
       "graph-0": "accent-1",
+      ...
     }`,
   },
   'global.edgeSize': {
@@ -211,7 +212,7 @@ export const themeDoc = {
   },
   'global.opacity': {
     description: 'The opacity of the Chart stroke.',
-    type: 'string',
+    type: 'object',
     defaultValue: `{
       strong: 0.8,
       medium: 0.4,

--- a/src/js/components/Chart/doc.js
+++ b/src/js/components/Chart/doc.js
@@ -178,7 +178,7 @@ const data = calcs(<values>, { coarseness: 5, steps: [1, 1] });`,
 export const themeDoc = {
   'chart.color': {
     description: 'Color of the Chart.',
-    type: 'string | (props) => {}',
+    type: 'string | {dark: string, light: string},
     defaultValue: 'accent-1',
   },
   'chart.extend': {

--- a/src/js/components/Diagram/Diagram.js
+++ b/src/js/components/Diagram/Diagram.js
@@ -198,10 +198,10 @@ const Diagram = ({ connections, theme, ...rest }) => {
             : 1;
           let colorName =
             color || (theme.diagram.line && theme.diagram.line.color);
-          if (!colorName && theme.global.graph && theme.global.graph.colors) {
-            const colors =
-              theme.global.graph.colors[theme.dark ? 'dark' : 'light']
-              || theme.global.graph.colors;
+          if (!colorName) {
+            const colors = Object.keys(theme.global.colors).filter(n =>
+              n.match(/^graph-[0-9]$/),
+            );
             colorName = colors[index % colors.length];
           }
 

--- a/src/js/components/Diagram/README.md
+++ b/src/js/components/Diagram/README.md
@@ -68,37 +68,6 @@ svg
 ```
 ## Theme
   
-**global.edgeSize**
-
-The possible sizes for the connections thickness and offset. Expects `object`.
-
-Defaults to
-
-```
-{
-        none: '0px',
-        hair: '1px',
-        xxsmall: '3px',
-        xsmall: '6px',
-        small: '12px',
-        medium: '24px',
-        large: '48px',
-        xlarge: '96px',
-        responsiveBreakpoint: 'small',
-    }
-```
-
-**global.graph.colors**
-
-The colors to use when not specified via connections or via
-    theme.diagram.line.color. Expects `[string] or { dark: [string], light: [string] }`.
-
-Defaults to
-
-```
-undefined
-```
-
 **diagram.extend**
 
 Any additional style for Diagram. Expects `string | (props) => {}`.
@@ -117,4 +86,38 @@ Defaults to
 
 ```
 accent-1
+```
+
+**global.colors**
+
+color options Expects `object`.
+
+Defaults to
+
+```
+{
+      "accent-1": "#6FFFB0",
+      "graph-0": "accent-1",
+      "graph-1": "neutral-1",
+    }
+```
+
+**global.edgeSize**
+
+The possible sizes for the connections thickness and offset. Expects `object`.
+
+Defaults to
+
+```
+{
+        none: '0px',
+        hair: '1px',
+        xxsmall: '3px',
+        xsmall: '6px',
+        small: '12px',
+        medium: '24px',
+        large: '48px',
+        xlarge: '96px',
+        responsiveBreakpoint: 'small',
+    }
 ```

--- a/src/js/components/Diagram/README.md
+++ b/src/js/components/Diagram/README.md
@@ -90,7 +90,7 @@ accent-1
 
 **global.colors**
 
-color options Expects `object`.
+Color options. Expects `object`.
 
 Defaults to
 
@@ -99,6 +99,7 @@ Defaults to
       "accent-1": "#6FFFB0",
       "graph-0": "accent-1",
       "graph-1": "neutral-1",
+      ...
     }
 ```
 

--- a/src/js/components/Diagram/README.md
+++ b/src/js/components/Diagram/README.md
@@ -80,7 +80,7 @@ undefined
 
 **diagram.line.color**
 
-The color of the connection line. Expects `string`.
+The color of the connection line. Expects `string | {dark: string, light: string}`.
 
 Defaults to
 

--- a/src/js/components/Diagram/doc.js
+++ b/src/js/components/Diagram/doc.js
@@ -64,7 +64,7 @@ export const themeDoc = {
     defaultValue: 'accent-1',
   },
   'global.colors': {
-    description: 'color options',
+    description: 'Color options.',
     type: 'object',
     defaultValue: `{
       "accent-1": "#6FFFB0",

--- a/src/js/components/Diagram/doc.js
+++ b/src/js/components/Diagram/doc.js
@@ -53,6 +53,25 @@ export const doc = Diagram => {
 };
 
 export const themeDoc = {
+  'diagram.extend': {
+    description: 'Any additional style for Diagram.',
+    type: 'string | (props) => {}',
+    defaultValue: undefined,
+  },
+  'diagram.line.color': {
+    description: 'The color of the connection line.',
+    type: 'string',
+    defaultValue: 'accent-1',
+  },
+  'global.colors': {
+    description: 'color options',
+    type: 'object',
+    defaultValue: `{
+      "accent-1": "#6FFFB0",
+      "graph-0": "accent-1",
+      "graph-1": "neutral-1",
+    }`,
+  },
   'global.edgeSize': {
     description: 'The possible sizes for the connections thickness and offset.',
     type: 'object',
@@ -67,20 +86,5 @@ export const themeDoc = {
         xlarge: '96px',
         responsiveBreakpoint: 'small',
     }`,
-  },
-  'global.graph.colors': {
-    description: `The colors to use when not specified via connections or via
-    theme.diagram.line.color.`,
-    type: '[string] or { dark: [string], light: [string] }',
-  },
-  'diagram.extend': {
-    description: 'Any additional style for Diagram.',
-    type: 'string | (props) => {}',
-    defaultValue: undefined,
-  },
-  'diagram.line.color': {
-    description: 'The color of the connection line.',
-    type: 'string',
-    defaultValue: 'accent-1',
   },
 };

--- a/src/js/components/Diagram/doc.js
+++ b/src/js/components/Diagram/doc.js
@@ -70,6 +70,7 @@ export const themeDoc = {
       "accent-1": "#6FFFB0",
       "graph-0": "accent-1",
       "graph-1": "neutral-1",
+      ...
     }`,
   },
   'global.edgeSize': {

--- a/src/js/components/Diagram/doc.js
+++ b/src/js/components/Diagram/doc.js
@@ -60,7 +60,7 @@ export const themeDoc = {
   },
   'diagram.line.color': {
     description: 'The color of the connection line.',
-    type: 'string',
+    type: 'string | {dark: string, light: string}',
     defaultValue: 'accent-1',
   },
   'global.colors': {

--- a/src/js/components/Meter/README.md
+++ b/src/js/components/Meter/README.md
@@ -205,6 +205,19 @@ Array of value objects describing the data.
   
 ## Theme
   
+**global.colors**
+
+color options Expects `object`.
+
+Defaults to
+
+```
+{
+      "accent-1": "#6FFFB0",
+      "graph-0": "accent-1",
+    }
+```
+
 **global.edgeSize**
 
 The border-radius of the styled Meter. thickness, height and 
@@ -224,16 +237,6 @@ Defaults to
         xlarge: '96px',
         responsiveBreakpoint: 'small',
     }
-```
-
-**global.graph.colors**
-
-The colors to use when not specified via values. Expects `[string] or { dark: [string], light: [string] }`.
-
-Defaults to
-
-```
-undefined
 ```
 
 **global.opacity.medium**

--- a/src/js/components/Meter/README.md
+++ b/src/js/components/Meter/README.md
@@ -207,7 +207,7 @@ Array of value objects describing the data.
   
 **global.colors**
 
-color options Expects `object`.
+Color options. Expects `object`.
 
 Defaults to
 
@@ -215,6 +215,7 @@ Defaults to
 {
       "accent-1": "#6FFFB0",
       "graph-0": "accent-1",
+      ...
     }
 ```
 

--- a/src/js/components/Meter/doc.js
+++ b/src/js/components/Meter/doc.js
@@ -70,6 +70,14 @@ export const doc = Meter => {
 };
 
 export const themeDoc = {
+  'global.colors': {
+    description: 'color options',
+    type: 'object',
+    defaultValue: `{
+      "accent-1": "#6FFFB0",
+      "graph-0": "accent-1",
+    }`,
+  },
   'global.edgeSize': {
     description: `The border-radius of the styled Meter. thickness, height and 
     width of the Bar Meter, height of the Circle Meter.`,
@@ -85,10 +93,6 @@ export const themeDoc = {
         xlarge: '96px',
         responsiveBreakpoint: 'small',
     }`,
-  },
-  'global.graph.colors': {
-    description: 'The colors to use when not specified via values.',
-    type: '[string] or { dark: [string], light: [string] }',
   },
   'global.opacity.medium': {
     description: 'The opacity value used on the Meter color.',

--- a/src/js/components/Meter/doc.js
+++ b/src/js/components/Meter/doc.js
@@ -71,11 +71,12 @@ export const doc = Meter => {
 
 export const themeDoc = {
   'global.colors': {
-    description: 'color options',
+    description: 'Color options.',
     type: 'object',
     defaultValue: `{
       "accent-1": "#6FFFB0",
       "graph-0": "accent-1",
+      ...
     }`,
   },
   'global.edgeSize': {

--- a/src/js/components/Meter/utils.js
+++ b/src/js/components/Meter/utils.js
@@ -30,10 +30,10 @@ export const defaultColor = (index, theme, valuesLength) => {
       theme.meter.colors[theme.dark ? 'dark' : 'light'] || theme.meter.colors;
     return colors[index % colors.length];
   }
-  if (theme.global.graph && theme.global.graph.colors) {
-    const colors =
-      theme.global.graph.colors[theme.dark ? 'dark' : 'light'] ||
-      theme.global.graph.colors;
+  const colors = Object.keys(theme.global.colors).filter(n =>
+    n.match(/^graph-[0-9]$/),
+  );
+  if (colors.length > 0) {
     return colors[index % colors.length];
   }
   // Deprecate using "neutral-*" color names. Remove eventually.

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -3142,7 +3142,7 @@ Required. Array of value objects describing the data.
   
 **chart.color**
 
-Color of the Chart. Expects \`string | (props) => {}\`.
+Color of the Chart. Expects \`string | {dark: string, light: string}\`.
 
 Defaults to
 
@@ -3162,7 +3162,7 @@ undefined
 
 **global.colors**
 
-color options Expects \`object\`.
+Color options. Expects \`object\`.
 
 Defaults to
 
@@ -3170,6 +3170,7 @@ Defaults to
 {
       \\"accent-1\\": \\"#6FFFB0\\",
       \\"graph-0\\": \\"accent-1\\",
+      ...
     }
 \`\`\`
 
@@ -3195,7 +3196,7 @@ Defaults to
 
 **global.opacity**
 
-The opacity of the Chart stroke. Expects \`string\`.
+The opacity of the Chart stroke. Expects \`object\`.
 
 Defaults to
 
@@ -4704,7 +4705,7 @@ accent-1
 
 **global.colors**
 
-color options Expects \`object\`.
+Color options. Expects \`object\`.
 
 Defaults to
 
@@ -4713,6 +4714,7 @@ Defaults to
       \\"accent-1\\": \\"#6FFFB0\\",
       \\"graph-0\\": \\"accent-1\\",
       \\"graph-1\\": \\"neutral-1\\",
+      ...
     }
 \`\`\`
 
@@ -8434,7 +8436,7 @@ Array of value objects describing the data.
   
 **global.colors**
 
-color options Expects \`object\`.
+Color options. Expects \`object\`.
 
 Defaults to
 
@@ -8442,6 +8444,7 @@ Defaults to
 {
       \\"accent-1\\": \\"#6FFFB0\\",
       \\"graph-0\\": \\"accent-1\\",
+      ...
     }
 \`\`\`
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4695,7 +4695,7 @@ undefined
 
 **diagram.line.color**
 
-The color of the connection line. Expects \`string\`.
+The color of the connection line. Expects \`string | {dark: string, light: string}\`.
 
 Defaults to
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -3140,6 +3140,16 @@ Required. Array of value objects describing the data.
   
 ## Theme
   
+**chart.color**
+
+Color of the Chart. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+accent-1
+\`\`\`
+
 **chart.extend**
 
 Any additional style for the Chart. Expects \`string | (props) => {}\`.
@@ -3152,12 +3162,15 @@ undefined
 
 **global.colors**
 
-color options used for Chart fill area. Expects \`object\`.
+color options Expects \`object\`.
 
 Defaults to
 
 \`\`\`
-accent-1
+{
+      \\"accent-1\\": \\"#6FFFB0\\",
+      \\"graph-0\\": \\"accent-1\\",
+    }
 \`\`\`
 
 **global.edgeSize**
@@ -3180,16 +3193,6 @@ Defaults to
     }
 \`\`\`
 
-**global.graph.colors**
-
-The color to use when not specified via color. Expects \`[string] or { dark: [string], light: [string] }\`.
-
-Defaults to
-
-\`\`\`
-undefined
-\`\`\`
-
 **global.opacity**
 
 The opacity of the Chart stroke. Expects \`string\`.
@@ -3197,7 +3200,11 @@ The opacity of the Chart stroke. Expects \`string\`.
 Defaults to
 
 \`\`\`
-undefined
+{
+      strong: 0.8,
+      medium: 0.4,
+      weak: 0.1,
+    }
 \`\`\`
 
 **global.size**
@@ -4675,37 +4682,6 @@ svg
 \`\`\`
 ## Theme
   
-**global.edgeSize**
-
-The possible sizes for the connections thickness and offset. Expects \`object\`.
-
-Defaults to
-
-\`\`\`
-{
-        none: '0px',
-        hair: '1px',
-        xxsmall: '3px',
-        xsmall: '6px',
-        small: '12px',
-        medium: '24px',
-        large: '48px',
-        xlarge: '96px',
-        responsiveBreakpoint: 'small',
-    }
-\`\`\`
-
-**global.graph.colors**
-
-The colors to use when not specified via connections or via
-    theme.diagram.line.color. Expects \`[string] or { dark: [string], light: [string] }\`.
-
-Defaults to
-
-\`\`\`
-undefined
-\`\`\`
-
 **diagram.extend**
 
 Any additional style for Diagram. Expects \`string | (props) => {}\`.
@@ -4724,6 +4700,40 @@ Defaults to
 
 \`\`\`
 accent-1
+\`\`\`
+
+**global.colors**
+
+color options Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+      \\"accent-1\\": \\"#6FFFB0\\",
+      \\"graph-0\\": \\"accent-1\\",
+      \\"graph-1\\": \\"neutral-1\\",
+    }
+\`\`\`
+
+**global.edgeSize**
+
+The possible sizes for the connections thickness and offset. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+        none: '0px',
+        hair: '1px',
+        xxsmall: '3px',
+        xsmall: '6px',
+        small: '12px',
+        medium: '24px',
+        large: '48px',
+        xlarge: '96px',
+        responsiveBreakpoint: 'small',
+    }
 \`\`\`
 ",
   "Distribution": "## Distribution
@@ -8422,6 +8432,19 @@ Array of value objects describing the data.
   
 ## Theme
   
+**global.colors**
+
+color options Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+      \\"accent-1\\": \\"#6FFFB0\\",
+      \\"graph-0\\": \\"accent-1\\",
+    }
+\`\`\`
+
 **global.edgeSize**
 
 The border-radius of the styled Meter. thickness, height and 
@@ -8441,16 +8464,6 @@ Defaults to
         xlarge: '96px',
         responsiveBreakpoint: 'small',
     }
-\`\`\`
-
-**global.graph.colors**
-
-The colors to use when not specified via values. Expects \`[string] or { dark: [string], light: [string] }\`.
-
-Defaults to
-
-\`\`\`
-undefined
 \`\`\`
 
 **global.opacity.medium**

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -322,6 +322,7 @@ export interface ThemeType {
     };
   };
   chart?: {
+    color?: ColorType;
     extend?: ExtendType;
   }
   checkBox?: {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -58,6 +58,12 @@ type Colors = typeof colors & {
   'status-ok'?: ColorType;
   'status-unknown'?: ColorType;
   'status-disabled'?: ColorType;
+  'graph-0'?: ColorType;
+  'graph-1'?: ColorType;
+  'graph-2'?: ColorType;
+  'graph-3'?: ColorType;
+  'graph-4'?: ColorType;
+  'graph-5'?: ColorType;
   [x: string]: ColorType;
 };
 

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -62,6 +62,10 @@ const colors = {
     light: 'brand',
   },
   focus: focusColor,
+  // "graph-0": 'accent-1',
+  // "graph-1": 'neutral-1',
+  // "graph-2": 'accent-2',
+  // "graph-3": 'neutral-2',
   placeholder: '#AAAAAA',
   selected: 'brand',
   text: {
@@ -230,9 +234,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // face: undefined,
         // family: undefined,
       },
-      // graph: {
-      //   colors: [],
-      // },
       hover: {
         background: {
           color: 'active',


### PR DESCRIPTION
#### What does this PR do?

Remove `theme.global.graph` and added ability to use `theme.global.colors.graph-*`.

`theme.global.graph.colors` didn't lend itself to making graph keys easy enough. So, removing this, which hasn't been part of an official grommet release yet, thankfully.

#### Where should the reviewer start?

base.js

#### What testing has been done on this PR?

unit
theme designer

#### How should this be manually tested?

unit

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
