### PR TITLE
Refined Box gap of value 'none'

### DIFF
--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -83,7 +83,7 @@ const Box = forwardRef(
     }
 
     let contents = children;
-    if (gap) {
+    if (gap && gap !== 'none') {
       contents = [];
       let firstIndex;
       Children.forEach(children, (child, index) => {

--- a/src/js/components/Box/__tests__/Box-test.js
+++ b/src/js/components/Box/__tests__/Box-test.js
@@ -253,7 +253,7 @@ describe('Box', () => {
   test('gap', () => {
     const component = renderer.create(
       <Grommet>
-        {['xsmall', 'small', 'medium', 'large', '80px'].map(gap => (
+        {['xsmall', 'small', 'medium', 'large', '80px', 'none'].map(gap => (
           <Box key={gap} gap={gap} direction="row">
             <Box />
           </Box>

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -2639,6 +2639,13 @@ exports[`Box gap 1`] = `
       className="c2"
     />
   </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    />
+  </div>
 </div>
 `;
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Refined Box gap of value 'none' to not apply gap

#### What testing has been done on this PR?
Added a unit test.

#### What are the relevant issues?
fixes https://github.com/grommet/grommet/issues/3837

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible