### PR TITLE
Changed DropButton to fix an issue with function refs.

### DIFF
--- a/src/js/components/DropButton/DropButton.js
+++ b/src/js/components/DropButton/DropButton.js
@@ -1,13 +1,8 @@
-import React, {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { forwardRef, useCallback, useEffect, useState } from 'react';
 
 import { Button } from '../Button';
 import { Drop } from '../Drop';
+import { useForwardedRef } from '../../utils';
 
 const DropButton = forwardRef(
   (
@@ -27,6 +22,7 @@ const DropButton = forwardRef(
     },
     ref,
   ) => {
+    const buttonRef = useForwardedRef(ref);
     const [show, setShow] = useState();
     useEffect(() => {
       if (open !== undefined && open !== show) {
@@ -34,22 +30,20 @@ const DropButton = forwardRef(
       }
     }, [open, show]);
 
-    const buttonRef = useRef();
-
     const onDropClose = useCallback(
       event => {
         // if the user has clicked on our Button, don't do anything here,
         // handle that in onClickInternal() below.
         let node = event.target;
-        while (node !== document && node !== (ref || buttonRef).current) {
+        while (node !== document && node !== buttonRef.current) {
           node = node.parentNode;
         }
-        if (node !== (ref || buttonRef).current) {
+        if (node !== buttonRef.current) {
           setShow(false);
           if (onClose) onClose(event);
         }
       },
-      [onClose, ref],
+      [buttonRef, onClose],
     );
 
     const onClickInternal = useCallback(
@@ -70,18 +64,18 @@ const DropButton = forwardRef(
       <>
         <Button
           id={id}
-          ref={ref || buttonRef}
+          ref={buttonRef}
           a11yTitle={a11yTitle}
           disabled={disabled}
           {...rest}
           onClick={onClickInternal}
         />
-        {show && (ref || buttonRef).current && (
+        {show && buttonRef.current && (
           <Drop
             id={id ? `${id}__drop` : undefined}
             restrictFocus
             align={dropAlign}
-            target={dropTarget || (ref || buttonRef).current}
+            target={dropTarget || buttonRef.current}
             onClickOutside={onDropClose}
             onEsc={onDropClose}
             {...dropProps}

--- a/src/js/components/DropButton/__tests__/DropButton-test.js
+++ b/src/js/components/DropButton/__tests__/DropButton-test.js
@@ -104,4 +104,19 @@ describe('DropButton', () => {
     expect(container.firstChild).toMatchSnapshot();
     expectPortal('drop-contents').toMatchSnapshot();
   });
+
+  test('ref function', () => {
+    const ref = jest.fn();
+    const { container } = render(
+      <DropButton
+        ref={ref}
+        open
+        label="Dropper"
+        dropContent={<div id="drop-contents">Drop Contents</div>}
+      />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+    expect(ref).toBeCalled();
+    expectPortal('drop-contents').toMatchSnapshot();
+  });
 });

--- a/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
+++ b/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
@@ -294,3 +294,61 @@ exports[`DropButton opened ref 2`] = `
 `;
 
 exports[`DropButton opened ref 3`] = `""`;
+
+exports[`DropButton ref function 1`] = `
+.c0 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c0:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
+<button
+  aria-label="Open Drop"
+  class="c0"
+  type="button"
+>
+  Dropper
+</button>
+`;
+
+exports[`DropButton ref function 2`] = `
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
+<div
+  id="drop-contents"
+>
+  Drop Contents
+</div>
+`;
+
+exports[`DropButton ref function 3`] = `""`;

--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -8,6 +8,7 @@ export * from './graphics';
 export * from './prop-types';
 export * from './styles';
 export * from './object';
+export * from './refs';
 export * from './responsive';
 export * from './router';
 export * from './throttle';

--- a/src/js/utils/refs.js
+++ b/src/js/utils/refs.js
@@ -1,0 +1,17 @@
+import { useEffect, useRef } from 'react';
+
+// https://medium.com/the-non-traditional-developer/how-to-use-the-forwarded-ref-in-react-1fb108f4e6af
+export const useForwardedRef = ref => {
+  const innerRef = useRef(null);
+  useEffect(() => {
+    if (!ref) return;
+    if (typeof ref === 'function') {
+      ref(innerRef.current);
+    } else {
+      // eslint-disable-next-line no-param-reassign
+      ref.current = innerRef.current;
+    }
+  });
+
+  return innerRef;
+};


### PR DESCRIPTION
#### What does this PR do?

Changed DropButton to fix an issue with function refs.
This just fixes DropButton for now. We likely will need to switch to `useForwardedRef()` in other components as well.

#### Where should the reviewer start?

utils/refs.js

#### What testing has been done on this PR?

Added a unit test for this, verified that it failed before changing the code.
Whitebox tested Select -> Simple story too.

#### How should this be manually tested?

should be covered by unit test

#### What are the relevant issues?

fixes #3942

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
