### PR TITLE
Fixed theme docs of CheckBox toggle.size

### DIFF
--- a/src/js/components/CheckBox/README.md
+++ b/src/js/components/CheckBox/README.md
@@ -292,5 +292,5 @@ The width size of the toggle. Expects `string`.
 Defaults to
 
 ```
-42px
+48px
 ```

--- a/src/js/components/CheckBox/doc.js
+++ b/src/js/components/CheckBox/doc.js
@@ -155,6 +155,6 @@ export const themeDoc = {
   'checkBox.toggle.size': {
     description: 'The width size of the toggle.',
     type: 'string',
-    defaultValue: '42px',
+    defaultValue: '48px',
   },
 };

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -3668,7 +3668,7 @@ The width size of the toggle. Expects \`string\`.
 Defaults to
 
 \`\`\`
-42px
+48px
 \`\`\`
 ",
   "Clock": "## Clock


### PR DESCRIPTION
Noticed this in-accuracy while comparing the HPE Designer theme with base.js.