### PR TITLE
Update ExtendType to support styled-components interpolations

### DIFF
--- a/.yarnclean
+++ b/.yarnclean
@@ -1,3 +1,0 @@
-# Working around styled-components types issue as suggested in
-# https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33311/#issuecomment-546727329
-@types/react-native

--- a/.yarnclean
+++ b/.yarnclean
@@ -1,0 +1,3 @@
+# Working around styled-components types issue as suggested in
+# https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33311/#issuecomment-546727329
+@types/react-native

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@types/react": "^16.9.11",
     "@types/react-dom": "^16.9.3",
     "@types/storybook__react": "^4.0.2",
-    "@types/styled-components": "^4.4.2",
+    "@types/styled-components": "^5.0.1",
     "awesome-typescript-loader": "^5.2.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@types/react": "^16.9.11",
     "@types/react-dom": "^16.9.3",
     "@types/storybook__react": "^4.0.2",
+    "@types/styled-components": "^4.4.2",
     "awesome-typescript-loader": "^5.2.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",

--- a/src/js/all/stories/typescript/ExtendTheme.tsx
+++ b/src/js/all/stories/typescript/ExtendTheme.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { css } from 'styled-components';
+import { storiesOf } from '@storybook/react';
+import { ThemeType, BoxTypes, Grommet, Box, Anchor, Button } from 'grommet';
+
+// Custom theme to verify that various `extend` types work correctly
+const custom: ThemeType = {
+  box: {
+    extend: css`
+      cursor: ${(props: BoxTypes) => (props.onClick ? 'cursor' : 'inherit')};
+    `,
+  },
+  anchor: {
+    extend: props => css`
+      color: ${props.href ? 'green' : 'red'};
+    `,
+  },
+  button: {
+    extend: props => {
+      let extraStyles = '';
+      if (props.primary) {
+        extraStyles = `
+          text-transform: uppercase;
+          color: white;
+        `;
+      }
+      return `
+        color: green;
+        font-size: 12px;
+        font-weight: bold;
+
+        ${extraStyles}
+      `;
+    },
+  },
+  icon: {
+    // Components without typed theme props should pass type-checking
+    extend: props => css`
+      color: ${props.untypedProp === 'some value' ? 'red' : 'green'};
+    `,
+  },
+};
+
+const ExtendTheme: React.FC = () => {
+  return (
+    <Grommet theme={custom}>
+      <Box pad="small" gap="medium" width="medium">
+        <Anchor href="#">Anchor (href)</Anchor>
+        <Anchor>Anchor (no href)</Anchor>
+
+        <Button label="Standard Button" onClick={() => {}} />
+        <Button label="Primary Button" primary onClick={() => {}} />
+
+        <Box onClick={() => {}}>Clickable box should use pointer cursor.</Box>
+
+        <Box>Un-clickable box should use standard cursor.</Box>
+      </Box>
+    </Grommet>
+  );
+};
+
+storiesOf('TypeScript/Theme', module).add('Extend', () => <ExtendTheme />);

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -21,8 +21,8 @@ import {
   PropsOf,
 } from '../utils';
 
+import { BoxProps } from '../components/Box';
 import { Anchor } from '../components/Anchor';
-import { Button } from '../components/Button';
 import { Box } from '../components/Box';
 import { Text, TextProps } from '../components/Text';
 import { ReactComponentElement } from 'react';
@@ -52,7 +52,7 @@ type ExtendValue<TProps> = string | FlattenSimpleInterpolation | FlattenInterpol
 type ExtendFn<TProps> = (props: ExtendProps<TProps>) => ExtendValue<TProps>;
 
 /**
- * ExtendType represents a valid value for `extend` in the theme.
+ * ExtendType represents the type for `extend` values in the theme.
  *
  * Acceptable values for `extend` are one of:
  *
@@ -112,7 +112,7 @@ type Colors = typeof colors & {
   'graph-3'?: ColorType;
   'graph-4'?: ColorType;
   'graph-5'?: ColorType;
-  [x: string]: ColorType | undefined;
+  [x: string]: ColorType;
 };
 
 interface ButtonKindType {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1,4 +1,10 @@
 import {
+  FlattenInterpolation,
+  FlattenSimpleInterpolation,
+  ThemedStyledProps,
+} from 'styled-components';
+
+import {
   BackgroundType,
   BorderType,
   BreakpointBorderSize,
@@ -12,10 +18,13 @@ import {
   OpacityType,
   RoundType,
   PadType,
+  PropsOf,
 } from '../utils';
 
-import { BoxProps } from '../components/Box';
-import { TextProps } from '../components/Text';
+import { Anchor } from '../components/Anchor';
+import { Button } from '../components/Button';
+import { Box } from '../components/Box';
+import { Text, TextProps } from '../components/Text';
 import { ReactComponentElement } from 'react';
 
 export declare const base: DeepReadonly<ThemeType>;
@@ -24,7 +33,34 @@ export declare const generate: (
   scale?: number,
 ) => DeepReadonly<ThemeType>;
 
-type ExtendType = string | ((...args: any) => void);
+/**
+ * ExtendProps represents the props that will be provided to an ExtendType.
+ */
+type ExtendProps<TProps> = ThemedStyledProps<TProps, ThemeType>;
+
+/**
+ * ExtendValue represents a valid `extend` value, which can be a CSS string or a
+ * styled-components interpolation. In the theme an ExtendValue can be provided
+ * directly to `extend` or it can be computed as the result of an ExtendFn.
+ */
+type ExtendValue<TProps> = string | FlattenSimpleInterpolation | FlattenInterpolation<ExtendProps<TProps>>;
+
+/**
+ * ExtendFn represents a function passed to `extend`. These functions receive
+ * props and produce an ExtendValue.
+ */
+type ExtendFn<TProps> = (props: ExtendProps<TProps>) => ExtendValue<TProps>;
+
+/**
+ * ExtendType represents a valid value for `extend` in the theme.
+ *
+ * Acceptable values for `extend` are one of:
+ *
+ * * A string containing css
+ * * An array of styled-components interpolations (usually returned by the styled-components `css` helper function)
+ * * A function taking props and returning one of the above values
+ */
+type ExtendType<TProps = Record<string, any>> = ExtendValue<TProps> | ExtendFn<TProps>;
 
 declare const colors: {
   active?: ColorType;
@@ -76,7 +112,7 @@ type Colors = typeof colors & {
   'graph-3'?: ColorType;
   'graph-4'?: ColorType;
   'graph-5'?: ColorType;
-  [x: string]: ColorType;
+  [x: string]: ColorType | undefined;
 };
 
 interface ButtonKindType {
@@ -277,10 +313,10 @@ export interface ThemeType {
   };
   anchor?: {
     color?: ColorType;
-    extend?: ExtendType;
+    extend?: ExtendType<PropsOf<typeof Anchor>>;
     fontWeight?: number;
     hover?: {
-      extend?: ExtendType;
+      extend?: ExtendType<PropsOf<typeof Anchor>>;
       textDecoration?: string;
     };
     textDecoration?: string;
@@ -923,10 +959,8 @@ export interface ThemeType {
       margin?: MarginType;
     };
     options?: {
-      container?: BoxProps;
-      text?: {
-        margin?: MarginType;
-      };
+      container?: PropsOf<typeof Box>;
+      text?: PropsOf<typeof Text>;
     };
     // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37506
     searchInput?: ReactComponentElement<any>;

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -40,9 +40,9 @@ export {isObject, deepFreeze, deepMerge, removeUndefined};
  * Example:
  *
  * ```typescript
- * import { Box } from 'grommet';
+ * import { SomeComponent } from 'grommet';
  *
- * type BoxProps = PropsOf<typeof Box>;
+ * type SomeComponentProps = PropsOf<typeof SomeComponent>;
  * ```
  */
 export type PropsOf<TComponent> = TComponent extends React.ComponentType<infer P> ? P : never;
@@ -97,7 +97,7 @@ declare const breakpointBorderSize: {
 }
 export type BreakpointBorderSize = typeof breakpointBorderSize;
 
-declare const breakpointSize: {          
+declare const breakpointSize: {
   xxsmall?: string;
   xsmall?: string;
   small?: string;

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -34,6 +34,19 @@ declare const removeUndefined: <T extends object>(obj: T) => NonUndefinedProps<T
 
 export {isObject, deepFreeze, deepMerge, removeUndefined};
 
+/*
+ * Utility type for inferring the props type of a component.
+ *
+ * Example:
+ *
+ * ```typescript
+ * import { Box } from 'grommet';
+ *
+ * type BoxProps = PropsOf<typeof Box>;
+ * ```
+ */
+export type PropsOf<TComponent> = TComponent extends React.ComponentType<infer P> ? P : never;
+
 // Extracting types for common properties among components
 type BoxSideType = "top" | "left" | "bottom" | "right" | "start" | "end" | "horizontal" | "vertical" | "all" | "between";
 type BoxSizeType = "xsmall" | "small" | "medium" | "large" | "xlarge" | string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,8 @@
       "grommet/themes": ["src/js/themes"],
       "grommet/utils": ["src/js/utils"]
     },
+    "lib": ["dom", "es2017"],
+    "types": [],
     "typeRoots": ["./node_modules/@types/", "./src/@types/"]
   },
   "exclude": ["node_modules"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2270,6 +2270,14 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.5.tgz#527d20ef68571a4af02ed74350164e7a67544860"
   integrity sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw==
 
+"@types/hoist-non-react-statics@*":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.0.tgz#551a4589b6ee2cc9c1dff08056128aec29b94880"
@@ -2370,6 +2378,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-native@*":
+  version "0.63.2"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.2.tgz#428a4d71351ccbc31ab170b5f32477c7ce78dfd7"
+  integrity sha512-oxbp084lUsZvwfdWmWxKjJAuqEraQDRf+cE/JgwmrHQMguSrmgIHZ3xkeoQ5FYnW5NHIPpHudB3BbjL1Zn3vnA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-syntax-highlighter@11.0.4":
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz#d86d17697db62f98046874f62fdb3e53a0bbc4cd"
@@ -2409,6 +2424,16 @@
   dependencies:
     "@types/react" "*"
     "@types/webpack-env" "*"
+
+"@types/styled-components@^5.0.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.1.tgz#17c3b3a299aa38254189e04a72a8ee009a22e42d"
+  integrity sha512-fIjKvDU1LJExBZWEQilHqzfpOK4KUwBsj5zC79lxa94ekz8oDQSBNcayMACBImxIuevF+NbBGL9O/2CQ67Zhig==
+  dependencies:
+    "@types/hoist-non-react-statics" "*"
+    "@types/react" "*"
+    "@types/react-native" "*"
+    csstype "^2.2.0"
 
 "@types/tapable@*", "@types/tapable@^1.0.5":
   version "1.0.5"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds TypeScript support for using styled-components interpolations as `extend` values in the `ThemeType`, fixing #3578.

#### Where should the reviewer start?

src/js/themes/base.d.ts
src/js/all/stories/typescript/ExtendTheme.tsx

#### What testing has been done on this PR?

* Created a TypeScript story to type-check various usages of `extend` in a custom theme.
* Updated my own project using locally linked `grommet` and confirmed our custom theme now passed type-checking

#### How should this be manually tested?

* Ensure that `yarn tsc --project .` reports no type-checking errors for the ExtendTheme story.

#### Any background context you want to provide?

1) I added a utility type called `PropsOf` which makes use of a TypeScript 2.8 feature called conditional types. This means that TypeScript Grommet users should be using TypeScript >= 2.8, which I think is a reasonable tradeoff. If one of the goals of Grommet's TypeScript support is to be compatible with TypeScript pre-2.8 let me know and I can come up with another solution to cover what that utility type does.

2) I spent some time also investigating the possibility of adding more types for the `extend` props, which could be convenient for TypeScript users since they would get intellisense about what `props` are available when `extend`ing the theme; however, I couldn't see a 100% reliable way of determining which props would be passed to the `styled` version of the component, so most of the extend props will be typed as `Record<string, any>` instead. It should be possible to progressively type more of the props given the new definition of `ExtendType`, but if you have any suggestions on how to tell with accuracy which props will be available in `extend` I'd be happy to look into adding more of them.

3) One other thing to note is that there is an open issue for conflicting react / react-native types at https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33311/. To work around this I've added a .yarnclean to remove `@types/react-native` post-install. There are a few other alternatives to work around this problem suggested in that issue, and if desired we can take another approach:

* Fix @types/styled-components version to an older version
* Declare types explicitly in tsconfig.json

Overall I thought the .yarnclean seemed like the most straightforward way, so long as this project is not planning to make use of `@types/react-native` at this time

#### What are the relevant issues?

#3578 

#### Do the grommet docs need to be updated?

I don't believe any updates are necessary.

#### Should this PR be mentioned in the release notes?

Potentially worth mentioning as a bug fix, but probably not worth drawing a large amount of attention to it or anything :)

#### Is this change backwards compatible or is it a breaking change?

Backward compatible for TypeScript >= 2.8.