### PR TITLE
[TS] Fix type issue of Menu icon

### DIFF
--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -1,7 +1,14 @@
 import * as React from "react";
 import { DropProps } from "../Drop";
 import { ButtonType } from "../Button";
-import { A11yTitleType, AlignSelfType, GridAreaType, JustifyContentType, MarginType } from "../../utils";
+import { 
+  A11yTitleType, 
+  AlignSelfType, 
+  GridAreaType, 
+  JustifyContentType, 
+  MarginType, 
+  Omit 
+} from "../../utils";
 
 export interface MenuProps {
   a11yTitle?: A11yTitleType;
@@ -22,6 +29,6 @@ export interface MenuProps {
   size?: "small" | "medium" | "large" | "xlarge" | string;
 }
 
-declare const Menu: React.FC<MenuProps & ButtonType>;
+declare const Menu: React.FC<MenuProps & Omit<ButtonType, 'icon'>>;
 
 export { Menu };

--- a/src/js/components/Menu/stories/typescript/Custom.tsx
+++ b/src/js/components/Menu/stories/typescript/Custom.tsx
@@ -15,6 +15,7 @@ const CustomMenu = () => (
     >
       <Menu
         plain
+        icon={false}
         items={[
           { label: 'Launch', onClick: () => {} },
           { label: 'Abort', onClick: () => {} },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Excluded the `icon` prop of Button, so it won't override the types of Menu icon.
#### Where should the reviewer start?
Menu/index.d.ts
#### What testing has been done on this PR?
storybook Menu/Custom example as modified on the story file
#### How should this be manually tested?
the loader of typescript and storybook
#### Any background context you want to provide?
Less than 5 seconds to verify the fix is working thanks to typescript on storybook 🎉 
#### What are the relevant issues?
Fixes #3711 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yep
#### Is this change backwards compatible or is it a breaking change?
backwards compatible 