### PR TITLE
Fixes test error of uncontrolled to controlled input

### DIFF
--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -234,6 +234,7 @@ exports[`renders 1`] = `
             onChange={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
+            value=""
           />
         </div>
       </div>

--- a/src/js/components/MaskedInput/MaskedInput.js
+++ b/src/js/components/MaskedInput/MaskedInput.js
@@ -315,7 +315,7 @@ const MaskedInput = forwardRef(
             placeholder={placeholder || renderPlaceholder()}
             focus={focus}
             {...rest}
-            value={value}
+            value={value || ''}
             theme={theme}
             onFocus={event => {
               setFocus(true);

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -4251,6 +4251,7 @@ exports[`Select renders custom icon 1`] = `
           readOnly={true}
           tabIndex="-1"
           type="text"
+          value=""
         />
       </div>
     </div>

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -359,7 +359,7 @@ const TextInput = forwardRef(
             focus={focus}
             {...rest}
             defaultValue={renderLabel(defaultValue)}
-            value={renderLabel(value)}
+            value={renderLabel(value) || ''}
             onFocus={event => {
               setFocus(true);
               if (suggestions && suggestions.length > 0) {


### PR DESCRIPTION
Removes the error
```
Warning: A component is changing a controlled input of type undefined to be uncontrolled. Input elements should not switch from controlled to uncontrolled (or vice versa).
```
when testing by giving a default value of an empty string to the components causing the error.
The issue was caused by the components starting at a value of undefined making the input uncontrolled.