### PR TITLE
Changed Form and FormContext to fix caret issues

### DIFF
--- a/src/js/components/Calendar/stories/Multiple.js
+++ b/src/js/components/Calendar/stories/Multiple.js
@@ -21,7 +21,7 @@ const Example = () => {
               nextDates.splice(index, 1);
             }
             setDates(nextDates);
-            console.log('!!! select', date, nextDates);
+            console.log('Select', date, nextDates);
           }}
           bounds={['2018-09-08', '2020-12-13']}
         />

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -346,28 +346,8 @@ exports[`CheckBox controlled 2`] = `
       <div
         class="StyledBox-sc-13pk1d4-0 lpqrQA StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
       >
-        .c0 {
-  box-sizing: border-box;
-  stroke-width: 4px;
-  stroke: #7D4CDB;
-  width: 24px;
-  height: 24px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-<svg
-          class="c0"
+        <svg
+          class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 gHRhNW"
           preserveAspectRatio="xMidYMid meet"
           viewBox="0 0 24 24"
         >

--- a/src/js/components/Form/Form.js
+++ b/src/js/components/Form/Form.js
@@ -157,42 +157,35 @@ const Form = forwardRef(
     // they can have access to it.
     //
     const useFormContext = (name, componentValue, initialValue) => {
+      const [contextValue, setContextValue] = useState(initialValue);
       const formValue = name ? value[name] : undefined;
-      const [contextValue, setContextValue] = useState(() => {
-        if (componentValue !== undefined) return componentValue;
-        if (valueProp) return formValue;
-        return initialValue;
-      });
+
       useEffect(() => {
-        if (componentValue !== undefined) {
-          // input controls value
-          if (componentValue !== contextValue) {
-            setContextValue(componentValue);
-            if (name && componentValue !== formValue)
-              update(name, componentValue);
-          } else if (name && formValue === undefined) {
-            update(name, componentValue, true);
-          }
-        } else if (name) {
-          if (valueProp) {
-            // Form controls value
-            if (formValue !== contextValue) {
-              setContextValue(formValue);
-            }
-          } else if (formValue === undefined) {
-            setContextValue(initialValue);
-          }
-        }
+        if (
+          name &&
+          componentValue !== undefined &&
+          componentValue !== formValue
+        )
+          // input drives
+          update(name, componentValue, formValue === undefined);
       }, [componentValue, contextValue, formValue, initialValue, name]);
 
+      let useValue;
+      if (componentValue !== undefined)
+        // input drives
+        useValue = componentValue;
+      else if (valueProp && name && formValue !== undefined)
+        // form drives
+        useValue = formValue;
+      else useValue = contextValue;
+
       return [
-        contextValue,
+        useValue,
         nextValue => {
-          // only set if the caller hasn't supplied a specific value
+          // only set if the input isn't driving
           if (componentValue === undefined) {
             if (name) update(name, nextValue);
-            if (valueProp || initialValue !== undefined)
-              setContextValue(nextValue);
+            if (initialValue !== undefined) setContextValue(nextValue);
           }
         },
       ];

--- a/src/js/components/Form/FormContext.js
+++ b/src/js/components/Form/FormContext.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 // When not a descendant of a Form, FormContext still provides a basic
 // useFormContext. It doesn't do anything for components like TextInput.
@@ -9,13 +9,8 @@ const useFormContext = (_, valueProp, initialValue) => {
   const [value, setValue] = useState(
     valueProp !== undefined ? valueProp : initialValue,
   );
-  useEffect(() => {
-    if (valueProp !== value && valueProp !== undefined) {
-      setValue(valueProp);
-    }
-  }, [value, valueProp]);
   return [
-    value,
+    valueProp !== undefined ? valueProp : value,
     nextValue => {
       if (initialValue !== undefined) setValue(nextValue);
     },

--- a/src/js/components/Form/__tests__/Form-test.js
+++ b/src/js/components/Form/__tests__/Form-test.js
@@ -478,7 +478,6 @@ describe('Form', () => {
     expect(onSubmit).toBeCalledWith(
       expect.objectContaining({
         value: { test: 'a' },
-        touched: { test: true },
       }),
     );
   });


### PR DESCRIPTION
#### What does this PR do?

Changed Form and FormContext to fix caret issues. The key problem was that the caret position would get reset to the end of the field when entering text in the middle of the field.

In general, this is a simpler approach to FormContext. Instead of trying to hold everything in the `contextValue` state, we only use that for uncontrolled situations when there is no `initialValue`. And, we pass the value to use by checking which source is correct when we pass it to the `useFormContext()` caller. This leaves the state wherever it should be controlled without introducing intermediate state.

#### Where should the reviewer start?

FormContext.js
Form.js useFormContext()

#### What testing has been done on this PR?

Storybook Form, Select, CheckBox, TextInput, etc.
Especially entering text from various caret positions.

#### How should this be manually tested?

Storybook Form flavors, entering text from various caret positions.

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
