### PR TITLE
Changed FormField.validate to accept an array

### DIFF
--- a/src/js/components/Form/__tests__/Form-test.js
+++ b/src/js/components/Form/__tests__/Form-test.js
@@ -38,6 +38,7 @@ describe('Form', () => {
       .fn()
       .mockReturnValueOnce('too short')
       .mockReturnValueOnce(undefined);
+    const validate2 = jest.fn().mockReturnValue(undefined);
     const onSubmit = jest.fn();
     const { getByPlaceholderText, getByText, container } = render(
       <Grommet>
@@ -48,7 +49,11 @@ describe('Form', () => {
             validate={validate}
             placeholder="test input"
           />
-          <FormField name="test2" placeholder="test-2 input" />
+          <FormField
+            name="test2"
+            placeholder="test-2 input"
+            validate={[validate2]}
+          />
           <Button type="submit" primary label="Submit" />
         </Form>
       </Grommet>,
@@ -59,6 +64,7 @@ describe('Form', () => {
     });
     fireEvent.click(getByText('Submit'));
     expect(validate).toBeCalledWith('v', { test: 'v' });
+    expect(validate2).toBeCalledWith(undefined, { test: 'v' });
     fireEvent.change(getByPlaceholderText('test input'), {
       target: { value: 'value' },
     });
@@ -67,6 +73,10 @@ describe('Form', () => {
     });
     fireEvent.click(getByText('Submit'));
     expect(validate).toBeCalledWith('value', {
+      test: 'value',
+      test2: 'value-2',
+    });
+    expect(validate2).toBeCalledWith('value-2', {
       test: 'value',
       test2: 'value-2',
     });

--- a/src/js/components/Form/stories/Submit.js
+++ b/src/js/components/Form/stories/Submit.js
@@ -27,7 +27,13 @@ const Example = () => (
             label="Name"
             name="name"
             required
-            validate={{ regexp: /^[a-z]/i }}
+            validate={[
+              { regexp: /^[a-z]/i },
+              name => {
+                if (name && name.length === 1) return 'must be >1 character';
+                return undefined;
+              },
+            ]}
           />
           <FormField label="Email" name="email" type="email" required />
           <FormField

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -18,7 +18,12 @@ const validateField = (required, validate, messages) => (value, data) => {
   if (required && (value === undefined || value === '')) {
     error = messages.required;
   } else if (validate) {
-    if (typeof validate === 'function') {
+    if (Array.isArray(validate)) {
+      validate.some(oneValidate => {
+        error = validateField(false, oneValidate, messages)(value, data);
+        return !!error;
+      });
+    } else if (typeof validate === 'function') {
       error = validate(value, data);
     } else if (validate.regexp) {
       if (!validate.regexp.test(value)) {

--- a/src/js/components/FormField/README.md
+++ b/src/js/components/FormField/README.md
@@ -169,6 +169,14 @@ Validation rule when used within a grommet Form. Provide a regular
   message: string
 }
 function
+[
+  {
+    regexp: object,
+    validate: function,
+    message: string
+  }
+  function
+]
 ```
   
 ## Intrinsic element

--- a/src/js/components/FormField/README.md
+++ b/src/js/components/FormField/README.md
@@ -156,8 +156,8 @@ boolean
 
 **validate**
 
-Validation rule when used within a grommet Form. Provide a regular
-      expression or a function. If a
+Validation rule when used within a grommet Form. Provide an object
+      with a regular expression, a function, or an array of these. If a
       function is provided, it will be called with two arguments, the value
       for this field and the entire value object. This permits validation to
       encompass multiple fields. The function should return a string message
@@ -172,7 +172,6 @@ function
 [
   {
     regexp: object,
-    validate: function,
     message: string
   }
   function

--- a/src/js/components/FormField/doc.js
+++ b/src/js/components/FormField/doc.js
@@ -55,6 +55,16 @@ export const doc = FormField => {
         message: PropTypes.string,
       }),
       PropTypes.func,
+      PropTypes.arrayOf(
+        PropTypes.oneOfType([
+          PropTypes.shape({
+            regexp: PropTypes.object, // regular expression
+            validate: PropTypes.func,
+            message: PropTypes.string,
+          }),
+          PropTypes.func,
+        ]),
+      ),
     ]).description(
       `Validation rule when used within a grommet Form. Provide a regular
       expression or a function. If a

--- a/src/js/components/FormField/doc.js
+++ b/src/js/components/FormField/doc.js
@@ -59,15 +59,14 @@ export const doc = FormField => {
         PropTypes.oneOfType([
           PropTypes.shape({
             regexp: PropTypes.object, // regular expression
-            validate: PropTypes.func,
             message: PropTypes.string,
           }),
           PropTypes.func,
         ]),
       ),
     ]).description(
-      `Validation rule when used within a grommet Form. Provide a regular
-      expression or a function. If a
+      `Validation rule when used within a grommet Form. Provide an object
+      with a regular expression, a function, or an array of these. If a
       function is provided, it will be called with two arguments, the value
       for this field and the entire value object. This permits validation to
       encompass multiple fields. The function should return a string message

--- a/src/js/components/FormField/index.d.ts
+++ b/src/js/components/FormField/index.d.ts
@@ -14,7 +14,7 @@ export interface FormFieldProps {
   placeholder?: PlaceHolderType
   required?: boolean;
   component?: any;
-  validate?: {regexp?: object,message?: string} | ((...args: any[]) => any);
+  validate?: {regexp?: object,message?: string|React.ReactNode} | ((...args: any[]) => any) | ({regexp?: object,message?: string|React.ReactNode} | ((...args: any[]) => any))[];
 }
 
 declare const FormField: React.ComponentClass<FormFieldProps & Omit<JSX.IntrinsicElements['input'], 'placeholder'>>;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5597,8 +5597,8 @@ boolean
 
 **validate**
 
-Validation rule when used within a grommet Form. Provide a regular
-      expression or a function. If a
+Validation rule when used within a grommet Form. Provide an object
+      with a regular expression, a function, or an array of these. If a
       function is provided, it will be called with two arguments, the value
       for this field and the entire value object. This permits validation to
       encompass multiple fields. The function should return a string message
@@ -5613,7 +5613,6 @@ function
 [
   {
     regexp: object,
-    validate: function,
     message: string
   }
   function

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5610,6 +5610,14 @@ Validation rule when used within a grommet Form. Provide a regular
   message: string
 }
 function
+[
+  {
+    regexp: object,
+    validate: function,
+    message: string
+  }
+  function
+]
 \`\`\`
   
 ## Intrinsic element

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2240,7 +2240,15 @@ string",
   regexp: object,
   message: string
 }
-function",
+function
+[
+  {
+    regexp: object,
+    validate: function,
+    message: string
+  }
+  function
+]",
         "name": "validate",
       },
     ],

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2230,8 +2230,8 @@ string",
         "name": "required",
       },
       Object {
-        "description": "Validation rule when used within a grommet Form. Provide a regular
-      expression or a function. If a
+        "description": "Validation rule when used within a grommet Form. Provide an object
+      with a regular expression, a function, or an array of these. If a
       function is provided, it will be called with two arguments, the value
       for this field and the entire value object. This permits validation to
       encompass multiple fields. The function should return a string message
@@ -2244,7 +2244,6 @@ function
 [
   {
     regexp: object,
-    validate: function,
     message: string
   }
   function


### PR DESCRIPTION
#### What does this PR do?

Changed FormField.validate to accept an array.
This allows supplying separate regexps with different messages for each of them.
This is a first step towards a set of updates coming to Form/FormField.

#### Where should the reviewer start?

index.d.ts

#### What testing has been done on this PR?

storybook, unit

#### How should this be manually tested?

manual

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible