### PR TITLE
fix: select dropdown entry when the input isnt controlled

### DIFF
--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -83,7 +83,7 @@ const Select = forwardRef(
     const inputRef = useRef();
     const formContext = useContext(FormContext);
 
-    const [value] = formContext.useFormContext(name, valueProp);
+    const [value, setValue] = formContext.useFormContext(name, valueProp);
 
     const [open, setOpen] = useState(propOpen);
     useEffect(() => {
@@ -106,6 +106,7 @@ const Select = forwardRef(
 
     const onSelectChange = (event, ...args) => {
       if (closeOnChange) onRequestClose();
+      setValue(event.value);
       if (onChange) onChange({ ...event, target: inputRef.current }, ...args);
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

In 2.11.0, when using a select without passing value as a prop, selecting
a dropdown entry won't update the Select component to have that entry
selected. This sets the value using `setValue` from the `useFormContext` hook.

#### Where should the reviewer start?

src/js/components/Select/Select.js

#### What testing has been done on this PR?

Before this change, the Select in the All storybook story would not update when a dropdown entry was clicked. Now it does.

#### How should this be manually tested?

This can be tested by creating a Select component with no value prop and no onChange prop and trying to click it.

#### Any background context you want to provide?

It looks like this was intentionally removed in https://github.com/grommet/grommet/commit/caa63f3715dfd7f21a1a7f7bbce898d6fef87c92#diff-19aa4813d5217c4120837104c9b593ff, so I'm not sure if adding this back in is the desired fix, but I thought I'd give it a shot.

#### What are the relevant issues?
#3772 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
I don't think so

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
It's a hotfix, so I don't think it would break any existing functionality