### PR TITLE
Check for theme existence for styled-components v5 compatibility

### DIFF
--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -107,6 +107,7 @@ const StyledButton = styled.button`
   ${props => !props.disabled && props.active && activeStyle}
   ${props =>
     props.disabled &&
+    props.theme.button &&
     disabledStyle(
       props.theme.button.disabled && props.theme.button.disabled.opacity,
     )}
@@ -136,7 +137,7 @@ ${props =>
   `
 padding: ${props.theme.global.edgeSize.small};
 `}
-  ${props => props.theme.button.extend}
+  ${props => props.theme.button && props.theme.button.extend}
 `;
 
 StyledButton.defaultProps = {};

--- a/src/js/utils/colors.js
+++ b/src/js/utils/colors.js
@@ -1,6 +1,6 @@
 export const normalizeColor = (color, theme, required) => {
   const colorSpec =
-    theme.global.colors[color] !== undefined
+    theme.global && theme.global.colors[color] !== undefined
       ? theme.global.colors[color]
       : color;
   // If the color has a light or dark object, use that
@@ -13,7 +13,7 @@ export const normalizeColor = (color, theme, required) => {
     }
   }
   // allow one level of indirection in color names
-  if (result && theme.global.colors[result] !== undefined) {
+  if (result && theme.global && theme.global.colors[result] !== undefined) {
     result = normalizeColor(result, theme);
   }
   return required && result === color ? 'inherit' : result;

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -251,6 +251,7 @@ export const genericStyles = css`
   ${props => props.gridArea && `grid-area: ${props.gridArea};`}
   ${props =>
     props.margin &&
+    props.theme.global &&
     edgeStyle(
       'margin',
       props.margin,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Related to #3667, I checked the latest master against my branch with styled-components v5 and had a few more TypeErrors when running automated tests where we had a Button component styled using the styled HOC, `styled(Button)`. 

Using theme object / context API is preferable, but this particular case isn't updated to do that yet.

This PR adds safety existential checks for the theme object where I was getting additional TypeErrors. 

#### Where should the reviewer start?
The changes are contained in the `StyledButton.js`, `colors.js`, and `style.js` utility functions files.

#### What testing has been done on this PR?
No additional tests have been added. Existing automated tests pass with the changes.

#### How should this be manually tested?
The Button stories in the storybook continue to work. Another option is trying to extend the Button styles using `styled()` yourself.

#### Any background context you want to provide?
The TypeErrors were occurring after upgrading to styled-components v5.

#### What are the relevant issues?
First mentioned on slack (noted in #3667)

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Maybe not, but additional testing might need to be done to announce that styled-components v5 is supported. Other components may need to be tested for behavior when styles are extended with the `styled` HOC.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.