### PR TITLE
Remove 'recompose' and 'fbjs' as dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "markdown-to-jsx": "^6.9.1",
     "polished": "^3.4.1",
     "prop-types": "^15.7.2",
-    "react-desc": "^4.1.2",
-    "recompose": "^0.30.0"
+    "react-desc": "^4.1.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",

--- a/src/js/components/Collapsible/Collapsible.js
+++ b/src/js/components/Collapsible/Collapsible.js
@@ -1,7 +1,8 @@
 import React, { createRef, Component } from 'react';
-import { compose } from 'recompose';
+
 import styled, { withTheme } from 'styled-components';
 
+import { compose } from '../../utils';
 import { defaultProps } from '../../default-props';
 
 import { Box } from '../Box';

--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { compose } from 'recompose';
 
 import { InfiniteScroll } from '../InfiniteScroll';
 import { TableRow } from '../TableRow';
 import { TableCell } from '../TableCell';
 import { Keyboard } from '../Keyboard';
 import { withFocus, withForwardRef } from '../hocs';
+import { compose } from '../../utils';
 
 import { Cell } from './Cell';
 import { StyledDataTableBody, StyledDataTableRow } from './StyledDataTable';

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -1,12 +1,11 @@
 import React from 'react';
-import { compose } from 'recompose';
 import styled, { withTheme } from 'styled-components';
 
 import { Box } from '../Box';
 import { InfiniteScroll } from '../InfiniteScroll';
 import { Keyboard } from '../Keyboard';
 import { Text } from '../Text';
-import { focusStyle, genericStyles } from '../../utils';
+import { focusStyle, genericStyles, compose } from '../../utils';
 import { withFocus, withForwardRef } from '../hocs';
 
 const StyledList = styled.ul`

--- a/src/js/components/Video/Video.js
+++ b/src/js/components/Video/Video.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
-import { compose } from 'recompose';
 
 import { withTheme } from 'styled-components';
 
+import { throttle, compose } from '../../utils';
 import { defaultProps } from '../../default-props';
 
 import { Box } from '../Box';
@@ -12,7 +12,6 @@ import { Meter } from '../Meter';
 import { Stack } from '../Stack';
 import { Text } from '../Text';
 import { withForwardRef } from '../hocs';
-import { throttle } from '../../utils';
 
 import {
   StyledVideo,
@@ -518,9 +517,6 @@ if (process.env.NODE_ENV !== 'production') {
   // eslint-disable-next-line global-require
   VideoDoc = require('./doc').doc(Video);
 }
-const VideoWrapper = compose(
-  withTheme,
-  withForwardRef,
-)(VideoDoc || Video);
+const VideoWrapper = compose(withTheme, withForwardRef)(VideoDoc || Video);
 
 export { VideoWrapper as Video };

--- a/src/js/components/hocs.js
+++ b/src/js/components/hocs.js
@@ -1,9 +1,9 @@
 /* eslint-disable react/no-multi-comp */
 import React, { Component } from 'react';
-import getDisplayName from 'recompose/getDisplayName';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { withTheme } from 'styled-components';
 import { AnnounceContext } from '../contexts';
+import { getDisplayName } from '../utils';
 
 export const withFocus = ({ focusWithMouse } = {}) => WrappedComponent => {
   class FocusableComponent extends Component {

--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -8,6 +8,7 @@ export * from './graphics';
 export * from './prop-types';
 export * from './styles';
 export * from './object';
+export * from './recompose';
 export * from './refs';
 export * from './responsive';
 export * from './router';

--- a/src/js/utils/recompose.js
+++ b/src/js/utils/recompose.js
@@ -1,0 +1,21 @@
+// Copied from Recompose (https://github.com/acdlite/recompose) under MIT license.
+// https://github.com/acdlite/recompose#readme
+// https://github.com/acdlite/recompose/pull/744
+
+export const compose = (...funcs) =>
+  funcs.reduce(
+    (a, b) => (...args) => a(b(...args)),
+    arg => arg,
+  );
+
+export const getDisplayName = Component => {
+  if (typeof Component === 'string') {
+    return Component;
+  }
+
+  if (!Component) {
+    return undefined;
+  }
+
+  return Component.displayName || Component.name || 'Component';
+};


### PR DESCRIPTION
Reasons are three-fold:

1. Package size of 'recompose' due to its dependency on 'fbjs' (see this [fixed but unreleased recompose issue](https://github.com/acdlite/recompose/issues/742))
2. 'recompose' is no longer maintained and Grommet only uses a tiny fraction of its functionality (see [repo message](https://github.com/acdlite/recompose#readme))
3. Grommet users see a 'corejs' deprecation warning on install due to this dependency tree:
```console
$ yarn install
...
warning grommet > recompose > fbjs > core-js@1.2.7: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
...
```

#### What does this PR do?
Copies the two functions that Grommet uses from 'recompose' into `src/js/utils` and removes the 'recompose' package as a production dependency in `package.json`.

#### Where should the reviewer start?
Verify the functions in `src/js/utils/recompose.js`. Then confirm that the `import` statements are correct.

#### What testing has been done on this PR?
Test suite passes and Storybook build and the functionality in the browser is as expected and unchanged from the release version.

#### How should this be manually tested?
Functionality of every component in the browser is unchanged and works as expected.

#### Any background context you want to provide?
See description above about the reasons.

#### What are the relevant issues?
None filed yet.

#### Screenshots (if appropriate)
Not available.

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Probably, since removing those dependencies might result in a bundle size reduction.

#### Is this change backwards compatible or is it a breaking change?
The change is backwards compatible and is non-breaking.