### PR TITLE
Fix SSR with document referenced in Grommet render

### DIFF
--- a/src/js/components/Grommet/Grommet.js
+++ b/src/js/components/Grommet/Grommet.js
@@ -123,7 +123,9 @@ class Grommet extends Component {
     const {
       children,
       full,
-      containerTarget = document.body,
+      containerTarget = typeof document === 'object'
+        ? document.body
+        : undefined,
       ...rest
     } = this.props;
     delete rest.theme;


### PR DESCRIPTION
Signed-off-by: Brent Burgoyne <brent47@gmail.com>

#### What does this PR do?

Fixes broken SSR (#3914) caused by me referencing `document` in the `Grommet` render method in a previous commit.

#### What testing has been done on this PR?

I have tested this with a reproduced failing nextjs build and it is working now. I started to go down the rabbit whole of adding better SSR tests, but with `styled-components` i was running in to issues with having those tests in the same test suite/babel config as everything else so I bailed. It may be worth revisiting something like that in another commit. Maybe a separate jest suite with `environment: node` that just does a sanity check `ReactDOMServer.renderToString()`.

#### How should this be manually tested?

This can be tested with a basic nextjs build rendering `<Grommet>`. For some reason I wasn't able to reproduce the issue with gatsby.

#### Any background context you want to provide?

No

#### What are the relevant issues?

#3914

#### Screenshots (if appropriate)

N/A

#### Do the grommet docs need to be updated?

 No

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

Yes
