### PR TITLE
Changed Layer to enable target to work for non-modal layers

### DIFF
--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -20,6 +20,8 @@ const HiddenAnchor = styled.a`
   position: absolute;
 `;
 
+const fullBounds = { left: 0, right: 0, top: 0, bottom: 0 };
+
 const LayerContainer = forwardRef(
   (
     {
@@ -39,7 +41,7 @@ const LayerContainer = forwardRef(
     ref,
   ) => {
     const theme = useContext(ThemeContext);
-    const [targetBounds, setTargetBounds] = useState();
+    const [targetBounds, setTargetBounds] = useState(fullBounds);
     const anchorRef = useRef();
     const containerRef = useRef();
     const layerRef = useRef();
@@ -79,9 +81,9 @@ const LayerContainer = forwardRef(
           const rect = findVisibleParent(layerTarget).getBoundingClientRect();
           setTargetBounds({
             left: rect.left,
-            right: rect.right,
+            right: window.innerWidth - rect.right,
             top: rect.top,
-            bottom: rect.bottom,
+            bottom: window.innerHeight - rect.bottom,
           });
         };
 
@@ -89,6 +91,7 @@ const LayerContainer = forwardRef(
         window.addEventListener('resize', updateBounds);
         return () => window.removeEventListener('resize', updateBounds);
       }
+      setTargetBounds(fullBounds);
       return undefined;
     }, [layerTarget]);
 
@@ -99,6 +102,7 @@ const LayerContainer = forwardRef(
         full={full}
         margin={margin}
         modal={modal}
+        targetBounds={!modal ? targetBounds : fullBounds}
         {...rest}
         position={position}
         plain={plain}

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -1,6 +1,11 @@
 import styled, { css, keyframes } from 'styled-components';
 
-import { baseStyle, backgroundStyle, breakpointStyle } from '../../utils';
+import {
+  baseStyle,
+  backgroundStyle,
+  breakpointStyle,
+  parseMetricToNum,
+} from '../../utils';
 import { defaultProps } from '../../default-props';
 
 const hiddenPositionStyle = css`
@@ -44,8 +49,8 @@ const StyledLayer = styled.div`
         position: fixed;
         top: ${top}px;
         left: ${left}px;
-        right: ${window.innerWidth - right}px;
-        bottom: ${window.innerHeight - bottom}px;
+        right: ${right}px;
+        bottom: ${bottom}px;
       `);
     } else {
       styles.push(desktopLayerStyle);
@@ -94,25 +99,25 @@ const getMargin = (margin, theme, position) => {
   const marginInTheme = !!theme.global.edgeSize[marginValue];
 
   return !marginInTheme && typeof marginValue !== 'string'
-    ? '0px'
-    : marginApplied;
+    ? 0
+    : parseMetricToNum(marginApplied);
 };
 
-const MARGINS = (margin, theme, position = undefined) => {
+const getBounds = (bounds, margin, theme, position = undefined) => {
   if (position) {
-    return getMargin(margin, theme, position);
+    return bounds[position] + getMargin(margin, theme, position);
   }
   return {
-    bottom: getMargin(margin, theme, 'bottom'),
-    'bottom-left': getMargin(margin, theme, 'bottom-left'),
-    'bottom-right': getMargin(margin, theme, 'bottom-right'),
-    end: getMargin(margin, theme, 'end'),
-    left: getMargin(margin, theme, 'left'),
-    right: getMargin(margin, theme, 'right'),
-    start: getMargin(margin, theme, 'start'),
-    top: getMargin(margin, theme, 'top'),
-    'top-right': getMargin(margin, theme, 'top-right'),
-    'top-left': getMargin(margin, theme, 'top-left'),
+    bottom: bounds.bottom + getMargin(margin, theme, 'bottom'),
+    // 'bottom-left': getMargin(margin, theme, 'bottom-left'),
+    // 'bottom-right': getMargin(margin, theme, 'bottom-right'),
+    end: bounds.right + getMargin(margin, theme, 'end'),
+    left: bounds.left + getMargin(margin, theme, 'left'),
+    right: bounds.right + getMargin(margin, theme, 'right'),
+    start: bounds.left + getMargin(margin, theme, 'start'),
+    top: bounds.top + getMargin(margin, theme, 'top'),
+    // 'top-right': getMargin(margin, theme, 'top-right'),
+    // 'top-left': getMargin(margin, theme, 'top-left'),
   };
 };
 
@@ -272,25 +277,25 @@ const getAnimationStyle = (props, position, full) => {
 // as well so they must take into account the non-animated positioning.
 const POSITIONS = {
   center: {
-    vertical: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
+    vertical: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
       left: 50%;
       transform: translateX(-50%);
       ${props => getAnimationStyle(props, 'center', 'vertical')}
     `,
-    horizontal: margin => css`
-      left: ${margin.left};
-      right: ${margin.right};
+    horizontal: bounds => css`
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
       top: 50%;
       transform: translateY(-50%);
       ${props => getAnimationStyle(props, 'center', 'horizontal')}
     `,
-    true: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      left: ${margin.left};
-      right: ${margin.right};
+    true: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
       ${props => getAnimationStyle(props, 'center', 'true')}
     `,
     false: () => css`
@@ -302,30 +307,30 @@ const POSITIONS = {
   },
 
   top: {
-    vertical: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
+    vertical: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
       left: 50%;
       transform: translate(-50%, 0%);
       ${props => getAnimationStyle(props, 'top', 'vertical')}
     `,
-    horizontal: margin => css`
-      left: ${margin.left};
-      right: ${margin.right};
-      top: ${margin.top};
+    horizontal: bounds => css`
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
+      top: ${bounds.top}px;
       transform: translateY(0);
       ${props => getAnimationStyle(props, 'top', 'horizontal')}
     `,
-    true: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      left: ${margin.left};
-      right: ${margin.right};
+    true: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
       transform: translateY(0);
       ${props => getAnimationStyle(props, 'top', 'true')}
     `,
-    false: margin => css`
-      top: ${margin.top};
+    false: bounds => css`
+      top: ${bounds.top}px;
       left: 50%;
       transform: translate(-50%, 0);
       ${props => getAnimationStyle(props, 'top', 'false')}
@@ -333,30 +338,30 @@ const POSITIONS = {
   },
 
   bottom: {
-    vertical: margin => css`
-      top: ${margin.top}
-      bottom: ${margin.bottom};
+    vertical: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
       left: 50%;
       transform: translate(-50%, 0);
       ${props => getAnimationStyle(props, 'bottom', 'vertical')}
     `,
-    horizontal: margin => css`
-      left: ${margin.left};
-      right: ${margin.top};
-      bottom: ${margin.bottom};
+    horizontal: bounds => css`
+      left: ${bounds.left}px;
+      right: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
       transform: translateY(0);
       ${props => getAnimationStyle(props, 'bottom', 'horizontal')}
     `,
-    true: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      left: ${margin.left};
-      right: ${margin.right};
+    true: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
       transform: translateY(0);
       ${props => getAnimationStyle(props, 'bottom', 'true')}
     `,
-    false: margin => css`
-      bottom: ${margin.bottom};
+    false: bounds => css`
+      bottom: ${bounds.bottom}px;
       left: 50%;
       transform: translate(-50%, 0);
       ${props => getAnimationStyle(props, 'bottom', 'false')}
@@ -364,30 +369,30 @@ const POSITIONS = {
   },
 
   left: {
-    vertical: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      left: ${margin.left};
+    vertical: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      left: ${bounds.left}px;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'left', 'vertical')}
     `,
-    horizontal: margin => css`
-      left: ${margin.left};
-      right: ${margin.right};
+    horizontal: bounds => css`
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
       top: 50%;
       transform: translate(0, -50%);
       ${props => getAnimationStyle(props, 'left', 'horizontal')}
     `,
-    true: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      left: ${margin.left};
-      right: ${margin.right};
+    true: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'left', 'true')}
     `,
-    false: margin => css`
-      left: ${margin.left};
+    false: bounds => css`
+      left: ${bounds.left}px;
       top: 50%;
       transform: translate(0, -50%);
       ${props => getAnimationStyle(props, 'left', 'false')}
@@ -395,30 +400,30 @@ const POSITIONS = {
   },
 
   right: {
-    vertical: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      right: ${margin.right};
+    vertical: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      right: ${bounds.right}px;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'right', 'vertical')}
     `,
-    horizontal: margin => css`
-      left: ${margin.left};
-      right: ${margin.right};
+    horizontal: bounds => css`
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
       top: 50%;
       transform: translate(0, -50%);
       ${props => getAnimationStyle(props, 'right', 'horizontal')}
     `,
-    true: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      left: ${margin.left};
-      right: ${margin.right};
+    true: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'right', 'true')}
     `,
-    false: margin => css`
-      right: ${margin.right};
+    false: bounds => css`
+      right: ${bounds.right}px;
       top: 50%;
       transform: translate(0, -50%);
       ${props => getAnimationStyle(props, 'right', 'false')}
@@ -426,30 +431,30 @@ const POSITIONS = {
   },
 
   start: {
-    vertical: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      inset-inline-start: ${margin.start};
+    vertical: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      inset-inline-start: ${bounds.start}px;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'start', 'vertical')}
     `,
-    horizontal: margin => css`
-      inset-inline-start: ${margin.start};
-      inset-inline-end: ${margin.end};
+    horizontal: bounds => css`
+      inset-inline-start: ${bounds.start}px;
+      inset-inline-end: ${bounds.end}px;
       top: 50%;
       transform: translate(0, -50%);
       ${props => getAnimationStyle(props, 'start', 'horizontal')}
     `,
-    true: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      inset-inline-start: ${margin.start};
-      inset-inline-end: ${margin.end};
+    true: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      inset-inline-start: ${bounds.start}px;
+      inset-inline-end: ${bounds.end}px;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'start', 'true')}
     `,
-    false: margin => css`
-      inset-inline-start: ${margin.start};
+    false: bounds => css`
+      inset-inline-start: ${bounds.start}px;
       top: 50%;
       transform: translate(0, -50%);
       ${props => getAnimationStyle(props, 'start', 'false')}
@@ -457,30 +462,30 @@ const POSITIONS = {
   },
 
   end: {
-    vertical: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      inset-inline-end: ${margin.end};
+    vertical: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      inset-inline-end: ${bounds.end}px;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'end', 'vertical')}
     `,
-    horizontal: margin => css`
-      inset-inline-start: ${margin.start};
-      inset-inline-end: ${margin.end};
+    horizontal: bounds => css`
+      inset-inline-start: ${bounds.start}px;
+      inset-inline-end: ${bounds.end}px;
       top: 50%;
       transform: translate(0, -50%);
       ${props => getAnimationStyle(props, 'end', 'horizontal')}
     `,
-    true: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      inset-inline-start: ${margin.start};
-      inset-inline-end: ${margin.end};
+    true: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      inset-inline-start: ${bounds.start}px;
+      inset-inline-end: ${bounds.end}px;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'end', 'true')}
     `,
-    false: margin => css`
-      inset-inline-end: ${margin.end};
+    false: bounds => css`
+      inset-inline-end: ${bounds.end}px;
       top: 50%;
       transform: translate(0, -50%);
       ${props => getAnimationStyle(props, 'end', 'false')}
@@ -488,124 +493,124 @@ const POSITIONS = {
   },
 
   'top-right': {
-    vertical: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      right: ${margin.right};
+    vertical: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      right: ${bounds.right}px;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'top', 'true')};
     `,
-    horizontal: margin => css`
-      left: ${margin.left};
-      right: ${margin.right};
+    horizontal: bounds => css`
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
       top: 0;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'top', 'true')};
     `,
-    true: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      left: ${margin.left};
-      right: ${margin.right};
+    true: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'top', 'true')};
     `,
-    false: margin => css`
-      top: ${margin.top};
-      right: ${margin.right};
+    false: bounds => css`
+      top: ${bounds.top}px;
+      right: ${bounds.right}px;
       transform: translateY(0);
       ${props => getAnimationStyle(props, 'top', 'true')};
     `,
   },
 
   'top-left': {
-    vertical: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      left: ${margin.left};
+    vertical: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      left: ${bounds.left}px;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'top', 'true')}
     `,
-    horizontal: margin => css`
-      left: ${margin.left};
-      right: ${margin.right};
+    horizontal: bounds => css`
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
       top: 0;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'top', 'true')}
     `,
-    true: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      left: ${margin.left};
-      right: ${margin.right};
+    true: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'top', 'true')}
     `,
-    false: margin => css`
-      top: ${margin.top};
-      left: ${margin.left};
+    false: bounds => css`
+      top: ${bounds.top}px;
+      left: ${bounds.left}px;
       transform: translateY(0);
       ${props => getAnimationStyle(props, 'top', 'true')}
     `,
   },
 
   'bottom-right': {
-    vertical: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      right: ${margin.right};
+    vertical: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      right: ${bounds.right}px;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'bottom', 'true')}
     `,
-    horizontal: margin => css`
-      left: ${margin.left};
-      right: ${margin.right};
-      bottom: ${margin.bottom};
+    horizontal: bounds => css`
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
+      bottom: ${bounds.bottom}px;
       transform: translateY(0);
       ${props => getAnimationStyle(props, 'bottom', 'true')}
     `,
-    true: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      left: ${margin.left};
-      right: ${margin.right};
+    true: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'bottom', 'true')}
     `,
-    false: margin => css`
-      bottom: ${margin.bottom};
-      right: ${margin.right};
+    false: bounds => css`
+      bottom: ${bounds.bottom}px;
+      right: ${bounds.right}px;
       transform: translateY(0);
       ${props => getAnimationStyle(props, 'bottom', 'true')}
     `,
   },
 
   'bottom-left': {
-    vertical: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      left: ${margin.left};
+    vertical: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      left: ${bounds.left}px;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'bottom', 'true')}
     `,
-    horizontal: margin => css`
-      left: ${margin.left};
-      right: ${margin.right};
-      bottom: ${margin.bottom};
+    horizontal: bounds => css`
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
+      bottom: ${bounds.bottom}px;
       transform: translateY(0);
       ${props => getAnimationStyle(props, 'bottom', 'true')}
     `,
-    true: margin => css`
-      top: ${margin.top};
-      bottom: ${margin.bottom};
-      left: ${margin.left};
-      right: ${margin.right};
+    true: bounds => css`
+      top: ${bounds.top}px;
+      bottom: ${bounds.bottom}px;
+      left: ${bounds.left}px;
+      right: ${bounds.right}px;
       transform: translateX(0);
       ${props => getAnimationStyle(props, 'bottom', 'true')}
     `,
-    false: margin => css`
-      bottom: ${margin.bottom};
-      left: ${margin.left};
+    false: bounds => css`
+      bottom: ${bounds.bottom}px;
+      left: ${bounds.left}px;
       transform: translateY(0);
       ${props => getAnimationStyle(props, 'bottom', 'true')}
     `,
@@ -615,23 +620,36 @@ const POSITIONS = {
 const desktopContainerStyle = css`
   position: ${props => (props.modal ? 'absolute' : 'fixed')};
   max-height: ${props =>
-    `calc(100% - ${MARGINS(props.margin, props.theme, 'top')} - ${MARGINS(
+    `calc(100% - ${getBounds(
+      props.targetBounds,
+      props.margin,
+      props.theme,
+      'top',
+    )}px - ${getBounds(
+      props.targetBounds,
       props.margin,
       props.theme,
       'bottom',
-    )})`};
+    )}px)`};
   max-width: ${props =>
-    `calc(100% - ${MARGINS(props.margin, props.theme, 'left')} - ${MARGINS(
+    `calc(100% - ${getBounds(
+      props.targetBounds,
+      props.margin,
+      props.theme,
+      'left',
+    )}px - ${getBounds(
+      props.targetBounds,
       props.margin,
       props.theme,
       'right',
-    )})`};
+    )}px)`};
   border-radius: ${props =>
     props.plain ? 0 : props.theme.layer.border.radius};
   ${props =>
     (props.position !== 'hidden' &&
       POSITIONS[props.position][props.full](
-        MARGINS(props.margin, props.theme),
+        getBounds(props.targetBounds, props.margin, props.theme),
+        props.targetBounds,
       )) ||
     ''};
 `;

--- a/src/js/components/Layer/__tests__/Layer-test.js
+++ b/src/js/components/Layer/__tests__/Layer-test.js
@@ -275,6 +275,18 @@ describe('Layer', () => {
     );
     expectPortal('target-test').toMatchSnapshot();
   });
+
+  test('target not modal', () => {
+    render(
+      <Grommet>
+        <TargetLayer id="target-test" modal={false}>
+          This layer has a target
+        </TargetLayer>
+      </Grommet>,
+    );
+    expectPortal('target-test').toMatchSnapshot();
+  });
+
   test('unmounts from dom', () => {
     render(
       <Grommet>

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -124,7 +124,7 @@ exports[`Layer animation fadeIn 1`] = `
 `;
 
 exports[`Layer animation fadeIn 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -145,7 +145,7 @@ exports[`Layer animation fadeIn 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -302,7 +302,7 @@ exports[`Layer animation false 1`] = `
 `;
 
 exports[`Layer animation false 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -323,7 +323,7 @@ exports[`Layer animation false 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -482,7 +482,7 @@ exports[`Layer animation slide 1`] = `
 `;
 
 exports[`Layer animation slide 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -503,7 +503,7 @@ exports[`Layer animation slide 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -662,7 +662,7 @@ exports[`Layer animation true 1`] = `
 `;
 
 exports[`Layer animation true 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -683,7 +683,7 @@ exports[`Layer animation true 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -842,7 +842,7 @@ exports[`Layer custom margin 1`] = `
 `;
 
 exports[`Layer custom margin 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -863,7 +863,7 @@ exports[`Layer custom margin 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -975,7 +975,7 @@ exports[`Layer dark context 1`] = `
 
 exports[`Layer dark context 2`] = `
 "@media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -1210,7 +1210,7 @@ exports[`Layer full false 1`] = `
 `;
 
 exports[`Layer full false 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1231,7 +1231,7 @@ exports[`Layer full false 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -1391,7 +1391,7 @@ exports[`Layer full horizontal 1`] = `
 `;
 
 exports[`Layer full horizontal 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1412,7 +1412,7 @@ exports[`Layer full horizontal 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -1570,7 +1570,7 @@ exports[`Layer full true 1`] = `
 `;
 
 exports[`Layer full true 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1591,7 +1591,7 @@ exports[`Layer full true 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -1751,7 +1751,7 @@ exports[`Layer full vertical 1`] = `
 `;
 
 exports[`Layer full vertical 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1772,7 +1772,7 @@ exports[`Layer full vertical 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -1915,7 +1915,7 @@ exports[`Layer hidden 1`] = `
 
 exports[`Layer hidden 2`] = `
 "@media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -1952,7 +1952,7 @@ exports[`Layer hidden 2`] = `
 
 exports[`Layer hidden 3`] = `
 <div
-  class="StyledLayer-rmtehz-0 jbCjtc"
+  class="StyledLayer-rmtehz-0 XIVyE"
   id="hidden-test"
   tabindex="-1"
 >
@@ -1974,7 +1974,7 @@ exports[`Layer hidden 3`] = `
 `;
 
 exports[`Layer hidden 4`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1995,7 +1995,7 @@ exports[`Layer hidden 4`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -2211,7 +2211,7 @@ exports[`Layer margin large 1`] = `
 `;
 
 exports[`Layer margin large 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2232,7 +2232,7 @@ exports[`Layer margin large 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -2391,7 +2391,7 @@ exports[`Layer margin medium 1`] = `
 `;
 
 exports[`Layer margin medium 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2412,7 +2412,7 @@ exports[`Layer margin medium 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -2571,7 +2571,7 @@ exports[`Layer margin none 1`] = `
 `;
 
 exports[`Layer margin none 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2592,7 +2592,7 @@ exports[`Layer margin none 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -2751,7 +2751,7 @@ exports[`Layer margin small 1`] = `
 `;
 
 exports[`Layer margin small 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2772,7 +2772,7 @@ exports[`Layer margin small 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -2931,7 +2931,7 @@ exports[`Layer margin xsmall 1`] = `
 `;
 
 exports[`Layer margin xsmall 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2952,7 +2952,7 @@ exports[`Layer margin xsmall 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -3064,7 +3064,7 @@ exports[`Layer non-modal 1`] = `
 
 exports[`Layer non-modal 2`] = `
 "@media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -3302,7 +3302,7 @@ exports[`Layer plain 1`] = `
 `;
 
 exports[`Layer plain 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3323,7 +3323,7 @@ exports[`Layer plain 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -3482,7 +3482,7 @@ exports[`Layer position bottom 1`] = `
 `;
 
 exports[`Layer position bottom 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3503,7 +3503,7 @@ exports[`Layer position bottom 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -3662,7 +3662,7 @@ exports[`Layer position center 1`] = `
 `;
 
 exports[`Layer position center 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3683,7 +3683,7 @@ exports[`Layer position center 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -3842,7 +3842,7 @@ exports[`Layer position end 1`] = `
 `;
 
 exports[`Layer position end 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3863,7 +3863,7 @@ exports[`Layer position end 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -4022,7 +4022,7 @@ exports[`Layer position left 1`] = `
 `;
 
 exports[`Layer position left 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4043,7 +4043,7 @@ exports[`Layer position left 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -4202,7 +4202,7 @@ exports[`Layer position right 1`] = `
 `;
 
 exports[`Layer position right 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4223,7 +4223,7 @@ exports[`Layer position right 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -4382,7 +4382,7 @@ exports[`Layer position start 1`] = `
 `;
 
 exports[`Layer position start 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4403,7 +4403,7 @@ exports[`Layer position start 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -4562,7 +4562,7 @@ exports[`Layer position top 1`] = `
 `;
 
 exports[`Layer position top 2`] = `
-".jbCjtc {
+".XIVyE {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4583,7 +4583,7 @@ exports[`Layer position top 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -4747,7 +4747,123 @@ exports[`Layer target 1`] = `
 
 exports[`Layer target 2`] = `
 "@media only screen and (max-width:768px) {
-  .jbCjtc {
+  .XIVyE {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    min-height: 100vh;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .bnUvKb {
+    position: relative;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .ckZaHQ {
+    position: relative;
+    max-height: none;
+    max-width: none;
+    border-radius: 0;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    -webkit-transform: none;
+    -ms-transform: none;
+    transform: none;
+    -webkit-animation: none;
+    animation: none;
+    height: 100vh;
+    width: 100vw;
+  }
+}"
+`;
+
+exports[`Layer target not modal 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-height: 48px;
+  background: #FFFFFF;
+  color: #444444;
+  outline: none;
+  pointer-events: all;
+  z-index: 15;
+  position: fixed;
+  max-height: calc(100% - 0px - 768px);
+  max-width: calc(100% - 0px - 1024px);
+  border-radius: 4px;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+  -webkit-animation: hWAzxx 0.2s ease-in-out forwards;
+  animation: hWAzxx 0.2s ease-in-out forwards;
+}
+
+.c1 {
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c0 {
+    position: relative;
+    max-height: none;
+    max-width: none;
+    border-radius: 0;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    -webkit-transform: none;
+    -ms-transform: none;
+    transform: none;
+    -webkit-animation: none;
+    animation: none;
+    height: 100vh;
+    width: 100vw;
+  }
+}
+
+<div
+  class="c0"
+  id="target-test"
+>
+  <a
+    aria-hidden="true"
+    class="c1"
+    tabindex="-1"
+  />
+  this is a test layer
+</div>
+`;
+
+exports[`Layer target not modal 2`] = `
+"@media only screen and (max-width:768px) {
+  .XIVyE {
     position: absolute;
     width: 100%;
     height: 100%;

--- a/src/js/components/Layer/stories/Target.js
+++ b/src/js/components/Layer/stories/Target.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { Box, Button, Grid, Grommet, Layer, Select } from 'grommet';
+import { Box, Button, CheckBox, Grid, Grommet, Layer, Select } from 'grommet';
 import { grommet } from 'grommet/themes';
 
 const positions = ['left', 'right', 'top', 'bottom', 'center'];
@@ -8,6 +8,7 @@ const positions = ['left', 'right', 'top', 'bottom', 'center'];
 const TargetLayer = () => {
   const [open, setOpen] = React.useState();
   const [gutter, setGutter] = React.useState('small');
+  const [modal, setModal] = React.useState(true);
   const [position, setPosition] = React.useState(positions[0]);
   React.useEffect(() => {
     window.dispatchEvent(new Event('resize'));
@@ -39,14 +40,20 @@ const TargetLayer = () => {
             value={position}
             onChange={({ option }) => setPosition(option)}
           />
+          <CheckBox
+            toggle
+            label="modal"
+            checked={modal}
+            onChange={() => setModal(!modal)}
+          />
           <Button label="Open" onClick={onOpen} />
         </Box>
       </Grid>
       {open && (
         <Layer
+          modal={modal}
           position={position}
           target={ref.current}
-          modal
           onClickOutside={onClose}
           onEsc={onClose}
         >


### PR DESCRIPTION
#### What does this PR do?

Changed Layer to enable target to work for non-modal layers

#### Where should the reviewer start?

All of the interesting stuff is in StyledLayer.js
The key here is that we include the target bounds, which will be 0,0,0,0 for the window, when calculating the position for the Layer.

#### What testing has been done on this PR?

Added Layer -> Target story
add unit test

#### How should this be manually tested?

Layer -> Target story

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
