### PR TITLE
Dont steal keystrokes from the user if the layer is not modal.

### DIFF
--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -34,7 +34,7 @@ class LayerContainer extends Component {
   layerRef = React.createRef();
 
   componentDidMount() {
-    const { position } = this.props;
+    const { position, modal } = this.props;
     if (position !== 'hidden') {
       this.makeLayerVisible();
       // Once layer is open we make sure it has focus so that you
@@ -49,7 +49,7 @@ class LayerContainer extends Component {
         }
         element = element.parentElement;
       }
-      if (!element && this.anchorRef.current) {
+      if (modal && !element && this.anchorRef.current) {
         this.anchorRef.current.focus();
       }
     }


### PR DESCRIPTION
This fixes the issue in which a non-modal notification may appear in the corner of the app and starts stealing keystrokes from a user active in an existing window.