### PR TITLE
Allow Tab to accept icon and reverse

### DIFF
--- a/src/js/components/Tab/README.md
+++ b/src/js/components/Tab/README.md
@@ -10,9 +10,26 @@ import { Tab } from 'grommet';
 
 ## Properties
 
+**icon**
+
+Icon element to place in the tab.
+
+```
+element
+```
+
 **plain**
 
 Whether this is a plain tab with no style.
+
+```
+boolean
+```
+
+**reverse**
+
+Whether an icon and label should be reversed so that the icon is at the
+              end of the tab.
 
 ```
 boolean

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -16,11 +16,13 @@ import { StyledTab } from './StyledTab';
 const Tab = ({
   active,
   forwardRef,
+  icon,
   plain,
   title,
   onActivate,
   onMouseOver,
   onMouseOut,
+  reverse,
   theme,
   ...rest
 }) => {
@@ -86,6 +88,35 @@ const Tab = ({
     tabStyles.margin = theme.tab.margin;
   }
 
+  // needed to apply hover/active styles to the icon
+  const renderIcon = iconProp => {
+    if (active) {
+      return React.cloneElement(iconProp, {
+        ...theme.tab.active,
+      });
+    }
+    return React.cloneElement(iconProp, {
+      color: over ? theme.tab.hover.color : theme.tab.color,
+    });
+  };
+
+  let normalizedIcon;
+  if (icon) {
+    normalizedIcon = renderIcon(icon);
+  }
+
+  const first = reverse ? normalizedTitle : normalizedIcon;
+  const second = reverse ? normalizedIcon : normalizedTitle;
+
+  let withIconStyles;
+  if (first && second) {
+    withIconStyles = {
+      direction: 'row',
+      align: 'center',
+      justify: 'center',
+      gap: 'small',
+    };
+  }
   return (
     <Button
       ref={forwardRef}
@@ -100,8 +131,9 @@ const Tab = ({
       onFocus={onMouseOver}
       onBlur={onMouseOut}
     >
-      <StyledTab as={Box} plain={plain} {...tabStyles}>
-        {normalizedTitle}
+      <StyledTab as={Box} plain={plain} {...withIconStyles} {...tabStyles}>
+        {first}
+        {second}
       </StyledTab>
     </Button>
   );
@@ -114,9 +146,6 @@ let TabDoc;
 if (process.env.NODE_ENV !== 'production') {
   TabDoc = require('./doc').doc(Tab); // eslint-disable-line global-require
 }
-const TabWrapper = compose(
-  withTheme,
-  withForwardRef,
-)(TabDoc || Tab);
+const TabWrapper = compose(withTheme, withForwardRef)(TabDoc || Tab);
 
 export { TabWrapper as Tab };

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -1,144 +1,146 @@
-import React, { useState } from 'react';
-import { compose } from 'recompose';
-
-import { withTheme } from 'styled-components';
+import React, { forwardRef, useContext, useState } from 'react';
+import { ThemeContext } from 'styled-components';
 
 import { defaultProps } from '../../default-props';
 
 import { Box } from '../Box';
 import { Button } from '../Button';
 import { Text } from '../Text';
-import { withForwardRef } from '../hocs';
 import { normalizeColor } from '../../utils';
 
 import { StyledTab } from './StyledTab';
 
-const Tab = ({
-  active,
-  forwardRef,
-  icon,
-  plain,
-  title,
-  onActivate,
-  onMouseOver,
-  onMouseOut,
-  reverse,
-  theme,
-  ...rest
-}) => {
-  const [over, setOver] = useState(undefined);
-  let normalizedTitle = title;
-  const tabStyles = {};
+const Tab = forwardRef(
+  (
+    {
+      active,
+      icon,
+      plain,
+      title,
+      onActivate,
+      onMouseOver,
+      onMouseOut,
+      reverse,
+      ...rest
+    },
+    ref,
+  ) => {
+    const theme = useContext(ThemeContext) || defaultProps.theme;
+    const [over, setOver] = useState(undefined);
+    let normalizedTitle = title;
+    const tabStyles = {};
 
-  const onMouseOverTab = event => {
-    setOver(true);
-    if (onMouseOver) {
-      onMouseOver(event);
-    }
-  };
-
-  const onMouseOutTab = event => {
-    setOver(undefined);
-    if (onMouseOut) {
-      onMouseOut(event);
-    }
-  };
-
-  const onClickTab = event => {
-    if (event) {
-      event.preventDefault();
-    }
-    onActivate();
-  };
-
-  if (!plain) {
-    if (typeof title !== 'string') {
-      normalizedTitle = title;
-    } else if (active) {
-      normalizedTitle = <Text {...theme.tab.active}>{title}</Text>;
-    } else {
-      normalizedTitle = (
-        <Text color={over ? theme.tab.hover.color : theme.tab.color}>
-          {title}
-        </Text>
-      );
-    }
-
-    if (theme.tab.border) {
-      let borderColor =
-        theme.tab.border.color || theme.global.control.border.color;
-      if (active) {
-        borderColor = theme.tab.border.active.color || borderColor;
-      } else if (over) {
-        borderColor = theme.tab.border.hover.color || borderColor;
+    const onMouseOverTab = event => {
+      setOver(true);
+      if (onMouseOver) {
+        onMouseOver(event);
       }
-      borderColor = normalizeColor(borderColor, theme);
+    };
 
-      tabStyles.border = {
-        side: theme.tab.border.side,
-        size: theme.tab.border.size,
-        color: borderColor,
+    const onMouseOutTab = event => {
+      setOver(undefined);
+      if (onMouseOut) {
+        onMouseOut(event);
+      }
+    };
+
+    const onClickTab = event => {
+      if (event) {
+        event.preventDefault();
+      }
+      onActivate();
+    };
+
+    if (!plain) {
+      if (typeof title !== 'string') {
+        normalizedTitle = title;
+      } else if (active) {
+        normalizedTitle = <Text {...theme.tab.active}>{title}</Text>;
+      } else {
+        normalizedTitle = (
+          <Text color={over ? theme.tab.hover.color : theme.tab.color}>
+            {title}
+          </Text>
+        );
+      }
+
+      if (theme.tab.border) {
+        let borderColor =
+          theme.tab.border.color || theme.global.control.border.color;
+        if (active) {
+          borderColor = theme.tab.border.active.color || borderColor;
+        } else if (over) {
+          borderColor = theme.tab.border.hover.color || borderColor;
+        }
+        borderColor = normalizeColor(borderColor, theme);
+
+        tabStyles.border = {
+          side: theme.tab.border.side,
+          size: theme.tab.border.size,
+          color: borderColor,
+        };
+      }
+
+      tabStyles.background = active
+        ? theme.tab.active.background || theme.tab.background
+        : theme.tab.background;
+      tabStyles.pad = theme.tab.pad;
+      tabStyles.margin = theme.tab.margin;
+    }
+
+    // needed to apply hover/active styles to the icon
+    const renderIcon = iconProp => {
+      if (active) {
+        return React.cloneElement(iconProp, {
+          ...theme.tab.active,
+        });
+      }
+      return React.cloneElement(iconProp, {
+        color: over ? theme.tab.hover.color : theme.tab.color,
+      });
+    };
+
+    let normalizedIcon;
+    if (icon) {
+      normalizedIcon = renderIcon(icon);
+    }
+
+    const first = reverse ? normalizedTitle : normalizedIcon;
+    const second = reverse ? normalizedIcon : normalizedTitle;
+
+    let withIconStyles;
+    if (first && second) {
+      withIconStyles = {
+        direction: 'row',
+        align: 'center',
+        justify: 'center',
+        gap: 'small',
       };
     }
+    return (
+      <Button
+        ref={ref}
+        plain
+        role="tab"
+        aria-selected={active}
+        aria-expanded={active}
+        {...rest}
+        onClick={onClickTab}
+        onMouseOver={onMouseOverTab}
+        onMouseOut={onMouseOutTab}
+        onFocus={onMouseOver}
+        onBlur={onMouseOut}
+      >
+        <StyledTab as={Box} plain={plain} {...withIconStyles} {...tabStyles}>
+          {first}
+          {second}
+        </StyledTab>
+      </Button>
+    );
+  },
+);
 
-    tabStyles.background = active
-      ? theme.tab.active.background || theme.tab.background
-      : theme.tab.background;
-    tabStyles.pad = theme.tab.pad;
-    tabStyles.margin = theme.tab.margin;
-  }
-
-  // needed to apply hover/active styles to the icon
-  const renderIcon = iconProp => {
-    if (active) {
-      return React.cloneElement(iconProp, {
-        ...theme.tab.active,
-      });
-    }
-    return React.cloneElement(iconProp, {
-      color: over ? theme.tab.hover.color : theme.tab.color,
-    });
-  };
-
-  let normalizedIcon;
-  if (icon) {
-    normalizedIcon = renderIcon(icon);
-  }
-
-  const first = reverse ? normalizedTitle : normalizedIcon;
-  const second = reverse ? normalizedIcon : normalizedTitle;
-
-  let withIconStyles;
-  if (first && second) {
-    withIconStyles = {
-      direction: 'row',
-      align: 'center',
-      justify: 'center',
-      gap: 'small',
-    };
-  }
-  return (
-    <Button
-      ref={forwardRef}
-      plain
-      role="tab"
-      aria-selected={active}
-      aria-expanded={active}
-      {...rest}
-      onClick={onClickTab}
-      onMouseOver={onMouseOverTab}
-      onMouseOut={onMouseOutTab}
-      onFocus={onMouseOver}
-      onBlur={onMouseOut}
-    >
-      <StyledTab as={Box} plain={plain} {...withIconStyles} {...tabStyles}>
-        {first}
-        {second}
-      </StyledTab>
-    </Button>
-  );
-};
-
+Tab.displayName = 'Tab';
 Tab.defaultProps = {};
 Object.setPrototypeOf(Tab.defaultProps, defaultProps);
 
@@ -146,6 +148,6 @@ let TabDoc;
 if (process.env.NODE_ENV !== 'production') {
   TabDoc = require('./doc').doc(Tab); // eslint-disable-line global-require
 }
-const TabWrapper = compose(withTheme, withForwardRef)(TabDoc || Tab);
+const TabWrapper = TabDoc || Tab;
 
 export { TabWrapper as Tab };

--- a/src/js/components/Tab/doc.js
+++ b/src/js/components/Tab/doc.js
@@ -10,8 +10,15 @@ export const doc = Tab => {
     .intrinsicElement('button');
 
   DocumentedTab.propTypes = {
+    icon: PropTypes.element.description('Icon element to place in the tab.'),
     plain: PropTypes.bool
       .description('Whether this is a plain tab with no style.')
+      .defaultValue(false),
+    reverse: PropTypes.bool
+      .description(
+        `Whether an icon and label should be reversed so that the icon is at the
+              end of the tab.`,
+      )
       .defaultValue(false),
     title: PropTypes.node.description('The title of the tab.'),
   };

--- a/src/js/components/Tab/index.d.ts
+++ b/src/js/components/Tab/index.d.ts
@@ -2,7 +2,9 @@ import * as React from "react";
 import { Omit } from "../../utils";
 
 export interface TabProps {
+  icon?: JSX.Element;
   plain?: boolean;
+  reverse?: boolean;
   title?: React.ReactNode;
 }
 

--- a/src/js/components/Tabs/__tests__/Tabs-test.js
+++ b/src/js/components/Tabs/__tests__/Tabs-test.js
@@ -43,6 +43,22 @@ describe('Tabs', () => {
     expect(component.toJSON()).toMatchSnapshot();
   });
 
+  test('with icon + reverse', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Tabs>
+          <Tab title="Tab 1" icon={<svg />}>
+            Tab body 1
+          </Tab>
+          <Tab title="Tab 2" icon={<svg />} reverse>
+            Tab body 2
+          </Tab>
+        </Tabs>
+      </Grommet>,
+    );
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
   test('change to second tab', () => {
     const onActive = jest.fn();
     const { getByText, container } = render(

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -1439,3 +1439,297 @@ exports[`Tabs set on hover 5`] = `
   </div>
 </div>
 `;
+
+exports[`Tabs with icon + reverse 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: solid 2px #000000;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-bottom: 6px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: solid 2px #7D4CDB;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-bottom: 6px;
+}
+
+.c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 12px;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  outline: none;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c7 {
+  font-size: 18px;
+  line-height: 24px;
+  color: #444444;
+}
+
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+  color: #7D4CDB;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c5 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
+}
+
+.c5:hover {
+  color: #000000;
+}
+
+.c10 {
+  min-height: 0;
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    margin-top: 2px;
+    margin-bottom: 2px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    border-bottom: solid 2px #000000;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    margin-top: 2px;
+    margin-bottom: 2px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    border-bottom: solid 2px #7D4CDB;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    padding-bottom: 3px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1 "
+    role="tablist"
+  >
+    <div
+      className="c2 "
+    >
+      <button
+        aria-expanded={true}
+        aria-selected={true}
+        className="c3"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+        role="tab"
+        type="button"
+      >
+        <div
+          className="c4 c5"
+        >
+          <svg
+            color="text"
+          />
+          <div
+            className="c6"
+          />
+          <span
+            className="c7"
+          >
+            Tab 1
+          </span>
+        </div>
+      </button>
+      <button
+        aria-expanded={false}
+        aria-selected={false}
+        className="c3"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+        role="tab"
+        type="button"
+      >
+        <div
+          className="c8 c5"
+        >
+          <span
+            className="c9"
+          >
+            Tab 2
+          </span>
+          <div
+            className="c6"
+          />
+          <svg
+            color="control"
+          />
+        </div>
+      </button>
+    </div>
+    <div
+      aria-label="Tab 1 Tab Contents"
+      className="c10"
+      role="tabpanel"
+    >
+      Tab body 1
+    </div>
+  </div>
+</div>
+`;

--- a/src/js/components/Tabs/stories/Icon.js
+++ b/src/js/components/Tabs/stories/Icon.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { css } from 'styled-components';
+import { storiesOf } from '@storybook/react';
+import { Attraction, Car, TreeOption } from 'grommet-icons';
+import { Box, Grommet, Tab, Tabs } from 'grommet';
+import { grommet } from 'grommet/themes';
+import { deepMerge } from 'grommet/utils';
+
+const customTheme = deepMerge(grommet, {
+  tab: {
+    color: 'text',
+    active: {
+      background: 'background-back',
+    },
+    hover: {
+      background: 'background-back',
+      color: 'control',
+    },
+    border: {
+      side: 'bottom',
+      color: 'background-back',
+      active: {
+        color: 'border',
+      },
+      hover: {
+        color: 'control',
+      },
+    },
+    pad: 'small',
+    margin: 'none',
+    extend: ({ theme }) => css`
+      border-top-left-radius: ${theme.global.control.border.radius};
+      border-top-right-radius: ${theme.global.control.border.radius};
+      font-weight: bold;
+    `,
+  },
+});
+const Icon = () => (
+  <Grommet theme={customTheme} full>
+    <Box pad="medium" fill>
+      <Tabs flex>
+        <Tab title="Tab 1" icon={<Attraction />}>
+          <Box fill pad="large" align="center" background="accent-1">
+            <Attraction size="xlarge" />
+          </Box>
+        </Tab>
+        <Tab title="Tab 2" icon={<TreeOption />}>
+          <Box fill pad="large" align="center" background="accent-2">
+            <TreeOption size="xlarge" />
+          </Box>
+        </Tab>
+        <Tab title="Tab 3" icon={<Car />}>
+          <Box fill pad="large" align="center" background="accent-3">
+            <Car size="xlarge" />
+          </Box>
+        </Tab>
+      </Tabs>
+    </Box>
+  </Grommet>
+);
+
+storiesOf('Tabs', module).add('Icon', () => <Icon />);

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11475,9 +11475,26 @@ import { Tab } from 'grommet';
 
 ## Properties
 
+**icon**
+
+Icon element to place in the tab.
+
+\`\`\`
+element
+\`\`\`
+
 **plain**
 
 Whether this is a plain tab with no style.
+
+\`\`\`
+boolean
+\`\`\`
+
+**reverse**
+
+Whether an icon and label should be reversed so that the icon is at the
+              end of the tab.
 
 \`\`\`
 boolean

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -4530,10 +4530,22 @@ function
     "name": "Tab",
     "properties": Array [
       Object {
+        "description": "Icon element to place in the tab.",
+        "format": "element",
+        "name": "icon",
+      },
+      Object {
         "defaultValue": false,
         "description": "Whether this is a plain tab with no style.",
         "format": "boolean",
         "name": "plain",
+      },
+      Object {
+        "defaultValue": false,
+        "description": "Whether an icon and label should be reversed so that the icon is at the
+              end of the tab.",
+        "format": "boolean",
+        "name": "reverse",
       },
       Object {
         "description": "The title of the tab.",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Allows user to provide an `icon` to the Tab and control its placement with `reverse`.

#### Where should the reviewer start?
src/js/components/Tab/Tab.js

#### What testing has been done on this PR?
A new storybook has been added, and a new jest-test has been added as a baseline.

#### How should this be manually tested?
Add an icon to a `Tab` and `reverse` if you want.

#### Any background context you want to provide?
To align with HPE Design system designs, teams would need to create complex `title` on a Tab to achieve an icon with the tab label -- this opens up lots of room for inconsistency. Because `Tab` is technically a Button, it felt well-suited to allow Tab to accept icon and reverse props like Button does.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, they're updated here.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.