### PR TITLE
Update Meter test to fix console warning

### DIFF
--- a/src/js/components/Meter/__tests__/Meter-test.js
+++ b/src/js/components/Meter/__tests__/Meter-test.js
@@ -128,7 +128,7 @@ describe('Meter', () => {
           values={VALUES}
         />
         <Meter
-          background={{ color: 'light-3', opacity: '0.2' }}
+          background={{ color: 'light-3', opacity: 0.2 }}
           values={VALUES}
         />
       </Grommet>,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changes Meter test to use 0.2 instead of '0.2' for opacity of background. The test should check that opacity accepts a number. This removes the console warning.

#### Where should the reviewer start?
src/js/components/Meter/__tests__/Meter-test.js

#### What testing has been done on this PR?
Tests have been updated and no warning was printed to the console.

#### How should this be manually tested?
yarn test-update

#### Any background context you want to provide?
A console warning was being printed since '0.2' (as a string) is not a valid value for opacity.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.