### PR TITLE
docs: fix indeterminate typo in Indeterminate story

### DIFF
--- a/src/js/components/CheckBox/stories/Indeterminate.js
+++ b/src/js/components/CheckBox/stories/Indeterminate.js
@@ -48,6 +48,6 @@ const IndeterminateCheckBox = () => {
   );
 };
 
-storiesOf('CheckBox', module).add('Interminate', () => (
+storiesOf('CheckBox', module).add('Indeterminate', () => (
   <IndeterminateCheckBox />
 ));


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This changes a story name from "Interminiate" to "Indeterminate"

#### Where should the reviewer start?
src/js/components/CheckBox/stories/Indeterminate.js

#### What testing has been done on this PR?

I ran storybook after making this change and saw that the story name change was reflected.

#### How should this be manually tested?

This can be tested by running storybook on this branch and seeing the "Indeterminate" story under CheckBox

#### Any background context you want to provide?
N/A

#### What are the relevant issues?

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/2539016/74696713-56763180-51ad-11ea-8edf-b1066a56cbec.png)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible