### PR TITLE
[TS] Theme - Added missing breakpoint types

### DIFF
--- a/src/js/components/Grid/stories/Responsive.js
+++ b/src/js/components/Grid/stories/Responsive.js
@@ -20,7 +20,9 @@ const customBreakpoints = deepMerge(grommet, {
       medium: {
         value: 900,
       },
-      large: 3000,
+      large: {
+        value: 3000,
+      },
     },
   },
 });

--- a/src/js/components/Menu/stories/typescript/Themed.tsx
+++ b/src/js/components/Menu/stories/typescript/Themed.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import isChromatic from 'storybook-chromatic/isChromatic';
+
+import { Grommet, Box, Menu, ThemeType } from 'grommet';
+import { Next } from 'grommet-icons';
+
+const customBreakpoints: ThemeType = {
+  global: {
+    breakpoints: {
+      small: {
+        value: 600,
+        edgeSize: {
+          small: '1px',
+        },
+        borderSize: {
+          small: '2px',
+        },
+        size: {
+          xxsmall: '24px',
+        },
+      },
+      medium: {
+        value: 900,
+        borderSize: {
+          small: '2px',
+        },
+        edgeSize: {
+          small: '1px',
+        },
+        size: {
+          xxsmall: '24px',
+        },
+      },
+      large: {
+        value: 3000,
+        borderSize: {
+          small: '2px',
+        },
+        edgeSize: {
+          small: '1px',
+        },
+        size: {
+          xxsmall: '24px',
+        },
+      },
+      xlarge: {
+        value: 3000,
+        borderSize: {
+          small: '2px',
+        },
+        edgeSize: {
+          small: '1px',
+        },
+        size: {
+          xxsmall: '24px',
+        },
+      },
+    },
+  },
+};
+const App = () => {
+  return (
+    <Grommet theme={customBreakpoints}>
+      <Box align="center" pad="large">
+        <Menu
+          dropProps={{ align: { top: 'bottom', left: 'left' } }}
+          label="actions"
+          icon={<Next />}
+          items={[
+            { label: 'Launch', onClick: () => {} },
+            { label: 'Abort', onClick: () => {} },
+            { label: 'Disabled', disabled: true },
+          ]}
+        />
+      </Box>
+    </Grommet>
+  );
+};
+
+if (!isChromatic()) {
+  storiesOf('TypeScript/Menu', module).add('Themed', () => <App />);
+}

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1,6 +1,9 @@
 import { 
   BackgroundType, 
   BorderType,
+  BreakpointBorderSize,
+  BreakpointEdgeSize,
+  BreakpointSize,
   ColorType,  
   DeepReadonly, 
   GapType,
@@ -96,38 +99,27 @@ export interface ThemeType {
     breakpoints?: {
       small?: {
         value?: number;
-        borderSize?: {
-          xsmall?: string;
-          small?: string;
-          medium?: string;
-          large?: string;
-          xlarge?: string;
-        };
-        edgeSize?: {
-          none?: string;
-          hair?: string;
-          xxsmall?: string;
-          xsmall?: string;
-          small?: string;
-          medium?: string;
-          large?: string;
-          xlarge?: string;
-        };
-        size?: {
-          xxsmall?: string;
-          xsmall?: string;
-          small?: string;
-          medium?: string;
-          large?: string;
-          xlarge?: string;
-          full?: string;
-        };
+        borderSize?: BreakpointBorderSize;
+        edgeSize?: BreakpointEdgeSize;
+        size?: BreakpointSize;
       };
       medium?: {
         value?: number;
+        borderSize?: BreakpointBorderSize;
+        edgeSize?: BreakpointEdgeSize;
+        size?: BreakpointSize;
       };
       large?: {
         value?: number;
+        borderSize?: BreakpointBorderSize;
+        edgeSize?: BreakpointEdgeSize;
+        size?: BreakpointSize;
+      };
+      [x: string]: {    
+        value?: number;
+        borderSize?: BreakpointBorderSize;
+        edgeSize?: BreakpointEdgeSize;
+        size?: BreakpointSize;
       };
     };
     deviceBreakpoints?: {

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -62,3 +62,35 @@ export type PadType = EdgeType;
 export type PlaceHolderType = string | JSX.Element | React.ReactNode;
 export type RoundType = boolean | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | string | {corner?: "top" | "left" | "bottom" | "right" | "top-left" | "top-right" | "bottom-left" | "bottom-right",size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string};
 export type TextAlignType = "start" | "center" | "end";
+
+declare const breakpointEdgeSize: {
+  none?: string;
+  hair?: string;
+  xxsmall?: string;
+  xsmall?: string;
+  small?: string;
+  medium?: string;
+  large?: string;
+  xlarge?: string;
+};
+export type BreakpointEdgeSize = typeof breakpointEdgeSize;
+
+declare const breakpointBorderSize: {
+    xsmall?: string;
+    small?: string;
+    medium?: string;
+    large?: string;
+    xlarge?: string;
+}
+export type BreakpointBorderSize = typeof breakpointBorderSize;
+
+declare const breakpointSize: {          
+  xxsmall?: string;
+  xsmall?: string;
+  small?: string;
+  medium?: string;
+  large?: string;
+  xlarge?: string;
+  full?: string;
+};
+export type BreakpointSize = typeof breakpointSize;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Added missing breakpoint types on ThemeType
#### Where should the reviewer start?
base.d.ts
#### What testing has been done on this PR?
run build for typescript with newly added story that reproduces the issue
#### How should this be manually tested?
running ts build on the new story
#### Any background context you want to provide?
The fix on Responsive.js story was something I caught along the way.

#### What are the relevant issues?
fixes #3787 
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/6320236/75469941-18b39e80-594d-11ea-8b98-6a959a7cd538.png)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes as a bug fix on TS
#### Is this change backwards compatible or is it a breaking change?
backwards compatible