### PR TITLE
Allow Meter to accept number value

### DIFF
--- a/src/js/components/Meter/README.md
+++ b/src/js/components/Meter/README.md
@@ -139,6 +139,7 @@ string
     weak
     medium
     strong
+    number
     boolean
 }
 ```

--- a/src/js/components/Meter/__tests__/Meter-test.js
+++ b/src/js/components/Meter/__tests__/Meter-test.js
@@ -127,6 +127,10 @@ describe('Meter', () => {
           background={{ color: 'light-3', opacity: 'medium' }}
           values={VALUES}
         />
+        <Meter
+          background={{ color: 'light-3', opacity: '0.2' }}
+          values={VALUES}
+        />
       </Grommet>,
     );
     const tree = component.toJSON();

--- a/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
+++ b/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
@@ -124,6 +124,31 @@ exports[`Meter background 1`] = `
       strokeWidth={24}
     />
   </svg>
+  <svg
+    className="c1"
+    height={24}
+    preserveAspectRatio="none"
+    viewBox="0 0 384 24"
+    width={384}
+  >
+    <path
+      d="M 0,12 L 384,12"
+      fill="none"
+      stroke="#EDEDED"
+      strokeLinecap="square"
+      strokeOpacity="0.2"
+      strokeWidth={24}
+    />
+    <path
+      d="M 0,12 L 76.8,12"
+      fill="none"
+      onMouseLeave={[Function]}
+      onMouseOver={[Function]}
+      stroke="#6FFFB0"
+      strokeLinecap="butt"
+      strokeWidth={24}
+    />
+  </svg>
 </div>
 `;
 

--- a/src/js/components/Meter/doc.js
+++ b/src/js/components/Meter/doc.js
@@ -21,6 +21,7 @@ export const doc = Meter => {
         color: PropTypes.string,
         opacity: PropTypes.oneOfType([
           PropTypes.oneOf(['weak', 'medium', 'strong']),
+          PropTypes.number,
           PropTypes.bool,
         ]),
       }),

--- a/src/js/components/Meter/utils.js
+++ b/src/js/components/Meter/utils.js
@@ -9,7 +9,7 @@ export const strokeProps = (color, theme) => {
         result.strokeOpacity = `${
           color.opacity === true
             ? theme.global.opacity.medium
-            : theme.global.opacity[color.opacity]
+            : theme.global.opacity[color.opacity] || color.opacity
         }`;
       }
     } else {

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -9059,6 +9059,7 @@ string
     weak
     medium
     strong
+    number
     boolean
 }
 \`\`\`


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Allows Meter to accept a background opacity value of number (such as 0.8).

#### Where should the reviewer start?
src/js/components/Meter/utils.js

#### What testing has been done on this PR?
A test has been added, and it was test on a local storybook.

#### How should this be manually tested?
Add `background={{color: 'red', opacity: 0.2}}` to a Meter.

#### Any background context you want to provide?
Meter could accept theme opacity values such as "weak" but not just a number value.

#### What are the relevant issues?
#3759 

#### Screenshots (if appropriate)
N/A

#### Do the grommet docs need to be updated?
They've been updated in this PR.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.