### PR TITLE
Allow tabindex to be restored to original value

### DIFF
--- a/src/js/utils/DOM.js
+++ b/src/js/utils/DOM.js
@@ -13,8 +13,12 @@ export const filterByFocusable = elements =>
     if (currentTag === 'svg' || currentTag === 'div') {
       return (
         isValidTag &&
-        element.hasAttribute('tabindex') &&
-        element.getAttribute('tabindex') !== '-1'
+        ((element.hasAttribute('tabindex') &&
+          element.getAttribute('tabindex') !== '-1') ||
+          // If element was previously focusable, we want to be able
+          // to access it in makeNodeFocusable
+          (element.hasAttribute('data-g-tabindex') &&
+            element.getAttribute('data-g-tabindex') === '0'))
       );
     }
     return isValidTag;

--- a/src/js/utils/DOM.js
+++ b/src/js/utils/DOM.js
@@ -18,7 +18,7 @@ export const filterByFocusable = elements =>
           // If element was previously focusable, we want to be able
           // to access it in makeNodeFocusable
           (element.hasAttribute('data-g-tabindex') &&
-            element.getAttribute('data-g-tabindex') === '0'))
+            element.getAttribute('data-g-tabindex') >= 0))
       );
     }
     return isValidTag;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes an issue that was occurring when FocusContainer was changing the tabindex of elements outside of the container. Essentially, certain elements were toggled to a tabIndex of "-1" but their original tab index was 0 or a value specified by the user. Then, when the function of "makeNodeFocusable" was called to restore their original tabIndex, these elements were not being included.

#### Where should the reviewer start?
src/js/utils/DOM.js

#### What testing has been done on this PR?
I tested other Drop examples to make sure the keyboard functionality had not changed.

#### How should this be manually tested?
Using storybook, add a focusable element after the TextInput Custom story. 

Before my changes: Tab through the elements once (TextInput and your focusable element should receive focus). Then, type into the text input to render the suggestions and tab to leave (You'll notice that your focusable element no longer receives focus because its tabindex is locked at -1).

After my changes: The focusable element will have its tabindex returned back to 0 after the textinput suggestions and tabbing through the elements will work as expected.

#### Any background context you want to provide?
After tabIndex was changed on focusable elements when the TextInput drop opened (FocusContainer was handling the modulation of the tabIndex), there was no way for the tab index to be restored. Even though we were already storing the original tab index value in something called 'data-g-tabindex', these elements were not being included in having their tab index restored from -1 to their original value. This fixes that.

#### What are the relevant issues?
N/A

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.
#### Should this PR be mentioned in the release notes?
No.
#### Is this change backwards compatible or is it a breaking change?
Yes, this is backwards compatible.