### PR TITLE
Fix Preact compatibility

### DIFF
--- a/src/js/components/hocs.js
+++ b/src/js/components/hocs.js
@@ -152,7 +152,6 @@ export const withAnnounce = WrappedComponent => {
   ));
 
   ForwardRef.displayName = getDisplayName(WrappedComponent);
-  ForwardRef.name = ForwardRef.displayName;
   ForwardRef.defaultProps = WrappedComponent.defaultProps;
   hoistNonReactStatics(ForwardRef, WrappedComponent);
 

--- a/src/js/components/hocs.js
+++ b/src/js/components/hocs.js
@@ -122,7 +122,6 @@ export const withFocus = ({ focusWithMouse } = {}) => WrappedComponent => {
   ));
 
   ForwardRef.displayName = getDisplayName(WrappedComponent);
-  ForwardRef.name = ForwardRef.displayName;
   ForwardRef.defaultProps = WrappedComponent.defaultProps;
   hoistNonReactStatics(ForwardRef, WrappedComponent);
 
@@ -135,7 +134,6 @@ export const withForwardRef = WrappedComponent => {
   ));
 
   ForwardRefComponent.displayName = getDisplayName(WrappedComponent);
-  ForwardRefComponent.name = ForwardRefComponent.displayName;
   ForwardRefComponent.defaultProps = WrappedComponent.defaultProps;
   hoistNonReactStatics(ForwardRefComponent, WrappedComponent);
 


### PR DESCRIPTION
Fixes compatibility with Preact.

In Preact, the React compatibility layer returns a function instead of an object for `forwardRef()`. In `hocs.js`, Grommet attempts to set the name property of the return value of `forwardRef()`, causing an issue as `Function.prototype.name` is read-only.

#### What does this PR do?
Allows compatibility with Preact.

#### Where should the reviewer start?
`src/js/components/hocs.js`

#### What testing has been done on this PR?
Basic testing using a pre-existing application (just making sure it works at all).

#### How should this be manually tested?
Ensure it still works with React.

#### Any background context you want to provide?
There's no reason why `name` should be set in the first place, as basically the entire React ecosystem has settled on using `displayName` instead. Also, [React itself only uses `displayName` and never `name`.](https://reactjs.org/docs/react-component.html#displayname)

#### What are the relevant issues?
[preactjs/preact#2484](https://github.com/preactjs/preact/issues/2484)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
It is fully backwards compatible. Nothing significant has changed.