### PR TITLE
Changed FormField to associate rest props with container when not used to automatically render input element

### DIFF
--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -158,6 +158,8 @@ const FormField = forwardRef(
     let normalizedError = error;
     let normalizedInfo = info;
     let onFieldBlur;
+    // put rest on container, unless we use renderInput()
+    let containerRest = rest;
     if (context && context.addValidation) {
       const {
         addValidation,
@@ -170,6 +172,7 @@ const FormField = forwardRef(
       addValidation(name, validateField(required, validate, messages));
       normalizedError = error || errors[name];
       normalizedInfo = info || infos[name];
+      if (!contents) containerRest = {};
       contents = contents || renderInput(formValue, !!normalizedError);
       if (onContextBlur) {
         onFieldBlur = () => onContextBlur(name);
@@ -282,6 +285,7 @@ const FormField = forwardRef(
           if (onFieldBlur) onFieldBlur(event);
           if (onBlur) onBlur(event);
         }}
+        {...containerRest}
       >
         {(label && component !== CheckBox) || help ? (
           <>


### PR DESCRIPTION
#### What does this PR do?

Changed FormField to associate rest props with container when not used to automatically render input element.

#### Where should the reviewer start?

FormField.js

#### What testing has been done on this PR?

grommet designer

#### How should this be manually tested?

???

#### Any background context you want to provide?

Without this change, there is no way to add attributes to a FormField element. The grommet designer wants this to be able to attach an `onClick` event handler to the FormField.

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
