### PR TITLE
List with 'action' property generates a warning #3861 fix

### DIFF
--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -140,7 +140,9 @@ const List = React.forwardRef((props, ref) => {
 
             if (action) {
               content = [
-                <Box align="start">{content}</Box>,
+                <Box align="start" key={`actionContainer${index}`}>
+                  {content}
+                </Box>,
                 action(item, index),
               ];
               boxProps = {

--- a/src/js/components/List/stories/action.js
+++ b/src/js/components/List/stories/action.js
@@ -12,7 +12,8 @@ const ActionList = () => (
     <Box pad="large">
       <List
         data={data.slice(0, 10)}
-        action={(elem, index) => {
+        pad={{ left: 'small', right: 'none' }}
+        action={(item, index) => {
           return (
             <Menu
               key={index}

--- a/src/js/components/List/stories/action.js
+++ b/src/js/components/List/stories/action.js
@@ -12,10 +12,16 @@ const ActionList = () => (
     <Box pad="large">
       <List
         data={data.slice(0, 10)}
-        pad={{ left: 'small', right: 'none' }}
-        action={() => (
-          <Menu icon={<More />} hoverIndicator items={[{ label: 'one' }]} />
-        )}
+        action={(elem, index) => {
+          return (
+            <Menu
+              key={index}
+              icon={<More />}
+              hoverIndicator
+              items={[{ label: 'one' }]}
+            />
+          );
+        }}
       />
     </Box>
   </Grommet>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes issue #3861 where adding the action prop to a List component would generate the react unique key error. 

I added a key of actionContainer[index] the content when action is passed in. I did not simply make it index because a key must still be provided in the action prop; shown in the list storybook example.

Both need a unique key to get rid of the warning. This issue seems to have been around since, at least 2.9.
```
        action={(elem, index) => {
          return (
            <Menu
             // this is needed as well to prevent the error
              key={index}
              icon={<More />}
              hoverIndicator
              items={[{ label: 'one' }]}
            />
          );
        }}
      />
```

#### Where should the reviewer start?
List.js
```
if (action) {
              content = [
                //added key here
                <Box align="start" key={`actionContainer${index}`}>
                  {content}
                </Box>,
                action(item, index),
              ];
```
#### What testing has been done on this PR?
Tested in the List storybook example action.js

#### How should this be manually tested?
Same as above

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible