### PR TITLE
[TS] - Changed docs and typescript for the open select control

### DIFF
--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -536,8 +536,8 @@ undefined
 
 **select.control.open**
 
-Any additional style for the control open state of the Select 
-component. Expects `object`.
+Any additional style for the Select DropButton when using the
+    controlled open state. Expects `string | object`.
 
 Defaults to
 

--- a/src/js/components/Select/doc.js
+++ b/src/js/components/Select/doc.js
@@ -250,9 +250,9 @@ export const themeDoc = {
     defaultValue: undefined,
   },
   'select.control.open': {
-    description: `Any additional style for the control open state of the Select 
-component.`,
-    type: 'object',
+    description: `Any additional style for the Select DropButton when using the
+    controlled open state.`,
+    type: 'string | object',
     defaultValue: undefined,
   },
   'select.control.extend': {

--- a/src/js/components/Select/stories/typescript/CreateOption.tsx
+++ b/src/js/components/Select/stories/typescript/CreateOption.tsx
@@ -4,7 +4,7 @@ import isChromatic from 'storybook-chromatic/isChromatic';
 import { FormDown, FormUp } from 'grommet-icons';
 
 import { Box, Grommet, Select } from 'grommet';
-import { grommet, ThemeType } from 'grommet/themes';
+import { ThemeType } from 'grommet/themes';
 
 // the prefix name of the Create option entry
 const prefix = 'Create';
@@ -12,6 +12,10 @@ const prefix = 'Create';
 const theme: ThemeType = {
   select: {
     control: {
+      open: {
+        background: '#ece0fa',
+        border: '1px solid #7D4CDB',
+      },
       extend: 'padding: 3px 6px;',
     },
     icons: {
@@ -55,9 +59,10 @@ const CreateOption = () => {
   const [searchValue, setSearchValue] = useState('');
 
   return (
-    <Grommet full theme={grommet}>
+    <Grommet full theme={theme}>
       <Box fill align="center" justify="start" pad="large">
         <Select
+          open
           size="medium"
           placeholder="Select"
           value={value}

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11121,8 +11121,8 @@ undefined
 
 **select.control.open**
 
-Any additional style for the control open state of the Select 
-component. Expects \`object\`.
+Any additional style for the Select DropButton when using the
+    controlled open state. Expects \`string | object\`.
 
 Defaults to
 

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -830,7 +830,7 @@ export interface ThemeType {
     };
     control?: {
       extend?: ExtendType;
-      open?: boolean;
+      open?: string | object;
     };
     extend?: ExtendType;
     icons?: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changed docs and typescript for the open select control
#### Where should the reviewer start?
bade.d.ts and doc.js
#### What testing has been done on this PR?
added the theme prop to tsx story
#### How should this be manually tested?
tsx story
#### Any background context you want to provide?
Noticed this problem when working on the Select component.
#### Do the grommet docs need to be updated?
Done
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible