### PR TITLE
Changed Drop to use hooks

### DIFF
--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -5434,14 +5434,6 @@ exports[`DataTable search 2`] = `
 
 }
 
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-
-}
-
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-
-}
-
 <div
               class="c0"
             >
@@ -5491,14 +5483,6 @@ exports[`DataTable search 2`] = `
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-
-}
-
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
 
 }
 

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -1,6 +1,11 @@
-import React, { Component } from 'react';
+import React, {
+  forwardRef,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 
-import { defaultProps } from '../../default-props';
 import { ThemeContext } from '../../contexts';
 import { FocusedContainer } from '../FocusedContainer';
 import {
@@ -9,9 +14,11 @@ import {
   findVisibleParent,
   parseMetricToNum,
 } from '../../utils';
+import { defaultProps } from '../../default-props';
 import { Box } from '../Box';
 import { Keyboard } from '../Keyboard';
 
+import { PortalContext } from './PortalContext';
 import { StyledDrop } from './StyledDrop';
 
 // using react synthetic event to be able to stop propagation that
@@ -24,281 +31,274 @@ const preventLayerClose = event => {
   }
 };
 
-class DropContainer extends Component {
-  static contextType = ThemeContext;
-
-  static defaultProps = {
-    align: {
-      top: 'top',
-      left: 'left',
-    },
-    overflow: 'auto',
-    stretch: 'width',
-  };
-
-  dropRef = React.createRef();
-
-  componentDidMount() {
-    const { restrictFocus } = this.props;
-    this.addScrollListener();
-    window.addEventListener('resize', this.onResize);
-    document.addEventListener('mousedown', this.onClickDocument);
-
-    this.place(false);
-
-    if (restrictFocus) {
-      this.dropRef.current.focus();
-    }
-  }
-
-  componentDidUpdate() {
-    this.place(true);
-  }
-
-  componentWillUnmount() {
-    this.removeScrollListener();
-    window.removeEventListener('resize', this.onResize);
-    document.removeEventListener('mousedown', this.onClickDocument);
-  }
-
-  addScrollListener = () => {
-    const { dropTarget } = this.props;
-    this.scrollParents = findScrollParents(dropTarget);
-    this.scrollParents.forEach(scrollParent =>
-      scrollParent.addEventListener('scroll', this.place),
-    );
-  };
-
-  removeScrollListener = () => {
-    this.scrollParents.forEach(scrollParent =>
-      scrollParent.removeEventListener('scroll', this.place),
-    );
-  };
-
-  onClickDocument = event => {
-    const { dropTarget, onClickOutside } = this.props;
-    const dropTargetNode = dropTarget;
-    const dropNode = this.dropRef.current;
-    if (
-      onClickOutside &&
-      dropNode && // need this for ie11
-      !dropTargetNode.contains(event.target) &&
-      !dropNode.contains(event.target)
-    ) {
-      onClickOutside();
-    }
-  };
-
-  onResize = () => {
-    this.removeScrollListener();
-    this.addScrollListener();
-    this.place(false);
-  };
-
-  // We try to preserve the maxHeight as changing it causes any scroll position
-  // to be lost. We set the maxHeight on mount and if the window is resized.
-  place = preserveHeight => {
-    const { align, dropTarget, responsive, stretch, theme } = this.props;
-    const windowWidth = window.innerWidth;
-    const windowHeight = window.innerHeight;
-    const target = dropTarget;
-    const container = this.dropRef.current;
-    if (container && target) {
-      // clear prior styling
-      container.style.left = '';
-      container.style.top = '';
-      container.style.bottom = '';
-      container.style.width = '';
-      if (!preserveHeight) {
-        container.style.maxHeight = '';
-      }
-      // get bounds
-      const targetRect = findVisibleParent(target).getBoundingClientRect();
-      const containerRect = container.getBoundingClientRect();
-      // determine width
-      const width = Math.min(
-        stretch
-          ? Math.max(targetRect.width, containerRect.width)
-          : containerRect.width,
-        windowWidth,
-      );
-      // set left position
-      let left;
-      if (align.left) {
-        if (align.left === 'left') {
-          ({ left } = targetRect);
-        } else if (align.left === 'right') {
-          left = targetRect.left + targetRect.width;
-        }
-      } else if (align.right) {
-        if (align.right === 'left') {
-          left = targetRect.left - width;
-        } else if (align.right === 'right') {
-          left = targetRect.left + targetRect.width - width;
-        }
-      } else {
-        left = targetRect.left + targetRect.width / 2 - width / 2;
-      }
-      if (left + width > windowWidth) {
-        left -= left + width - windowWidth;
-      } else if (left < 0) {
-        left = 0;
-      }
-      // set top or bottom position
-      let top;
-      let bottom;
-      let maxHeight = containerRect.height;
-      if (align.top) {
-        if (align.top === 'top') {
-          ({ top } = targetRect);
-        } else {
-          top = targetRect.bottom;
-        }
-
-        // Calculate visible area underneath the control w.r.t window height
-        const percentVisibleAreaBelow =
-          100 - (targetRect.bottom / windowHeight) * 100;
-
-        // Check whether it is within 20% from bottom of the window or visible
-        // area to flip the control
-        // DropContainer doesn't fit well within visible area when
-        // percentVisibleAreaBelow value<=20%
-        // There is enough space from DropContainer to bottom of the window
-        // when percentVisibleAreaBelow>20%.
-
-        if (windowHeight === top || percentVisibleAreaBelow <= 20) {
-          // We need more room than we have.
-          // We put it below, but there's more room above, put it above
-          top = '';
-          if (align.top === 'bottom') {
-            bottom = targetRect.top;
-          } else {
-            ({ bottom } = targetRect);
-          }
-          maxHeight = bottom;
-          container.style.maxHeight = `${maxHeight}px`;
-        } else if (top > 0) {
-          maxHeight = windowHeight - top;
-          container.style.maxHeight = `${maxHeight}px`;
-        } else {
-          maxHeight = windowHeight - top;
-        }
-      } else if (align.bottom) {
-        if (align.bottom === 'bottom') {
-          ({ bottom } = targetRect);
-        } else {
-          bottom = targetRect.top;
-        }
-        maxHeight = bottom;
-        container.style.maxHeight = `${maxHeight}px`;
-      } else {
-        // center
-        top = targetRect.top + targetRect.height / 2 - containerRect.height / 2;
-        maxHeight = windowHeight - top;
-      }
-      // if we can't fit it all, or we're rather close,
-      // see if there's more room the other direction
-      if (
-        responsive &&
-        (containerRect.height > maxHeight || maxHeight < windowHeight / 10)
-      ) {
-        // We need more room than we have.
-        if (align.top && top > windowHeight / 2) {
-          // We put it below, but there's more room above, put it above
-          top = '';
-          if (align.top === 'bottom') {
-            // top = Math.max(targetRect.top - containerRect.height, 0);
-            // maxHeight = targetRect.top - top;
-            bottom = targetRect.top;
-          } else {
-            // top = Math.max(targetRect.bottom - containerRect.height, 0);
-            // maxHeight = targetRect.bottom - top;
-            ({ bottom } = targetRect);
-          }
-          maxHeight = bottom;
-        } else if (align.bottom && maxHeight < windowHeight / 2) {
-          // We put it above but there's more room below, put it below
-          bottom = '';
-          if (align.bottom === 'bottom') {
-            ({ top } = targetRect);
-          } else {
-            top = targetRect.bottom;
-          }
-          maxHeight = windowHeight - top;
-        }
-      }
-      container.style.left = `${left}px`;
-      if (stretch) {
-        // offset width by 0.1 to avoid a bug in ie11 that
-        // unnecessarily wraps the text if width is the same
-        // NOTE: turned off for now
-        container.style.width = `${width + 0.1}px`;
-      }
-      // the (position:absolute + scrollTop)
-      // is presenting issues with desktop scroll flickering
-      if (top !== '') {
-        container.style.top = `${top}px`;
-      }
-      if (bottom !== '') {
-        container.style.bottom = `${windowHeight - bottom}px`;
-      }
-      if (!preserveHeight) {
-        if (theme.drop && theme.drop.maxHeight) {
-          maxHeight = Math.min(
-            maxHeight,
-            parseMetricToNum(theme.drop.maxHeight),
-          );
-        }
-        container.style.maxHeight = `${maxHeight}px`;
-      }
-    }
-  };
-
-  onEsc = event => {
-    const { onEsc } = this.props;
-    event.stopPropagation();
-    if (onEsc) {
-      onEsc(event);
-    }
-  };
-
-  /**
-   * prevents mouse events from propagating upward to elements behind the drop.
-   * this prevents a nested drop from closing its parent when the user clicks
-   * inside it, since a 'nested' drop is technically an unrelated sibling in the
-   * DOM due to React portals.
-   */
-  preventClickBubbling = event => {
-    event.stopPropagation();
-    /**
-     * the React event system actually listens to all events at the top level
-     * and then handles its own bubbling / capturing virtually. This means that
-     * even if we call stopPropagation, it only affects the React synthetic
-     * event, and the native event still bubbles upward.
-     * Any code that uses native events (like the close listener in this class)
-     * will still get the bubbled event, unless we also call
-     * event.nativeEvent.stopImmediatePropagation, which bridges the gap from
-     * React synthetic event to native DOM event.
-     */
-    event.nativeEvent.stopImmediatePropagation();
-  };
-
-  render() {
-    const {
-      align: alignProp,
+const DropContainer = forwardRef(
+  (
+    {
+      align = {
+        top: 'top',
+        left: 'left',
+      },
       children,
+      dropTarget,
       elevation,
       onClickOutside,
       onEsc,
       onKeyDown,
+      overflow = 'auto',
       plain,
-      theme: propsTheme,
+      responsive,
+      restrictFocus,
+      stretch = 'width',
       ...rest
-    } = this.props;
-    const theme = this.context || propsTheme;
+    },
+    ref,
+  ) => {
+    const theme = useContext(ThemeContext) || defaultProps.theme;
+    const portalContext = useContext(PortalContext) || [];
+    const portalId = useMemo(() => portalContext.length, [portalContext]);
+    const nextPortalContext = useMemo(() => [...portalContext, portalId], [
+      portalContext,
+      portalId,
+    ]);
+    const dropRef = useRef();
+
+    useEffect(() => {
+      // We try to preserve the maxHeight as changing it causes any scroll
+      // position to be lost. We set the maxHeight on mount and if the window
+      // is resized.
+      const place = preserveHeight => {
+        const windowWidth = window.innerWidth;
+        const windowHeight = window.innerHeight;
+        const target = dropTarget;
+        const container = (ref || dropRef).current;
+        if (container && target) {
+          // clear prior styling
+          container.style.left = '';
+          container.style.top = '';
+          container.style.bottom = '';
+          container.style.width = '';
+          if (!preserveHeight) {
+            container.style.maxHeight = '';
+          }
+          // get bounds
+          const targetRect = findVisibleParent(target).getBoundingClientRect();
+          const containerRect = container.getBoundingClientRect();
+          // determine width
+          const width = Math.min(
+            stretch
+              ? Math.max(targetRect.width, containerRect.width)
+              : containerRect.width,
+            windowWidth,
+          );
+          // set left position
+          let left;
+          if (align.left) {
+            if (align.left === 'left') {
+              ({ left } = targetRect);
+            } else if (align.left === 'right') {
+              left = targetRect.left + targetRect.width;
+            }
+          } else if (align.right) {
+            if (align.right === 'left') {
+              left = targetRect.left - width;
+            } else if (align.right === 'right') {
+              left = targetRect.left + targetRect.width - width;
+            }
+          } else {
+            left = targetRect.left + targetRect.width / 2 - width / 2;
+          }
+          if (left + width > windowWidth) {
+            left -= left + width - windowWidth;
+          } else if (left < 0) {
+            left = 0;
+          }
+          // set top or bottom position
+          let top;
+          let bottom;
+          let maxHeight = containerRect.height;
+          if (align.top) {
+            if (align.top === 'top') {
+              ({ top } = targetRect);
+            } else {
+              top = targetRect.bottom;
+            }
+
+            // Calculate visible area underneath the control w.r.t window height
+            const percentVisibleAreaBelow =
+              100 - (targetRect.bottom / windowHeight) * 100;
+
+            // Check whether it is within 20% from bottom of the window or
+            // visible area to flip the control
+            // DropContainer doesn't fit well within visible area when
+            // percentVisibleAreaBelow value<=20%
+            // There is enough space from DropContainer to bottom of the window
+            // when percentVisibleAreaBelow>20%.
+
+            if (windowHeight === top || percentVisibleAreaBelow <= 20) {
+              // We need more room than we have.
+              // We put it below, but there's more room above, put it above
+              top = '';
+              if (align.top === 'bottom') {
+                bottom = targetRect.top;
+              } else {
+                ({ bottom } = targetRect);
+              }
+              maxHeight = bottom;
+              container.style.maxHeight = `${maxHeight}px`;
+            } else if (top > 0) {
+              maxHeight = windowHeight - top;
+              container.style.maxHeight = `${maxHeight}px`;
+            } else {
+              maxHeight = windowHeight - top;
+            }
+          } else if (align.bottom) {
+            if (align.bottom === 'bottom') {
+              ({ bottom } = targetRect);
+            } else {
+              bottom = targetRect.top;
+            }
+            maxHeight = bottom;
+            container.style.maxHeight = `${maxHeight}px`;
+          } else {
+            // center
+            top =
+              targetRect.top + targetRect.height / 2 - containerRect.height / 2;
+            maxHeight = windowHeight - top;
+          }
+          // if we can't fit it all, or we're rather close,
+          // see if there's more room the other direction
+          if (
+            responsive &&
+            (containerRect.height > maxHeight || maxHeight < windowHeight / 10)
+          ) {
+            // We need more room than we have.
+            if (align.top && top > windowHeight / 2) {
+              // We put it below, but there's more room above, put it above
+              top = '';
+              if (align.top === 'bottom') {
+                // top = Math.max(targetRect.top - containerRect.height, 0);
+                // maxHeight = targetRect.top - top;
+                bottom = targetRect.top;
+              } else {
+                // top = Math.max(targetRect.bottom - containerRect.height, 0);
+                // maxHeight = targetRect.bottom - top;
+                ({ bottom } = targetRect);
+              }
+              maxHeight = bottom;
+            } else if (align.bottom && maxHeight < windowHeight / 2) {
+              // We put it above but there's more room below, put it below
+              bottom = '';
+              if (align.bottom === 'bottom') {
+                ({ top } = targetRect);
+              } else {
+                top = targetRect.bottom;
+              }
+              maxHeight = windowHeight - top;
+            }
+          }
+          container.style.left = `${left}px`;
+          if (stretch) {
+            // offset width by 0.1 to avoid a bug in ie11 that
+            // unnecessarily wraps the text if width is the same
+            // NOTE: turned off for now
+            container.style.width = `${width + 0.1}px`;
+          }
+          // the (position:absolute + scrollTop)
+          // is presenting issues with desktop scroll flickering
+          if (top !== '') {
+            container.style.top = `${top}px`;
+          }
+          if (bottom !== '') {
+            container.style.bottom = `${windowHeight - bottom}px`;
+          }
+          if (!preserveHeight) {
+            if (theme.drop && theme.drop.maxHeight) {
+              maxHeight = Math.min(
+                maxHeight,
+                parseMetricToNum(theme.drop.maxHeight),
+              );
+            }
+            container.style.maxHeight = `${maxHeight}px`;
+          }
+        }
+      };
+
+      let scrollParents;
+
+      const addScrollListeners = () => {
+        scrollParents = findScrollParents(dropTarget);
+        scrollParents.forEach(scrollParent =>
+          scrollParent.addEventListener('scroll', place),
+        );
+      };
+
+      const removeScrollListeners = () => {
+        scrollParents.forEach(scrollParent =>
+          scrollParent.removeEventListener('scroll', place),
+        );
+        scrollParents = [];
+      };
+
+      const onClickDocument = event => {
+        // determine which portal id the target is in, if any
+        let clickedPortalId = null;
+        let node = event.target;
+        while (clickedPortalId === null && node !== document) {
+          const attr = node.getAttribute('data-g-portal-id');
+          if (attr !== null) clickedPortalId = parseInt(attr, 10);
+          node = node.parentNode;
+        }
+        if (
+          clickedPortalId === null ||
+          portalContext.indexOf(clickedPortalId) !== -1
+        ) {
+          onClickOutside(event);
+        }
+      };
+
+      const onResize = () => {
+        removeScrollListeners();
+        addScrollListeners();
+        place(false);
+      };
+
+      addScrollListeners();
+      window.addEventListener('resize', onResize);
+      if (onClickOutside) {
+        document.addEventListener('mousedown', onClickDocument);
+      }
+
+      place(false);
+
+      return () => {
+        removeScrollListeners();
+        window.removeEventListener('resize', onResize);
+        if (onClickOutside) {
+          document.removeEventListener('mousedown', onClickDocument);
+        }
+      };
+    }, [
+      align,
+      dropTarget,
+      onClickOutside,
+      portalContext,
+      portalId,
+      ref,
+      responsive,
+      restrictFocus,
+      stretch,
+      theme.drop,
+    ]);
+
+    useEffect(() => {
+      if (restrictFocus) {
+        (ref || dropRef).current.focus();
+      }
+    }, [ref, restrictFocus]);
 
     let content = (
       <StyledDrop
+        ref={ref || dropRef}
         as={Box}
         plain={plain}
         elevation={
@@ -307,9 +307,9 @@ class DropContainer extends Component {
             : undefined
         }
         tabIndex="-1"
-        ref={this.dropRef}
-        alignProp={alignProp}
-        onMouseDown={this.preventClickBubbling}
+        alignProp={align}
+        overflow={overflow}
+        data-g-portal-id={portalId}
         {...rest}
       >
         {children}
@@ -328,19 +328,26 @@ class DropContainer extends Component {
     }
 
     return (
-      <FocusedContainer onKeyDown={onEsc && preventLayerClose}>
-        <Keyboard
-          onEsc={onEsc && this.onEsc}
-          onKeyDown={onKeyDown}
-          target="document"
-        >
-          {content}
-        </Keyboard>
-      </FocusedContainer>
+      <PortalContext.Provider value={nextPortalContext}>
+        <FocusedContainer onKeyDown={onEsc && preventLayerClose}>
+          <Keyboard
+            onEsc={
+              onEsc
+                ? event => {
+                    event.stopPropagation();
+                    onEsc(event);
+                  }
+                : undefined
+            }
+            onKeyDown={onKeyDown}
+            target="document"
+          >
+            {content}
+          </Keyboard>
+        </FocusedContainer>
+      </PortalContext.Provider>
     );
-  }
-}
-
-Object.setPrototypeOf(DropContainer.defaultProps, defaultProps);
+  },
+);
 
 export { DropContainer };

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -5,8 +5,8 @@ import React, {
   useMemo,
   useRef,
 } from 'react';
+import { ThemeContext } from 'styled-components';
 
-import { ThemeContext } from '../../contexts';
 import { FocusedContainer } from '../FocusedContainer';
 import {
   backgroundIsDark,

--- a/src/js/components/Drop/PortalContext.js
+++ b/src/js/components/Drop/PortalContext.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const PortalContext = React.createContext(undefined);

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -57,6 +57,7 @@ exports[`Drop align left left 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="max-height: 0px; left: 0px; width: 0.1px; bottom: 768px;"
   tabindex="-1"
@@ -154,6 +155,7 @@ exports[`Drop align left right top bottom 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -275,6 +277,7 @@ exports[`Drop align right left top top 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -372,6 +375,7 @@ exports[`Drop align right right 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -469,6 +473,7 @@ exports[`Drop align right right bottom top 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="max-height: 0px; left: 0px; width: 0.1px; bottom: 768px;"
   tabindex="-1"
@@ -566,6 +571,7 @@ exports[`Drop align right right bottom top 3`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="max-height: 0px; left: 0px; width: 0.1px; bottom: 768px;"
   tabindex="-1"
@@ -663,6 +669,7 @@ exports[`Drop basic 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -784,6 +791,7 @@ exports[`Drop close 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -905,6 +913,7 @@ exports[`Drop default elevation renders 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
   tabindex="-1"
@@ -1026,6 +1035,7 @@ exports[`Drop invalid align 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -1147,6 +1157,7 @@ exports[`Drop invoke onClickOutside 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -1268,6 +1279,7 @@ exports[`Drop no stretch 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -1386,6 +1398,7 @@ exports[`Drop plain renders 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
   tabindex="-1"
@@ -1466,6 +1479,7 @@ exports[`Drop props elevation renders 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
   tabindex="-1"
@@ -1570,6 +1584,7 @@ exports[`Drop resize 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
   tabindex="-1"
@@ -1691,6 +1706,7 @@ exports[`Drop restrict focus 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
   tabindex="-1"
@@ -1702,6 +1718,7 @@ exports[`Drop restrict focus 1`] = `
 exports[`Drop restrict focus 2`] = `
 <div
   class="StyledBox-sc-13pk1d4-0 fUuNUq StyledDrop-sc-16s5rx8-0 exrnbV"
+  data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
   tabindex="-1"
@@ -1831,6 +1848,7 @@ exports[`Drop theme elevation renders 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
   tabindex="-1"

--- a/src/js/components/Drop/stories/Multiple.js
+++ b/src/js/components/Drop/stories/Multiple.js
@@ -1,0 +1,73 @@
+import React, { useRef, useState } from 'react';
+import { storiesOf } from '@storybook/react';
+
+import {
+  Box,
+  Button,
+  Drop,
+  DropButton,
+  Grommet,
+  Layer,
+  TextInput,
+} from 'grommet';
+import { grommet } from 'grommet/themes';
+
+const MultipleDrop = () => {
+  const [showDrop, setShowDrop] = useState(false);
+  const [showLayer, setShowLayer] = useState(false);
+  const targetRef = useRef();
+
+  return (
+    <Grommet theme={grommet} full>
+      <Box fill align="center" justify="center">
+        <DropButton
+          label="drop button"
+          dropAlign={{ right: 'left' }}
+          dropContent={
+            <Box pad="large">
+              <TextInput
+                value=""
+                onChange={() => {}}
+                suggestions={['one', 'two']}
+              />
+            </Box>
+          }
+        />
+        <Button
+          ref={targetRef}
+          label="button"
+          onClick={() => setShowDrop(true)}
+        />
+        {showDrop && (
+          <Drop
+            align={{ left: 'right' }}
+            target={targetRef.current}
+            onClickOutside={() => setShowDrop(false)}
+          >
+            <Box pad="large">
+              <TextInput
+                value=""
+                onChange={() => {}}
+                suggestions={['one', 'two']}
+              />
+            </Box>
+          </Drop>
+        )}
+        <Button label="layer" onClick={() => setShowLayer(!showLayer)} />
+        {showLayer && (
+          <Layer position="left" modal={false}>
+            <Box pad="large" border>
+              <TextInput
+                value=""
+                onChange={() => {}}
+                suggestions={['one', 'two']}
+              />
+            </Box>
+          </Layer>
+        )}
+      </Box>
+    </Grommet>
+  );
+};
+
+storiesOf('Drop', module).add('Multiple', () => <MultipleDrop />);

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -478,8 +478,9 @@ exports[`MaskedInput event target props are available option via mouse 2`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="masked-input-drop__item"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -742,8 +743,9 @@ exports[`MaskedInput mask 2`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="masked-input-drop__item"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -1127,8 +1129,9 @@ exports[`MaskedInput option via mouse 2`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="masked-input-drop__item"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -486,8 +486,9 @@ exports[`Menu close by clicking outside 2`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="test-menu__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -2482,8 +2483,9 @@ exports[`Menu open and close on click 3`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="test-menu__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -3404,6 +3406,7 @@ exports[`Menu with dropAlign renders 2`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="test-menu__drop"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -1011,8 +1011,9 @@ exports[`Select complex options and children 3`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -1822,8 +1823,9 @@ exports[`Select empty results search 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -2080,8 +2082,9 @@ exports[`Select large drop container height 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -2346,8 +2349,9 @@ exports[`Select medium drop container height 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -3368,8 +3372,9 @@ exports[`Select multiple values 3`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -3916,8 +3921,9 @@ exports[`Select opens 3`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -5889,8 +5895,9 @@ exports[`Select search 2`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -7251,8 +7258,9 @@ exports[`Select small drop container height 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="test-select__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -352,24 +352,13 @@ const TextInput = forwardRef(
               setFocus(true);
               if (suggestions && suggestions.length > 0) {
                 announce(messages.suggestionsExist);
+                setShowDrop(true);
               }
-              setShowDrop(true);
-              if (onFocus) {
-                onFocus(event);
-              }
+              if (onFocus) onFocus(event);
             }}
             onBlur={event => {
               setFocus(false);
-              // This will be called when the user clicks on a suggestion,
-              // check for that and don't remove the drop in that case.
-              // Drop will already have removed itself if the user has focused
-              // outside of the Drop.
-              if (!dropRef.current) {
-                closeDrop();
-                if (onBlur) {
-                  onBlur(event);
-                }
-              }
+              if (onBlur) onBlur(event);
             }}
             onChange={event => {
               setValue(event.target.value);

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -293,8 +293,9 @@ exports[`TextInput close suggestion drop 2`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="text-input-drop__item"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -567,8 +568,9 @@ exports[`TextInput complex suggestions 2`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="text-input-drop__item"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -918,6 +920,7 @@ exports[`TextInput large drop height 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -1127,6 +1130,7 @@ exports[`TextInput medium drop height 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -1483,8 +1487,9 @@ exports[`TextInput select suggestion 2`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="text-input-drop__item"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
@@ -1711,6 +1716,7 @@ exports[`TextInput small drop height 1`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="text-input-drop__item"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -1978,8 +1984,9 @@ exports[`TextInput suggestions 2`] = `
 
 <div
   class="c0 c1"
+  data-g-portal-id="0"
   id="text-input-drop__item"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2033,7 +2033,128 @@ vertical",
 <Diagram />",
   },
   "Distribution": [Function],
-  "Drop": [Function],
+  "Drop": Object {
+    "availableAt": Array [
+      Object {
+        "badge": "https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png",
+        "label": "Storybook",
+        "url": "https://storybook.grommet.io/?selectedKind=Drop&full=0&addons=0&stories=1&panelRight=0",
+      },
+      Object {
+        "badge": "https://codesandbox.io/static/img/play-codesandbox.svg",
+        "label": "CodeSandbox",
+        "url": "https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=drop&module=%2Fsrc%2FDrop.js",
+      },
+    ],
+    "description": "A container that is overlaid next to a target.",
+    "intrinsicElement": "div",
+    "name": "Drop",
+    "properties": Array [
+      Object {
+        "defaultValue": Object {
+          "left": "left",
+          "top": "top",
+        },
+        "description": "How to align the drop with respect to the target element. Not 
+        specifying a vertical or horizontal alignment will cause it to be 
+        aligned in the center.",
+        "format": "{
+  top: 
+    top
+    bottom,
+  bottom: 
+    top
+    bottom,
+  right: 
+    left
+    right,
+  left: 
+    left
+    right
+}",
+        "name": "align",
+      },
+      Object {
+        "description": "Function that will be invoked when the user clicks outside the drop.",
+        "format": "function",
+        "name": "onClickOutside",
+      },
+      Object {
+        "description": "Function that will be called when the user presses the escape key inside
+       the drop.",
+        "format": "function",
+        "name": "onEsc",
+      },
+      Object {
+        "defaultValue": "auto",
+        "description": "How to control the overflow inside the drop.",
+        "format": "auto
+hidden
+scroll
+visible
+{
+  horizontal: 
+    auto
+    hidden
+    scroll
+    visible,
+  vertical: 
+    auto
+    hidden
+    scroll
+    visible
+}
+string",
+        "name": "overflow",
+      },
+      Object {
+        "defaultValue": true,
+        "description": "Whether to dynamically re-place when resized.",
+        "format": "boolean",
+        "name": "responsive",
+      },
+      Object {
+        "defaultValue": false,
+        "description": "Whether the drop should control focus.",
+        "format": "boolean",
+        "name": "restrictFocus",
+      },
+      Object {
+        "defaultValue": true,
+        "description": "Whether the drop element should be stretched to at least match the
+      width of the target element. The default is true because
+      that is what most uses of Drop want, like Select and Menu.",
+        "format": "boolean",
+        "name": "stretch",
+      },
+      Object {
+        "description": "Target where the drop will be aligned to. This should be a React 
+      reference.",
+        "format": "object",
+        "name": "target",
+        "required": true,
+      },
+      Object {
+        "description": "Elevated height of the target, indicated via a drop shadow.",
+        "format": "none
+xsmall
+small
+medium
+large
+xlarge
+string",
+        "name": "elevation",
+      },
+      Object {
+        "defaultValue": false,
+        "description": "Whether the drop element should have no background nor shadow",
+        "format": "boolean",
+        "name": "plain",
+      },
+    ],
+    "usage": "import { Drop } from 'grommet';
+<Drop target={reference}>...</Drop>",
+  },
   "DropButton": Object {
     "availableAt": Array [
       Object {


### PR DESCRIPTION
#### What does this PR do?

Changed Drop to use hooks.
Also, fixed the lingering issues from https://github.com/grommet/grommet/pull/2745.
Now, you can close a drop opened from within another drop without closing the first drop.

#### Where should the reviewer start?

DropContainer.js

#### What testing has been done on this PR?

Storybook for Drop, DropButton, Menu, TextInput, MaskedInput, Select.
Added Drop Multiple story to show more flavors.

#### How should this be manually tested?

Storybook

#### Any background context you want to provide?

See https://github.com/grommet/grommet/pull/2745

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
