### PR TITLE
Test that checked if layer component unmounts from DOM

### DIFF
--- a/src/js/components/Layer/__tests__/Layer-test.js
+++ b/src/js/components/Layer/__tests__/Layer-test.js
@@ -8,6 +8,18 @@ import { createPortal, expectPortal } from '../../../utils/portal';
 import { Grommet, Box, Layer } from '../..';
 import { LayerContainer } from '../LayerContainer';
 
+const SimpleLayer = () => {
+  const [showLayer, setShowLayer] = React.useState(true);
+
+  React.useEffect(() => setShowLayer(false), []);
+
+  let layer;
+  if (showLayer) {
+    layer = <Layer data-testid="test-dom-removal">This is a test</Layer>;
+  }
+  return <Box>{layer}</Box>;
+};
+
 const FakeLayer = ({ children, dataTestid }) => {
   const [showLayer, setShowLayer] = React.useState(false);
 
@@ -262,5 +274,15 @@ describe('Layer', () => {
       </Grommet>,
     );
     expectPortal('target-test').toMatchSnapshot();
+  });
+  test('unmounts from dom', () => {
+    render(
+      <Grommet>
+        <SimpleLayer />
+      </Grommet>,
+    );
+    setTimeout(() => {
+      expect(queryByTestId(document, 'test-dom-removal')).toBeNull();
+    }, 1000);
   });
 });


### PR DESCRIPTION
#### What does this PR do?
Adds a test that checks if layer unmounts from dom

#### Where should the reviewer start?
Final test in Layer-test.js

#### What testing has been done on this PR?
Checked if test fails if layer is not unmounted

#### How should this be manually tested?
Can change the setShowLayer from true to false in SimpleLayer component.

#### What are the relevant issues?
None

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
backwards compatible