### PR TITLE
fix(MaskedInput): set nextValue as event's value in onChangeInput

### DIFF
--- a/src/js/components/MaskedInput/MaskedInput.js
+++ b/src/js/components/MaskedInput/MaskedInput.js
@@ -203,9 +203,14 @@ const MaskedInput = forwardRef(
         // Align with the mask.
         const nextValueParts = parseValue(mask, event.target.value);
         const nextValue = nextValueParts.map(part => part.part).join('');
-        if (value !== nextValue) setInputValue(nextValue);
-        if (onChange) onChange(event);
-        setValue(nextValue);
+        // eslint-disable-next-line no-param-reassign
+        event.target.value = nextValue;
+
+        if (value !== nextValue) {
+          setInputValue(nextValue);
+          if (onChange) onChange(event);
+          setValue(nextValue);
+        }
       },
       [mask, onChange, setInputValue, setValue, value],
     );

--- a/src/js/components/MaskedInput/MaskedInput.js
+++ b/src/js/components/MaskedInput/MaskedInput.js
@@ -203,8 +203,6 @@ const MaskedInput = forwardRef(
         // Align with the mask.
         const nextValueParts = parseValue(mask, event.target.value);
         const nextValue = nextValueParts.map(part => part.part).join('');
-        // eslint-disable-next-line no-param-reassign
-        event.target.value = nextValue;
 
         if (value !== nextValue) {
           setInputValue(nextValue);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR fixes a bug in `MaskedInput` where a user can input a value that doesn't match the mask given for the input.

For example, if a mask was given for a date (dd-mm-yyyy) https://storybook.grommet.io/?path=/story/maskedinput--date, the user could input 01-01-19999, which is one character too many for the mask to be valid.

The issue is because the event given to the onChange function is the original change event from the user typing into the input. The `event.target.value` doesn't reflect the validation and masking done by `parseValue`. `onChange` does fire an event with the updated text on the input ref, but then also calls the `onChange` prop provided with the old event which doesn't have the updated input value.

This updates `event.target.value` with the `nextValue` build by `parseValue`.
https://github.com/grommet/grommet/blob/master/src/js/components/MaskedInput/MaskedInput.js#L207 

#### Where should the reviewer start?

src/js/components/MaskedInput/MaskedInput.js

#### What testing has been done on this PR?

I've tested this manually

#### How should this be manually tested?

Going to http://localhost:9001/?path=/story/maskedinput--date on this branch's storybook and trying to enter a year on the Date story larger than 4 digits

#### Any background context you want to provide?
So mutating the `event.target.value` seems to do the trick, but if you have other ideas about how to accomplish I'm totally open to hearing those out!

#### What are the relevant issues?

#3807 

#### Screenshots (if appropriate)

Master:
![2020-02-29 17 19 12](https://user-images.githubusercontent.com/2539016/75618086-b362d780-5b1d-11ea-8ad6-e8a3a01a561d.gif)

This branch:
![2020-02-29 18 01 18](https://user-images.githubusercontent.com/2539016/75618088-b9f14f00-5b1d-11ea-9a93-b6bc2d36cc40.gif)

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

If you think that'd be useful

#### Is this change backwards compatible or is it a breaking change?

It's backwards compatible