### PR TITLE
Changed RadioButtonGroup to set option ids based on group id

### DIFF
--- a/src/js/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/js/components/RadioButtonGroup/RadioButtonGroup.js
@@ -21,9 +21,11 @@ const RadioButtonGroup = forwardRef(
     const options = useMemo(
       () =>
         optionsProp.map(o =>
-          typeof o === 'string' ? { id: o, label: o, value: o } : o,
+          typeof o === 'string'
+            ? { id: rest.id ? `${rest.id}-${o}` : o, label: o, value: o }
+            : o,
         ),
-      [optionsProp],
+      [optionsProp, rest.id],
     );
     const [value, setValue] = useState(valueProp);
     useEffect(() => setValue(valueProp), [valueProp]);


### PR DESCRIPTION
#### What does this PR do?

Changed RadioButtonGroup to set option ids based on group id.

This makes it easier for callers to not have to pass object to the `options` prop of RadioButtonGroup and just set an `id` for the group.

#### What testing has been done on this PR?

grommet designer

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
