### PR TITLE
Fix how low opacity backgrounds affect text color

### DIFF
--- a/src/js/components/Box/stories/Background.js
+++ b/src/js/components/Box/stories/Background.js
@@ -39,6 +39,16 @@ const BackgroundBox = () => (
       >
         image + color
       </Box>
+      <Box background="dark-1" pad="medium">
+        <Box background="#FFFFFF08" pad="small">
+          low opacity on dark background
+        </Box>
+      </Box>
+      <Box background="light-5" pad="medium">
+        <Box background="#11111108" pad="small">
+          low opacity on light background
+        </Box>
+      </Box>
     </Box>
   </Grommet>
 );

--- a/src/js/utils/background.js
+++ b/src/js/utils/background.js
@@ -113,8 +113,8 @@ export const backgroundStyle = (backgroundArg, theme, textColorArg) => {
       `;
     }
     const backgroundColor = normalizeColor(background, theme);
-    const backgroundDark = colorIsDark(backgroundColor);
     if (backgroundColor) {
+      const backgroundDark = colorIsDark(backgroundColor);
       return css`
         background: ${backgroundColor};
         color: ${normalizeColor(

--- a/src/js/utils/background.js
+++ b/src/js/utils/background.js
@@ -113,13 +113,13 @@ export const backgroundStyle = (backgroundArg, theme, textColorArg) => {
       `;
     }
     const backgroundColor = normalizeColor(background, theme);
+    const backgroundDark = colorIsDark(backgroundColor);
     if (backgroundColor) {
       return css`
         background: ${backgroundColor};
         color: ${normalizeColor(
           textColor[
-            colorIsDark(backgroundColor) ||
-            (colorIsDark(backgroundColor) === undefined && theme.dark)
+            backgroundDark || (backgroundDark === undefined && theme.dark)
               ? 'dark'
               : 'light'
           ] || textColor,

--- a/src/js/utils/background.js
+++ b/src/js/utils/background.js
@@ -117,8 +117,12 @@ export const backgroundStyle = (backgroundArg, theme, textColorArg) => {
       return css`
         background: ${backgroundColor};
         color: ${normalizeColor(
-          textColor[colorIsDark(backgroundColor) ? 'dark' : 'light'] ||
-            textColor,
+          textColor[
+            colorIsDark(backgroundColor) ||
+            (colorIsDark(backgroundColor) === undefined && theme.dark)
+              ? 'dark'
+              : 'light'
+          ] || textColor,
           theme,
         )};
       `;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes how low opacity backgrounds control the text color that appears on them.

#### Where should the reviewer start?
src/js/utils/background.js

#### What testing has been done on this PR?
Stories were added to test how this would affect text on light and dark backgrounds.

#### How should this be manually tested?
Use stories Box Background.

#### Any background context you want to provide?
When low opacities were used for backgrounds, the background behind them should drive if text renders as light or dark. This currently wasn't being done, so in some cases, text on dark backgrounds was being rendered dark.

#### What are the relevant issues?
N/A

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.