### PR TITLE
Changed FormField to allow react nodes for help, error, and info

### DIFF
--- a/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
@@ -673,6 +673,14 @@ exports[`Form validate 2`] = `
 
 }
 
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
 <span
   class="c0"
 >
@@ -681,8 +689,38 @@ exports[`Form validate 2`] = `
 `;
 
 exports[`Form validate 3`] = `
+.c0 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #FF4040;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
 <span
-  class="StyledText-sc-1sadyjn-0 keDfiS"
+  class="c0"
 >
   status error
 </span>
@@ -697,6 +735,14 @@ exports[`Form validate 4`] = `
   font-size: 18px;
   line-height: 24px;
   color: #666666;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/Form/stories/ValidateOnBlur.js
+++ b/src/js/components/Form/stories/ValidateOnBlur.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import { Box, Button, Grommet, Form, FormField, TextInput } from 'grommet';
+import { StatusGood } from 'grommet-icons';
 import { grommet } from 'grommet/themes';
 
 const Example = () => (
@@ -21,6 +22,18 @@ const Example = () => (
               { regexp: /^[a-z]/i },
               name => {
                 if (name && name.length === 1) return 'must be >1 character';
+                return undefined;
+              },
+              name => {
+                if (name === 'good')
+                  return {
+                    message: (
+                      <Box align="end">
+                        <StatusGood />
+                      </Box>
+                    ),
+                    status: 'info',
+                  };
                 return undefined;
               },
             ]}

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -52,6 +52,14 @@ const FormFieldBox = styled(Box)`
   ${props => props.theme.formField && props.theme.formField.extend}
 `;
 
+const Message = ({ message, ...rest }) => {
+  if (message) {
+    if (typeof message === 'string') return <Text {...rest}>{message}</Text>;
+    return <Box {...rest}>{message}</Box>;
+  }
+  return null;
+};
+
 const FormField = forwardRef(
   (
     {
@@ -314,29 +322,14 @@ const FormField = forwardRef(
                 {label}
               </Text>
             )}
-            {help &&
-              (typeof help === 'string' ? (
-                <Text {...formField.help}>{help}</Text>
-              ) : (
-                <Box {...formField.help}>{help}</Box>
-              ))}
+            <Message message={help} {...formField.help} />
           </>
         ) : (
           undefined
         )}
         {contents}
-        {normalizedError &&
-          (typeof normalizedError === 'string' ? (
-            <Text {...formField.error}>{normalizedError}</Text>
-          ) : (
-            <Box {...formField.error}>{normalizedError}</Box>
-          ))}
-        {normalizedInfo &&
-          (typeof normalizedInfo === 'string' ? (
-            <Text {...formField.info}>{normalizedInfo}</Text>
-          ) : (
-            <Box {...formField.info}>{normalizedInfo}</Box>
-          ))}
+        <Message message={normalizedError} {...formField.error} />
+        <Message message={normalizedInfo} {...formField.info} />
       </FormFieldBox>
     );
   },

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -314,14 +314,29 @@ const FormField = forwardRef(
                 {label}
               </Text>
             )}
-            {help && <Text {...formField.help}>{help}</Text>}
+            {help &&
+              (typeof help === 'string' ? (
+                <Text {...formField.help}>{help}</Text>
+              ) : (
+                <Box {...formField.help}>{help}</Box>
+              ))}
           </>
         ) : (
           undefined
         )}
         {contents}
-        {normalizedError && <Text {...formField.error}>{normalizedError}</Text>}
-        {normalizedInfo && <Text {...formField.info}>{normalizedInfo}</Text>}
+        {normalizedError &&
+          (typeof normalizedError === 'string' ? (
+            <Text {...formField.error}>{normalizedError}</Text>
+          ) : (
+            <Box {...formField.error}>{normalizedError}</Box>
+          ))}
+        {normalizedInfo &&
+          (typeof normalizedInfo === 'string' ? (
+            <Text {...formField.info}>{normalizedInfo}</Text>
+          ) : (
+            <Box {...formField.info}>{normalizedInfo}</Box>
+          ))}
       </FormFieldBox>
     );
   },

--- a/src/js/components/FormField/README.md
+++ b/src/js/components/FormField/README.md
@@ -200,7 +200,9 @@ Validation rule when used within a grommet Form. Provide an object
 ```
 {
   regexp: object,
-  message: string,
+  message: 
+    string
+    node,
   status: 
     error
     info
@@ -209,7 +211,9 @@ function
 [
   {
     regexp: object,
-    message: string,
+    message: 
+      string
+      node,
     status: 
       error
       info

--- a/src/js/components/FormField/doc.js
+++ b/src/js/components/FormField/doc.js
@@ -58,7 +58,7 @@ export const doc = FormField => {
     validate: PropTypes.oneOfType([
       PropTypes.shape({
         regexp: PropTypes.object, // regular expression
-        message: PropTypes.string,
+        message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
         status: PropTypes.oneOf(['error', 'info']),
       }),
       PropTypes.func,
@@ -66,7 +66,7 @@ export const doc = FormField => {
         PropTypes.oneOfType([
           PropTypes.shape({
             regexp: PropTypes.object, // regular expression
-            message: PropTypes.string,
+            message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
             status: PropTypes.oneOf(['error', 'info']),
           }),
           PropTypes.func,

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5999,7 +5999,9 @@ Validation rule when used within a grommet Form. Provide an object
 \`\`\`
 {
   regexp: object,
-  message: string,
+  message: 
+    string
+    node,
   status: 
     error
     info
@@ -6008,7 +6010,9 @@ function
 [
   {
     regexp: object,
-    message: string,
+    message: 
+      string
+      node,
     status: 
       error
       info

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2472,7 +2472,9 @@ string",
       and 'status' properties.",
         "format": "{
   regexp: object,
-  message: string,
+  message: 
+    string
+    node,
   status: 
     error
     info
@@ -2481,7 +2483,9 @@ function
 [
   {
     regexp: object,
-    message: string,
+    message: 
+      string
+      node,
     status: 
       error
       info


### PR DESCRIPTION
#### What does this PR do?

Changed FormField to allow react nodes for help, error, and info

#### Where should the reviewer start?

FormField/doc.js

#### What testing has been done on this PR?

Form -> Validate on Blur story

#### How should this be manually tested?

storybook

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
