### PR TITLE
Changed Box to fix an issue with background color darkness

### DIFF
--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -98,6 +98,19 @@ const Box = forwardRef(
       });
     }
 
+    if (background || theme.darkChanged) {
+      let dark = backgroundIsDark(background, theme);
+      const darkChanged = dark !== undefined && dark !== theme.dark;
+      if (darkChanged || theme.darkChanged) {
+        dark = dark === undefined ? theme.dark : dark;
+        contents = (
+          <ThemeContext.Provider value={{ ...theme, dark }}>
+            {contents}
+          </ThemeContext.Provider>
+        );
+      }
+    }
+
     let content = (
       <StyledBox
         as={!as && tag ? tag : as}
@@ -123,22 +136,6 @@ const Box = forwardRef(
 
     if (onClick) {
       content = <Keyboard onEnter={onClick}>{content}</Keyboard>;
-    }
-
-    // When a Box changes the darkness, it sets darkChanged so that StyledBox
-    // can know what the underlying darkness is when deciding which elevation
-    // to show.
-    if (background || theme.darkChanged) {
-      let dark = backgroundIsDark(background, theme);
-      const darkChanged = dark !== undefined && dark !== theme.dark;
-      if (darkChanged || theme.darkChanged) {
-        dark = dark === undefined ? theme.dark : dark;
-        content = (
-          <ThemeContext.Provider value={{ ...theme, dark, darkChanged }}>
-            {content}
-          </ThemeContext.Provider>
-        );
-      }
     }
 
     return content;

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -89,12 +89,9 @@ const directionStyle = (direction, theme) => {
 
 const elevationStyle = css`
   box-shadow: ${props =>
-    props.theme.global.elevation[
-      (props.theme.dark && !props.theme.darkChanged) ||
-      (!props.theme.dark && props.theme.darkChanged)
-        ? 'dark'
-        : 'light'
-    ][props.elevationProp]};
+    props.theme.global.elevation[props.theme.dark ? 'dark' : 'light'][
+      props.elevationProp
+    ]};
 `;
 
 const FLEX_MAP = {

--- a/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
+++ b/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
@@ -318,6 +318,24 @@ exports[`RadioButton children 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
+  background: #7D4CDB;
+  color: #f8f8f8;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 12px;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
   background: #6FFFB0;
   color: #444444;
   min-width: 0;
@@ -370,6 +388,12 @@ exports[`RadioButton children 1`] = `
   }
 }
 
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding: 6px;
+  }
+}
+
 <div
   className="c0"
 >
@@ -410,7 +434,7 @@ exports[`RadioButton children 1`] = `
         value="2"
       />
       <div
-        className="c4"
+        className="c5"
       />
     </div>
   </label>

--- a/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
+++ b/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
@@ -34,8 +34,8 @@ exports[`RadioButtonGroup children 1`] = `
   box-sizing: border-box;
   outline: none;
   max-width: 100%;
-  background: #6FFFB0;
-  color: #444444;
+  background: #7D4CDB;
+  color: #f8f8f8;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;


### PR DESCRIPTION
#### What does this PR do?

Changed Box to fix an issue with background color darkness.
Specifically, Box was updating the ThemeContext to contain itself, and therefore using the darkness of the Box to influence the Box's styling. This change moves the ThemeContext resetting to apply to only the children of Box. So, `theme.dark` for StyledBox refers to the context the Box is in while `theme.dark` for the children of Box reflects the background of the Box.

One note on the RadioButton snapshot changes, the snapshots now look correct, with the background of the children reflecting the checked state. I don't think we reviewed the styling details of the previous snapshots enough.

#### Where should the reviewer start?

Box.js

#### What testing has been done on this PR?

grommet-designer with latest HPE theme and a variety of color mixes.

#### How should this be manually tested?

storybook

#### Any background context you want to provide?

see above

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
