### PR TITLE
Update types of RadioButtonGroup value prop

### DIFF
--- a/src/js/components/RadioButtonGroup/README.md
+++ b/src/js/components/RadioButtonGroup/README.md
@@ -72,6 +72,7 @@ Currently selected option value.
 
 ```
 string
+object
 ```
   
 ## Intrinsic element

--- a/src/js/components/RadioButtonGroup/doc.js
+++ b/src/js/components/RadioButtonGroup/doc.js
@@ -43,7 +43,10 @@ export const doc = RadioButtonGroup => {
         }),
       ),
     ]).description(`Options can be either a string or an object.`).isRequired,
-    value: PropTypes.string.description(`Currently selected option value.`),
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
+    ]).description(`Currently selected option value.`),
   };
 
   return DocumentedRadioButtonGroup;

--- a/src/js/components/RadioButtonGroup/index.d.ts
+++ b/src/js/components/RadioButtonGroup/index.d.ts
@@ -6,7 +6,7 @@ export interface RadioButtonGroupProps {
   name: string;
   onChange?: ((event: React.ChangeEvent<HTMLInputElement>) => void);
   options: (string | { disabled?: boolean, id?: string, label?: (string | React.ReactNode), value: string})[];
-  value?: string;
+  value?: string | object;
 }
 
 declare const RadioButtonGroup: React.ComponentClass<RadioButtonGroupProps & BoxProps>;

--- a/src/js/components/RadioButtonGroup/stories/typescript/Simple.tsx
+++ b/src/js/components/RadioButtonGroup/stories/typescript/Simple.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import isChromatic from 'storybook-chromatic/isChromatic';
+
+import { RadioButtonGroup } from 'grommet';
+
+export const App = () => {
+  const postMethods = [
+    { label: 'FTP', value: 'FTP' },
+    {
+      label: 'File System',
+      value: 'FileSystem',
+    },
+    {
+      label: 'FTP & File System',
+      value: 'FTPCopy',
+    },
+  ];
+
+  const [value, setValue] = useState<string | object>(postMethods[0]);
+
+  return (
+    <RadioButtonGroup
+      name="radio"
+      options={postMethods}
+      value={value}
+      onChange={event => setValue(event.target.value)}
+    />
+  );
+};
+
+if (!isChromatic()) {
+  storiesOf('TypeScript/RadioButtonGroup', module).add('Simple', () => <App />);
+}

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -9774,6 +9774,7 @@ Currently selected option value.
 
 \`\`\`
 string
+object
 \`\`\`
   
 ## Intrinsic element

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -3454,7 +3454,8 @@ with the same name so form submissions work.",
       },
       Object {
         "description": "Currently selected option value.",
-        "format": "string",
+        "format": "string
+object",
         "name": "value",
       },
     ],


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds object type to RadioButtonGroup `value` prop
#### Where should the reviewer start?
doc.js
#### What testing has been done on this PR?
Added typescript story file for RadioButtonGroup

#### How should this be manually tested?
storybook
#### Any background context you want to provide?
Coming from a slack conversation https://grommet.slack.com/archives/C04LMHN59/p1582222660202300
 
#### What are the relevant issues?
Shared on slack
https://codesandbox.io/s/strange-star-trfpe
![image](https://user-images.githubusercontent.com/6320236/74987597-c298a580-53f8-11ea-9b2c-8665d61dde63.png)

#### Do the grommet docs need to be updated?
yep, done
#### Should this PR be mentioned in the release notes?
yep
#### Is this change backwards compatible or is it a breaking change?
backwards compatible