### PR TITLE
Changed FormField theme extend reference

### DIFF
--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -30,7 +30,7 @@ const validateField = (required, validate, messages) => (value, data) => {
 };
 
 const FormFieldBox = styled(Box)`
-  ${props => props.theme.formField.extend}
+  ${props => props.theme.formField && props.theme.formField.extend}
 `;
 
 class FormFieldContent extends Component {


### PR DESCRIPTION
This PR is coming from a slack request:
https://grommet.slack.com/archives/C04LMHN59/p1579558921032600

>srallen 3:22 PM
>I updated to styled-components v5 today and then started getting test failures with components using Grommet’s FormField . The line that throws is https://github.com/grommet/grommet/blob/362b1a3d4a8266d0cc3d9e5f9e8d21a51c8fbb39/src/js/components/FormField/FormField.js#L33
>specifically the issue is that I’m trying to test in isolation, but since the theme is not defined, a type error is thrown
If I wrap the component with Grommet with a theme prop, it fixes the type error, but it can interfere with using shallow rendering with enzyme, like trying to use enzyme’s setProps API method for instance.
It seems like there needs to be a existential check there for the theme?
oh, I’m not running the latest Grommet, but I did update to 2.10 and this is a bug there too
```
