### PR TITLE
added column-reverse to also calcualte gap height

### DIFF
--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -576,7 +576,7 @@ const gapStyle = (directionProp, gap, responsive, border, theme) => {
   const hasBetweenBorder =
     border === 'between' || (border && border.side === 'between');
   const styles = [];
-  if (directionProp === 'column' || 'column-reverse') {
+  if (directionProp === 'column-reverse' || directionProp === 'column' ) {
     const height = theme.global.edgeSize[gap] || gap;
     styles.push(
       css`

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -576,7 +576,7 @@ const gapStyle = (directionProp, gap, responsive, border, theme) => {
   const hasBetweenBorder =
     border === 'between' || (border && border.side === 'between');
   const styles = [];
-  if (directionProp === 'column-reverse' || directionProp === 'column' ) {
+  if (directionProp === 'column' || directionProp === 'column-reverse' ) {
     const height = theme.global.edgeSize[gap] || gap;
     styles.push(
       css`

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -576,7 +576,7 @@ const gapStyle = (directionProp, gap, responsive, border, theme) => {
   const hasBetweenBorder =
     border === 'between' || (border && border.side === 'between');
   const styles = [];
-  if (directionProp === 'column') {
+  if (directionProp === 'column' || 'column-reverse') {
     const height = theme.global.edgeSize[gap] || gap;
     styles.push(
       css`


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes the gapStyle to include column-reverse in the way that height is calculated for the box gap
#### Where should the reviewer start?
Box/StyledBox.js
#### What testing has been done on this PR?
Storybook testing was done I used this simple code to check
```

  <Grommet theme={grommet}>
  <Box
      background="brand"
      gap="medium"
      direction="column-reverse"
      pad="medium"
    >
      <Text>Copyright</Text>
      <Anchor label="About" />
    </Box>
  </Grommet>

```

#### How should this be manually tested?
StoryBook

#### Any background context you want to provide?
gapStyle function was taken into account if direction prop was column then push the height for the gap otherwise it was calculating the width which was being used for row 
#### What are the relevant issues?
I made a quick code sandBox in order to show my issue. 
https://codesandbox.io/s/elated-sea-2m3cs
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible 