### PR TITLE
fix custom placeholder bug (#3657)

### DIFF
--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -269,11 +269,7 @@ class TextInput extends Component {
 
   onChange = event => {
     const { onChange } = this.props;
-    if (event.target.value.length > 0) {
-      this.setState({ isInputEmpty: false });
-    } else {
-      this.setState({ isInputEmpty: true });
-    }
+    this.setState({ isInputEmpty: !Boolean(event.target.value) });
     this.resetSuggestions();
     if (onChange) {
       onChange(event);

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -356,7 +356,7 @@ class TextInput extends Component {
     delete rest.onSuggestionsClose;
     const { showDrop, isInputEmpty } = this.state;
     const showStyledPlaceholder =
-      placeholder && typeof placeholder !== 'string' && !value && isInputEmpty;
+      placeholder && typeof placeholder !== 'string' && isInputEmpty;
     // needed so that styled components does not invoke
     // onSelect when text input is clicked
     delete rest.onSelect;

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -269,7 +269,7 @@ class TextInput extends Component {
 
   onChange = event => {
     const { onChange } = this.props;
-    this.setState({ isInputEmpty: !Boolean(event.target.value) });
+    this.setState({ isInputEmpty: !event.target.value });
     this.resetSuggestions();
     if (onChange) {
       onChange(event);

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -72,6 +72,7 @@ class TextInput extends Component {
   state = {
     activeSuggestionIndex: -1,
     showDrop: false,
+    isInputEmpty: true,
   };
 
   inputRef = React.createRef();
@@ -268,6 +269,11 @@ class TextInput extends Component {
 
   onChange = event => {
     const { onChange } = this.props;
+    if (event.target.value.length > 0) {
+      this.setState({ isInputEmpty: false });
+    } else {
+      this.setState({ isInputEmpty: true });
+    }
     this.resetSuggestions();
     if (onChange) {
       onChange(event);
@@ -348,7 +354,9 @@ class TextInput extends Component {
     delete rest.onChange; // se we can manage in this.onChange()
     delete rest.onSuggestionsOpen;
     delete rest.onSuggestionsClose;
-    const { showDrop } = this.state;
+    const { showDrop, isInputEmpty } = this.state;
+    const showStyledPlaceholder =
+      placeholder && typeof placeholder !== 'string' && !value && isInputEmpty;
     // needed so that styled components does not invoke
     // onSelect when text input is clicked
     delete rest.onSelect;
@@ -371,10 +379,11 @@ class TextInput extends Component {
       );
     }
     return (
+      // { render placeHoldr && <Styled...}
       <StyledTextInputContainer plain={plain}>
-        {placeholder && typeof placeholder !== 'string' && !value ? (
+        {showStyledPlaceholder && (
           <StyledPlaceholder>{placeholder}</StyledPlaceholder>
-        ) : null}
+        )}
         <Keyboard
           onEnter={this.onSuggestionSelect}
           onEsc={this.onEsc}

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -379,7 +379,6 @@ class TextInput extends Component {
       );
     }
     return (
-      // { render placeHoldr && <Styled...}
       <StyledTextInputContainer plain={plain}>
         {showStyledPlaceholder && (
           <StyledPlaceholder>{placeholder}</StyledPlaceholder>

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -352,7 +352,7 @@ class TextInput extends Component {
     delete rest.onSuggestionsClose;
     const { showDrop, isInputEmpty } = this.state;
     const showStyledPlaceholder =
-      placeholder && typeof placeholder !== 'string' && isInputEmpty;
+      placeholder && typeof placeholder !== 'string' && isInputEmpty && !value;
     // needed so that styled components does not invoke
     // onSelect when text input is clicked
     delete rest.onSelect;

--- a/src/js/components/TextInput/stories/Placeholder.js
+++ b/src/js/components/TextInput/stories/Placeholder.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Box, Form, TextInput, Text } from 'grommet';
+
+const Placeholder = () => {
+  return (
+    <Box>
+      <Form>
+        <TextInput name="name" placeholder={<Text>footer</Text>} />
+        <TextInput name="name" placeholder="foobar" />
+      </Form>
+    </Box>
+  );
+};
+
+storiesOf('TextInput', module).add('Placeholder', () => <Placeholder />);

--- a/src/js/components/TextInput/stories/StyledPlaceholder.js
+++ b/src/js/components/TextInput/stories/StyledPlaceholder.js
@@ -2,15 +2,16 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Box, Form, TextInput, Text } from 'grommet';
 
-const Placeholder = () => {
+const StyledPlaceholder = () => {
   return (
     <Box>
       <Form>
         <TextInput name="name" placeholder={<Text>footer</Text>} />
-        <TextInput name="name" placeholder="foobar" />
       </Form>
     </Box>
   );
 };
 
-storiesOf('TextInput', module).add('Placeholder', () => <Placeholder />);
+storiesOf('TextInput', module).add('StyledPlaceholder', () => (
+  <StyledPlaceholder />
+));


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix a bug when a React.node is passed at placeholder props in TextInput.
Created a isInputEmpty flag in TextInput state to not render a StyledPlaceholder when a React.node is passed by props in placeholder and the input value is empty.
#### Where should the reviewer start?
TextInput.js
#### What testing has been done on this PR?

Placeholder Story TextInput
#### How should this be manually tested?

StoryBook
#### Any background context you want to provide?
no
#### What are the relevant issues?
https://github.com/grommet/grommet/issues/3657

#### Screenshots (if appropriate)
|Before|After|
|-|-|
|<img src="https://i.imgur.com/wZ78xbZ.gif" width="300"/>|<img src="https://i.imgur.com/mCkgGel.gif" width="300"/>|


#### Do the grommet docs need to be updated?

yes, a story  was added in TextInput
#### Should this PR be mentioned in the release notes?

yes, 'cause it's a bug a fix.

#### Is this change backwards compatible or is it a breaking change?

no
