### PR TITLE
Changed sort condition when resolving the icon on DataTable

### DIFF
--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -67,7 +67,7 @@ const Header = ({
                 sort &&
                 sort.property === property &&
                 theme.dataTable.icons[
-                  sort.ascending ? 'ascending' : 'descending'
+                  sort.direction !== 'asc' ? 'ascending' : 'descending'
                 ];
               content = (
                 <Button plain fill="vertical" onClick={onSort(property)}>

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -109,7 +109,7 @@ describe('DataTable', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('sort', () => {
+  test('sortable', () => {
     const { container, getByText } = render(
       <Grommet>
         <DataTable
@@ -525,5 +525,4 @@ describe('DataTable', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
   });
-
 });

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -6007,7 +6007,7 @@ exports[`DataTable search 2`] = `
 </div>
 `;
 
-exports[`DataTable sort 1`] = `
+exports[`DataTable sortable 1`] = `
 .c0 {
   font-size: 18px;
   line-height: 24px;
@@ -6245,7 +6245,7 @@ exports[`DataTable sort 1`] = `
 </div>
 `;
 
-exports[`DataTable sort 2`] = `
+exports[`DataTable sortable 2`] = `
 <div
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changed sort condition when resolving the icon on DataTable

#### What testing has been done on this PR?
before the fix, the sort icon on https://storybook.grommet.io/?path=/story/datatable--sort wasn't resolved properly, now it should work as expected.
Also tested the `sortable` examples on https://storybook.grommet.io/?path=/story/all--all to make sure they are not being impacted by this change, and it seems to work as expected as well.

#### What are the relevant issues?
fixes https://github.com/grommet/grommet/issues/3916

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yea
#### Is this change backwards compatible or is it a breaking change?
backwards compatible 