### PR TITLE
Changed Grid to add pad

### DIFF
--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -570,8 +570,8 @@ string
 **pad**
 
 The amount of padding around the box contents. An
-        object can be specified to distinguish horizontal padding, vertical
-        padding, and padding on a particular side of the box Defaults to `none`.
+    object can be specified to distinguish horizontal padding, vertical
+    padding, and padding on a particular side of the box Defaults to `none`.
 
 ```
 none

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -4,10 +4,10 @@ import {
   getAvailableAtBadge,
   genericProps,
   hoverIndicatorPropType,
+  padPropType,
   themeDocUtils,
 } from '../../utils';
 
-const PAD_SIZES = ['xxsmall', 'xsmall', 'small', 'medium', 'large', 'xlarge'];
 export const OVERFLOW_VALUES = ['auto', 'hidden', 'scroll', 'visible'];
 
 const ANIMATION_TYPE = PropTypes.oneOf([
@@ -295,50 +295,7 @@ export const doc = Box => {
       the DOM for accessibility.`,
     ),
     overflow: overflowPropType.description('box overflow.'),
-    pad: PropTypes.oneOfType([
-      PropTypes.oneOf(['none', ...PAD_SIZES]),
-      PropTypes.shape({
-        bottom: PropTypes.oneOfType([
-          PropTypes.oneOf(PAD_SIZES),
-          PropTypes.string,
-        ]),
-        end: PropTypes.oneOfType([
-          PropTypes.oneOf(PAD_SIZES),
-          PropTypes.string,
-        ]),
-        horizontal: PropTypes.oneOfType([
-          PropTypes.oneOf(PAD_SIZES),
-          PropTypes.string,
-        ]),
-        left: PropTypes.oneOfType([
-          PropTypes.oneOf(PAD_SIZES),
-          PropTypes.string,
-        ]),
-        right: PropTypes.oneOfType([
-          PropTypes.oneOf(PAD_SIZES),
-          PropTypes.string,
-        ]),
-        start: PropTypes.oneOfType([
-          PropTypes.oneOf(PAD_SIZES),
-          PropTypes.string,
-        ]),
-        top: PropTypes.oneOfType([
-          PropTypes.oneOf(PAD_SIZES),
-          PropTypes.string,
-        ]),
-        vertical: PropTypes.oneOfType([
-          PropTypes.oneOf(PAD_SIZES),
-          PropTypes.string,
-        ]),
-      }),
-      PropTypes.string,
-    ])
-      .description(
-        `The amount of padding around the box contents. An
-        object can be specified to distinguish horizontal padding, vertical
-        padding, and padding on a particular side of the box`,
-      )
-      .defaultValue('none'),
+    pad: padPropType,
     responsive: PropTypes.bool
       .description(
         `Whether margin, pad, and border

--- a/src/js/components/Grid/README.md
+++ b/src/js/components/Grid/README.md
@@ -319,6 +319,89 @@ around
 stretch
 ```
 
+**pad**
+
+The amount of padding around the box contents. An
+    object can be specified to distinguish horizontal padding, vertical
+    padding, and padding on a particular side of the box Defaults to `none`.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  end: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  start: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **rows**
 
 Row sizes.

--- a/src/js/components/Grid/StyledGrid.js
+++ b/src/js/components/Grid/StyledGrid.js
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { genericStyles } from '../../utils';
+import { edgeStyle, genericStyles } from '../../utils';
 import { defaultProps } from '../../default-props';
 
 const fillStyle = fill => {
@@ -221,6 +221,15 @@ const StyledGrid = styled.div.attrs(props => ({
   ${props => props.gap && gapStyle(props)}
   ${props => props.justify && justifyStyle}
   ${props => props.justifyContent && justifyContentStyle}
+  ${props =>
+    props.pad &&
+    edgeStyle(
+      'padding',
+      props.pad,
+      props.responsive,
+      props.theme.global.edgeSize.responsiveBreakpoint,
+      props.theme,
+    )}
   ${props => props.rowsProp && rowsStyle(props)}
   ${props => props.theme.grid && props.theme.grid.extend}
 `;

--- a/src/js/components/Grid/__tests__/Grid-test.js
+++ b/src/js/components/Grid/__tests__/Grid-test.js
@@ -6,198 +6,220 @@ import 'jest-styled-components';
 import { Grommet } from '../../Grommet';
 import { Grid } from '..';
 
-test('Grid renders', () => {
-  const component = renderer.create(
-    <Grommet>
-      <Grid />
-    </Grommet>,
-  );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-});
+describe('Grid', () => {
+  test('renders', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-test('a11yTitle renders', () => {
-  const { container, getByLabelText } = render(
-    <Grommet>
-      <Grid a11yTitle="My Grid" />
-    </Grommet>,
-  );
-  const gridWithLabel = getByLabelText('My Grid');
-  expect(gridWithLabel).toBeTruthy();
-  expect(container).toMatchSnapshot();
-});
+  test('a11yTitle renders', () => {
+    const { container, getByLabelText } = render(
+      <Grommet>
+        <Grid a11yTitle="My Grid" />
+      </Grommet>,
+    );
+    const gridWithLabel = getByLabelText('My Grid');
+    expect(gridWithLabel).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
 
-test('Grid rows renders', () => {
-  const component = renderer.create(
-    <Grommet>
-      <Grid rows={['small', 'large', 'medium']} />
-      <Grid rows="small" />
-    </Grommet>,
-  );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-});
+  test('rows renders', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid rows={['small', 'large', 'medium']} />
+        <Grid rows="small" />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-test('Grid columns renders', () => {
-  const component = renderer.create(
-    <Grommet>
-      <Grid columns={['1/2', '2/4']} />
-      <Grid columns={['1/3', '2/3']} />
-      <Grid columns={['1/4', '3/4']} />
-      <Grid columns="small" />
-      <Grid columns={{ count: 'fit', size: 'small' }} />
-      <Grid columns={{ count: 'fill', size: ['small', 'medium'] }} />
-    </Grommet>,
-  );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-});
+  test('columns renders', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid columns={['1/2', '2/4']} />
+        <Grid columns={['1/3', '2/3']} />
+        <Grid columns={['1/4', '3/4']} />
+        <Grid columns="small" />
+        <Grid columns={{ count: 'fit', size: 'small' }} />
+        <Grid columns={{ count: 'fill', size: ['small', 'medium'] }} />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-test('Grid areas renders', () => {
-  const component = renderer.create(
-    <Grommet>
-      <Grid
-        rows={['xxsmall', 'medium', 'xsmall']}
-        columns={['3/4', '1/4']}
-        areas={[
-          { name: 'header', start: [0, 0], end: [0, 1] },
-          { name: 'main', start: [1, 0], end: [1, 0] },
-          { name: 'sidebar', start: [1, 1], end: [1, 1] },
-          { name: 'footer', start: [2, 0], end: [2, 1] },
-        ]}
-      />
-    </Grommet>,
-  );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-});
+  test('areas renders', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid
+          rows={['xxsmall', 'medium', 'xsmall']}
+          columns={['3/4', '1/4']}
+          areas={[
+            { name: 'header', start: [0, 0], end: [0, 1] },
+            { name: 'main', start: [1, 0], end: [1, 0] },
+            { name: 'sidebar', start: [1, 1], end: [1, 1] },
+            { name: 'footer', start: [2, 0], end: [2, 1] },
+          ]}
+        />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-test('Grid areas renders when given an array of string arrays', () => {
-  const component = renderer.create(
-    <Grommet>
-      <Grid
-        rows={['xxsmall', 'medium', 'xsmall']}
-        columns={['3/4', '1/4']}
-        areas={[
-          ['header', 'header'],
-          ['sidebar', 'main'],
-          ['footer', 'footer'],
-        ]}
-      />
-    </Grommet>,
-  );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-});
+  test('areas renders when given an array of string arrays', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid
+          rows={['xxsmall', 'medium', 'xsmall']}
+          columns={['3/4', '1/4']}
+          areas={[
+            ['header', 'header'],
+            ['sidebar', 'main'],
+            ['footer', 'footer'],
+          ]}
+        />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-test('Grid justify renders', () => {
-  const component = renderer.create(
-    <Grommet>
-      <Grid justify="start" />
-      <Grid justify="center" />
-      <Grid justify="end" />
-      <Grid justify="stretch" />
-    </Grommet>,
-  );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-});
+  test('justify renders', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid justify="start" />
+        <Grid justify="center" />
+        <Grid justify="end" />
+        <Grid justify="stretch" />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-test('Grid align renders', () => {
-  const component = renderer.create(
-    <Grommet>
-      <Grid align="start" />
-      <Grid align="center" />
-      <Grid align="end" />
-      <Grid align="stretch" />
-    </Grommet>,
-  );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-});
+  test('align renders', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid align="start" />
+        <Grid align="center" />
+        <Grid align="end" />
+        <Grid align="stretch" />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-test('Grid justifyContent renders', () => {
-  const component = renderer.create(
-    <Grommet>
-      <Grid justifyContent="start" />
-      <Grid justifyContent="center" />
-      <Grid justifyContent="between" />
-      <Grid justifyContent="around" />
-      <Grid justifyContent="end" />
-      <Grid justifyContent="stretch" />
-    </Grommet>,
-  );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-});
+  test('justifyContent renders', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid justifyContent="start" />
+        <Grid justifyContent="center" />
+        <Grid justifyContent="between" />
+        <Grid justifyContent="around" />
+        <Grid justifyContent="end" />
+        <Grid justifyContent="stretch" />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-test('Grid alignContent renders', () => {
-  const component = renderer.create(
-    <Grommet>
-      <Grid alignContent="start" />
-      <Grid alignContent="center" />
-      <Grid alignContent="between" />
-      <Grid alignContent="around" />
-      <Grid alignContent="end" />
-      <Grid alignContent="stretch" />
-    </Grommet>,
-  );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-});
+  test('alignContent renders', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid alignContent="start" />
+        <Grid alignContent="center" />
+        <Grid alignContent="between" />
+        <Grid alignContent="around" />
+        <Grid alignContent="end" />
+        <Grid alignContent="stretch" />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-test('Grid gap renders', () => {
-  const component = renderer.create(
-    <Grommet>
-      <Grid gap="small" />
-      <Grid gap="medium" />
-      <Grid gap="large" />
-      <Grid gap={{ row: 'small' }} />
-      <Grid gap={{ row: 'medium' }} />
-      <Grid gap={{ row: 'large' }} />
-      <Grid gap={{ column: 'small' }} />
-      <Grid gap={{ column: 'medium' }} />
-      <Grid gap={{ column: 'large' }} />
-      <Grid gap={{ row: 'small', column: 'medium' }} />
-    </Grommet>,
-  );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-});
+  test('gap renders', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid gap="small" />
+        <Grid gap="medium" />
+        <Grid gap="large" />
+        <Grid gap={{ row: 'small' }} />
+        <Grid gap={{ row: 'medium' }} />
+        <Grid gap={{ row: 'large' }} />
+        <Grid gap={{ column: 'small' }} />
+        <Grid gap={{ column: 'medium' }} />
+        <Grid gap={{ column: 'large' }} />
+        <Grid gap={{ row: 'small', column: 'medium' }} />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-test('Grid fill renders', () => {
-  const component = renderer.create(
-    <Grommet>
-      <Grid fill />
-      <Grid fill={false} />
-      <Grid fill="horizontal" />
-      <Grid fill="vertical" />
-    </Grommet>,
-  );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-});
+  test('fill renders', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid fill />
+        <Grid fill={false} />
+        <Grid fill="horizontal" />
+        <Grid fill="vertical" />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-test('Grid as renders', () => {
-  const component = renderer.create(
-    <Grommet>
-      <Grid as="article" />
-    </Grommet>,
-  );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-});
+  test('as renders', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid as="article" />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-test('Grid proxies tag', () => {
-  const tagComponent = renderer.create(
-    <Grommet>
-      <Grid tag="article" />
-    </Grommet>,
-  );
-  const asComponent = renderer.create(
-    <Grommet>
-      <Grid as="article" />
-    </Grommet>,
-  );
-  expect(tagComponent.toJSON()).toEqual(asComponent.toJSON());
+  test('proxies tag', () => {
+    const tagComponent = renderer.create(
+      <Grommet>
+        <Grid tag="article" />
+      </Grommet>,
+    );
+    const asComponent = renderer.create(
+      <Grommet>
+        <Grid as="article" />
+      </Grommet>,
+    );
+    expect(tagComponent.toJSON()).toEqual(asComponent.toJSON());
+  });
+
+  test('pad', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid pad="small" />
+        <Grid pad="medium" />
+        <Grid pad="large" />
+        <Grid pad={{ horizontal: 'small' }} />
+        <Grid pad={{ vertical: 'small' }} />
+        <Grid pad={{ bottom: 'small' }} />
+        <Grid pad={{ left: 'small' }} />
+        <Grid pad={{ right: 'small' }} />
+        <Grid pad={{ start: 'small' }} />
+        <Grid pad={{ end: 'small' }} />
+        <Grid pad={{ top: 'small' }} />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
+++ b/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Grid a11yTitle renders 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <div
+      aria-label="My Grid"
+      class="c1"
+    />
+  </div>
+</div>
+`;
+
 exports[`Grid align renders 1`] = `
 .c0 {
   font-size: 18px;
@@ -603,6 +631,124 @@ exports[`Grid justifyContent renders 1`] = `
 </div>
 `;
 
+exports[`Grid pad 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  padding: 12px;
+}
+
+.c2 {
+  display: grid;
+  box-sizing: border-box;
+  padding: 24px;
+}
+
+.c3 {
+  display: grid;
+  box-sizing: border-box;
+  padding: 48px;
+}
+
+.c4 {
+  display: grid;
+  box-sizing: border-box;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c5 {
+  display: grid;
+  box-sizing: border-box;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c6 {
+  display: grid;
+  box-sizing: border-box;
+  padding-bottom: 12px;
+}
+
+.c7 {
+  display: grid;
+  box-sizing: border-box;
+  padding-left: 12px;
+}
+
+.c8 {
+  display: grid;
+  box-sizing: border-box;
+  padding-right: 12px;
+}
+
+.c9 {
+  display: grid;
+  box-sizing: border-box;
+  padding-inline-start: 12px;
+}
+
+.c10 {
+  display: grid;
+  box-sizing: border-box;
+  padding-inline-end: 12px;
+}
+
+.c11 {
+  display: grid;
+  box-sizing: border-box;
+  padding-top: 12px;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  />
+  <div
+    className="c2"
+  />
+  <div
+    className="c3"
+  />
+  <div
+    className="c4"
+  />
+  <div
+    className="c5"
+  />
+  <div
+    className="c6"
+  />
+  <div
+    className="c7"
+  />
+  <div
+    className="c8"
+  />
+  <div
+    className="c9"
+  />
+  <div
+    className="c10"
+  />
+  <div
+    className="c11"
+  />
+</div>
+`;
+
 exports[`Grid renders 1`] = `
 .c0 {
   font-size: 18px;
@@ -660,33 +806,5 @@ exports[`Grid rows renders 1`] = `
   <div
     className="c2"
   />
-</div>
-`;
-
-exports[`a11yTitle renders 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: grid;
-  box-sizing: border-box;
-}
-
-<div>
-  <div
-    class="c0"
-  >
-    <div
-      aria-label="My Grid"
-      class="c1"
-    />
-  </div>
 </div>
 `;

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -1,6 +1,11 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { genericProps, getAvailableAtBadge, themeDocUtils } from '../../utils';
+import {
+  genericProps,
+  getAvailableAtBadge,
+  padPropType,
+  themeDocUtils,
+} from '../../utils';
 
 const fixedSizes = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
 const sizes = [
@@ -142,6 +147,7 @@ space in the row axis.`,
       'around',
       'stretch',
     ]).description('How to align the contents along the row axis.'),
+    pad: padPropType,
     rows: PropTypes.oneOfType([
       PropTypes.arrayOf(
         PropTypes.oneOfType([

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -8,6 +8,7 @@ import {
   GridAreaType, 
   JustifyContentType, 
   MarginType, 
+  PadType,
   PolymorphicType,
 } from "../../utils";
 
@@ -25,6 +26,7 @@ export interface GridProps {
   justify?: "start" | "center" | "end" | "stretch";
   justifyContent?: JustifyContentType;
   margin?: MarginType;
+  pad?: PadType;
   rows?: ("xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "flex" | "auto" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | string | string[])[] | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
   tag?: PolymorphicType;
 }

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1203,8 +1203,8 @@ string
 **pad**
 
 The amount of padding around the box contents. An
-        object can be specified to distinguish horizontal padding, vertical
-        padding, and padding on a particular side of the box Defaults to \`none\`.
+    object can be specified to distinguish horizontal padding, vertical
+    padding, and padding on a particular side of the box Defaults to \`none\`.
 
 \`\`\`
 none
@@ -6424,6 +6424,89 @@ end
 between
 around
 stretch
+\`\`\`
+
+**pad**
+
+The amount of padding around the box contents. An
+    object can be specified to distinguish horizontal padding, vertical
+    padding, and padding on a particular side of the box Defaults to \`none\`.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  end: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  start: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
 \`\`\`
 
 **rows**

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -728,8 +728,8 @@ string",
       Object {
         "defaultValue": "none",
         "description": "The amount of padding around the box contents. An
-        object can be specified to distinguish horizontal padding, vertical
-        padding, and padding on a particular side of the box",
+    object can be specified to distinguish horizontal padding, vertical
+    padding, and padding on a particular side of the box",
         "format": "none
 xxsmall
 xsmall

--- a/src/js/utils/prop-types.js
+++ b/src/js/utils/prop-types.js
@@ -65,6 +65,35 @@ export const marginProp = PropTypes.oneOfType([
     be specified to distinguish horizontal margin, vertical margin, and
     margin on a particular side.`);
 
+const PAD_SIZES = ['xxsmall', 'xsmall', 'small', 'medium', 'large', 'xlarge'];
+
+export const padPropType = PropTypes.oneOfType([
+  PropTypes.oneOf(['none', ...PAD_SIZES]),
+  PropTypes.shape({
+    bottom: PropTypes.oneOfType([PropTypes.oneOf(PAD_SIZES), PropTypes.string]),
+    end: PropTypes.oneOfType([PropTypes.oneOf(PAD_SIZES), PropTypes.string]),
+    horizontal: PropTypes.oneOfType([
+      PropTypes.oneOf(PAD_SIZES),
+      PropTypes.string,
+    ]),
+    left: PropTypes.oneOfType([PropTypes.oneOf(PAD_SIZES), PropTypes.string]),
+    right: PropTypes.oneOfType([PropTypes.oneOf(PAD_SIZES), PropTypes.string]),
+    start: PropTypes.oneOfType([PropTypes.oneOf(PAD_SIZES), PropTypes.string]),
+    top: PropTypes.oneOfType([PropTypes.oneOf(PAD_SIZES), PropTypes.string]),
+    vertical: PropTypes.oneOfType([
+      PropTypes.oneOf(PAD_SIZES),
+      PropTypes.string,
+    ]),
+  }),
+  PropTypes.string,
+])
+  .description(
+    `The amount of padding around the box contents. An
+    object can be specified to distinguish horizontal padding, vertical
+    padding, and padding on a particular side of the box`,
+  )
+  .defaultValue('none');
+
 export const genericProps = {
   a11yTitle: a11yTitlePropType,
   alignSelf: PropTypes.oneOf(['start', 'center', 'end', 'stretch'])


### PR DESCRIPTION
#### What does this PR do?

Changed Grid to add pad
This allows Grid `fill` to work. Without it, Grid has `margin` but that doesn't work with `fill`.

#### Where should the reviewer start?

Grid/index.d.ts

#### What testing has been done on this PR?

unit

#### How should this be manually tested?

unit

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
