### PR TITLE
onEsc and onClickOutside does not work when modal set to false in layers :: Don't Merge Yet

### DIFF
--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -63,6 +63,7 @@ const LayerContainer = forwardRef(
           }
           element = element.parentElement;
         }
+        // this is keeping onEsc from working with modal set to false
         if (modal && !element && anchorRef.current) {
           anchorRef.current.focus();
         }
@@ -131,6 +132,8 @@ const LayerContainer = forwardRef(
           tabIndex="-1"
           dir={theme.dir}
         >
+          {/* This handles to onclickoutside which is not present 
+          when modal is set to false */}
           <StyledOverlay
             plain={plain}
             onMouseDown={onClickOutside}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Nothing yet. The goal is to address issue #3771 with either a code change or through examples.

#### Where should the reviewer start?
LayerContainer.js. I have some coments.

#### What testing has been done on this PR?
None yet. Will test with storybook.

#### How should this be manually tested?
Same as above

#### Any background context you want to provide?
onEsc functionality of layers with modal set to false was removed with this PR #3632. I assume it prevents the layer from taking keystrokes when it is used as a type of drop.

To fix this i can revert the changes made in that pr. The layer would still steal keystrokes, but maybe we can provide an example with drop(or any other component) that achieves the same thing that the pr was trying to address.

onClickOutside was never available for layers with modal set to false. This seems intentional to me. My suggestion would be to update the documentation(saying that outclickoutside no longer functions when modal is set to false), and adding an example that shows how to create your own onclickoutside handler.

#### What are the relevant issues?
#3771 

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
It will be when it is complete.