### PR TITLE
Fix TS type errors for global and icon size

### DIFF
--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -3,8 +3,7 @@ import {
   BorderType,
   ColorType,  
   DeepReadonly, 
-  GapType,
-  GraphColorsType,
+  GapType, 
   MarginType,
   OpacityType,
   PadType,
@@ -58,12 +57,6 @@ type Colors = typeof colors & {
   'status-ok'?: ColorType;
   'status-unknown'?: ColorType;
   'status-disabled'?: ColorType;
-  'graph-0'?: ColorType;
-  'graph-1'?: ColorType;
-  'graph-2'?: ColorType;
-  'graph-3'?: ColorType;
-  'graph-4'?: ColorType;
-  'graph-5'?: ColorType;
   [x: string]: ColorType;
 };
 
@@ -193,9 +186,6 @@ export interface ThemeType {
       maxWidth?: string;
       size?: string;
     };
-    graph?: {
-      colors?: GraphColorsType;
-    },
     hover?: {
       background?: BackgroundType;
       color?: ColorType;
@@ -223,7 +213,7 @@ export interface ThemeType {
       xlarge?: string;
       xxlarge?: string;
       full?: string;
-      [x: string]: string;
+      [x: string]: string | undefined;
     };
   };
   accordion?: {
@@ -322,7 +312,6 @@ export interface ThemeType {
     };
   };
   chart?: {
-    color?: ColorType;
     extend?: ExtendType;
   }
   checkBox?: {
@@ -461,7 +450,7 @@ export interface ThemeType {
   diagram?: {
     extend?: ExtendType;
     line?: {
-      color?: ColorType;
+      color: 'accent-1';
     };
   };
   drop?: {
@@ -640,7 +629,7 @@ export interface ThemeType {
       medium?: string;
       large?: string;
       xlarge?: string;
-      [x: string]: string,
+      [x: string]: string | undefined,
     };
   };
   layer?: {
@@ -683,7 +672,6 @@ export interface ThemeType {
   };
   meter?: {
     color?: ColorType,
-    colors?: GraphColorsType,
     extend?: ExtendType,
   },
   paragraph?: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Currently grommet causes a bunch of typescript errors when our project compiles. This PR makes a some small tweaks to the type definitions of the `global` and `icon` size objects, allowing custom properties added to these objects to have a value of undefined.

#### Where should the reviewer start?

This is a small 2 line change in themes/base.d.ts.


#### What testing has been done on this PR?

Code now compiles without errors using Typescript `6.13.1`

#### How should this be manually tested?

Compiling the grommet code using Typescript v. `6.13.1`

#### Any background context you want to provide?

Hopefully this is pretty self explanatory :)

#### What are the relevant issues?

Our codebase fails typescript compilation due to these issues.

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

Nope.

#### Should this PR be mentioned in the release notes?

🤷‍♀️ up to you!

#### Is this change backwards compatible or is it a breaking change?

It should be backwards compatible