### PR TITLE
Changed Menu to propagate dropProps

### DIFF
--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -238,6 +238,7 @@ const Menu = props => {
         disabled={disabled}
         dropAlign={align}
         dropTarget={dropTarget}
+        dropProps={dropProps}
         plain={plain}
         open={isOpen}
         onOpen={onDropOpen}

--- a/src/js/components/Menu/stories/Simple.js
+++ b/src/js/components/Menu/stories/Simple.js
@@ -8,7 +8,10 @@ const SimpleMenu = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
       <Menu
-        dropProps={{ align: { top: 'bottom', left: 'left' } }}
+        dropProps={{
+          align: { top: 'bottom', left: 'left' },
+          elevation: 'xlarge',
+        }}
         label="actions"
         items={[
           { label: 'Launch', onClick: () => {} },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changed Menu drop to propagate props
#### Where should the reviewer start?
Menu.js
#### What testing has been done on this PR?
storybook quick example on Simple
#### How should this be manually tested?
storybook Menu->Simple
#### Any background context you want to provide?
According to documentation https://v2.grommet.io/menu?#dropProps
Menu should be able to propagate dropProps, it currently only propagates the alignment.
#### What are the relevant issues?
fixes https://github.com/grommet/grommet/issues/3963
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible