### PR TITLE
Menudrop not receiving rtl from theme

### DIFF
--- a/src/js/components/Drop/Drop.js
+++ b/src/js/components/Drop/Drop.js
@@ -2,7 +2,7 @@ import React, { forwardRef, useEffect, useState, useContext } from 'react';
 import { createPortal } from 'react-dom';
 
 import { getNewContainer, setFocusWithoutScroll } from '../../utils';
-
+import { ThemeContext } from '../../contexts';
 import { DropContainer } from './DropContainer';
 import { ContainerTargetContext } from '../../contexts/ContainerTargetContext';
 
@@ -46,12 +46,17 @@ const Drop = forwardRef(
 
     return dropContainer
       ? createPortal(
-          <DropContainer
-            ref={ref}
-            dropTarget={dropTarget}
-            restrictFocus={restrictFocus}
-            {...rest}
-          />,
+          <ThemeContext.Consumer>
+            {theme => (
+              <DropContainer
+                ref={ref}
+                dir={theme && theme.dir}
+                dropTarget={dropTarget}
+                restrictFocus={restrictFocus}
+                {...rest}
+              />
+            )}
+          </ThemeContext.Consumer>,
           dropContainer,
         )
       : null;

--- a/src/js/components/Drop/Drop.js
+++ b/src/js/components/Drop/Drop.js
@@ -1,8 +1,9 @@
 import React, { forwardRef, useEffect, useState, useContext } from 'react';
 import { createPortal } from 'react-dom';
 
+import { ThemeContext } from 'styled-components';
+import { defaultProps } from '../../default-props';
 import { getNewContainer, setFocusWithoutScroll } from '../../utils';
-import { ThemeContext } from '../../contexts';
 import { DropContainer } from './DropContainer';
 import { ContainerTargetContext } from '../../contexts/ContainerTargetContext';
 
@@ -15,6 +16,7 @@ const Drop = forwardRef(
     },
     ref,
   ) => {
+    const theme = useContext(ThemeContext) || defaultProps.theme;
     const [originalFocusedElement, setOriginalFocusedElement] = useState();
     useEffect(() => setOriginalFocusedElement(document.activeElement), []);
     const [dropContainer, setDropContainer] = useState();
@@ -46,17 +48,13 @@ const Drop = forwardRef(
 
     return dropContainer
       ? createPortal(
-          <ThemeContext.Consumer>
-            {theme => (
-              <DropContainer
-                ref={ref}
-                dir={theme && theme.dir}
-                dropTarget={dropTarget}
-                restrictFocus={restrictFocus}
-                {...rest}
-              />
-            )}
-          </ThemeContext.Consumer>,
+          <DropContainer
+            ref={ref}
+            dir={theme && theme.dir}
+            dropTarget={dropTarget}
+            restrictFocus={restrictFocus}
+            {...rest}
+          />,
           dropContainer,
         )
       : null;


### PR DESCRIPTION
#### What does this PR do?
Fixes issue #3755 by adding ThemeContext.Consumer to drop js

#### Where should the reviewer start?
Drop.js
#### What testing has been done on this PR?
Tested on storybook and using the codesandbox example here.
https://codesandbox.io/s/frosty-hofstadter-rhqkd

#### How should this be manually tested?
Storybook and codesanbox is best

#### Any background context you want to provide?
I'm assume this issue is occuring because of createPortal(). The drop container is created outside of root, and misses out on some props that are passed into grommet.

#### What are the relevant issues?
#3755 

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Should be backwards compatible