### PR TITLE
WIP: Fixes persistent focus issue and related bugs.

### DIFF
--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -3,7 +3,6 @@ import React, {
   forwardRef,
   useContext,
   useEffect,
-  useState,
 } from 'react';
 
 import { ThemeContext } from 'styled-components';
@@ -25,16 +24,13 @@ const Anchor = forwardRef(
       href,
       icon,
       label,
-      onBlur,
       onClick,
-      onFocus,
       reverse,
       ...rest
     },
     ref,
   ) => {
     const theme = useContext(ThemeContext) || defaultProps.theme;
-    const [focus, setFocus] = useState();
 
     useEffect(() => {
       if ((icon || label) && children) {
@@ -62,19 +58,10 @@ const Anchor = forwardRef(
         colorProp={color}
         disabled={disabled}
         hasIcon={!!icon}
-        focus={focus}
         hasLabel={label}
         reverse={reverse}
         href={!disabled ? href : undefined}
         onClick={!disabled ? onClick : undefined}
-        onFocus={event => {
-          setFocus(true);
-          if (onFocus) onFocus(event);
-        }}
-        onBlur={event => {
-          setFocus(false);
-          if (onBlur) onBlur(event);
-        }}
       >
         {first && second ? (
           <Box

--- a/src/js/components/Anchor/StyledAnchor.js
+++ b/src/js/components/Anchor/StyledAnchor.js
@@ -49,6 +49,9 @@ const StyledAnchor = styled.a`
         `font-weight: ${props.theme.anchor.hover.fontWeight};`}
       ${props.theme.anchor.hover.extend}
     }
+    &:focus {
+      ...focusStyle,
+    }
   `}
   ${props =>
     props.hasIcon &&
@@ -57,7 +60,6 @@ const StyledAnchor = styled.a`
     padding: ${props.theme.global.edgeSize.small};
   `}
   ${props => props.disabled && disabledStyle}
-  ${props => props.focus && focusStyle}
   ${props => props.theme.anchor.extend}
 `;
 

--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -3,7 +3,6 @@ import React, {
   Children,
   forwardRef,
   useContext,
-  useState,
 } from 'react';
 
 import { ThemeContext } from 'styled-components';
@@ -41,7 +40,6 @@ const Button = forwardRef(
     ref,
   ) => {
     const theme = useContext(ThemeContext) || defaultProps.theme;
-    const [focus, setFocus] = useState();
 
     if ((icon || label) && children) {
       console.warn(
@@ -64,8 +62,6 @@ const Button = forwardRef(
       return colorIsDark(backgroundColor, theme);
     };
 
-    const [hover, setHover] = useState(false);
-
     let buttonIcon = icon;
     // only change color if user did not specify the color themselves...
     if (primary && icon && !icon.props.color) {
@@ -87,7 +83,7 @@ const Button = forwardRef(
         </Box>
       );
     } else if (typeof children === 'function') {
-      contents = children({ hover, focus });
+      contents = children({ });
     } else {
       contents = first || second || children;
     }

--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -18,18 +18,17 @@ const Button = forwardRef(
   (
     {
       a11yTitle,
-      color, // munged to avoid styled-components putting it in the DOM
+      color,
       children,
       disabled,
       icon,
-      focusIndicator = true,
+      focusIndicator = false,
       gap = 'small',
       fill, // munged to avoid styled-components putting it in the DOM
       href,
       label,
       onBlur,
       onClick,
-      onFocus,
       onMouseOut,
       onMouseOver,
       plain,
@@ -66,20 +65,6 @@ const Button = forwardRef(
     };
 
     const [hover, setHover] = useState(false);
-
-    const onMouseOverButton = event => {
-      setHover(true);
-      if (onMouseOver) {
-        onMouseOver(event);
-      }
-    };
-
-    const onMouseOutButton = event => {
-      setHover(false);
-      if (onMouseOut) {
-        onMouseOut(event);
-      }
-    };
 
     let buttonIcon = icon;
     // only change color if user did not specify the color themselves...
@@ -118,20 +103,9 @@ const Button = forwardRef(
         gap={gap}
         hasLabel={!!label}
         fillContainer={fill}
-        focus={focus}
         focusIndicator={focusIndicator}
         href={href}
         onClick={onClick}
-        onFocus={event => {
-          setFocus(true);
-          if (onFocus) onFocus(event);
-        }}
-        onBlur={event => {
-          setFocus(false);
-          if (onBlur) onBlur(event);
-        }}
-        onMouseOver={onMouseOverButton}
-        onMouseOut={onMouseOutButton}
         pad={!plain}
         plain={
           typeof plain !== 'undefined'

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -96,7 +96,9 @@ const StyledButton = styled.button`
   background: transparent;
   overflow: visible;
   text-transform: none;
-
+  &:focus {
+     // button focus styles here
+  }
   ${genericStyles}
   ${props => props.plain && plainStyle(props)}
   ${props => !props.plain && basicStyle(props)}


### PR DESCRIPTION
#### What does this PR do?
Fixes a number of pesky issues that stem using JS events to juggle element focus state instead of pseudo element selectors like `&:focus {/* style properties */}`. Currently, Grommet reinvents the wheel – it attempts to do what browsers already know how to do well: determine if an element is in focus. 


#### What are the relevant issues?
- https://github.com/grommet/grommet/issues/3706
- https://github.com/grommet/grommet/issues/3656
- https://github.com/grommet/grommet/issues/3642


- [x]  Fixes core issue by making certain elements stateless (let the browser determine focus, not local react state)
- [ ]  Add necessary default styles to Styled elements using pseudo elements (e.g focus, hover)
- [ ]  Fix tests as needed
- [ ]  Document how to override focus styles. Providing developers with an easy way to dial in their A11Y aesthetic to their hearts content.


#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes, developers will sigh in relief. 

#### Is this change backwards compatible or is it a breaking change?
Yes