### PR TITLE
Heading storybook example using extend, reorganize heading storybook files

### DIFF
--- a/src/js/components/Heading/stories/All.js
+++ b/src/js/components/Heading/stories/All.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
-
 import { Grommet, Grid, Heading } from 'grommet';
 import { grommet } from 'grommet/themes';
-import { deepMerge } from 'grommet/utils';
 
 const H = ({ level, size }) => (
   <Heading level={level} size={size}>
@@ -40,40 +38,4 @@ const All = () => (
   </Grommet>
 );
 
-const Color = () => (
-  <Grommet theme={grommet}>
-    <Heading color="accent-1">Colored Heading</Heading>
-  </Grommet>
-);
-
-const customlevel = deepMerge(grommet, {
-  heading: {
-    level: {
-      5: {
-        small: {
-          size: '12px',
-          height: '16px',
-        },
-        medium: {
-          size: '14px',
-          height: '18px',
-        },
-        large: {
-          size: '16px',
-          height: '20px',
-        },
-      },
-    },
-    extend: props => `color: ${props.theme.global.colors.brand}`,
-  },
-});
-const CustomHeading = () => (
-  <Grommet theme={customlevel}>
-    <Heading level={5}>Heading level 5</Heading>
-  </Grommet>
-);
-
-storiesOf('Heading', module)
-  .add('All', () => <All />)
-  .add('Color', () => <Color />)
-  .add('Custom', () => <CustomHeading />);
+storiesOf('Heading', module).add('All', () => <All />);

--- a/src/js/components/Heading/stories/Color.js
+++ b/src/js/components/Heading/stories/Color.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Grommet, Heading } from 'grommet';
+import { grommet } from 'grommet/themes';
+
+const Color = () => (
+  <Grommet theme={grommet}>
+    <Heading color="accent-1">Colored Heading</Heading>
+  </Grommet>
+);
+
+storiesOf('Heading', module).add('Color', () => <Color />);

--- a/src/js/components/Heading/stories/CustomHeading.js
+++ b/src/js/components/Heading/stories/CustomHeading.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Grommet, Heading } from 'grommet';
+import { grommet } from 'grommet/themes';
+import { deepMerge } from 'grommet/utils';
+
+const customlevel = deepMerge(grommet, {
+  heading: {
+    level: {
+      5: {
+        small: {
+          size: '12px',
+          height: '16px',
+        },
+        medium: {
+          size: '14px',
+          height: '18px',
+        },
+        large: {
+          size: '16px',
+          height: '20px',
+        },
+      },
+    },
+    extend: props => `color: ${props.theme.global.colors.brand}`,
+  },
+});
+const CustomHeading = () => (
+  <Grommet theme={customlevel}>
+    <Heading level={5} size="small">
+      Heading level 5 small
+    </Heading>
+    <Heading level={5} size="medium">
+      Heading level 5 small
+    </Heading>
+    <Heading level={5} size="large">
+      Heading level 5 small
+    </Heading>
+  </Grommet>
+);
+
+storiesOf('Heading', module).add('Custom', () => <CustomHeading />);

--- a/src/js/components/Heading/stories/Extend.js
+++ b/src/js/components/Heading/stories/Extend.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Grommet, Heading } from 'grommet';
+import { deepMerge } from 'grommet/utils';
+import { grommet } from 'grommet/themes';
+
+const letterSpace = {
+  1: {
+    small: '-1px',
+    medium: '-1.22px',
+    large: '-1.45px',
+  },
+  2: {
+    small: '-0.47px',
+    medium: '-0.57px',
+    large: '-0.7px',
+  },
+  3: {
+    small: '-0.42px',
+    medium: '-0.47px',
+    large: '-0.47px',
+  },
+};
+
+const letterSpacing = ({ level, size }) =>
+  level && size ? `letter-spacing: ${letterSpace[level][size]}` : '';
+
+const customTheme = deepMerge(grommet, {
+  heading: { extend: props => `${letterSpacing(props)}` },
+});
+
+const HeadingExtend = () => (
+  <Grommet theme={customTheme}>
+    <Heading level="1" size="large">
+      This is using the extend property on Heading
+    </Heading>
+    <Heading level="2" size="medium">
+      This is using the extend property on Heading
+    </Heading>
+    <Heading level="3" size="small">
+      This is using the extend property on Heading
+    </Heading>
+  </Grommet>
+);
+
+storiesOf('Heading', module).add('Extend', () => <HeadingExtend />);


### PR DESCRIPTION
Added a storybook example using extend property for heading.
Gave each storybook example for heading an individual file.