### PR TITLE
added missing parameter to announce context [TS]

### DIFF
--- a/src/js/contexts/AnnounceContext/index.d.ts
+++ b/src/js/contexts/AnnounceContext/index.d.ts
@@ -2,9 +2,11 @@ import * as React from 'react';
 
 export type AnnounceMessage = string;
 export type AnnounceMode = 'off' | 'polite' | 'assertive';
+export type Timeout = number;
 export type AnnounceValue = (
   message: AnnounceMessage,
   mode: AnnounceMode,
+  timeout: Timeout,
 ) => void;
 
 declare const AnnounceContext: React.Context<AnnounceValue>;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds timeout parameter to announce context

#### Where should the reviewer start?
contexts/AnnounceContext/indext.d.ts

#### What testing has been done on this PR?
using this code
```
import React from 'react';
import PropTypes from 'prop-types';
import { storiesOf } from '@storybook/react';
import isChromatic from 'storybook-chromatic/isChromatic';
import { Grommet,  Box, Text, AnnounceContext, Heading } from 'grommet';
import { grommet } from 'grommet/themes';
const Announcer = ({ announce, message, mode, role }) => {
  React.useEffect(() => {
    const timeout = 3000;
    announce(message, mode, timeout);
  }, [announce, message, mode]);
  return (
    <Text  role={role} aria-live={mode}>
      {message}
    </Text>
  );
};
Announcer.propTypes = {
  announce: PropTypes.func.isRequired,
  message: PropTypes.string,
  mode: PropTypes.string,
  role: PropTypes.string,
};
Announcer.defaultProps = {
  message: 'Here is a simple announcement. This will soon disappear',
  mode: 'polite',
  role: 'log',
};
const SimpleBox = props => (
  <Grommet theme={grommet} full>
    <Box justify="center" align="center" background="brand" fill>
      <Heading>Welcome to announcement section</Heading>
      <AnnounceContext.Consumer>
        {announce => <Announcer announce={announce} {...props} />}
      </AnnounceContext.Consumer>
    </Box>
  </Grommet>
);
```

#### How should this be manually tested?
With the code above

#### What are the relevant issues?
#3760 

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible