### PR TITLE
Fixes an error with select test

### DIFF
--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -83,7 +83,7 @@ const Select = forwardRef(
     const inputRef = useRef();
     const formContext = useContext(FormContext);
 
-    const [value, setValue] = formContext.useFormContext(name, valueProp);
+    const [value] = formContext.useFormContext(name, valueProp);
 
     const [open, setOpen] = useState(propOpen);
     useEffect(() => {
@@ -105,13 +105,8 @@ const Select = forwardRef(
     };
 
     const onSelectChange = (event, ...args) => {
-      if (closeOnChange) {
-        onRequestClose();
-      }
-      setValue(event.value);
-      if (onChange) {
-        onChange({ ...event, target: inputRef.current }, ...args);
-      }
+      if (closeOnChange) onRequestClose();
+      if (onChange) onChange({ ...event, target: inputRef.current }, ...args);
     };
 
     let SelectIcon;


### PR DESCRIPTION
setValue(event.value) was causing the select test -- select an option with complex options -- to fail. an object was being passed into the values prop, causing the error.
