### PR TITLE
Added HPE NEXT theme for All Components story

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "grommet-theme-dxc": "^0.1.1",
     "grommet-theme-hp": "^0.1.1",
     "grommet-theme-hpe": "^1.0.0",
+    "grommet-theme-hpe-next": "https://github.com/grommet/grommet-theme-hpe/tarball/NEXT-stable",
     "grommet-theme-hpe-v0": "npm:grommet-theme-hpe@0.4.2",
     "grommet-theme-v1": "^0.1.1",
     "jest": "^25.1.0",

--- a/src/js/all/stories/AllComponents.js
+++ b/src/js/all/stories/AllComponents.js
@@ -38,6 +38,7 @@ import { generate } from 'grommet/themes/base';
 import { deepMerge } from 'grommet/utils';
 import { hpe } from 'grommet-theme-hpe';
 import { hpe as hpeV0 } from 'grommet-theme-hpe-v0';
+import { hpe as hpeNext } from 'grommet-theme-hpe-next';
 import { aruba } from 'grommet-theme-aruba';
 import { hp } from 'grommet-theme-hp';
 import { dxc } from 'grommet-theme-dxc';
@@ -69,6 +70,7 @@ const themes = {
   dark,
   grommet,
   hpe,
+  hpeNext,
   hpeV0,
   aruba,
   hp,
@@ -293,16 +295,7 @@ const Components = () => {
             <Select
               plain
               size="small"
-              options={[
-                'grommet',
-                'dark',
-                'hpe',
-                'hpeV0',
-                'aruba',
-                'hp',
-                'dxc',
-                'v1',
-              ]}
+              options={Object.keys(themes)}
               value={themeName}
               onChange={event => setThemeName(event.option)}
             />

--- a/yarn.lock
+++ b/yarn.lock
@@ -6057,6 +6057,10 @@ grommet-theme-hp@^0.1.1:
   resolved "https://registry.yarnpkg.com/grommet-theme-hp/-/grommet-theme-hp-0.1.2.tgz#52eac70d7cce2136b9ca6d7f6bf37649a40208a8"
   integrity sha512-pRJxgzJ6oWKNg4hq8csi7hEgH0qeMyP3m/cjQVTk473lH1OdgzqNfjyjQXJf80Fnp6Azm+ovwuNNGCKWCZxcvg==
 
+"grommet-theme-hpe-next@https://github.com/grommet/grommet-theme-hpe/tarball/NEXT-stable":
+  version "0.0.0"
+  resolved "https://github.com/grommet/grommet-theme-hpe/tarball/NEXT-stable#515122ebbab9f9312bcba0e2457b94a84e44913a"
+
 "grommet-theme-hpe-v0@npm:grommet-theme-hpe@0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/grommet-theme-hpe/-/grommet-theme-hpe-0.4.2.tgz#f2c4d02341056a34d32f1fbc4f843b523912dce5"


### PR DESCRIPTION
#### What does this PR do?

Adds the HPE NEXT theme to the available themes in the All Components story.
This makes it a bit easier to work on grommet changes needed for the theme.

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
