### PR TITLE
Toggle zindex to keep focus intact

### DIFF
--- a/src/js/components/Drop/Drop.js
+++ b/src/js/components/Drop/Drop.js
@@ -1,8 +1,9 @@
 import React, { forwardRef, useEffect, useState, useContext } from 'react';
 import { createPortal } from 'react-dom';
 
+import { ThemeContext } from 'styled-components';
+import { defaultProps } from '../../default-props';
 import { getNewContainer, setFocusWithoutScroll } from '../../utils';
-
 import { DropContainer } from './DropContainer';
 import { ContainerTargetContext } from '../../contexts/ContainerTargetContext';
 
@@ -15,6 +16,7 @@ const Drop = forwardRef(
     },
     ref,
   ) => {
+    const theme = useContext(ThemeContext) || defaultProps.theme;
     const [originalFocusedElement, setOriginalFocusedElement] = useState();
     useEffect(() => setOriginalFocusedElement(document.activeElement), []);
     const [dropContainer, setDropContainer] = useState();
@@ -48,6 +50,7 @@ const Drop = forwardRef(
       ? createPortal(
           <DropContainer
             ref={ref}
+            dir={theme && theme.dir}
             dropTarget={dropTarget}
             restrictFocus={restrictFocus}
             {...rest}

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -27,7 +27,7 @@ const Tab = forwardRef(
   ) => {
     const theme = useContext(ThemeContext) || defaultProps.theme;
     const [over, setOver] = useState(undefined);
-    const [zIndex, setZIndex] = useState();
+    const [focus, setFocus] = useState();
     let normalizedTitle = title;
     const tabStyles = {};
 
@@ -131,16 +131,16 @@ const Tab = forwardRef(
         onMouseOver={onMouseOverTab}
         onMouseOut={onMouseOutTab}
         onFocus={() => {
-          // ensure focus outline is not covered by hover styling
-          // of adjacent tabs
-          setZIndex(1);
+          setFocus(true);
           if (onMouseOver) onMouseOver();
         }}
         onBlur={() => {
-          setZIndex();
+          setFocus();
           if (onMouseOut) onMouseOut();
         }}
-        style={zIndex && { zIndex }}
+        // ensure focus outline is not covered by hover styling
+        // of adjacent tabs
+        style={focus && { zIndex: 1 }}
       >
         <StyledTab as={Box} plain={plain} {...withIconStyles} {...tabStyles}>
           {first}

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -27,6 +27,7 @@ const Tab = forwardRef(
   ) => {
     const theme = useContext(ThemeContext) || defaultProps.theme;
     const [over, setOver] = useState(undefined);
+    const [zIndex, setZIndex] = useState();
     let normalizedTitle = title;
     const tabStyles = {};
 
@@ -117,6 +118,7 @@ const Tab = forwardRef(
         gap: 'small',
       };
     }
+
     return (
       <Button
         ref={ref}
@@ -128,8 +130,17 @@ const Tab = forwardRef(
         onClick={onClickTab}
         onMouseOver={onMouseOverTab}
         onMouseOut={onMouseOutTab}
-        onFocus={onMouseOver}
-        onBlur={onMouseOut}
+        onFocus={() => {
+          // ensure focus outline is not covered by hover styling
+          // of adjacent tabs
+          setZIndex(1);
+          if (onMouseOver) onMouseOver();
+        }}
+        onBlur={() => {
+          setZIndex();
+          if (onMouseOut) onMouseOut();
+        }}
+        style={zIndex && { zIndex }}
       >
         <StyledTab as={Box} plain={plain} {...withIconStyles} {...tabStyles}>
           {first}

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -27,7 +27,7 @@ const Tab = forwardRef(
   ) => {
     const theme = useContext(ThemeContext) || defaultProps.theme;
     const [over, setOver] = useState(undefined);
-    const [focus, setFocus] = useState();
+    const [focus, setFocus] = useState(undefined);
     let normalizedTitle = title;
     const tabStyles = {};
 
@@ -135,7 +135,7 @@ const Tab = forwardRef(
           if (onMouseOver) onMouseOver();
         }}
         onBlur={() => {
-          setFocus();
+          setFocus(undefined);
           if (onMouseOut) onMouseOut();
         }}
         // ensure focus outline is not covered by hover styling


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR ensures that the focus outline around a tab does not get hidden by the hover styling of adjacent tabs. When a tab receives focus, it is given a zindex of 1 to pull it on top of surrounding tabs. onblur, the zindex returns to undefined.

#### Where should the reviewer start?
src/js/components/Tab/Tab.js

#### What testing has been done on this PR?
Tested in storybook.

#### How should this be manually tested?
Use the Icon example on Tabs in storybook. Tab onto one of the tabs, then hover on adjacent tabs. The focus outline should remain visible on all sides.

#### Any background context you want to provide?
Hover styling was covering one edge of the tab when there was no space between tabs.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, this is backwards compatible.