### PR TITLE
Changed RadioButtonGroup to add disabled

### DIFF
--- a/src/js/components/RadioButtonGroup/README.md
+++ b/src/js/components/RadioButtonGroup/README.md
@@ -24,6 +24,14 @@ Function that will be called to render the visual representation.
 function
 ```
 
+**disabled**
+
+Disables all options.
+
+```
+boolean
+```
+
 **name**
 
 Required. The DOM name attribute value to use for the underlying <input/> 

--- a/src/js/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/js/components/RadioButtonGroup/RadioButtonGroup.js
@@ -16,6 +16,7 @@ const RadioButtonGroup = forwardRef(
   (
     {
       children,
+      disabled,
       gap = 'small',
       name,
       onChange,
@@ -32,10 +33,15 @@ const RadioButtonGroup = forwardRef(
       () =>
         optionsProp.map(o =>
           typeof o === 'string'
-            ? { id: rest.id ? `${rest.id}-${o}` : o, label: o, value: o }
-            : o,
+            ? {
+                disabled,
+                id: rest.id ? `${rest.id}-${o}` : o,
+                label: o,
+                value: o,
+              }
+            : { disabled, ...o },
         ),
-      [optionsProp, rest.id],
+      [disabled, optionsProp, rest.id],
     );
 
     const [value, setValue] = formContext.useFormContext(name, valueProp);
@@ -98,7 +104,13 @@ const RadioButtonGroup = forwardRef(
         <Box ref={ref} gap={gap} {...rest}>
           {options.map(
             (
-              { disabled, id, label, value: optionValue, ...optionRest },
+              {
+                disabled: optionDisabled,
+                id,
+                label,
+                value: optionValue,
+                ...optionRest
+              },
               index,
             ) => (
               <RadioButton
@@ -108,7 +120,7 @@ const RadioButtonGroup = forwardRef(
                 key={optionValue}
                 name={name}
                 label={!children ? label : undefined}
-                disabled={disabled}
+                disabled={optionDisabled}
                 checked={optionValue === value}
                 focus={
                   focus &&

--- a/src/js/components/RadioButtonGroup/doc.js
+++ b/src/js/components/RadioButtonGroup/doc.js
@@ -21,6 +21,9 @@ export const doc = RadioButtonGroup => {
       \`children={(option, { checked }) => <Box ...>{...}</Box>}\`
       `,
     ),
+    disabled: PropTypes.bool
+      .description(`Disables all options.`)
+      .defaultValue(false),
     name: PropTypes.string.description(
       `The DOM name attribute value to use for the underlying <input/> 
       elements.`,

--- a/src/js/components/RadioButtonGroup/index.d.ts
+++ b/src/js/components/RadioButtonGroup/index.d.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import { BoxProps } from '../Box' 
 
 export interface RadioButtonGroupProps {
+  disabled?: boolean;
   name: string;
   onChange?: ((event: React.ChangeEvent<HTMLInputElement>) => void);
   options: (string | { disabled?: boolean, id?: string, label?: (string | React.ReactNode), value: string})[];

--- a/src/js/components/RadioButtonGroup/stories/Disabled.js
+++ b/src/js/components/RadioButtonGroup/stories/Disabled.js
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { Box, Grommet, RadioButtonGroup } from 'grommet';
+import { grommet } from 'grommet/themes';
+
+const DisabledRadioButtonGroup = ({ value: initialValue, ...props }) => {
+  const [value, setValue] = useState(initialValue);
+
+  return (
+    <Grommet theme={grommet}>
+      <Box align="center" pad="large">
+        <RadioButtonGroup
+          name="radio"
+          options={[
+            { label: 'Choice 1', value: 'c1' },
+            { label: 'Choice 2', value: 'c2' },
+            { label: 'Choice 3', value: 'c3' },
+          ]}
+          disabled
+          value={value}
+          onChange={event => setValue(event.target.value)}
+          {...props}
+        />
+      </Box>
+    </Grommet>
+  );
+};
+
+storiesOf('RadioButtonGroup', module).add('Disabled', () => (
+  <DisabledRadioButtonGroup />
+));

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -9459,6 +9459,14 @@ Function that will be called to render the visual representation.
 function
 \`\`\`
 
+**disabled**
+
+Disables all options.
+
+\`\`\`
+boolean
+\`\`\`
+
 **name**
 
 Required. The DOM name attribute value to use for the underlying <input/> 

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -3388,6 +3388,12 @@ with the same name so form submissions work.",
         "name": "children",
       },
       Object {
+        "defaultValue": false,
+        "description": "Disables all options.",
+        "format": "boolean",
+        "name": "disabled",
+      },
+      Object {
         "description": "The DOM name attribute value to use for the underlying <input/> 
       elements.",
         "format": "string",


### PR DESCRIPTION
### What does this PR do?

Changed RadioButtonGroup to add a disabled property.
This makes it easier to disable a simple RadioButtonGroup than having to convert an options array of strings to objects.

#### Where should the reviewer start?

doc.js

#### What testing has been done on this PR?

storybook, added RadioButtonGroup Disabled story

#### How should this be manually tested?

storybook

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
