### PR TITLE
Pass onKeyDown handler to TextArea

### DIFF
--- a/src/js/components/TextArea/TextArea.js
+++ b/src/js/components/TextArea/TextArea.js
@@ -15,7 +15,7 @@ const TextArea = ({ fill, forwardRef, ...rest }) => {
   };
 
   return (
-    <Keyboard onEsc={onEsc}>
+    <Keyboard onEsc={onEsc} onKeyDown={rest.onKeyDown}>
       <StyledTextArea ref={forwardRef} fillArg={fill} {...rest} />
     </Keyboard>
   );

--- a/src/js/components/TextArea/__tests__/TextArea-test.js
+++ b/src/js/components/TextArea/__tests__/TextArea-test.js
@@ -93,9 +93,19 @@ describe('TextArea', () => {
 
   describe('Event tests', () => {
     afterEach(cleanup);
+    const keyEvent = {
+      key: 'Backspace',
+      keyCode: 8,
+      which: 8,
+    };
 
-    test('onKeyDown', () => {
-      const callback = jest.fn();
+    test(`onKeyDown`, () => {
+      let capturedEvent = null;
+      const callback = event => {
+        const { key, keyCode, which } = event;
+        capturedEvent = { key, keyCode, which };
+      };
+
       const component = render(
         <Grommet>
           <TextArea
@@ -109,13 +119,34 @@ describe('TextArea', () => {
 
       const textArea = component.getByPlaceholderText('item');
 
-      fireEvent.keyDown(textArea, {
-        key: 'Backspace',
-        keyCode: 8,
-        which: 8,
-      });
+      fireEvent.keyDown(textArea, keyEvent);
 
-      expect(callback).toHaveBeenCalled();
+      expect(capturedEvent).toEqual(expect.objectContaining(keyEvent));
+    });
+
+    test(`onKeyUp`, () => {
+      let capturedEvent = null;
+      const callback = event => {
+        const { key, keyCode, which } = event;
+        capturedEvent = { key, keyCode, which };
+      };
+
+      const component = render(
+        <Grommet>
+          <TextArea
+            id="item"
+            name="item"
+            placeholder="item"
+            onKeyUp={callback}
+          />
+        </Grommet>,
+      );
+
+      const textArea = component.getByPlaceholderText('item');
+
+      fireEvent.keyUp(textArea, keyEvent);
+
+      expect(capturedEvent).toEqual(expect.objectContaining(keyEvent));
     });
   });
 });

--- a/src/js/components/TextArea/__tests__/TextArea-test.js
+++ b/src/js/components/TextArea/__tests__/TextArea-test.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
 import { TextArea } from '..';
-
-jest.mock('react-dom');
 
 describe('TextArea', () => {
   test('basic', () => {
@@ -89,6 +88,34 @@ describe('TextArea', () => {
       );
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe('Event tests', () => {
+    afterEach(cleanup);
+
+    test('onKeyDown', () => {
+      const callback = jest.fn();
+      const component = render(
+        <Grommet>
+          <TextArea
+            id="item"
+            name="item"
+            placeholder="item"
+            onKeyDown={callback}
+          />
+        </Grommet>,
+      );
+
+      const textArea = component.getByPlaceholderText('item');
+
+      fireEvent.keyDown(textArea, {
+        key: 'Backspace',
+        keyCode: 8,
+        which: 8,
+      });
+
+      expect(callback).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

- Allows the TextArea component to receive an onKeyDown handler
- Add tests for TextArea receiving onKeyDown and onKeyUp events

#### Where should the reviewer start?

Take a look at the TextArea component. Strangely the onKeyUp handler was already getting called with no additional changes but the onKeyDown handler needed to be passed to the Keyboard component in order for it to work.

#### What testing has been done on this PR?

Added two unit tests for the TextArea to the existing test file.

#### How should this be manually tested?

I've tested this on a projected where I needed to detect the backspace button being pressed in a textarea and it works. There's possibly something I'm not understanding because onKeyUp was already working so it feels strange that it would only be an issue of onKeyDown - maybe it was disabled for a reason I don't know about?

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/3664

#### Do the grommet docs need to be updated?

Don't think so

#### Should this PR be mentioned in the release notes?

Possibly counts as a bug fix

#### Is this change backwards compatible or is it a breaking change?

AFAIK this shouldn't break any existing code