### PR TITLE
Select flicker fix

### DIFF
--- a/src/js/components/InfiniteScroll/InfiniteScroll.js
+++ b/src/js/components/InfiniteScroll/InfiniteScroll.js
@@ -209,6 +209,7 @@ const InfiniteScroll = ({
   });
 
   if (endPage < lastPage || replace || onMore) {
+    // The height being calculated here seems to cause the issue
     let marker = (
       <Box
         key="below"

--- a/src/js/components/InfiniteScroll/InfiniteScroll.js
+++ b/src/js/components/InfiniteScroll/InfiniteScroll.js
@@ -22,7 +22,7 @@ const InfiniteScroll = ({
   step = 50,
 }) => {
   // the last page we have items for
-  const lastPage = useMemo(() => Math.ceil(items.length / step), [
+  const lastPage = useMemo(() => Math.floor(items.length / step), [
     items.length,
     step,
   ]);
@@ -109,16 +109,11 @@ const InfiniteScroll = ({
           (!replace && endPage) || 0,
           multiColumn
             ? Math.ceil(((top + height + offset) * width) / pageArea)
-            : Math.ceil((top + height + offset) / pageHeight),
+            : Math.floor((top + height + offset) / pageHeight),
         ),
       );
       if (nextBeginPage !== beginPage) setBeginPage(nextBeginPage);
-      if (nextEndPage !== endPage) {
-        console.log('TOP', top);
-        console.log('MATH', top - offset);
-        console.log('MATH AGAIN', (top - offset) / pageHeight);
-        setEndPage(nextEndPage);
-      }
+      if (nextEndPage !== endPage) setEndPage(nextEndPage);
     };
 
     if (pageHeight && belowMarkerRef.current) {
@@ -213,9 +208,6 @@ const InfiniteScroll = ({
   });
 
   if (endPage < lastPage || replace || onMore) {
-    // The height being calculated here seems to cause the
-    // issue at certain option lengths.
-    // endPage is always less than lastPage at certain lengths.
     let marker = (
       <Box
         key="below"

--- a/src/js/components/InfiniteScroll/InfiniteScroll.js
+++ b/src/js/components/InfiniteScroll/InfiniteScroll.js
@@ -109,12 +109,16 @@ const InfiniteScroll = ({
           (!replace && endPage) || 0,
           multiColumn
             ? Math.ceil(((top + height + offset) * width) / pageArea)
-            : Math.floor((top + height + offset) / pageHeight),
+            : Math.ceil((top + height + offset) / pageHeight),
         ),
       );
-
       if (nextBeginPage !== beginPage) setBeginPage(nextBeginPage);
-      if (nextEndPage !== endPage) setEndPage(nextEndPage);
+      if (nextEndPage !== endPage) {
+        console.log('TOP', top);
+        console.log('MATH', top - offset);
+        console.log('MATH AGAIN', (top - offset) / pageHeight);
+        setEndPage(nextEndPage);
+      }
     };
 
     if (pageHeight && belowMarkerRef.current) {
@@ -209,7 +213,9 @@ const InfiniteScroll = ({
   });
 
   if (endPage < lastPage || replace || onMore) {
-    // The height being calculated here seems to cause the issue
+    // The height being calculated here seems to cause the
+    // issue at certain option lengths.
+    // endPage is always less than lastPage at certain lengths.
     let marker = (
       <Box
         key="below"

--- a/src/js/components/Select/stories/ManyOptions.js
+++ b/src/js/components/Select/stories/ManyOptions.js
@@ -23,42 +23,38 @@ const dummyOptions = Array(2000)
     a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }),
   );
 
+const dummyOptions2 = Array(81)
+  .fill()
+  .map((_, i) => `option ${i}`)
+  .sort((a, b) =>
+    a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }),
+  );
+
 const ManyOptions = () => {
-  const [selected, setSelected] = React.useState([]);
-  const [options, setOptions] = React.useState(dummyOptions);
+  const [selected] = React.useState([]);
+  const [options] = React.useState(dummyOptions);
+  const [options2] = React.useState(dummyOptions2);
 
   return (
     <Grommet full theme={grommet}>
-      <Box fill align="center" justify="start" pad="large">
+      <Box fill align="center" justify="start" pad="large" direction="row">
         <Select
           multiple
           closeOnChange={false}
           placeholder="select an option..."
-          selected={selected}
           options={options}
           dropHeight="medium"
-          onClose={() =>
-            setOptions(
-              options.sort((p1, p2) => {
-                const p1Exists = selected.includes(p1);
-                const p2Exists = selected.includes(p2);
-
-                if (!p1Exists && p2Exists) {
-                  return 1;
-                }
-                if (p1Exists && !p2Exists) {
-                  return -1;
-                }
-                return p1.localeCompare(p2, undefined, {
-                  numeric: true,
-                  sensitivity: 'base',
-                });
-              }),
-            )
-          }
-          onChange={({ selected: nextSelected }) => {
-            setSelected(nextSelected);
-          }}
+        >
+          {(option, index) => (
+            <Option value={option} selected={selected.indexOf(index) !== -1} />
+          )}
+        </Select>
+        <Select
+          multiple
+          closeOnChange={false}
+          placeholder="select an option..."
+          options={options2}
+          dropHeight="medium"
         >
           {(option, index) => (
             <Option value={option} selected={selected.indexOf(index) !== -1} />

--- a/src/js/components/Select/stories/ManyOptions.js
+++ b/src/js/components/Select/stories/ManyOptions.js
@@ -23,38 +23,42 @@ const dummyOptions = Array(2000)
     a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }),
   );
 
-const dummyOptions2 = Array(81)
-  .fill()
-  .map((_, i) => `option ${i}`)
-  .sort((a, b) =>
-    a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }),
-  );
-
 const ManyOptions = () => {
-  const [selected] = React.useState([]);
-  const [options] = React.useState(dummyOptions);
-  const [options2] = React.useState(dummyOptions2);
+  const [selected, setSelected] = React.useState([]);
+  const [options, setOptions] = React.useState(dummyOptions);
 
   return (
     <Grommet full theme={grommet}>
-      <Box fill align="center" justify="start" pad="large" direction="row">
+      <Box fill align="center" justify="start" pad="large">
         <Select
           multiple
           closeOnChange={false}
           placeholder="select an option..."
+          selected={selected}
           options={options}
           dropHeight="medium"
-        >
-          {(option, index) => (
-            <Option value={option} selected={selected.indexOf(index) !== -1} />
-          )}
-        </Select>
-        <Select
-          multiple
-          closeOnChange={false}
-          placeholder="select an option..."
-          options={options2}
-          dropHeight="medium"
+          onClose={() =>
+            setOptions(
+              options.sort((p1, p2) => {
+                const p1Exists = selected.includes(p1);
+                const p2Exists = selected.includes(p2);
+
+                if (!p1Exists && p2Exists) {
+                  return 1;
+                }
+                if (p1Exists && !p2Exists) {
+                  return -1;
+                }
+                return p1.localeCompare(p2, undefined, {
+                  numeric: true,
+                  sensitivity: 'base',
+                });
+              }),
+            )
+          }
+          onChange={({ selected: nextSelected }) => {
+            setSelected(nextSelected);
+          }}
         >
           {(option, index) => (
             <Option value={option} selected={selected.indexOf(index) !== -1} />


### PR DESCRIPTION
Proposed solution to select flickering at certain option lengths. It looks like top changes its value at times and causes nextPageEnd to change value at the end of a selection list causing the flicker. Changing the calculation to math.ceil instead of math.floor seemed to have fixed the issue. But, I want to clarify the reason for each calculation. 