### PR TITLE
Fix Storybook TypeScript errors

### DIFF
--- a/src/js/components/List/stories/typescript/selected.tsx
+++ b/src/js/components/List/stories/typescript/selected.tsx
@@ -5,30 +5,28 @@ import isChromatic from 'storybook-chromatic/isChromatic';
 import { Grommet, Box, List } from 'grommet';
 import { grommet } from 'grommet/themes';
 
-
 export const locations = [
-    'Boise',
-    'Fort Collins',
-    'Los Gatos',
-    'Palo Alto',
-    'San Francisco',
-  ];
-  
-  export const data = [];
-  
-  for (let i = 0; i < 40; i += 1) {
-    data.push({
-      entry: `entry-${i + 1}`,
-      location: locations[i % locations.length],
-      date: `2018-07-${(i % 30) + 1}`,
-      percent: (i % 11) * 10,
-      paid: ((i + 1) * 17) % 1000,
-    });
-  }
-  
+  'Boise',
+  'Fort Collins',
+  'Los Gatos',
+  'Palo Alto',
+  'San Francisco',
+];
+
+export const data = [];
+
+for (let i = 0; i < 40; i += 1) {
+  data.push({
+    entry: `entry-${i + 1}`,
+    location: locations[i % locations.length],
+    date: `2018-07-${(i % 30) + 1}`,
+    percent: (i % 11) * 10,
+    paid: ((i + 1) * 17) % 1000,
+  });
+}
 
 const SelectedItem = () => {
-  const [selected, setSelected] = React.useState();
+  const [selected, setSelected] = React.useState(undefined);
 
   return (
     <Grommet theme={grommet}>
@@ -36,7 +34,9 @@ const SelectedItem = () => {
         <List
           data={data.slice(0, 10)}
           itemProps={
-            selected >= 0 ? { [selected]: { background: 'accent-1' } } : undefined
+            selected >= 0
+              ? { [selected]: { background: 'accent-1' } }
+              : undefined
           }
           onClickItem={event =>
             setSelected(selected === event.index ? undefined : event.index)
@@ -48,5 +48,7 @@ const SelectedItem = () => {
 };
 
 if (!isChromatic()) {
-    storiesOf('TypeScript/List', module).add('selectedItem', () => <SelectedItem />);
-  }
+  storiesOf('TypeScript/List', module).add('selectedItem', () => (
+    <SelectedItem />
+  ));
+}

--- a/src/js/components/Meter/stories/typescript/MultipleValues.tsx
+++ b/src/js/components/Meter/stories/typescript/MultipleValues.tsx
@@ -7,8 +7,8 @@ import { grommet } from 'grommet/themes';
 
 const MultipleValues = () => {
   const total = 100;
-  const [active, setActive] = useState();
-  const [label, setLabel] = useState();
+  const [active, setActive] = useState(0);
+  const [label, setLabel] = useState('');
 
   return (
     <Grommet theme={grommet}>

--- a/src/js/components/Tabs/stories/typescript/Controlled.tsx
+++ b/src/js/components/Tabs/stories/typescript/Controlled.tsx
@@ -6,7 +6,7 @@ import { Box, Grommet, Tab, Tabs } from 'grommet';
 import { grommet } from 'grommet/themes';
 
 const ControlledTabs = () => {
-  const [index, setIndex] = React.useState();
+  const [index, setIndex] = React.useState(0);
 
   const onActive = (nextIndex: number) => setIndex(nextIndex);
 


### PR DESCRIPTION
When testing a different pull request, I encountered Storybook build failures due to TypeScript errors.

#### What does this PR do?
This pull request clears the errors and allows the build to finish and Storybook to be available in the browser. The errors are cleared by initializing `useState()` to something other than `undefined`.

#### Where should the reviewer start?
The `useState()` initialization in each of these files:

- `src/js/components/List/stories/typescript/selected.tsx`
- `src/js/components/Meter/stories/typescript/MultipleValues.tsx`
- `src/js/components/Tabs/stories/typescript/Controlled.tsx`

#### What testing has been done on this PR?
Storybook builds and components function as expected in the browser.

#### How should this be manually tested?
Storybook builds and List, Meter, and Tabs function in the browser.

#### Any background context you want to provide?
None.

#### What are the relevant issues?
None at the moment.

#### Screenshots (if appropriate)
Not available.

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No preference.

#### Is this change backwards compatible or is it a breaking change?
Not applicable.