### PR TITLE
Add disabled to Tab docs

### DIFF
--- a/src/js/components/Tab/README.md
+++ b/src/js/components/Tab/README.md
@@ -10,6 +10,14 @@ import { Tab } from 'grommet';
 
 ## Properties
 
+**disabled**
+
+Whether the tab is disabled.
+
+```
+boolean
+```
+
 **icon**
 
 Icon element to place in the tab.

--- a/src/js/components/Tab/doc.js
+++ b/src/js/components/Tab/doc.js
@@ -10,6 +10,9 @@ export const doc = Tab => {
     .intrinsicElement('button');
 
   DocumentedTab.propTypes = {
+    disabled: PropTypes.bool
+      .description('Whether the tab is disabled.')
+      .defaultValue(false),
     icon: PropTypes.element.description('Icon element to place in the tab.'),
     plain: PropTypes.bool
       .description('Whether this is a plain tab with no style.')

--- a/src/js/components/Tab/index.d.ts
+++ b/src/js/components/Tab/index.d.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Omit } from "../../utils";
 
 export interface TabProps {
+  disabled?: boolean;
   icon?: JSX.Element;
   plain?: boolean;
   reverse?: boolean;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11475,6 +11475,14 @@ import { Tab } from 'grommet';
 
 ## Properties
 
+**disabled**
+
+Whether the tab is disabled.
+
+\`\`\`
+boolean
+\`\`\`
+
 **icon**
 
 Icon element to place in the tab.

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -4530,6 +4530,12 @@ function
     "name": "Tab",
     "properties": Array [
       Object {
+        "defaultValue": false,
+        "description": "Whether the tab is disabled.",
+        "format": "boolean",
+        "name": "disabled",
+      },
+      Object {
         "description": "Icon element to place in the tab.",
         "format": "element",
         "name": "icon",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds disabled to Tab docs. This functionality already works on the grommet end since Tab is built on top of Button, but it is not a prop we document for Tab.

#### Where should the reviewer start?
src/js/components/Tab/doc.js

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
