### PR TITLE
Changed Box to ensure background.dark forces color choice

### DIFF
--- a/src/js/components/Box/stories/Background.js
+++ b/src/js/components/Box/stories/Background.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import { Grommet, Box } from 'grommet';
+import { Grommet, Box, Text } from 'grommet';
 import { grommet } from '../../../themes';
 
 const BackgroundBox = () => (
@@ -47,6 +47,14 @@ const BackgroundBox = () => (
       <Box background="light-5" pad="medium">
         <Box background="#11111108" pad="small">
           low opacity on light background
+        </Box>
+      </Box>
+      <Box background={{ color: 'background', dark: true }} pad="medium">
+        <Text color="brand">force dark background</Text>
+      </Box>
+      <Box background="dark-1" pad="medium">
+        <Box background={{ color: 'background', dark: false }} pad="medium">
+          <Text color="brand">force light background</Text>
         </Box>
       </Box>
     </Box>

--- a/src/js/utils/background.js
+++ b/src/js/utils/background.js
@@ -86,7 +86,7 @@ export const backgroundStyle = (backgroundArg, theme, textColorArg) => {
       `);
     }
     if (background.color) {
-      const color = normalizeColor(background.color, theme);
+      const color = normalizeColor(background.color, theme, background.dark);
       const backgroundColor =
         getRGBA(
           color,

--- a/src/js/utils/colors.js
+++ b/src/js/utils/colors.js
@@ -1,4 +1,6 @@
-export const normalizeColor = (color, theme, forceDark) => {
+// Returns the specific color that should be used according to the theme.
+// If 'dark' is supplied, it takes precedence over 'theme.dark'.
+export const normalizeColor = (color, theme, dark) => {
   const colorSpec =
     theme.global && theme.global.colors[color] !== undefined
       ? theme.global.colors[color]
@@ -7,12 +9,12 @@ export const normalizeColor = (color, theme, forceDark) => {
   let result = colorSpec;
   if (colorSpec) {
     if (
-      (forceDark === true || (forceDark === undefined && theme.dark)) &&
+      (dark === true || (dark === undefined && theme.dark)) &&
       colorSpec.dark !== undefined
     ) {
       result = colorSpec.dark;
     } else if (
-      (forceDark === false || !theme.dark) &&
+      (dark === false || !theme.dark) &&
       colorSpec.light !== undefined
     ) {
       result = colorSpec.light;

--- a/src/js/utils/colors.js
+++ b/src/js/utils/colors.js
@@ -1,4 +1,4 @@
-export const normalizeColor = (color, theme) => {
+export const normalizeColor = (color, theme, forceDark) => {
   const colorSpec =
     theme.global && theme.global.colors[color] !== undefined
       ? theme.global.colors[color]
@@ -6,9 +6,15 @@ export const normalizeColor = (color, theme) => {
   // If the color has a light or dark object, use that
   let result = colorSpec;
   if (colorSpec) {
-    if (theme.dark && colorSpec.dark !== undefined) {
+    if (
+      (forceDark === true || (forceDark === undefined && theme.dark)) &&
+      colorSpec.dark !== undefined
+    ) {
       result = colorSpec.dark;
-    } else if (!theme.dark && colorSpec.light !== undefined) {
+    } else if (
+      (forceDark === false || !theme.dark) &&
+      colorSpec.light !== undefined
+    ) {
       result = colorSpec.light;
     }
   }


### PR DESCRIPTION
#### What does this PR do?

Changed Box to ensure background.dark forces color choice.
When a background color name is used that has both dark and light variants, passing the `dark` sub-property now controls which variant is used. `<Box background={{ color: 'background', dark: true }} />`

#### Where should the reviewer start?

backgroundStyle() and normalizeColor()

#### What testing has been done on this PR?

Added two new examples in the Box -> Background story

#### How should this be manually tested?

Storybook Box -> Background

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
