### PR TITLE
Changed Image to take `a11yTitle`

### DIFF
--- a/src/js/components/Image/Image.js
+++ b/src/js/components/Image/Image.js
@@ -4,6 +4,7 @@ import { withForwardRef } from '../hocs';
 import { StyledImage } from './StyledImage';
 
 const Image = ({
+  a11yTitle,
   fallback,
   forwardRef,
   onError,
@@ -24,6 +25,7 @@ const Image = ({
   };
   return (
     <StyledImage
+      aria-label={a11yTitle}
       {...rest}
       {...extraProps}
       ref={forwardRef}

--- a/src/js/components/Image/__tests__/Image-test.js
+++ b/src/js/components/Image/__tests__/Image-test.js
@@ -19,6 +19,16 @@ test('Image renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('Image renders with aria-label', () => {
+  const component = renderer.create(
+    <Grommet>
+      <Image a11yTitle="aria-label-text" src={SRC} />
+    </Grommet>,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('Image fit renders', () => {
   const component = renderer.create(
     <Grommet>

--- a/src/js/components/Image/__tests__/__snapshots__/Image-test.js.snap
+++ b/src/js/components/Image/__tests__/__snapshots__/Image-test.js.snap
@@ -253,3 +253,25 @@ exports[`Image renders 1`] = `
   />
 </div>
 `;
+
+exports[`Image renders with aria-label 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+  className="c0"
+>
+  <img
+    aria-label="aria-label-text"
+    className=""
+    src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
+  />
+</div>
+`;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Account for the `a11yTitle` prop that is already documented but not being fetched to aria-label.
#### Where should the reviewer start?

#### What testing has been done on this PR?
Added a test.
#### How should this be manually tested?
see the snapshot with the aria-label added.
#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #3930
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible