### PR TITLE
Changed Select to fix an issue with propagating onClick

### DIFF
--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -61,6 +61,7 @@ const Select = forwardRef(
       multiple,
       name,
       onChange,
+      onClick,
       onClose,
       onKeyDown,
       onMore,
@@ -200,6 +201,7 @@ const Select = forwardRef(
           margin={margin}
           onOpen={onRequestOpen}
           onClose={onRequestClose}
+          onClick={onClick}
           dropContent={
             <SelectContainer
               disabled={disabled}


### PR DESCRIPTION
#### What does this PR do?

Changed Select to fix an issue with propagating onClick.
Before this change, the `rest.onClick` was being passed to the underlying TextInput but then being overridden by Select's own onClick.

#### Where should the reviewer start?

Select.js

#### What testing has been done on this PR?

manually with grommet designer

#### How should this be manually tested?

#### Any background context you want to provide?

This was causing issues in the grommet designer where the Select component couldn't be selected via clicking on it.

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

sure

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
