### PR TITLE
Make styled-components external.

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -23,6 +23,7 @@ export default {
   externals: {
     react: 'React',
     'react-dom': 'ReactDOM',
+    'styled-components': 'styled',
   },
   resolve: {
     extensions: ['.js', '.json'],


### PR DESCRIPTION
#### What does this PR do?

Make styled-components external.

#### What testing has been done on this PR?

grommet-designer using react, react-do, styled-components, grommet, and grommet-icons all loaded via `<script />` tags.

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
