### PR TITLE
Fix type error in theme breakpoints field

### DIFF
--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -123,7 +123,7 @@ export interface ThemeType {
         borderSize?: BreakpointBorderSize;
         edgeSize?: BreakpointEdgeSize;
         size?: BreakpointSize;
-      };
+      } | undefined;
     };
     deviceBreakpoints?: {
       phone?: string;


### PR DESCRIPTION
Since the literal breakpoint fields are optional
(and can be undefined), the string index type has to be
optional as well.

This broke as part of https://github.com/grommet/grommet/pull/3793/files

Signed-off-by: Stevche Radevski <stevche@balena.io>

#### What does this PR do?
Fixes a typing error

#### Where should the reviewer start?
N/A

#### What testing has been done on this PR?
N/A

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
N/A

#### What are the relevant issues?
N/A

#### Screenshots (if appropriate)
N/A

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Yes