### PR TITLE
Changed propTypes of DataTable background

### DIFF
--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -136,12 +136,24 @@ string
 {
   header: 
     string
+    {
+      dark: string,
+      light: string
+    }
     [string],
   body: 
     string
+    {
+      dark: string,
+      light: string
+    }
     [string],
   footer: 
     string
+    {
+      dark: string,
+      light: string
+    }
     [string]
 }
 ```

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -23,6 +23,10 @@ const backgroundShape = {};
 parts.forEach(part => {
   backgroundShape[part] = PropTypes.oneOfType([
     PropTypes.string,
+    PropTypes.shape({
+      dark: PropTypes.string,
+      light: PropTypes.string,
+    }),
     PropTypes.arrayOf(PropTypes.string),
   ]);
 });

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4485,12 +4485,24 @@ string
 {
   header: 
     string
+    {
+      dark: string,
+      light: string
+    }
     [string],
   body: 
     string
+    {
+      dark: string,
+      light: string
+    }
     [string],
   footer: 
     string
+    {
+      dark: string,
+      light: string
+    }
     [string]
 }
 \`\`\`


### PR DESCRIPTION
Adding dark/light object support to DataTable PropTypes `background` prop.
Tested on 'Styled.js' story by injecting the example provided on #3937, it works as expected without a warning.

Fixes #3937 