### PR TITLE
[TS] Fixed typing for Diagram connections

### DIFF
--- a/src/js/components/Diagram/index.d.ts
+++ b/src/js/components/Diagram/index.d.ts
@@ -3,16 +3,20 @@ import * as React from "react";
 import { 
   ColorType 
 } from "../../utils";
+
+export type DiagramConnectionAnchor = "center" | "vertical" | "horizontal";
+export type DiagramConnectionType = "direct" | "curved" | "rectilinear";
+
 export interface DiagramProps {
   connections: {
-    anchor?: "center" | "vertical" | "horizontal" | string, 
+    anchor?: DiagramConnectionAnchor, 
     color?: ColorType,
     fromTarget: string | object,
     label?: string,
     offset?: "xsmall" | "small" | "medium" | "large" | string,
     thickness?: "hair" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,
     toTarget: string | object,
-    type?: "direct" | "curved" | "rectilinear" | string
+    type?: DiagramConnectionType
   }[];
 }
 

--- a/src/js/components/Diagram/index.d.ts
+++ b/src/js/components/Diagram/index.d.ts
@@ -5,14 +5,15 @@ import {
 } from "../../utils";
 export interface DiagramProps {
   connections: {
-    anchor?: "center" | "vertical" | "horizontal", 
+    anchor?: "center" | "vertical" | "horizontal" | string, 
     color?: ColorType,
     fromTarget: string | object,
     label?: string,
     offset?: "xsmall" | "small" | "medium" | "large" | string,
     thickness?: "hair" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | string,
     toTarget: string | object,
-    type?: "direct" | "curved" | "rectilinear"}[];
+    type?: "direct" | "curved" | "rectilinear" | string
+  }[];
 }
 
 declare const Diagram: React.FC<DiagramProps & JSX.IntrinsicElements['svg']>;

--- a/src/js/components/Diagram/stories/typescript/Connections.tsx
+++ b/src/js/components/Diagram/stories/typescript/Connections.tsx
@@ -4,12 +4,17 @@ import { storiesOf } from '@storybook/react';
 import { Gremlin, IceCream } from 'grommet-icons';
 import { Stack, grommet, Grommet, Box, Diagram } from 'grommet';
 
+import { DiagramConnectionAnchor, DiagramConnectionType } from '../../index';
+
+const anchor: DiagramConnectionAnchor = 'horizontal';
+const type: DiagramConnectionType = 'curved';
+
 const connection = {
   id: 'shimi',
-  anchor: 'horizontal',
+  anchor,
   color: 'accent-1',
   thickness: 'xsmall',
-  type: 'curved',
+  type,
   toTarget: 'yummy',
   fromTarget: 'gremlin',
   round: true,

--- a/src/js/components/Diagram/stories/typescript/Connections.tsx
+++ b/src/js/components/Diagram/stories/typescript/Connections.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { Gremlin, IceCream } from 'grommet-icons';
+import { Stack, grommet, Grommet, Box, Diagram } from 'grommet';
+
+const connection = {
+  id: 'shimi',
+  anchor: 'horizontal',
+  color: 'accent-1',
+  thickness: 'xsmall',
+  type: 'curved',
+  toTarget: 'yummy',
+  fromTarget: 'gremlin',
+  round: true,
+};
+
+const connections = [connection];
+
+const Connections = () => {
+  return (
+    <Grommet theme={grommet}>
+      <Stack>
+        <Box fill pad="xlarge">
+          <Box align="start">
+            <Gremlin id="gremlin" color="neutral-2" size="xlarge" />
+          </Box>
+          <Box align="end" pad={{ vertical: 'large' }}>
+            <IceCream id="yummy" color="neutral-2" size="xlarge" />
+          </Box>
+        </Box>
+        <Diagram connections={connections} />
+      </Stack>
+    </Grommet>
+  );
+};
+
+storiesOf('TypeScript/Diagram', module).add('Connections', () => (
+  <Connections />
+));


### PR DESCRIPTION
The issue is coming from slack https://grommet.slack.com/archives/C04LMHN59/p1579887376150400

Fixing types of the connections object and adding the example shared on slack.