### PR TITLE
Added background colors

### DIFF
--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -36,6 +36,9 @@ type Colors = typeof colors & {
   'accent-2'?: ColorType;
   'accent-3'?: ColorType;
   'accent-4'?: ColorType;
+  'background-back'?: ColorType;
+  'background-contrast'?: ColorType;
+  'background-front'?: ColorType;
   'neutral-1'?: ColorType;
   'neutral-2'?: ColorType;
   'neutral-3'?: ColorType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -51,6 +51,18 @@ const focusColor = accentColors[0];
 
 const colors = {
   active: rgba(221, 221, 221, 0.5),
+  'background-back': {
+    dark: '#33333308',
+    light: '#EDEDED',
+  },
+  'background-front': {
+    dark: '#444444',
+    light: '#FFFFFF',
+  },
+  'background-contrast': {
+    dark: '#33333308',
+    light: '#FFFFFF08',
+  },
   black: '#000000',
   border: {
     dark: rgba(255, 255, 255, 0.33),


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Added colors of `background-contrast`, `background-front`, `background-back` with dark/light modes.
The text color changes will be filed on a separate PR as we haven't got it yet.
#### Where should the reviewer start?
base.js
#### What testing has been done on this PR?
Not being used yet.
#### How should this be manually tested?

#### Any background context you want to provide?
Following the HPE theme changes, this proposal came for grommet base theme as well.
Chris sent the following:
![](https://files.slack.com/files-pri/T04LMHMUT-FT98FE204/screen_shot_2020-01-29_at_10.18.15_am.png)
I've updated the colors but kept the opacity similar to HPE theme.
#### What are the relevant issues?
None.
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
yes