### PR TITLE
Form - Fixed validate when error is a react node

### DIFF
--- a/src/js/components/Form/Form.js
+++ b/src/js/components/Form/Form.js
@@ -19,11 +19,16 @@ const updateErrors = (nextErrors, name, error) => {
   // we disable no-param-reassing so we can use this as a utility function
   // to update nextErrors, to avoid code duplication
   /* eslint-disable no-param-reassign */
+  const hasStatusError = typeof error === 'object' && error.status === 'error';
+
+  // typeof error === 'object' is implied for both cases of error with
+  // a status message and for an error object that is a react node
   if (
-    (typeof error === 'object' && error.status === 'error') ||
+    (typeof error === 'object' && !error.status) ||
+    hasStatusError ||
     typeof error === 'string'
   ) {
-    nextErrors[name] = typeof error === 'object' ? error.message : error;
+    nextErrors[name] = hasStatusError ? error.message : error;
   } else {
     delete nextErrors[name];
   }

--- a/src/js/components/Form/__tests__/Form-test.js
+++ b/src/js/components/Form/__tests__/Form-test.js
@@ -7,6 +7,7 @@ import { Grommet } from '../../Grommet';
 import { Form } from '..';
 import { FormField } from '../../FormField';
 import { Button } from '../../Button';
+import { Text } from '../../Text';
 
 describe('Form', () => {
   afterEach(cleanup);
@@ -63,6 +64,7 @@ describe('Form', () => {
       .mockReturnValueOnce('too short')
       .mockReturnValueOnce(undefined);
     const validate2 = jest.fn().mockReturnValue(undefined);
+
     const onSubmit = jest.fn();
     const { getByPlaceholderText, getByText, container } = render(
       <Grommet>
@@ -87,14 +89,17 @@ describe('Form', () => {
       target: { value: 'v' },
     });
     fireEvent.click(getByText('Submit'));
+
     expect(validate).toBeCalledWith('v', { test: 'v' });
     expect(validate2).toBeCalledWith(undefined, { test: 'v' });
+
     fireEvent.change(getByPlaceholderText('test input'), {
       target: { value: 'value' },
     });
     fireEvent.change(getByPlaceholderText('test-2 input'), {
       target: { value: 'value-2' },
     });
+
     fireEvent.click(getByText('Submit'));
     expect(validate).toBeCalledWith('value', {
       test: 'value',
@@ -104,6 +109,7 @@ describe('Form', () => {
       test: 'value',
       test2: 'value-2',
     });
+
     expect(onSubmit).toBeCalledWith(
       expect.objectContaining({
         value: { test: 'value', test2: 'value-2' },
@@ -139,6 +145,64 @@ describe('Form', () => {
     });
     fireEvent.click(getByText('Submit'));
     expect(queryByText('invalid')).toBeNull();
+  });
+
+  test('validate', () => {
+    const onSubmit = jest.fn();
+    const { getByPlaceholderText, getByText } = render(
+      <Grommet>
+        <Form onSubmit={onSubmit}>
+          <FormField
+            name="test"
+            required
+            validate={[
+              name => {
+                return name.length === 1 ? 'simple string' : undefined;
+              },
+              name => {
+                return name.length === 2 ? <Text> ReactNode </Text> : undefined;
+              },
+              name => {
+                return name.length === 3
+                  ? { message: 'status error', status: 'error' }
+                  : undefined;
+              },
+              name => {
+                return name.length === 4
+                  ? { message: 'status info', status: 'info' }
+                  : undefined;
+              },
+            ]}
+            placeholder="test input"
+          />
+          <Button type="submit" primary label="Submit" />
+        </Form>
+      </Grommet>,
+    );
+
+    fireEvent.change(getByPlaceholderText('test input'), {
+      target: { value: 'a' },
+    });
+    fireEvent.click(getByText('Submit'));
+    expect(getByText('simple string')).toMatchSnapshot();
+
+    fireEvent.change(getByPlaceholderText('test input'), {
+      target: { value: 'ab' },
+    });
+    fireEvent.click(getByText('Submit'));
+    expect(getByText('ReactNode')).toMatchSnapshot();
+
+    fireEvent.change(getByPlaceholderText('test input'), {
+      target: { value: 'abc' },
+    });
+    fireEvent.click(getByText('Submit'));
+    expect(getByText('status error')).toMatchSnapshot();
+
+    fireEvent.change(getByPlaceholderText('test input'), {
+      target: { value: 'abcd' },
+    });
+    fireEvent.click(getByText('Submit'));
+    expect(getByText('status info')).toMatchSnapshot();
   });
 
   test('required validation', () => {

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
@@ -625,6 +625,99 @@ exports[`Form update 1`] = `
 </div>
 `;
 
+exports[`Form validate 1`] = `
+.c0 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #FF4040;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<span
+  class="c0"
+>
+  simple string
+</span>
+`;
+
+exports[`Form validate 2`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<span
+  class="c0"
+>
+   ReactNode 
+</span>
+`;
+
+exports[`Form validate 3`] = `
+<span
+  class="StyledText-sc-1sadyjn-0 keDfiS"
+>
+  status error
+</span>
+`;
+
+exports[`Form validate 4`] = `
+.c0 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #666666;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<span
+  class="c0"
+>
+  status info
+</span>
+`;
+
 exports[`Form with field 1`] = `
 .c0 {
   font-size: 18px;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixed validate when the error object is a react node.

#### Where should the reviewer start?
Form.js

#### What testing has been done on this PR?
Added a section of tests for the validate props with all of its different flavors.

#### How should this be manually tested?
storybook-> Form -> All
storybook-> Form -> Validate onBlur (when wrapping the string with `<Text>`)
Read the tests.

#### What are the relevant issues?
#3762 

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no - it's a fix for a new feature on master so never released with this bug.

#### Is this change backwards compatible or is it a breaking change?
backwards compatible 