### PR TITLE
Footer + Main - Updated docs to refer to Box

### DIFF
--- a/src/js/components/Footer/README.md
+++ b/src/js/components/Footer/README.md
@@ -1,5 +1,5 @@
 ## Footer
-Footer for a document or section
+is a Box container for a document or a section footer
 
 [![](https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png)](https://storybook.grommet.io/?selectedKind=Footer&full=0&addons=0&stories=1&panelRight=0) [![](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=footer&module=%2Fsrc%2FFooter.js)
 ## Usage

--- a/src/js/components/Footer/doc.js
+++ b/src/js/components/Footer/doc.js
@@ -5,7 +5,7 @@ import { getAvailableAtBadge } from '../../utils';
 export const doc = Footer => {
   const DocumentedFooter = describe(Footer)
     .availableAt(getAvailableAtBadge('Footer'))
-    .description('Footer for a document or section')
+    .description('is a Box container for a document or a section footer')
     .usage(
       `import { Footer } from 'grommet';
 <Footer />`,

--- a/src/js/components/Main/README.md
+++ b/src/js/components/Main/README.md
@@ -1,5 +1,5 @@
 ## Main
-main content of a document.
+is a Box container for main content of a document.
 
 [![](https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png)](https://storybook.grommet.io/?selectedKind=Main&full=0&addons=0&stories=1&panelRight=0) [![](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=main&module=%2Fsrc%2FMain.js)
 ## Usage

--- a/src/js/components/Main/doc.js
+++ b/src/js/components/Main/doc.js
@@ -5,7 +5,7 @@ import { getAvailableAtBadge } from '../../utils';
 export const doc = Main => {
   const DocumentedMain = describe(Main)
     .availableAt(getAvailableAtBadge('Main'))
-    .description('main content of a document.')
+    .description('is a Box container for main content of a document.')
     .usage(
       `import { Main } from 'grommet';
 <Main />`,

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5346,7 +5346,7 @@ boolean
 button
 \`\`\`",
   "Footer": "## Footer
-Footer for a document or section
+is a Box container for a document or a section footer
 
 [![](https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png)](https://storybook.grommet.io/?selectedKind=Footer&full=0&addons=0&stories=1&panelRight=0) [![](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=footer&module=%2Fsrc%2FFooter.js)
 ## Usage
@@ -7706,7 +7706,7 @@ undefined
 \`\`\`
 ",
   "Main": "## Main
-main content of a document.
+is a Box container for main content of a document.
 
 [![](https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png)](https://storybook.grommet.io/?selectedKind=Main&full=0&addons=0&stories=1&panelRight=0) [![](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=main&module=%2Fsrc%2FMain.js)
 ## Usage


### PR DESCRIPTION
Until we find an improved way to communicate the inherit props of Box, I'm adding this description for Footer and Main. It already in place for Header.
I think we are good for a release after this change. one thing that is still missing is document the default props of the components.