### PR TITLE
Enhanced ability to style focus with theme

### DIFF
--- a/src/js/__tests__/__snapshots__/default-props-test.js.snap
+++ b/src/js/__tests__/__snapshots__/default-props-test.js.snap
@@ -7,7 +7,6 @@ exports[`default theme is used 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -30,7 +29,6 @@ exports[`extends default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: red;
   color: #444444;
@@ -53,7 +51,6 @@ exports[`extends default theme twice 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: red;
   color: #444444;
@@ -76,7 +73,6 @@ exports[`extends default theme twice 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: blue;
   color: #444444;
@@ -109,7 +105,6 @@ exports[`uses Grommet theme instead of default 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;

--- a/src/js/all/stories/AllComponents.js
+++ b/src/js/all/stories/AllComponents.js
@@ -33,16 +33,22 @@ import {
   TextInput,
   Video,
 } from 'grommet';
-import { grommet, dark } from 'grommet/themes';
+import { grommet } from 'grommet/themes';
 import { generate } from 'grommet/themes/base';
 import { deepMerge } from 'grommet/utils';
 import { hpe } from 'grommet-theme-hpe';
 import { hpe as hpeV0 } from 'grommet-theme-hpe-v0';
-import { hpe as hpeNext } from 'grommet-theme-hpe-next';
+import { hpe as hpeNextBase } from 'grommet-theme-hpe-next';
 import { aruba } from 'grommet-theme-aruba';
 import { hp } from 'grommet-theme-hp';
 import { dxc } from 'grommet-theme-dxc';
 import { v1 } from 'grommet-theme-v1';
+
+// Temporarily added to make testing focus changes easier.
+// This is the expected HPE theme focus.
+const hpeNext = deepMerge(hpeNextBase, {
+  global: { focus: { border: undefined } },
+});
 
 const Node = ({ id, ...rest }) => (
   <Box
@@ -67,7 +73,6 @@ const connection = (fromTarget, toTarget, { color, ...rest } = {}) => ({
 });
 
 const themes = {
-  dark,
   grommet,
   hpe,
   hpeNext,

--- a/src/js/all/stories/AllComponents.js
+++ b/src/js/all/stories/AllComponents.js
@@ -107,7 +107,7 @@ const Components = () => {
   );
 
   const content = [
-    <Box key="type" align="start">
+    <Box key="type" align="start" gap="small">
       <Heading margin={{ top: 'none' }}>Heading</Heading>
       <Paragraph>Paragraph</Paragraph>
       <Text>Text</Text>
@@ -117,6 +117,9 @@ const Components = () => {
         items={[{ label: 'One', onClick: () => {} }, { label: 'Two' }]}
       />
       <Button label="Button" onClick={() => {}} />
+      <Button plain onClick={() => {}}>
+        <Text>plain button</Text>
+      </Button>
     </Box>,
     <Box key="input" gap="small">
       <Select

--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -41,7 +41,6 @@ exports[`Accordion AccordionPanel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -56,7 +55,6 @@ exports[`Accordion AccordionPanel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -74,7 +72,6 @@ exports[`Accordion AccordionPanel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -97,7 +94,6 @@ exports[`Accordion AccordionPanel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -114,7 +110,6 @@ exports[`Accordion AccordionPanel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -131,7 +126,6 @@ exports[`Accordion AccordionPanel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -145,7 +139,6 @@ exports[`Accordion AccordionPanel 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -376,7 +369,6 @@ exports[`Accordion change active index 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -391,7 +383,6 @@ exports[`Accordion change active index 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -409,7 +400,6 @@ exports[`Accordion change active index 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -432,7 +422,6 @@ exports[`Accordion change active index 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -449,7 +438,6 @@ exports[`Accordion change active index 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -466,7 +454,6 @@ exports[`Accordion change active index 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -480,7 +467,6 @@ exports[`Accordion change active index 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -646,24 +632,24 @@ exports[`Accordion change active index 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -672,7 +658,7 @@ exports[`Accordion change active index 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormDown"
@@ -690,24 +676,24 @@ exports[`Accordion change active index 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       />
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -716,7 +702,7 @@ exports[`Accordion change active index 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormUp"
@@ -735,7 +721,7 @@ exports[`Accordion change active index 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         Panel body 2
       </div>
@@ -785,7 +771,6 @@ exports[`Accordion change to second Panel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -800,7 +785,6 @@ exports[`Accordion change to second Panel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -818,7 +802,6 @@ exports[`Accordion change to second Panel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -841,7 +824,6 @@ exports[`Accordion change to second Panel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -858,7 +840,6 @@ exports[`Accordion change to second Panel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -875,7 +856,6 @@ exports[`Accordion change to second Panel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -889,7 +869,6 @@ exports[`Accordion change to second Panel 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1072,24 +1051,24 @@ exports[`Accordion change to second Panel 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -1098,7 +1077,7 @@ exports[`Accordion change to second Panel 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormDown"
@@ -1116,31 +1095,31 @@ exports[`Accordion change to second Panel 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 jJdKAu Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -1149,7 +1128,7 @@ exports[`Accordion change to second Panel 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             .c0 {
   display: inline-block;
@@ -1218,11 +1197,11 @@ exports[`Accordion change to second Panel 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         <div
           aria-hidden="false"
-          class="StyledBox-sc-13pk1d4-0 jJdKAu Collapsible__AnimatedBox-sc-15kniua-0 hCnAXH"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 hCnAXH"
           open=""
         >
           Panel body 2
@@ -1274,7 +1253,6 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1289,7 +1267,6 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1307,7 +1284,6 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1330,7 +1306,6 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1347,7 +1322,6 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1364,7 +1338,6 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1378,7 +1351,6 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1541,24 +1513,24 @@ exports[`Accordion change to second Panel without onActive 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -1567,7 +1539,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormDown"
@@ -1585,24 +1557,24 @@ exports[`Accordion change to second Panel without onActive 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       />
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -1611,7 +1583,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             .c0 {
   display: inline-block;
@@ -1680,7 +1652,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         Panel body 2
       </div>
@@ -1696,7 +1668,6 @@ exports[`Accordion complex header 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1711,7 +1682,6 @@ exports[`Accordion complex header 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1729,7 +1699,6 @@ exports[`Accordion complex header 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1743,7 +1712,6 @@ exports[`Accordion complex header 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1873,7 +1841,6 @@ exports[`Accordion complex title 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #333333;
   color: #f8f8f8;
@@ -1890,7 +1857,6 @@ exports[`Accordion complex title 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1905,7 +1871,6 @@ exports[`Accordion complex title 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1923,7 +1888,6 @@ exports[`Accordion complex title 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1946,7 +1910,6 @@ exports[`Accordion complex title 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1963,7 +1926,6 @@ exports[`Accordion complex title 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(255,255,255,0.33);
   min-width: 0;
@@ -1977,7 +1939,6 @@ exports[`Accordion complex title 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2178,7 +2139,6 @@ exports[`Accordion custom accordion 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2193,7 +2153,6 @@ exports[`Accordion custom accordion 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2211,7 +2170,6 @@ exports[`Accordion custom accordion 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2234,7 +2192,6 @@ exports[`Accordion custom accordion 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2251,7 +2208,6 @@ exports[`Accordion custom accordion 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2268,7 +2224,6 @@ exports[`Accordion custom accordion 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -2282,7 +2237,6 @@ exports[`Accordion custom accordion 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2456,7 +2410,6 @@ exports[`Accordion multiple panels 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2471,7 +2424,6 @@ exports[`Accordion multiple panels 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2489,7 +2441,6 @@ exports[`Accordion multiple panels 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2512,7 +2463,6 @@ exports[`Accordion multiple panels 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2529,7 +2479,6 @@ exports[`Accordion multiple panels 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2546,7 +2495,6 @@ exports[`Accordion multiple panels 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -2560,7 +2508,6 @@ exports[`Accordion multiple panels 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2723,24 +2670,24 @@ exports[`Accordion multiple panels 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -2749,7 +2696,7 @@ exports[`Accordion multiple panels 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormDown"
@@ -2767,24 +2714,24 @@ exports[`Accordion multiple panels 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       />
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -2793,7 +2740,7 @@ exports[`Accordion multiple panels 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             .c0 {
   display: inline-block;
@@ -2862,7 +2809,7 @@ exports[`Accordion multiple panels 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         Panel body 2
       </div>
@@ -2876,24 +2823,24 @@ exports[`Accordion multiple panels 3`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -2902,7 +2849,7 @@ exports[`Accordion multiple panels 3`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             .c0 {
   display: inline-block;
@@ -2971,26 +2918,26 @@ exports[`Accordion multiple panels 3`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         Panel body 1
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -2999,7 +2946,7 @@ exports[`Accordion multiple panels 3`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormUp"
@@ -3018,7 +2965,7 @@ exports[`Accordion multiple panels 3`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         Panel body 2
       </div>
@@ -3032,24 +2979,24 @@ exports[`Accordion multiple panels 4`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -3058,7 +3005,7 @@ exports[`Accordion multiple panels 4`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormUp"
@@ -3077,26 +3024,26 @@ exports[`Accordion multiple panels 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         Panel body 1
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -3105,7 +3052,7 @@ exports[`Accordion multiple panels 4`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             .c0 {
   display: inline-block;
@@ -3173,7 +3120,7 @@ exports[`Accordion multiple panels 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       />
     </div>
   </div>
@@ -3185,24 +3132,24 @@ exports[`Accordion multiple panels 5`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -3211,7 +3158,7 @@ exports[`Accordion multiple panels 5`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             .c0 {
   display: inline-block;
@@ -3279,24 +3226,24 @@ exports[`Accordion multiple panels 5`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       />
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -3305,7 +3252,7 @@ exports[`Accordion multiple panels 5`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormDown"
@@ -3323,7 +3270,7 @@ exports[`Accordion multiple panels 5`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       />
     </div>
   </div>
@@ -3337,7 +3284,6 @@ exports[`Accordion no AccordionPanel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3407,7 +3353,6 @@ exports[`Accordion set on hover 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3422,7 +3367,6 @@ exports[`Accordion set on hover 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3440,7 +3384,6 @@ exports[`Accordion set on hover 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -3463,7 +3406,6 @@ exports[`Accordion set on hover 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3480,7 +3422,6 @@ exports[`Accordion set on hover 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3497,7 +3438,6 @@ exports[`Accordion set on hover 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -3511,7 +3451,6 @@ exports[`Accordion set on hover 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3694,24 +3633,24 @@ exports[`Accordion set on hover 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 iXwLsH"
@@ -3720,7 +3659,7 @@ exports[`Accordion set on hover 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormDown"
@@ -3738,31 +3677,31 @@ exports[`Accordion set on hover 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 jJdKAu Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -3771,7 +3710,7 @@ exports[`Accordion set on hover 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormDown"
@@ -3789,11 +3728,11 @@ exports[`Accordion set on hover 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 jJdKAu Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
         >
           Panel body 2
         </div>
@@ -3808,24 +3747,24 @@ exports[`Accordion set on hover 3`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 iXwLsH"
@@ -3834,7 +3773,7 @@ exports[`Accordion set on hover 3`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormDown"
@@ -3852,31 +3791,31 @@ exports[`Accordion set on hover 3`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 jJdKAu Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 iXwLsH"
@@ -3885,7 +3824,7 @@ exports[`Accordion set on hover 3`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormDown"
@@ -3903,11 +3842,11 @@ exports[`Accordion set on hover 3`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 jJdKAu Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
         >
           Panel body 2
         </div>
@@ -3922,24 +3861,24 @@ exports[`Accordion set on hover 4`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -3948,7 +3887,7 @@ exports[`Accordion set on hover 4`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormDown"
@@ -3966,31 +3905,31 @@ exports[`Accordion set on hover 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 jJdKAu Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 iXwLsH"
@@ -3999,7 +3938,7 @@ exports[`Accordion set on hover 4`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormDown"
@@ -4017,11 +3956,11 @@ exports[`Accordion set on hover 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 jJdKAu Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
         >
           Panel body 2
         </div>
@@ -4036,24 +3975,24 @@ exports[`Accordion set on hover 5`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -4062,7 +4001,7 @@ exports[`Accordion set on hover 5`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormDown"
@@ -4080,31 +4019,31 @@ exports[`Accordion set on hover 5`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 jJdKAu Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -4113,7 +4052,7 @@ exports[`Accordion set on hover 5`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormDown"
@@ -4131,11 +4070,11 @@ exports[`Accordion set on hover 5`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 jJdKAu Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bQEdvX"
         >
           Panel body 2
         </div>
@@ -4186,7 +4125,6 @@ exports[`Accordion wrapped panel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4201,7 +4139,6 @@ exports[`Accordion wrapped panel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4219,7 +4156,6 @@ exports[`Accordion wrapped panel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -4242,7 +4178,6 @@ exports[`Accordion wrapped panel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4259,7 +4194,6 @@ exports[`Accordion wrapped panel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4276,7 +4210,6 @@ exports[`Accordion wrapped panel 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -4290,7 +4223,6 @@ exports[`Accordion wrapped panel 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4453,24 +4385,24 @@ exports[`Accordion wrapped panel 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -4479,7 +4411,7 @@ exports[`Accordion wrapped panel 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             .c0 {
   display: inline-block;
@@ -4548,27 +4480,27 @@ exports[`Accordion wrapped panel 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       >
         Panel body 
         1
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hTZIev"
+      class="StyledBox-sc-13pk1d4-0 gzfjUM"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kDANyu"
+          class="StyledBox-sc-13pk1d4-0 VvbUh"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ksaQUA"
+            class="StyledBox-sc-13pk1d4-0 ckSWz"
           >
             <h4
               class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
@@ -4577,7 +4509,7 @@ exports[`Accordion wrapped panel 2`] = `
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 goKxjo"
+            class="StyledBox-sc-13pk1d4-0 iEnXND"
           >
             <svg
               aria-label="FormDown"
@@ -4595,7 +4527,7 @@ exports[`Accordion wrapped panel 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 GCqjV"
+        class="StyledBox-sc-13pk1d4-0 cptOIG"
       />
     </div>
   </div>

--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -147,6 +147,7 @@ exports[`Accordion AccordionPanel 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -475,6 +476,7 @@ exports[`Accordion change active index 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -641,7 +643,7 @@ exports[`Accordion change active index 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -685,7 +687,7 @@ exports[`Accordion change active index 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -877,6 +879,7 @@ exports[`Accordion change to second Panel 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1060,7 +1063,7 @@ exports[`Accordion change to second Panel 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -1111,7 +1114,7 @@ exports[`Accordion change to second Panel 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -1359,6 +1362,7 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1522,7 +1526,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -1566,7 +1570,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -1720,6 +1724,7 @@ exports[`Accordion complex header 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1947,6 +1952,7 @@ exports[`Accordion complex title 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2245,6 +2251,7 @@ exports[`Accordion custom accordion 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2516,6 +2523,7 @@ exports[`Accordion multiple panels 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2679,7 +2687,7 @@ exports[`Accordion multiple panels 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -2723,7 +2731,7 @@ exports[`Accordion multiple panels 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -2832,7 +2840,7 @@ exports[`Accordion multiple panels 3`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -2929,7 +2937,7 @@ exports[`Accordion multiple panels 3`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -2988,7 +2996,7 @@ exports[`Accordion multiple panels 4`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -3035,7 +3043,7 @@ exports[`Accordion multiple panels 4`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -3141,7 +3149,7 @@ exports[`Accordion multiple panels 5`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -3235,7 +3243,7 @@ exports[`Accordion multiple panels 5`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -3459,6 +3467,7 @@ exports[`Accordion set on hover 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -3642,7 +3651,7 @@ exports[`Accordion set on hover 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -3693,7 +3702,7 @@ exports[`Accordion set on hover 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -3756,7 +3765,7 @@ exports[`Accordion set on hover 3`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -3807,7 +3816,7 @@ exports[`Accordion set on hover 3`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -3870,7 +3879,7 @@ exports[`Accordion set on hover 4`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -3921,7 +3930,7 @@ exports[`Accordion set on hover 4`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -3984,7 +3993,7 @@ exports[`Accordion set on hover 5`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -4035,7 +4044,7 @@ exports[`Accordion set on hover 5`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -4231,6 +4240,7 @@ exports[`Accordion wrapped panel 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -4394,7 +4404,7 @@ exports[`Accordion wrapped panel 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -4492,7 +4502,7 @@ exports[`Accordion wrapped panel 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >

--- a/src/js/components/Anchor/README.md
+++ b/src/js/components/Anchor/README.md
@@ -317,12 +317,52 @@ Defaults to
 
 **global.focus.border.color**
 
-The color around the component when in focus. Expects `string | { dark: string, light: string }`.
+The border color of the component when in focus. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 
 ```
 focus
+```
+
+**global.focus.outline.color**
+
+The outline color around the component when in focus. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+undefined
+```
+
+**global.focus.outline.size**
+
+The size of the outline around the component when in focus. Expects `string`.
+
+Defaults to
+
+```
+undefined
+```
+
+**global.focus.shadow.color**
+
+The shadow color around the component when in focus. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+focus
+```
+
+**global.focus.shadow.size**
+
+The size of the shadow around the component when in focus. Expects `string`.
+
+Defaults to
+
+```
+2px
 ```
 
 **global.edgeSize**

--- a/src/js/components/Anchor/StyledAnchor.js
+++ b/src/js/components/Anchor/StyledAnchor.js
@@ -35,7 +35,6 @@ const StyledAnchor = styled.a`
   text-decoration: ${props =>
     props.hasIcon ? 'none' : props.theme.anchor.textDecoration};
   cursor: pointer;
-  outline: none;
   ${genericStyles}
 
   ${props =>
@@ -57,7 +56,7 @@ const StyledAnchor = styled.a`
     padding: ${props.theme.global.edgeSize.small};
   `}
   ${props => props.disabled && disabledStyle}
-  ${props => props.focus && focusStyle}
+  ${props => props.focus && focusStyle()}
   ${props => props.theme.anchor.extend}
 `;
 

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
@@ -74,7 +74,8 @@ exports[`Anchor focus renders 1`] = `
 .c1 > polygon,
 .c1 > polyline,
 .c1 > rect {
-  outline: #6FFFB0 solid 2px;
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
 .c1::-moz-focus-inner {

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
@@ -20,7 +20,6 @@ exports[`Anchor disabled renders 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
   opacity: 0.3;
   cursor: default;
   -webkit-text-decoration: none;
@@ -60,8 +59,6 @@ exports[`Anchor focus renders 1`] = `
   text-decoration: none;
   cursor: pointer;
   outline: none;
-  outline-color: #6FFFB0;
-  border-color: #6FFFB0;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
@@ -113,7 +110,6 @@ exports[`Anchor icon label renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -145,7 +141,6 @@ exports[`Anchor icon label renders 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
 }
 
 .c1:hover {
@@ -202,7 +197,6 @@ exports[`Anchor primary renders 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
 }
 
 .c1:hover {
@@ -244,7 +238,6 @@ exports[`Anchor renders 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
 }
 
 .c1:hover {
@@ -283,7 +276,6 @@ exports[`Anchor renders tag 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
 }
 
 .c1:hover {
@@ -325,7 +317,6 @@ exports[`Anchor renders with children 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
 }
 
 .c1:hover {
@@ -364,7 +355,6 @@ exports[`Anchor reverse icon label renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -396,7 +386,6 @@ exports[`Anchor reverse icon label renders 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
 }
 
 .c1:hover {
@@ -453,7 +442,6 @@ exports[`Anchor warns about invalid icon render 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
   padding: 12px;
 }
 
@@ -498,7 +486,6 @@ exports[`Anchor warns about invalid label render 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
 }
 
 .c1:hover {

--- a/src/js/components/Avatar/__tests__/__snapshots__/Avatar-test.js.snap
+++ b/src/js/components/Avatar/__tests__/__snapshots__/Avatar-test.js.snap
@@ -7,7 +7,6 @@ exports[`Avatar icon renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -56,7 +55,6 @@ exports[`Avatar renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -108,7 +106,6 @@ exports[`Avatar round renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -136,7 +133,6 @@ exports[`Avatar round renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -165,7 +161,6 @@ exports[`Avatar round renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -194,7 +189,6 @@ exports[`Avatar round renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -223,7 +217,6 @@ exports[`Avatar round renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -252,7 +245,6 @@ exports[`Avatar round renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -340,7 +332,6 @@ exports[`Avatar size renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -369,7 +360,6 @@ exports[`Avatar size renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -398,7 +388,6 @@ exports[`Avatar size renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -427,7 +416,6 @@ exports[`Avatar size renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -485,7 +473,6 @@ exports[`Avatar stack renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -500,7 +487,6 @@ exports[`Avatar stack renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -515,7 +501,6 @@ exports[`Avatar stack renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -544,7 +529,6 @@ exports[`Avatar stack renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -560,7 +544,6 @@ exports[`Avatar stack renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -659,7 +642,6 @@ exports[`Avatar text renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -688,7 +670,6 @@ exports[`Avatar text renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -502,7 +502,6 @@ const widthStyle = css`
 const StyledBox = styled.div`
   display: flex;
   box-sizing: border-box;
-  outline: none;
   ${props => !props.basis && 'max-width: 100%;'};
 
   ${genericStyles}
@@ -548,7 +547,7 @@ const StyledBox = styled.div`
     props.onClick &&
     props.focus &&
     props.focusIndicator !== false &&
-    focusStyle}
+    focusStyle()}
   ${props => props.theme.box && props.theme.box.extend}
 `;
 

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -17,7 +17,6 @@ exports[`Box align 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -36,7 +35,6 @@ exports[`Box align 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -55,7 +53,6 @@ exports[`Box align 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
@@ -74,7 +71,6 @@ exports[`Box align 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -93,7 +89,6 @@ exports[`Box align 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -144,7 +139,6 @@ exports[`Box alignContent 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-content: flex-start;
   -ms-flex-line-pack: start;
@@ -162,7 +156,6 @@ exports[`Box alignContent 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -180,7 +173,6 @@ exports[`Box alignContent 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-content: between;
   -ms-flex-line-pack: between;
@@ -198,7 +190,6 @@ exports[`Box alignContent 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-content: around;
   -ms-flex-line-pack: around;
@@ -216,7 +207,6 @@ exports[`Box alignContent 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-content: stretch;
   -ms-flex-line-pack: stretch;
@@ -234,7 +224,6 @@ exports[`Box alignContent 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-content: flex-end;
   -ms-flex-line-pack: end;
@@ -287,7 +276,6 @@ exports[`Box alignSelf 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
@@ -305,7 +293,6 @@ exports[`Box alignSelf 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: center;
   -ms-flex-item-align: center;
@@ -323,7 +310,6 @@ exports[`Box alignSelf 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -341,7 +327,6 @@ exports[`Box alignSelf 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
@@ -388,7 +373,6 @@ exports[`Box animation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -406,7 +390,6 @@ exports[`Box animation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -424,7 +407,6 @@ exports[`Box animation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -444,7 +426,6 @@ exports[`Box animation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -464,7 +445,6 @@ exports[`Box animation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -484,7 +464,6 @@ exports[`Box animation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -504,7 +483,6 @@ exports[`Box animation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -524,7 +502,6 @@ exports[`Box animation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -544,7 +521,6 @@ exports[`Box animation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -564,7 +540,6 @@ exports[`Box animation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -584,7 +559,6 @@ exports[`Box animation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -605,7 +579,6 @@ exports[`Box animation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -623,7 +596,6 @@ exports[`Box animation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -700,7 +672,6 @@ exports[`Box as 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -735,7 +706,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -752,7 +722,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #6FFFB0;
   color: #444444;
@@ -769,7 +738,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #00873D;
   color: #f8f8f8;
@@ -786,7 +754,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #F8F8F8;
   color: #444444;
@@ -803,7 +770,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #333333;
   color: #f8f8f8;
@@ -820,7 +786,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #FF4040;
   color: #f8f8f8;
@@ -837,7 +802,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #aabbcc;
   color: #444444;
@@ -854,7 +818,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #def;
   color: #444444;
@@ -871,7 +834,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: rgb(90,80,50);
   color: #f8f8f8;
@@ -888,7 +850,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: rgba(200,100,150,0.8);
   color: #444444;
@@ -905,7 +866,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: hsl(10,50%,20%);
   color: #f8f8f8;
@@ -922,7 +882,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: hsla(10,50%,70%,0.7);
   color: #444444;
@@ -939,7 +898,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==) no-repeat center center;
   background-size: cover;
@@ -956,7 +914,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==);
   background-repeat: no-repeat;
@@ -977,7 +934,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==);
   background-repeat: no-repeat;
@@ -998,7 +954,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==);
   background-repeat: no-repeat;
@@ -1018,7 +973,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==);
   background-repeat: no-repeat;
@@ -1040,7 +994,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==);
   background-repeat: no-repeat;
@@ -1060,7 +1013,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==);
   background-repeat: repeat;
@@ -1080,7 +1032,6 @@ exports[`Box background 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==);
   background-repeat: no-repeat;
@@ -1177,7 +1128,6 @@ exports[`Box basis 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1192,7 +1142,6 @@ exports[`Box basis 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1209,7 +1158,6 @@ exports[`Box basis 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1226,7 +1174,6 @@ exports[`Box basis 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1243,7 +1190,6 @@ exports[`Box basis 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1260,7 +1206,6 @@ exports[`Box basis 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1277,7 +1222,6 @@ exports[`Box basis 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1292,7 +1236,6 @@ exports[`Box basis 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1309,7 +1252,6 @@ exports[`Box basis 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1326,7 +1268,6 @@ exports[`Box basis 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1343,7 +1284,6 @@ exports[`Box basis 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1360,7 +1300,6 @@ exports[`Box basis 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1377,7 +1316,6 @@ exports[`Box basis 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1467,7 +1405,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1483,7 +1420,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-top: solid 1px rgba(0,0,0,0.33);
   border-bottom: solid 1px rgba(0,0,0,0.33);
@@ -1500,7 +1436,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-left: solid 1px rgba(0,0,0,0.33);
   border-right: solid 1px rgba(0,0,0,0.33);
@@ -1517,7 +1452,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-top: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1533,7 +1467,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-left: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1549,7 +1482,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1565,7 +1497,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-right: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1581,7 +1512,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border: solid 1px #6FFFB0;
   min-width: 0;
@@ -1597,7 +1527,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border: solid 2px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1613,7 +1542,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border: solid 4px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1629,7 +1557,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border: solid 12px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1645,7 +1572,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border: solid 24px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1661,7 +1587,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border: dotted 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1677,7 +1602,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border: double 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1693,7 +1617,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border: dashed 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1709,7 +1632,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-top: dotted 4px #6FFFB0;
   border-left: dashed 12px #FD6FFF;
@@ -1726,7 +1648,6 @@ exports[`Box border 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1964,7 +1885,6 @@ exports[`Box default 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1999,7 +1919,6 @@ exports[`Box direction 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2014,7 +1933,6 @@ exports[`Box direction 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2029,7 +1947,6 @@ exports[`Box direction 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2044,7 +1961,6 @@ exports[`Box direction 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2059,7 +1975,6 @@ exports[`Box direction 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2125,7 +2040,6 @@ exports[`Box elevation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2141,7 +2055,6 @@ exports[`Box elevation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2157,7 +2070,6 @@ exports[`Box elevation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2173,7 +2085,6 @@ exports[`Box elevation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2189,7 +2100,6 @@ exports[`Box elevation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2205,7 +2115,6 @@ exports[`Box elevation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2221,7 +2130,6 @@ exports[`Box elevation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #333333;
   color: #f8f8f8;
@@ -2239,7 +2147,6 @@ exports[`Box elevation 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2297,7 +2204,6 @@ exports[`Box fill 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2312,7 +2218,6 @@ exports[`Box fill 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2329,7 +2234,6 @@ exports[`Box fill 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2345,7 +2249,6 @@ exports[`Box fill 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2394,7 +2297,6 @@ exports[`Box flex 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2409,7 +2311,6 @@ exports[`Box flex 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2427,7 +2328,6 @@ exports[`Box flex 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2445,7 +2345,6 @@ exports[`Box flex 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2463,7 +2362,6 @@ exports[`Box flex 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2481,7 +2379,6 @@ exports[`Box flex 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2499,7 +2396,6 @@ exports[`Box flex 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2517,7 +2413,6 @@ exports[`Box flex 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2577,7 +2472,6 @@ exports[`Box gap 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2592,7 +2486,6 @@ exports[`Box gap 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2666,7 +2559,6 @@ exports[`Box gridArea 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   grid-area: header;
   min-width: 0;
@@ -2702,7 +2594,6 @@ exports[`Box height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2718,7 +2609,6 @@ exports[`Box height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2734,7 +2624,6 @@ exports[`Box height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2750,7 +2639,6 @@ exports[`Box height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2766,7 +2654,6 @@ exports[`Box height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2782,7 +2669,6 @@ exports[`Box height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2833,7 +2719,6 @@ exports[`Box justify 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2852,7 +2737,6 @@ exports[`Box justify 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2871,7 +2755,6 @@ exports[`Box justify 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2890,7 +2773,6 @@ exports[`Box justify 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2909,7 +2791,6 @@ exports[`Box justify 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2928,7 +2809,6 @@ exports[`Box justify 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2982,7 +2862,6 @@ exports[`Box margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin: 12px;
   min-width: 0;
@@ -2998,7 +2877,6 @@ exports[`Box margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin: 24px;
   min-width: 0;
@@ -3014,7 +2892,6 @@ exports[`Box margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin: 48px;
   min-width: 0;
@@ -3030,7 +2907,6 @@ exports[`Box margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -3047,7 +2923,6 @@ exports[`Box margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-top: 12px;
   margin-bottom: 12px;
@@ -3064,7 +2939,6 @@ exports[`Box margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -3080,7 +2954,6 @@ exports[`Box margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   min-width: 0;
@@ -3096,7 +2969,6 @@ exports[`Box margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-right: 12px;
   min-width: 0;
@@ -3112,7 +2984,6 @@ exports[`Box margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-inline-start: 12px;
   min-width: 0;
@@ -3128,7 +2999,6 @@ exports[`Box margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-inline-end: 12px;
   min-width: 0;
@@ -3144,7 +3014,6 @@ exports[`Box margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-top: 12px;
   min-width: 0;
@@ -3160,7 +3029,6 @@ exports[`Box margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 48px;
   margin-right: 48px;
@@ -3179,7 +3047,6 @@ exports[`Box margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-top: 48px;
   margin-bottom: 48px;
@@ -3197,7 +3064,6 @@ exports[`Box margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-top: 12px;
   margin-bottom: 12px;
@@ -3216,7 +3082,6 @@ exports[`Box margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 24px;
   margin-right: 24px;
@@ -3466,7 +3331,6 @@ exports[`Box onClick 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3505,7 +3369,6 @@ exports[`Box pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3521,7 +3384,6 @@ exports[`Box pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3537,7 +3399,6 @@ exports[`Box pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3553,7 +3414,6 @@ exports[`Box pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3570,7 +3430,6 @@ exports[`Box pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3587,7 +3446,6 @@ exports[`Box pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3603,7 +3461,6 @@ exports[`Box pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3619,7 +3476,6 @@ exports[`Box pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3635,7 +3491,6 @@ exports[`Box pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3651,7 +3506,6 @@ exports[`Box pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3667,7 +3521,6 @@ exports[`Box pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3683,7 +3536,6 @@ exports[`Box pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3702,7 +3554,6 @@ exports[`Box pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3723,7 +3574,6 @@ exports[`Box pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3744,7 +3594,6 @@ exports[`Box pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4014,7 +3863,6 @@ exports[`Box responsive 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4052,7 +3900,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4068,7 +3915,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4084,7 +3930,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4100,7 +3945,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4116,7 +3960,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4132,7 +3975,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4149,7 +3991,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4166,7 +4007,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4183,7 +4023,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4200,7 +4039,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4216,7 +4054,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4232,7 +4069,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4248,7 +4084,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4264,7 +4099,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4280,7 +4114,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4296,7 +4129,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4312,7 +4144,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4328,7 +4159,6 @@ exports[`Box round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4472,7 +4302,6 @@ exports[`Box width 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4488,7 +4317,6 @@ exports[`Box width 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4504,7 +4332,6 @@ exports[`Box width 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4520,7 +4347,6 @@ exports[`Box width 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4536,7 +4362,6 @@ exports[`Box width 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4552,7 +4377,6 @@ exports[`Box width 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4603,7 +4427,6 @@ exports[`Box wrap 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4621,7 +4444,6 @@ exports[`Box wrap 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4636,7 +4458,6 @@ exports[`Box wrap 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;

--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -724,12 +724,52 @@ undefined
 
 **global.focus.border.color**
 
-The color around the component when in focus. Expects `string | { dark: string, light: string }`.
+The border color of the component when in focus. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 
 ```
 focus
+```
+
+**global.focus.outline.color**
+
+The outline color around the component when in focus. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+undefined
+```
+
+**global.focus.outline.size**
+
+The size of the outline around the component when in focus. Expects `string`.
+
+Defaults to
+
+```
+undefined
+```
+
+**global.focus.shadow.color**
+
+The shadow color around the component when in focus. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+focus
+```
+
+**global.focus.shadow.size**
+
+The size of the shadow around the component when in focus. Expects `string`.
+
+Defaults to
+
+```
+2px
 ```
 
 **global.control.disabled.opacity**

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -130,6 +130,7 @@ const fillStyle = fillContainer => {
 
 const plainStyle = props => css`
   color: ${normalizeColor(props.colorValue || 'inherit', props.theme)};
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -180,7 +180,6 @@ const StyledButton = styled.button`
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   text-decoration: none;
   margin: 0;
@@ -202,7 +201,7 @@ const StyledButton = styled.button`
     props.theme.button.disabled &&
     disabledButtonStyle(props)}
   ${props =>
-    props.focus && (!props.plain || props.focusIndicator) && focusStyle}
+    props.focus && (!props.plain || props.focusIndicator) && focusStyle()}
   ${props =>
     !props.plain &&
     props.theme.button.transition &&

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -584,6 +584,7 @@ exports[`Button disabled 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -603,6 +604,7 @@ exports[`Button disabled 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -624,6 +626,7 @@ exports[`Button disabled 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -835,6 +838,7 @@ exports[`Button fill 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1098,6 +1102,7 @@ exports[`Button hoverIndicator as object with color 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1148,6 +1153,7 @@ exports[`Button hoverIndicator as object with invalid color 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1198,6 +1204,7 @@ exports[`Button hoverIndicator background 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1248,6 +1255,7 @@ exports[`Button hoverIndicator color 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1889,6 +1897,7 @@ exports[`Button size 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2208,6 +2217,7 @@ exports[`Button warns about invalid icon 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2255,6 +2265,7 @@ exports[`Button warns about invalid label 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -1060,7 +1060,8 @@ exports[`Button focus 1`] = `
 .c1 > polygon,
 .c1 > polyline,
 .c1 > rect {
-  outline: #6FFFB0 solid 2px;
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
 .c1::-moz-focus-inner {

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -5,7 +5,6 @@ exports[`Button active + primary 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -67,7 +66,6 @@ exports[`Button active 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -126,7 +124,6 @@ exports[`Button as 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -181,7 +178,6 @@ exports[`Button basic 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -239,7 +235,6 @@ exports[`Button children function 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -306,7 +301,6 @@ exports[`Button color 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -336,7 +330,6 @@ exports[`Button color 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -369,7 +362,6 @@ exports[`Button color 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -402,7 +394,6 @@ exports[`Button color 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -498,7 +489,6 @@ exports[`Button disabled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -529,7 +519,6 @@ exports[`Button disabled 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -557,7 +546,6 @@ exports[`Button disabled 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -588,7 +576,6 @@ exports[`Button disabled 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -608,7 +595,6 @@ exports[`Button disabled 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -630,7 +616,6 @@ exports[`Button disabled 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -651,7 +636,6 @@ exports[`Button disabled 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -843,7 +827,6 @@ exports[`Button fill 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -861,7 +844,6 @@ exports[`Button fill 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -897,7 +879,6 @@ exports[`Button fill 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -927,7 +908,6 @@ exports[`Button fill 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -958,7 +938,6 @@ exports[`Button fill 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1047,7 +1026,6 @@ exports[`Button focus 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1061,8 +1039,7 @@ exports[`Button focus 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  outline-color: #6FFFB0;
-  border-color: #6FFFB0;
+  outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -1113,7 +1090,6 @@ exports[`Button hoverIndicator as object with color 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1164,7 +1140,6 @@ exports[`Button hoverIndicator as object with invalid color 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1215,7 +1190,6 @@ exports[`Button hoverIndicator background 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1266,7 +1240,6 @@ exports[`Button hoverIndicator color 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1317,7 +1290,6 @@ exports[`Button href 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1374,7 +1346,6 @@ exports[`Button icon label 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1405,7 +1376,6 @@ exports[`Button icon label 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1471,7 +1441,6 @@ exports[`Button primary 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1534,7 +1503,6 @@ exports[`Button reverse icon label 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1565,7 +1533,6 @@ exports[`Button reverse icon label 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1701,7 +1668,6 @@ exports[`Button size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1732,7 +1698,6 @@ exports[`Button size 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1762,7 +1727,6 @@ exports[`Button size 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1792,7 +1756,6 @@ exports[`Button size 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1822,7 +1785,6 @@ exports[`Button size 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1855,7 +1817,6 @@ exports[`Button size 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1888,7 +1849,6 @@ exports[`Button size 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1921,7 +1881,6 @@ exports[`Button size 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2241,7 +2200,6 @@ exports[`Button warns about invalid icon 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2289,7 +2247,6 @@ exports[`Button warns about invalid label 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/src/js/components/Calendar/StyledCalendar.js
+++ b/src/js/components/Calendar/StyledCalendar.js
@@ -31,8 +31,7 @@ const StyledWeeksContainer = styled.div`
   ${props =>
     `height: ${parseMetricToNum(props.theme.calendar[props.sizeProp].daySize) *
       6}px;`};
-  outline: none;
-  ${props => props.focus && !props.plain && focusStyle};
+  ${props => props.focus && !props.plain && focusStyle()};
 `;
 
 StyledWeeksContainer.defaultProps = {};

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -41,7 +41,6 @@ exports[`Calendar date 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -56,7 +55,6 @@ exports[`Calendar date 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -79,7 +77,6 @@ exports[`Calendar date 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -99,7 +96,6 @@ exports[`Calendar date 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -119,7 +115,6 @@ exports[`Calendar date 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -139,7 +134,6 @@ exports[`Calendar date 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -170,7 +164,6 @@ exports[`Calendar date 1`] = `
 .c9 {
   overflow: hidden;
   height: 329.1428571428571px;
-  outline: none;
 }
 
 .c10 {
@@ -1322,7 +1315,6 @@ exports[`Calendar dates 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1337,7 +1329,6 @@ exports[`Calendar dates 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1360,7 +1351,6 @@ exports[`Calendar dates 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1380,7 +1370,6 @@ exports[`Calendar dates 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1400,7 +1389,6 @@ exports[`Calendar dates 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1420,7 +1408,6 @@ exports[`Calendar dates 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1451,7 +1438,6 @@ exports[`Calendar dates 1`] = `
 .c9 {
   overflow: hidden;
   height: 329.1428571428571px;
-  outline: none;
 }
 
 .c10 {
@@ -2603,7 +2589,6 @@ exports[`Calendar daysOfWeek 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2618,7 +2603,6 @@ exports[`Calendar daysOfWeek 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2641,7 +2625,6 @@ exports[`Calendar daysOfWeek 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2661,7 +2644,6 @@ exports[`Calendar daysOfWeek 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2681,7 +2663,6 @@ exports[`Calendar daysOfWeek 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2701,7 +2682,6 @@ exports[`Calendar daysOfWeek 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2732,7 +2712,6 @@ exports[`Calendar daysOfWeek 1`] = `
 .c12 {
   overflow: hidden;
   height: 329.1428571428571px;
-  outline: none;
 }
 
 .c13 {
@@ -3951,7 +3930,6 @@ exports[`Calendar firstDayOfWeek 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3966,7 +3944,6 @@ exports[`Calendar firstDayOfWeek 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -3989,7 +3966,6 @@ exports[`Calendar firstDayOfWeek 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4009,7 +3985,6 @@ exports[`Calendar firstDayOfWeek 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -4029,7 +4004,6 @@ exports[`Calendar firstDayOfWeek 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4049,7 +4023,6 @@ exports[`Calendar firstDayOfWeek 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4080,7 +4053,6 @@ exports[`Calendar firstDayOfWeek 1`] = `
 .c9 {
   overflow: hidden;
   height: 329.1428571428571px;
-  outline: none;
 }
 
 .c10 {
@@ -6225,7 +6197,6 @@ exports[`Calendar header 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -6240,7 +6211,6 @@ exports[`Calendar header 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -6261,7 +6231,6 @@ exports[`Calendar header 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -6279,7 +6248,6 @@ exports[`Calendar header 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -6309,7 +6277,6 @@ exports[`Calendar header 1`] = `
 .c7 {
   overflow: hidden;
   height: 164.57142857142856px;
-  outline: none;
 }
 
 .c8 {
@@ -7478,7 +7445,6 @@ exports[`Calendar reference 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -7493,7 +7459,6 @@ exports[`Calendar reference 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -7516,7 +7481,6 @@ exports[`Calendar reference 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -7536,7 +7500,6 @@ exports[`Calendar reference 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -7556,7 +7519,6 @@ exports[`Calendar reference 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -7576,7 +7538,6 @@ exports[`Calendar reference 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -7607,7 +7568,6 @@ exports[`Calendar reference 1`] = `
 .c9 {
   overflow: hidden;
   height: 329.1428571428571px;
-  outline: none;
 }
 
 .c10 {
@@ -8739,7 +8699,6 @@ exports[`Calendar select date 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -8754,7 +8713,6 @@ exports[`Calendar select date 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -8777,7 +8735,6 @@ exports[`Calendar select date 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -8797,7 +8754,6 @@ exports[`Calendar select date 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -8817,7 +8773,6 @@ exports[`Calendar select date 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -8837,7 +8792,6 @@ exports[`Calendar select date 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -8868,7 +8822,6 @@ exports[`Calendar select date 1`] = `
 .c9 {
   overflow: hidden;
   height: 329.1428571428571px;
-  outline: none;
 }
 
 .c10 {
@@ -9761,13 +9714,13 @@ exports[`Calendar select date 2`] = `
     class="StyledCalendar-sc-1y4xhmp-0 eMLsHu"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 jJdKAu"
+      class="StyledBox-sc-13pk1d4-0 bFwQzJ"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 kDANyu"
+        class="StyledBox-sc-13pk1d4-0 VvbUh"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 dKPJuK"
+          class="StyledBox-sc-13pk1d4-0 ecbFEh"
         >
           <h3
             class="StyledHeading-sc-1rdh4aw-0 eEcLoL"
@@ -9776,11 +9729,11 @@ exports[`Calendar select date 2`] = `
           </h3>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 kDGHLb"
+          class="StyledBox-sc-13pk1d4-0 bBymtc"
         >
           <button
             aria-label="December 2017"
-            class="StyledButton-sc-323bzc-0 jvkqEN"
+            class="StyledButton-sc-323bzc-0 yquOu"
             type="button"
           >
             <svg
@@ -9799,7 +9752,7 @@ exports[`Calendar select date 2`] = `
           </button>
           <button
             aria-label="February 2018"
-            class="StyledButton-sc-323bzc-0 jvkqEN"
+            class="StyledButton-sc-323bzc-0 yquOu"
             type="button"
           >
             <svg
@@ -9818,7 +9771,7 @@ exports[`Calendar select date 2`] = `
         </div>
       </div>
       <div
-        class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 oKujh"
+        class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 jSjbHS"
         tabindex="0"
       >
         <div
@@ -9832,7 +9785,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Dec 31 2017"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -9848,7 +9801,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 01 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -9864,7 +9817,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 02 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -9880,7 +9833,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 03 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -9896,7 +9849,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 04 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -9912,7 +9865,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 05 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -9928,7 +9881,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Jan 06 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -9948,7 +9901,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Jan 07 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -9964,7 +9917,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 08 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -9980,7 +9933,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 09 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -9996,7 +9949,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 10 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10012,7 +9965,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 11 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10028,7 +9981,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 12 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10044,7 +9997,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Jan 13 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10064,7 +10017,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Jan 14 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10080,7 +10033,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 15 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10096,7 +10049,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 16 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10112,7 +10065,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 17 2018"
-                class="StyledButton-sc-323bzc-0 bmILgb"
+                class="StyledButton-sc-323bzc-0 kA-drUA"
                 tabindex="-1"
                 type="button"
               >
@@ -10128,7 +10081,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 18 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10144,7 +10097,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 19 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10160,7 +10113,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Jan 20 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10180,7 +10133,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Jan 21 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10196,7 +10149,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 22 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10212,7 +10165,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 23 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10228,7 +10181,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 24 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10244,7 +10197,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 25 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10260,7 +10213,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 26 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10276,7 +10229,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Jan 27 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10296,7 +10249,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Jan 28 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10312,7 +10265,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 29 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10328,7 +10281,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 30 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10344,7 +10297,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 31 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10360,7 +10313,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Feb 01 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10376,7 +10329,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Feb 02 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10392,7 +10345,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Feb 03 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10412,7 +10365,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Feb 04 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10428,7 +10381,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Feb 05 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10444,7 +10397,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Feb 06 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10460,7 +10413,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Feb 07 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10476,7 +10429,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Feb 08 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10492,7 +10445,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Feb 09 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10508,7 +10461,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Feb 10 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -10568,7 +10521,6 @@ exports[`Calendar select dates 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -10583,7 +10535,6 @@ exports[`Calendar select dates 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -10606,7 +10557,6 @@ exports[`Calendar select dates 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -10626,7 +10576,6 @@ exports[`Calendar select dates 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -10646,7 +10595,6 @@ exports[`Calendar select dates 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -10666,7 +10614,6 @@ exports[`Calendar select dates 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -10697,7 +10644,6 @@ exports[`Calendar select dates 1`] = `
 .c9 {
   overflow: hidden;
   height: 329.1428571428571px;
-  outline: none;
 }
 
 .c10 {
@@ -11590,13 +11536,13 @@ exports[`Calendar select dates 2`] = `
     class="StyledCalendar-sc-1y4xhmp-0 eMLsHu"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 jJdKAu"
+      class="StyledBox-sc-13pk1d4-0 bFwQzJ"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 kDANyu"
+        class="StyledBox-sc-13pk1d4-0 VvbUh"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 dKPJuK"
+          class="StyledBox-sc-13pk1d4-0 ecbFEh"
         >
           <h3
             class="StyledHeading-sc-1rdh4aw-0 eEcLoL"
@@ -11605,11 +11551,11 @@ exports[`Calendar select dates 2`] = `
           </h3>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 kDGHLb"
+          class="StyledBox-sc-13pk1d4-0 bBymtc"
         >
           <button
             aria-label="December 2017"
-            class="StyledButton-sc-323bzc-0 jvkqEN"
+            class="StyledButton-sc-323bzc-0 yquOu"
             type="button"
           >
             <svg
@@ -11628,7 +11574,7 @@ exports[`Calendar select dates 2`] = `
           </button>
           <button
             aria-label="February 2018"
-            class="StyledButton-sc-323bzc-0 jvkqEN"
+            class="StyledButton-sc-323bzc-0 yquOu"
             type="button"
           >
             <svg
@@ -11647,7 +11593,7 @@ exports[`Calendar select dates 2`] = `
         </div>
       </div>
       <div
-        class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 oKujh"
+        class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 jSjbHS"
         tabindex="0"
       >
         <div
@@ -11661,7 +11607,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Dec 31 2017"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11677,7 +11623,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 01 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11693,7 +11639,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 02 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11709,7 +11655,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 03 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11725,7 +11671,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 04 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11741,7 +11687,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 05 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11757,7 +11703,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Jan 06 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11777,7 +11723,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Jan 07 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11793,7 +11739,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 08 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11809,7 +11755,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 09 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11825,7 +11771,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 10 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11841,7 +11787,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 11 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11857,7 +11803,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 12 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11873,7 +11819,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Jan 13 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11893,7 +11839,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Jan 14 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11909,7 +11855,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 15 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11925,7 +11871,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 16 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11941,7 +11887,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 17 2018"
-                class="StyledButton-sc-323bzc-0 bmILgb"
+                class="StyledButton-sc-323bzc-0 kA-drUA"
                 tabindex="-1"
                 type="button"
               >
@@ -11957,7 +11903,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 18 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11973,7 +11919,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 19 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -11989,7 +11935,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Jan 20 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12009,7 +11955,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Jan 21 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12025,7 +11971,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 22 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12041,7 +11987,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 23 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12057,7 +12003,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 24 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12073,7 +12019,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 25 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12089,7 +12035,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 26 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12105,7 +12051,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Jan 27 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12125,7 +12071,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Jan 28 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12141,7 +12087,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 29 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12157,7 +12103,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 30 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12173,7 +12119,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 31 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12189,7 +12135,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Feb 01 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12205,7 +12151,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Feb 02 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12221,7 +12167,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Feb 03 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12241,7 +12187,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Feb 04 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12257,7 +12203,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Feb 05 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12273,7 +12219,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Feb 06 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12289,7 +12235,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Feb 07 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12305,7 +12251,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Feb 08 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12321,7 +12267,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Feb 09 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12337,7 +12283,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Feb 10 2018"
-                class="StyledButton-sc-323bzc-0 dnCEuz"
+                class="StyledButton-sc-323bzc-0 ohdLU"
                 tabindex="-1"
                 type="button"
               >
@@ -12431,7 +12377,6 @@ exports[`Calendar size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -12446,7 +12391,6 @@ exports[`Calendar size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -12469,7 +12413,6 @@ exports[`Calendar size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -12489,7 +12432,6 @@ exports[`Calendar size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -12511,7 +12453,6 @@ exports[`Calendar size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -12531,7 +12472,6 @@ exports[`Calendar size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -12549,7 +12489,6 @@ exports[`Calendar size 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -12569,7 +12508,6 @@ exports[`Calendar size 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -12628,19 +12566,16 @@ exports[`Calendar size 1`] = `
 .c9 {
   overflow: hidden;
   height: 164.57142857142856px;
-  outline: none;
 }
 
 .c20 {
   overflow: hidden;
   height: 329.1428571428571px;
-  outline: none;
 }
 
 .c28 {
   overflow: hidden;
   height: 658.2857142857142px;
-  outline: none;
 }
 
 .c10 {

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -123,6 +123,7 @@ exports[`Calendar date 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -142,6 +143,7 @@ exports[`Calendar date 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1397,6 +1399,7 @@ exports[`Calendar dates 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1416,6 +1419,7 @@ exports[`Calendar dates 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2671,6 +2675,7 @@ exports[`Calendar daysOfWeek 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2690,6 +2695,7 @@ exports[`Calendar daysOfWeek 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -4012,6 +4018,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -4031,6 +4038,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -6239,6 +6247,7 @@ exports[`Calendar header 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -6256,6 +6265,7 @@ exports[`Calendar header 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -7527,6 +7537,7 @@ exports[`Calendar reference 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -7546,6 +7557,7 @@ exports[`Calendar reference 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -8781,6 +8793,7 @@ exports[`Calendar select date 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -8800,6 +8813,7 @@ exports[`Calendar select date 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -9733,7 +9747,7 @@ exports[`Calendar select date 2`] = `
         >
           <button
             aria-label="December 2017"
-            class="StyledButton-sc-323bzc-0 yquOu"
+            class="StyledButton-sc-323bzc-0 tdSht"
             type="button"
           >
             <svg
@@ -9752,7 +9766,7 @@ exports[`Calendar select date 2`] = `
           </button>
           <button
             aria-label="February 2018"
-            class="StyledButton-sc-323bzc-0 yquOu"
+            class="StyledButton-sc-323bzc-0 tdSht"
             type="button"
           >
             <svg
@@ -9785,7 +9799,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Dec 31 2017"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -9801,7 +9815,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 01 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -9817,7 +9831,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 02 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -9833,7 +9847,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 03 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -9849,7 +9863,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 04 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -9865,7 +9879,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 05 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -9881,7 +9895,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Jan 06 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -9901,7 +9915,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Jan 07 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -9917,7 +9931,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 08 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -9933,7 +9947,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 09 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -9949,7 +9963,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 10 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -9965,7 +9979,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 11 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -9981,7 +9995,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 12 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -9997,7 +10011,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Jan 13 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10017,7 +10031,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Jan 14 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10033,7 +10047,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 15 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10049,7 +10063,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 16 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10065,7 +10079,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 17 2018"
-                class="StyledButton-sc-323bzc-0 kA-drUA"
+                class="StyledButton-sc-323bzc-0 PtHXf"
                 tabindex="-1"
                 type="button"
               >
@@ -10081,7 +10095,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 18 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10097,7 +10111,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 19 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10113,7 +10127,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Jan 20 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10133,7 +10147,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Jan 21 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10149,7 +10163,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 22 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10165,7 +10179,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 23 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10181,7 +10195,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 24 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10197,7 +10211,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 25 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10213,7 +10227,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 26 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10229,7 +10243,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Jan 27 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10249,7 +10263,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Jan 28 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10265,7 +10279,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 29 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10281,7 +10295,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 30 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10297,7 +10311,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 31 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10313,7 +10327,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Feb 01 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10329,7 +10343,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Feb 02 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10345,7 +10359,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Feb 03 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10365,7 +10379,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Feb 04 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10381,7 +10395,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Feb 05 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10397,7 +10411,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Feb 06 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10413,7 +10427,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Feb 07 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10429,7 +10443,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Feb 08 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10445,7 +10459,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Feb 09 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10461,7 +10475,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Feb 10 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -10603,6 +10617,7 @@ exports[`Calendar select dates 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -10622,6 +10637,7 @@ exports[`Calendar select dates 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -11555,7 +11571,7 @@ exports[`Calendar select dates 2`] = `
         >
           <button
             aria-label="December 2017"
-            class="StyledButton-sc-323bzc-0 yquOu"
+            class="StyledButton-sc-323bzc-0 tdSht"
             type="button"
           >
             <svg
@@ -11574,7 +11590,7 @@ exports[`Calendar select dates 2`] = `
           </button>
           <button
             aria-label="February 2018"
-            class="StyledButton-sc-323bzc-0 yquOu"
+            class="StyledButton-sc-323bzc-0 tdSht"
             type="button"
           >
             <svg
@@ -11607,7 +11623,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Dec 31 2017"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11623,7 +11639,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 01 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11639,7 +11655,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 02 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11655,7 +11671,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 03 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11671,7 +11687,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 04 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11687,7 +11703,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 05 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11703,7 +11719,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Jan 06 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11723,7 +11739,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Jan 07 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11739,7 +11755,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 08 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11755,7 +11771,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 09 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11771,7 +11787,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 10 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11787,7 +11803,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 11 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11803,7 +11819,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 12 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11819,7 +11835,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Jan 13 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11839,7 +11855,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Jan 14 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11855,7 +11871,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 15 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11871,7 +11887,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 16 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11887,7 +11903,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 17 2018"
-                class="StyledButton-sc-323bzc-0 kA-drUA"
+                class="StyledButton-sc-323bzc-0 PtHXf"
                 tabindex="-1"
                 type="button"
               >
@@ -11903,7 +11919,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 18 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11919,7 +11935,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 19 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11935,7 +11951,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Jan 20 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11955,7 +11971,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Jan 21 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11971,7 +11987,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 22 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -11987,7 +12003,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 23 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12003,7 +12019,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 24 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12019,7 +12035,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 25 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12035,7 +12051,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 26 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12051,7 +12067,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Jan 27 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12071,7 +12087,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Jan 28 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12087,7 +12103,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 29 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12103,7 +12119,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 30 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12119,7 +12135,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 31 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12135,7 +12151,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Feb 01 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12151,7 +12167,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Feb 02 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12167,7 +12183,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Feb 03 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12187,7 +12203,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Feb 04 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12203,7 +12219,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Feb 05 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12219,7 +12235,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Feb 06 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12235,7 +12251,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Feb 07 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12251,7 +12267,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Feb 08 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12267,7 +12283,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Feb 09 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12283,7 +12299,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Feb 10 2018"
-                class="StyledButton-sc-323bzc-0 ohdLU"
+                class="StyledButton-sc-323bzc-0 bwJeiP"
                 tabindex="-1"
                 type="button"
               >
@@ -12497,6 +12513,7 @@ exports[`Calendar size 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -12516,6 +12533,7 @@ exports[`Calendar size 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -85,7 +85,6 @@ exports[`Carousel basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -101,7 +100,6 @@ exports[`Carousel basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -116,7 +114,6 @@ exports[`Carousel basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -134,7 +131,6 @@ exports[`Carousel basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -155,7 +151,6 @@ exports[`Carousel basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -174,7 +169,6 @@ exports[`Carousel basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -191,7 +185,6 @@ exports[`Carousel basic 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -213,7 +206,6 @@ exports[`Carousel basic 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -233,7 +225,6 @@ exports[`Carousel basic 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -509,7 +500,6 @@ exports[`Carousel basic with \`initialChild: 1\` 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -525,7 +515,6 @@ exports[`Carousel basic with \`initialChild: 1\` 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -543,7 +532,6 @@ exports[`Carousel basic with \`initialChild: 1\` 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -558,7 +546,6 @@ exports[`Carousel basic with \`initialChild: 1\` 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -579,7 +566,6 @@ exports[`Carousel basic with \`initialChild: 1\` 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -598,7 +584,6 @@ exports[`Carousel basic with \`initialChild: 1\` 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -615,7 +600,6 @@ exports[`Carousel basic with \`initialChild: 1\` 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -640,7 +624,6 @@ exports[`Carousel basic with \`initialChild: 1\` 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -660,7 +643,6 @@ exports[`Carousel basic with \`initialChild: 1\` 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -933,7 +915,6 @@ exports[`Carousel navigate 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -949,7 +930,6 @@ exports[`Carousel navigate 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -964,7 +944,6 @@ exports[`Carousel navigate 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -982,7 +961,6 @@ exports[`Carousel navigate 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1003,7 +981,6 @@ exports[`Carousel navigate 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1022,7 +999,6 @@ exports[`Carousel navigate 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1039,7 +1015,6 @@ exports[`Carousel navigate 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1061,7 +1036,6 @@ exports[`Carousel navigate 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1081,7 +1055,6 @@ exports[`Carousel navigate 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1261,10 +1234,10 @@ exports[`Carousel navigate 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 gzpmgV"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fwGXuR"
+        class="StyledBox-sc-13pk1d4-0 kpwHpK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 EaYGa"
+          class="StyledBox-sc-13pk1d4-0 fijLVp"
         >
           <img
             class="StyledImage-ey4zx9-0 gtXVuX"
@@ -1277,10 +1250,10 @@ exports[`Carousel navigate 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 eFfYoG"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fwGXuR"
+        class="StyledBox-sc-13pk1d4-0 kpwHpK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fdJwEo"
+          class="StyledBox-sc-13pk1d4-0 fyNJTz"
         >
           <img
             class="StyledImage-ey4zx9-0 gtXVuX"
@@ -1293,11 +1266,11 @@ exports[`Carousel navigate 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 gzpmgV"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 NqokZ"
+        class="StyledBox-sc-13pk1d4-0 iLSfXS"
         tabindex="0"
       >
         <button
-          class="StyledButton-sc-323bzc-0 bYeHmo"
+          class="StyledButton-sc-323bzc-0 bOIOdP"
           type="button"
         >
           <svg
@@ -1315,13 +1288,13 @@ exports[`Carousel navigate 2`] = `
           </svg>
         </button>
         <div
-          class="StyledBox-sc-13pk1d4-0 QbJgA"
+          class="StyledBox-sc-13pk1d4-0 idXMGj"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hNgxQO"
+            class="StyledBox-sc-13pk1d4-0 jmTzhV"
           >
             <button
-              class="StyledButton-sc-323bzc-0 jvkqEN"
+              class="StyledButton-sc-323bzc-0 yquOu"
               type="button"
             >
               <svg
@@ -1338,7 +1311,7 @@ exports[`Carousel navigate 2`] = `
               </svg>
             </button>
             <button
-              class="StyledButton-sc-323bzc-0 jvkqEN"
+              class="StyledButton-sc-323bzc-0 yquOu"
               type="button"
             >
               <svg
@@ -1357,7 +1330,7 @@ exports[`Carousel navigate 2`] = `
           </div>
         </div>
         <button
-          class="StyledButton-sc-323bzc-0 lbekSm"
+          class="StyledButton-sc-323bzc-0 bJuENl"
           disabled=""
           type="button"
         >
@@ -1392,10 +1365,10 @@ exports[`Carousel navigate 3`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 eFfYoG"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fwGXuR"
+        class="StyledBox-sc-13pk1d4-0 kpwHpK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 gaLfCI"
+          class="StyledBox-sc-13pk1d4-0 dGhOz"
         >
           <img
             class="StyledImage-ey4zx9-0 gtXVuX"
@@ -1408,10 +1381,10 @@ exports[`Carousel navigate 3`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 gzpmgV"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fwGXuR"
+        class="StyledBox-sc-13pk1d4-0 kpwHpK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 EaYGa"
+          class="StyledBox-sc-13pk1d4-0 fijLVp"
         >
           <img
             class="StyledImage-ey4zx9-0 gtXVuX"
@@ -1424,11 +1397,11 @@ exports[`Carousel navigate 3`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 gzpmgV"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 NqokZ"
+        class="StyledBox-sc-13pk1d4-0 iLSfXS"
         tabindex="0"
       >
         <button
-          class="StyledButton-sc-323bzc-0 lbekSm"
+          class="StyledButton-sc-323bzc-0 bJuENl"
           disabled=""
           type="button"
         >
@@ -1447,13 +1420,13 @@ exports[`Carousel navigate 3`] = `
           </svg>
         </button>
         <div
-          class="StyledBox-sc-13pk1d4-0 QbJgA"
+          class="StyledBox-sc-13pk1d4-0 idXMGj"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hNgxQO"
+            class="StyledBox-sc-13pk1d4-0 jmTzhV"
           >
             <button
-              class="StyledButton-sc-323bzc-0 jvkqEN"
+              class="StyledButton-sc-323bzc-0 yquOu"
               type="button"
             >
               <svg
@@ -1470,7 +1443,7 @@ exports[`Carousel navigate 3`] = `
               </svg>
             </button>
             <button
-              class="StyledButton-sc-323bzc-0 jvkqEN"
+              class="StyledButton-sc-323bzc-0 yquOu"
               type="button"
             >
               <svg
@@ -1489,7 +1462,7 @@ exports[`Carousel navigate 3`] = `
           </div>
         </div>
         <button
-          class="StyledButton-sc-323bzc-0 bYeHmo"
+          class="StyledButton-sc-323bzc-0 bOIOdP"
           type="button"
         >
           <svg
@@ -1596,7 +1569,6 @@ exports[`Carousel play 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1612,7 +1584,6 @@ exports[`Carousel play 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1627,7 +1598,6 @@ exports[`Carousel play 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1645,7 +1615,6 @@ exports[`Carousel play 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1666,7 +1635,6 @@ exports[`Carousel play 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1685,7 +1653,6 @@ exports[`Carousel play 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1702,7 +1669,6 @@ exports[`Carousel play 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1724,7 +1690,6 @@ exports[`Carousel play 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1744,7 +1709,6 @@ exports[`Carousel play 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1922,10 +1886,10 @@ exports[`Carousel play 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 gzpmgV"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fwGXuR"
+        class="StyledBox-sc-13pk1d4-0 kpwHpK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 EaYGa"
+          class="StyledBox-sc-13pk1d4-0 fijLVp"
         >
           <img
             class="StyledImage-ey4zx9-0 gtXVuX"
@@ -1938,10 +1902,10 @@ exports[`Carousel play 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 eFfYoG"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fwGXuR"
+        class="StyledBox-sc-13pk1d4-0 kpwHpK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fdJwEo"
+          class="StyledBox-sc-13pk1d4-0 fyNJTz"
         >
           <img
             class="StyledImage-ey4zx9-0 gtXVuX"
@@ -1954,11 +1918,11 @@ exports[`Carousel play 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 gzpmgV"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 NqokZ"
+        class="StyledBox-sc-13pk1d4-0 iLSfXS"
         tabindex="0"
       >
         <button
-          class="StyledButton-sc-323bzc-0 bYeHmo"
+          class="StyledButton-sc-323bzc-0 bOIOdP"
           type="button"
         >
           <svg
@@ -1976,13 +1940,13 @@ exports[`Carousel play 2`] = `
           </svg>
         </button>
         <div
-          class="StyledBox-sc-13pk1d4-0 QbJgA"
+          class="StyledBox-sc-13pk1d4-0 idXMGj"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hNgxQO"
+            class="StyledBox-sc-13pk1d4-0 jmTzhV"
           >
             <button
-              class="StyledButton-sc-323bzc-0 jvkqEN"
+              class="StyledButton-sc-323bzc-0 yquOu"
               type="button"
             >
               <svg
@@ -1999,7 +1963,7 @@ exports[`Carousel play 2`] = `
               </svg>
             </button>
             <button
-              class="StyledButton-sc-323bzc-0 jvkqEN"
+              class="StyledButton-sc-323bzc-0 yquOu"
               type="button"
             >
               <svg
@@ -2018,7 +1982,7 @@ exports[`Carousel play 2`] = `
           </div>
         </div>
         <button
-          class="StyledButton-sc-323bzc-0 lbekSm"
+          class="StyledButton-sc-323bzc-0 bJuENl"
           disabled=""
           type="button"
         >

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -193,6 +193,7 @@ exports[`Carousel basic 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -214,6 +215,7 @@ exports[`Carousel basic 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -233,6 +235,7 @@ exports[`Carousel basic 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -608,6 +611,7 @@ exports[`Carousel basic with \`initialChild: 1\` 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -632,6 +636,7 @@ exports[`Carousel basic with \`initialChild: 1\` 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -651,6 +656,7 @@ exports[`Carousel basic with \`initialChild: 1\` 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1023,6 +1029,7 @@ exports[`Carousel navigate 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1044,6 +1051,7 @@ exports[`Carousel navigate 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1063,6 +1071,7 @@ exports[`Carousel navigate 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1270,7 +1279,7 @@ exports[`Carousel navigate 2`] = `
         tabindex="0"
       >
         <button
-          class="StyledButton-sc-323bzc-0 bOIOdP"
+          class="StyledButton-sc-323bzc-0 ccwczA"
           type="button"
         >
           <svg
@@ -1294,7 +1303,7 @@ exports[`Carousel navigate 2`] = `
             class="StyledBox-sc-13pk1d4-0 jmTzhV"
           >
             <button
-              class="StyledButton-sc-323bzc-0 yquOu"
+              class="StyledButton-sc-323bzc-0 tdSht"
               type="button"
             >
               <svg
@@ -1311,7 +1320,7 @@ exports[`Carousel navigate 2`] = `
               </svg>
             </button>
             <button
-              class="StyledButton-sc-323bzc-0 yquOu"
+              class="StyledButton-sc-323bzc-0 tdSht"
               type="button"
             >
               <svg
@@ -1330,7 +1339,7 @@ exports[`Carousel navigate 2`] = `
           </div>
         </div>
         <button
-          class="StyledButton-sc-323bzc-0 bJuENl"
+          class="StyledButton-sc-323bzc-0 khdMiC"
           disabled=""
           type="button"
         >
@@ -1401,7 +1410,7 @@ exports[`Carousel navigate 3`] = `
         tabindex="0"
       >
         <button
-          class="StyledButton-sc-323bzc-0 bJuENl"
+          class="StyledButton-sc-323bzc-0 khdMiC"
           disabled=""
           type="button"
         >
@@ -1426,7 +1435,7 @@ exports[`Carousel navigate 3`] = `
             class="StyledBox-sc-13pk1d4-0 jmTzhV"
           >
             <button
-              class="StyledButton-sc-323bzc-0 yquOu"
+              class="StyledButton-sc-323bzc-0 tdSht"
               type="button"
             >
               <svg
@@ -1443,7 +1452,7 @@ exports[`Carousel navigate 3`] = `
               </svg>
             </button>
             <button
-              class="StyledButton-sc-323bzc-0 yquOu"
+              class="StyledButton-sc-323bzc-0 tdSht"
               type="button"
             >
               <svg
@@ -1462,7 +1471,7 @@ exports[`Carousel navigate 3`] = `
           </div>
         </div>
         <button
-          class="StyledButton-sc-323bzc-0 bOIOdP"
+          class="StyledButton-sc-323bzc-0 ccwczA"
           type="button"
         >
           <svg
@@ -1677,6 +1686,7 @@ exports[`Carousel play 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1698,6 +1708,7 @@ exports[`Carousel play 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1717,6 +1728,7 @@ exports[`Carousel play 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1922,7 +1934,7 @@ exports[`Carousel play 2`] = `
         tabindex="0"
       >
         <button
-          class="StyledButton-sc-323bzc-0 bOIOdP"
+          class="StyledButton-sc-323bzc-0 ccwczA"
           type="button"
         >
           <svg
@@ -1946,7 +1958,7 @@ exports[`Carousel play 2`] = `
             class="StyledBox-sc-13pk1d4-0 jmTzhV"
           >
             <button
-              class="StyledButton-sc-323bzc-0 yquOu"
+              class="StyledButton-sc-323bzc-0 tdSht"
               type="button"
             >
               <svg
@@ -1963,7 +1975,7 @@ exports[`Carousel play 2`] = `
               </svg>
             </button>
             <button
-              class="StyledButton-sc-323bzc-0 yquOu"
+              class="StyledButton-sc-323bzc-0 tdSht"
               type="button"
             >
               <svg
@@ -1982,7 +1994,7 @@ exports[`Carousel play 2`] = `
           </div>
         </div>
         <button
-          class="StyledButton-sc-323bzc-0 bJuENl"
+          class="StyledButton-sc-323bzc-0 khdMiC"
           disabled=""
           type="button"
         >

--- a/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
+++ b/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
@@ -361,7 +361,6 @@ exports[`Chart gap renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -531,7 +530,6 @@ exports[`Chart size renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;

--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -67,7 +67,7 @@ StyledCheckBoxInput.defaultProps = {};
 Object.setPrototypeOf(StyledCheckBoxInput.defaultProps, defaultProps);
 
 const StyledCheckBoxBox = styled.div`
-  ${props => props.focus && focusStyle};
+  ${props => props.focus && focusStyle()};
   ${props => props.theme.checkBox.check.extend};
 `;
 
@@ -89,7 +89,7 @@ const StyledCheckBoxToggle = styled.span`
       ? normalizeColor(props.theme.checkBox.toggle.background, props.theme)
       : 'transparent'};
 
-  ${props => props.focus && focusStyle};
+  ${props => props.focus && focusStyle()};
   ${props => props.theme.checkBox.toggle.extend};
 `;
 

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -17,7 +17,6 @@ exports[`CheckBox checked renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -40,7 +39,6 @@ exports[`CheckBox checked renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -180,7 +178,6 @@ exports[`CheckBox controlled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-right: 12px;
   -webkit-align-items: center;
@@ -204,7 +201,6 @@ exports[`CheckBox controlled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -336,7 +332,7 @@ exports[`CheckBox controlled 2`] = `
     class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 fASNub StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+      class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
     >
       <input
         checked=""
@@ -344,7 +340,7 @@ exports[`CheckBox controlled 2`] = `
         type="checkbox"
       />
       <div
-        class="StyledBox-sc-13pk1d4-0 lpqrQA StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+        class="StyledBox-sc-13pk1d4-0 KsQmP StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
       >
         <svg
           class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 gHRhNW"
@@ -382,7 +378,6 @@ exports[`CheckBox disabled renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -405,7 +400,6 @@ exports[`CheckBox disabled renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -432,7 +426,6 @@ exports[`CheckBox disabled renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -614,7 +607,6 @@ exports[`CheckBox indeterminate renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -637,7 +629,6 @@ exports[`CheckBox indeterminate renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -664,7 +655,6 @@ exports[`CheckBox indeterminate renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-right: 12px;
   -webkit-align-items: center;
@@ -845,7 +835,6 @@ exports[`CheckBox label renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-right: 12px;
   -webkit-align-items: center;
@@ -869,7 +858,6 @@ exports[`CheckBox label renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1024,7 +1012,6 @@ exports[`CheckBox renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1047,7 +1034,6 @@ exports[`CheckBox renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1193,7 +1179,6 @@ exports[`CheckBox reverse renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   -webkit-align-items: center;
@@ -1217,7 +1202,6 @@ exports[`CheckBox reverse renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1346,7 +1330,6 @@ exports[`CheckBox toggle renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1369,7 +1352,6 @@ exports[`CheckBox toggle renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-right: 12px;
   -webkit-align-items: center;

--- a/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
+++ b/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
@@ -26,7 +26,6 @@ exports[`Clock hourLimit 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -197,7 +196,6 @@ exports[`Clock run 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -461,7 +459,7 @@ exports[`Clock run 2`] = `
     />
   </svg>
   <div
-    class="StyledBox-sc-13pk1d4-0 eitMOG"
+    class="StyledBox-sc-13pk1d4-0 bIdaiR"
   >
     <div
       class="StyledClock__StyledDigitalDigit-y4xw8s-4 gvEvWO"
@@ -536,7 +534,7 @@ exports[`Clock run 2`] = `
     </div>
   </div>
   <div
-    class="StyledBox-sc-13pk1d4-0 eitMOG"
+    class="StyledBox-sc-13pk1d4-0 bIdaiR"
   >
     <div
       class="StyledClock__StyledDigitalDigit-y4xw8s-4 gvEvWO"
@@ -639,7 +637,6 @@ exports[`Clock time 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2013,7 +2010,6 @@ exports[`Clock type digital precision hours size large 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2070,7 +2066,6 @@ exports[`Clock type digital precision hours size medium 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2127,7 +2122,6 @@ exports[`Clock type digital precision hours size small 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2184,7 +2178,6 @@ exports[`Clock type digital precision hours size xlarge 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2241,7 +2234,6 @@ exports[`Clock type digital precision hours size xsmall 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2298,7 +2290,6 @@ exports[`Clock type digital precision minutes size large 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2373,7 +2364,6 @@ exports[`Clock type digital precision minutes size medium 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2448,7 +2438,6 @@ exports[`Clock type digital precision minutes size small 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2523,7 +2512,6 @@ exports[`Clock type digital precision minutes size xlarge 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2598,7 +2586,6 @@ exports[`Clock type digital precision minutes size xsmall 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2673,7 +2660,6 @@ exports[`Clock type digital precision seconds size large 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2766,7 +2752,6 @@ exports[`Clock type digital precision seconds size medium 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2859,7 +2844,6 @@ exports[`Clock type digital precision seconds size small 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2952,7 +2936,6 @@ exports[`Clock type digital precision seconds size xlarge 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3045,7 +3028,6 @@ exports[`Clock type digital precision seconds size xsmall 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;

--- a/src/js/components/DataTable/StyledDataTable.js
+++ b/src/js/components/DataTable/StyledDataTable.js
@@ -79,7 +79,7 @@ const StyledDataTableBody = styled(TableBody)`
     max-height: ${props.theme.global.size[props.size]};
     overflow: auto;
   `}
-  ${props => props.focus && focusStyle}
+  ${props => props.focus && focusStyle()}
 `;
 
 StyledDataTableBody.defaultProps = {};

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2183,6 +2183,7 @@ exports[`DataTable groupBy 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2460,7 +2461,7 @@ exports[`DataTable groupBy 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 hvdwlH"
+            class="StyledButton-sc-323bzc-0 iCVMHc"
             type="button"
           >
             <div
@@ -2514,7 +2515,7 @@ exports[`DataTable groupBy 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 hvdwlH"
+            class="StyledButton-sc-323bzc-0 iCVMHc"
             type="button"
           >
             <div
@@ -2557,7 +2558,7 @@ exports[`DataTable groupBy 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 hvdwlH"
+            class="StyledButton-sc-323bzc-0 iCVMHc"
             type="button"
           >
             <div
@@ -2673,6 +2674,7 @@ exports[`DataTable groupBy expand 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -3087,6 +3089,7 @@ exports[`DataTable groupBy property 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -3364,7 +3367,7 @@ exports[`DataTable groupBy property 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 hvdwlH"
+            class="StyledButton-sc-323bzc-0 iCVMHc"
             type="button"
           >
             <div
@@ -3418,7 +3421,7 @@ exports[`DataTable groupBy property 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 hvdwlH"
+            class="StyledButton-sc-323bzc-0 iCVMHc"
             type="button"
           >
             <div
@@ -3461,7 +3464,7 @@ exports[`DataTable groupBy property 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 hvdwlH"
+            class="StyledButton-sc-323bzc-0 iCVMHc"
             type="button"
           >
             <div
@@ -3542,6 +3545,7 @@ exports[`DataTable onSort 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -3755,7 +3759,7 @@ exports[`DataTable onSort 2`] = `
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 jHVuIG"
+            class="StyledButton-sc-323bzc-0 grapNN"
             type="button"
           >
             <div
@@ -3842,7 +3846,7 @@ exports[`DataTable onSort 2`] = `
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 jHVuIG"
+            class="StyledButton-sc-323bzc-0 grapNN"
             type="button"
           >
             <div
@@ -5616,6 +5620,7 @@ exports[`DataTable search 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -6015,6 +6020,7 @@ exports[`DataTable sortable 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -6228,7 +6234,7 @@ exports[`DataTable sortable 2`] = `
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 jHVuIG"
+            class="StyledButton-sc-323bzc-0 grapNN"
             type="button"
           >
             <div
@@ -6315,7 +6321,7 @@ exports[`DataTable sortable 2`] = `
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 jHVuIG"
+            class="StyledButton-sc-323bzc-0 grapNN"
             type="button"
           >
             <div

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -5885,7 +5885,8 @@ exports[`DataTable search 2`] = `
 .c2 > polygon,
 .c2 > polyline,
 .c2 > rect {
-  outline: #6FFFB0 solid 2px;
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
 .c2::-moz-focus-inner {

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2158,7 +2158,6 @@ exports[`DataTable groupBy 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2176,7 +2175,6 @@ exports[`DataTable groupBy 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2462,11 +2460,11 @@ exports[`DataTable groupBy 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 fQsUEE"
+            class="StyledButton-sc-323bzc-0 hvdwlH"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 guJnsz"
+              class="StyledBox-sc-13pk1d4-0 bCSAfw"
             >
               <svg
                 aria-label="FormDown"
@@ -2516,11 +2514,11 @@ exports[`DataTable groupBy 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 fQsUEE"
+            class="StyledButton-sc-323bzc-0 hvdwlH"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 guJnsz"
+              class="StyledBox-sc-13pk1d4-0 bCSAfw"
             >
               <svg
                 aria-label="FormDown"
@@ -2559,11 +2557,11 @@ exports[`DataTable groupBy 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 fQsUEE"
+            class="StyledButton-sc-323bzc-0 hvdwlH"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 guJnsz"
+              class="StyledBox-sc-13pk1d4-0 bCSAfw"
             >
               <svg
                 aria-label="FormDown"
@@ -2650,7 +2648,6 @@ exports[`DataTable groupBy expand 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2668,7 +2665,6 @@ exports[`DataTable groupBy expand 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3066,7 +3062,6 @@ exports[`DataTable groupBy property 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -3084,7 +3079,6 @@ exports[`DataTable groupBy property 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3370,11 +3364,11 @@ exports[`DataTable groupBy property 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 fQsUEE"
+            class="StyledButton-sc-323bzc-0 hvdwlH"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 guJnsz"
+              class="StyledBox-sc-13pk1d4-0 bCSAfw"
             >
               <svg
                 aria-label="FormDown"
@@ -3424,11 +3418,11 @@ exports[`DataTable groupBy property 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 fQsUEE"
+            class="StyledButton-sc-323bzc-0 hvdwlH"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 guJnsz"
+              class="StyledBox-sc-13pk1d4-0 bCSAfw"
             >
               <svg
                 aria-label="FormDown"
@@ -3467,11 +3461,11 @@ exports[`DataTable groupBy property 2`] = `
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 fQsUEE"
+            class="StyledButton-sc-323bzc-0 hvdwlH"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 guJnsz"
+              class="StyledBox-sc-13pk1d4-0 bCSAfw"
             >
               <svg
                 aria-label="FormDown"
@@ -3524,7 +3518,6 @@ exports[`DataTable onSort 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -3541,7 +3534,6 @@ exports[`DataTable onSort 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3763,11 +3755,11 @@ exports[`DataTable onSort 2`] = `
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 fQBEfF"
+            class="StyledButton-sc-323bzc-0 jHVuIG"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 hErwNa"
+              class="StyledBox-sc-13pk1d4-0 rpWqh"
             >
               <span
                 class="StyledText-sc-1sadyjn-0 hUokoe"
@@ -3850,11 +3842,11 @@ exports[`DataTable onSort 2`] = `
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 fQBEfF"
+            class="StyledButton-sc-323bzc-0 jHVuIG"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 hErwNa"
+              class="StyledBox-sc-13pk1d4-0 rpWqh"
             >
               <span
                 class="StyledText-sc-1sadyjn-0 hUokoe"
@@ -4919,7 +4911,6 @@ exports[`DataTable replace 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -5108,7 +5099,6 @@ exports[`DataTable resizeable 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -5132,7 +5122,6 @@ exports[`DataTable resizeable 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-inline-end: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -5588,7 +5577,6 @@ exports[`DataTable search 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -5620,7 +5608,6 @@ exports[`DataTable search 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -5818,7 +5805,7 @@ exports[`DataTable search 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eDJNoM"
+            class="StyledBox-sc-13pk1d4-0 empHH"
           >
             <span
               class="StyledText-sc-1sadyjn-0 hUokoe"
@@ -5834,7 +5821,6 @@ exports[`DataTable search 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -5854,35 +5840,16 @@ exports[`DataTable search 2`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
   font-weight: 600;
   margin: 0;
-  outline-color: #6FFFB0;
-  border-color: #6FFFB0;
-  box-shadow: 0 0 2px 2px #6FFFB0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
-  outline-color: #6FFFB0;
-  border-color: #6FFFB0;
+  outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c2 > circle,
-.c2 > ellipse,
-.c2 > line,
-.c2 > path,
-.c2 > polygon,
-.c2 > polyline,
-.c2 > rect {
-  outline: #6FFFB0 solid 2px;
-}
-
-.c2::-moz-focus-inner {
-  border: 0;
 }
 
 .c2::-webkit-search-decoration {
@@ -6024,7 +5991,6 @@ exports[`DataTable sortable 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -6041,7 +6007,6 @@ exports[`DataTable sortable 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -6263,11 +6228,11 @@ exports[`DataTable sortable 2`] = `
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 fQBEfF"
+            class="StyledButton-sc-323bzc-0 jHVuIG"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 hErwNa"
+              class="StyledBox-sc-13pk1d4-0 rpWqh"
             >
               <span
                 class="StyledText-sc-1sadyjn-0 hUokoe"
@@ -6350,11 +6315,11 @@ exports[`DataTable sortable 2`] = `
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 fQBEfF"
+            class="StyledButton-sc-323bzc-0 jHVuIG"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 hErwNa"
+              class="StyledBox-sc-13pk1d4-0 rpWqh"
             >
               <span
                 class="StyledText-sc-1sadyjn-0 hUokoe"

--- a/src/js/components/Diagram/__tests__/__snapshots__/Diagram-test.js.snap
+++ b/src/js/components/Diagram/__tests__/__snapshots__/Diagram-test.js.snap
@@ -7,7 +7,6 @@ exports[`Diagram anchor 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -22,7 +21,6 @@ exports[`Diagram anchor 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -140,7 +138,6 @@ exports[`Diagram basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -155,7 +152,6 @@ exports[`Diagram basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -257,7 +253,6 @@ exports[`Diagram color 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -272,7 +267,6 @@ exports[`Diagram color 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -374,7 +368,6 @@ exports[`Diagram offset 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -389,7 +382,6 @@ exports[`Diagram offset 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -507,7 +499,6 @@ exports[`Diagram thickness 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -522,7 +513,6 @@ exports[`Diagram thickness 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -664,7 +654,6 @@ exports[`Diagram type 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -679,7 +668,6 @@ exports[`Diagram type 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;

--- a/src/js/components/Distribution/__tests__/__snapshots__/Distribution-test.js.snap
+++ b/src/js/components/Distribution/__tests__/__snapshots__/Distribution-test.js.snap
@@ -17,7 +17,6 @@ exports[`Distribution gap renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -36,7 +35,6 @@ exports[`Distribution gap renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -57,7 +55,6 @@ exports[`Distribution gap renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -78,7 +75,6 @@ exports[`Distribution gap renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -376,7 +372,6 @@ exports[`Distribution values renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -395,7 +390,6 @@ exports[`Distribution values renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -416,7 +410,6 @@ exports[`Distribution values renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -437,7 +430,6 @@ exports[`Distribution values renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -458,7 +450,6 @@ exports[`Distribution values renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -479,7 +470,6 @@ exports[`Distribution values renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -500,7 +490,6 @@ exports[`Distribution values renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -7,7 +7,6 @@ exports[`Drop align left left 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -67,13 +66,12 @@ exports[`Drop align left left 1`] = `
 `;
 
 exports[`Drop align left left 2`] = `
-".fUuNUq {
+".glPSfV {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -105,7 +103,6 @@ exports[`Drop align left right top bottom 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -165,13 +162,12 @@ exports[`Drop align left right top bottom 1`] = `
 `;
 
 exports[`Drop align left right top bottom 2`] = `
-".fUuNUq {
+".glPSfV {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -227,7 +223,6 @@ exports[`Drop align right left top top 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -287,13 +282,12 @@ exports[`Drop align right left top top 1`] = `
 `;
 
 exports[`Drop align right left top top 2`] = `
-".fUuNUq {
+".glPSfV {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -325,7 +319,6 @@ exports[`Drop align right right 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -385,13 +378,12 @@ exports[`Drop align right right 1`] = `
 `;
 
 exports[`Drop align right right 2`] = `
-".fUuNUq {
+".glPSfV {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -423,7 +415,6 @@ exports[`Drop align right right bottom top 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -483,13 +474,12 @@ exports[`Drop align right right bottom top 1`] = `
 `;
 
 exports[`Drop align right right bottom top 2`] = `
-".fUuNUq {
+".glPSfV {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -521,7 +511,6 @@ exports[`Drop align right right bottom top 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -581,13 +570,12 @@ exports[`Drop align right right bottom top 3`] = `
 `;
 
 exports[`Drop align right right bottom top 4`] = `
-".fUuNUq {
+".glPSfV {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -619,7 +607,6 @@ exports[`Drop basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -679,13 +666,12 @@ exports[`Drop basic 1`] = `
 `;
 
 exports[`Drop basic 2`] = `
-".fUuNUq {
+".glPSfV {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -741,7 +727,6 @@ exports[`Drop close 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -801,13 +786,12 @@ exports[`Drop close 1`] = `
 `;
 
 exports[`Drop close 2`] = `
-".fUuNUq {
+".glPSfV {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -863,7 +847,6 @@ exports[`Drop default elevation renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -923,13 +906,12 @@ exports[`Drop default elevation renders 1`] = `
 `;
 
 exports[`Drop default elevation renders 2`] = `
-".fUuNUq {
+".glPSfV {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -985,7 +967,6 @@ exports[`Drop invalid align 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1045,13 +1026,12 @@ exports[`Drop invalid align 1`] = `
 `;
 
 exports[`Drop invalid align 2`] = `
-".fUuNUq {
+".glPSfV {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1107,7 +1087,6 @@ exports[`Drop invoke onClickOutside 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1167,13 +1146,12 @@ exports[`Drop invoke onClickOutside 1`] = `
 `;
 
 exports[`Drop invoke onClickOutside 2`] = `
-".fUuNUq {
+".glPSfV {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1229,7 +1207,6 @@ exports[`Drop no stretch 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1289,13 +1266,12 @@ exports[`Drop no stretch 1`] = `
 `;
 
 exports[`Drop no stretch 2`] = `
-".fUuNUq {
+".glPSfV {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1351,7 +1327,6 @@ exports[`Drop plain renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1429,7 +1404,6 @@ exports[`Drop props elevation renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1534,7 +1508,6 @@ exports[`Drop resize 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1594,13 +1567,12 @@ exports[`Drop resize 1`] = `
 `;
 
 exports[`Drop resize 2`] = `
-".fUuNUq {
+".glPSfV {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1656,7 +1628,6 @@ exports[`Drop restrict focus 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1717,7 +1688,7 @@ exports[`Drop restrict focus 1`] = `
 
 exports[`Drop restrict focus 2`] = `
 <div
-  class="StyledBox-sc-13pk1d4-0 fUuNUq StyledDrop-sc-16s5rx8-0 exrnbV"
+  class="StyledBox-sc-13pk1d4-0 glPSfV StyledDrop-sc-16s5rx8-0 exrnbV"
   data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -1728,13 +1699,12 @@ exports[`Drop restrict focus 2`] = `
 `;
 
 exports[`Drop restrict focus 3`] = `
-".fUuNUq {
+".glPSfV {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1798,7 +1768,6 @@ exports[`Drop theme elevation renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;

--- a/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
+++ b/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
@@ -5,7 +5,6 @@ exports[`DropButton close by clicking outside 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -59,7 +58,6 @@ exports[`DropButton closed 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -104,7 +102,6 @@ exports[`DropButton disabled 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -143,7 +140,6 @@ exports[`DropButton open and close 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -197,7 +193,6 @@ exports[`DropButton opened 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -242,7 +237,6 @@ exports[`DropButton opened ref 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -300,7 +294,6 @@ exports[`DropButton ref function 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
@@ -102,6 +102,7 @@ exports[`Form controlled 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -199,7 +200,7 @@ exports[`Form controlled 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
+              class="StyledTextInput-sc-1x30a0s-0 jsQcHW"
               name="test"
               placeholder="test input"
               value="v"
@@ -237,7 +238,7 @@ exports[`Form controlled 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
+              class="StyledTextInput-sc-1x30a0s-0 jsQcHW"
               name="test"
               placeholder="test input"
               value="v"
@@ -367,6 +368,7 @@ exports[`Form controlled FormField deprecated 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -476,7 +478,7 @@ exports[`Form controlled FormField deprecated 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
+              class="StyledTextInput-sc-1x30a0s-0 jsQcHW"
               id="test"
               name="test"
               value="v"
@@ -520,7 +522,7 @@ exports[`Form controlled FormField deprecated 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
+              class="StyledTextInput-sc-1x30a0s-0 jsQcHW"
               id="test"
               name="test"
               value="v"
@@ -641,6 +643,7 @@ exports[`Form controlled input 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -738,7 +741,7 @@ exports[`Form controlled input 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
+              class="StyledTextInput-sc-1x30a0s-0 jsQcHW"
               name="test"
               placeholder="test input"
               value="v"
@@ -776,7 +779,7 @@ exports[`Form controlled input 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
+              class="StyledTextInput-sc-1x30a0s-0 jsQcHW"
               name="test"
               placeholder="test input"
               value="v"
@@ -897,6 +900,7 @@ exports[`Form controlled input lazy 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -994,7 +998,7 @@ exports[`Form controlled input lazy 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
+              class="StyledTextInput-sc-1x30a0s-0 jsQcHW"
               name="test"
               placeholder="test input"
               value="v"
@@ -1032,7 +1036,7 @@ exports[`Form controlled input lazy 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
+              class="StyledTextInput-sc-1x30a0s-0 jsQcHW"
               name="test"
               placeholder="test input"
               value="v"
@@ -1153,6 +1157,7 @@ exports[`Form controlled lazy 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -1250,7 +1255,7 @@ exports[`Form controlled lazy 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
+              class="StyledTextInput-sc-1x30a0s-0 jsQcHW"
               name="test"
               placeholder="test input"
               value="v"
@@ -1288,7 +1293,7 @@ exports[`Form controlled lazy 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
+              class="StyledTextInput-sc-1x30a0s-0 jsQcHW"
               name="test"
               placeholder="test input"
               value="v"
@@ -1408,6 +1413,7 @@ exports[`Form errors 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -1573,6 +1579,7 @@ exports[`Form infos 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -1931,6 +1938,7 @@ exports[`Form uncontrolled 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -2028,7 +2036,7 @@ exports[`Form uncontrolled 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
+              class="StyledTextInput-sc-1x30a0s-0 jsQcHW"
               name="test"
               placeholder="test input"
               value=""
@@ -2066,7 +2074,7 @@ exports[`Form uncontrolled 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
+              class="StyledTextInput-sc-1x30a0s-0 jsQcHW"
               name="test"
               placeholder="test input"
               value=""
@@ -2187,6 +2195,7 @@ exports[`Form update 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -2497,6 +2506,7 @@ exports[`Form with field 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
@@ -17,7 +17,6 @@ exports[`Form controlled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -33,7 +32,6 @@ exports[`Form controlled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -50,7 +48,6 @@ exports[`Form controlled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -63,7 +60,6 @@ exports[`Form controlled 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -98,7 +94,6 @@ exports[`Form controlled 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -156,7 +151,7 @@ exports[`Form controlled 1`] = `
       class="c1 "
     >
       <div
-        class="c2"
+        class="c2 "
       >
         <div
           class="c3"
@@ -191,20 +186,20 @@ exports[`Form controlled 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 eIRqpH FormField__FormFieldBox-m9hood-0 ddgSii"
+      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cIDibG"
+        class="StyledBox-sc-13pk1d4-0 kGPDbB FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jJdKAu"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 dofnYn"
+              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
               name="test"
               placeholder="test input"
               value="v"
@@ -214,7 +209,7 @@ exports[`Form controlled 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 etKeHw"
+      class="StyledButton-sc-323bzc-0 kpnlyr"
       type="submit"
     >
       Submit
@@ -229,20 +224,20 @@ exports[`Form controlled 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 eIRqpH FormField__FormFieldBox-m9hood-0 ddgSii"
+      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cIDibG"
+        class="StyledBox-sc-13pk1d4-0 kGPDbB FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jJdKAu"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 dofnYn"
+              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
               name="test"
               placeholder="test input"
               value="v"
@@ -252,7 +247,7 @@ exports[`Form controlled 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 etKeHw"
+      class="StyledButton-sc-323bzc-0 kpnlyr"
       type="submit"
     >
       Submit
@@ -278,7 +273,6 @@ exports[`Form controlled FormField deprecated 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -294,7 +288,6 @@ exports[`Form controlled FormField deprecated 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -311,7 +304,6 @@ exports[`Form controlled FormField deprecated 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -333,7 +325,6 @@ exports[`Form controlled FormField deprecated 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -368,7 +359,6 @@ exports[`Form controlled FormField deprecated 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -432,7 +422,7 @@ exports[`Form controlled FormField deprecated 1`] = `
         test
       </label>
       <div
-        class="c3"
+        class="c3 "
       >
         <div
           class="c4"
@@ -467,7 +457,7 @@ exports[`Form controlled FormField deprecated 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 eIRqpH FormField__FormFieldBox-m9hood-0 ddgSii"
+      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <label
         class="StyledText-sc-1sadyjn-0 enbIRN"
@@ -476,17 +466,17 @@ exports[`Form controlled FormField deprecated 2`] = `
         test
       </label>
       <div
-        class="StyledBox-sc-13pk1d4-0 cIDibG"
+        class="StyledBox-sc-13pk1d4-0 kGPDbB FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jJdKAu"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 dofnYn"
+              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
               id="test"
               name="test"
               value="v"
@@ -496,7 +486,7 @@ exports[`Form controlled FormField deprecated 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 etKeHw"
+      class="StyledButton-sc-323bzc-0 kpnlyr"
       type="submit"
     >
       Submit
@@ -511,7 +501,7 @@ exports[`Form controlled FormField deprecated 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 eIRqpH FormField__FormFieldBox-m9hood-0 ddgSii"
+      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <label
         class="StyledText-sc-1sadyjn-0 enbIRN"
@@ -520,17 +510,17 @@ exports[`Form controlled FormField deprecated 3`] = `
         test
       </label>
       <div
-        class="StyledBox-sc-13pk1d4-0 cIDibG"
+        class="StyledBox-sc-13pk1d4-0 kGPDbB FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jJdKAu"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 dofnYn"
+              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
               id="test"
               name="test"
               value="v"
@@ -540,7 +530,7 @@ exports[`Form controlled FormField deprecated 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 etKeHw"
+      class="StyledButton-sc-323bzc-0 kpnlyr"
       type="submit"
     >
       Submit
@@ -566,7 +556,6 @@ exports[`Form controlled input 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -582,7 +571,6 @@ exports[`Form controlled input 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -599,7 +587,6 @@ exports[`Form controlled input 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -612,7 +599,6 @@ exports[`Form controlled input 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -647,7 +633,6 @@ exports[`Form controlled input 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -705,7 +690,7 @@ exports[`Form controlled input 1`] = `
       class="c1 "
     >
       <div
-        class="c2"
+        class="c2 "
       >
         <div
           class="c3"
@@ -740,20 +725,20 @@ exports[`Form controlled input 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 eIRqpH FormField__FormFieldBox-m9hood-0 ddgSii"
+      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cIDibG"
+        class="StyledBox-sc-13pk1d4-0 kGPDbB FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jJdKAu"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 dofnYn"
+              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
               name="test"
               placeholder="test input"
               value="v"
@@ -763,7 +748,7 @@ exports[`Form controlled input 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 etKeHw"
+      class="StyledButton-sc-323bzc-0 kpnlyr"
       type="submit"
     >
       Submit
@@ -778,20 +763,20 @@ exports[`Form controlled input 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 eIRqpH FormField__FormFieldBox-m9hood-0 ddgSii"
+      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cIDibG"
+        class="StyledBox-sc-13pk1d4-0 kGPDbB FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jJdKAu"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 dofnYn"
+              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
               name="test"
               placeholder="test input"
               value="v"
@@ -801,7 +786,7 @@ exports[`Form controlled input 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 etKeHw"
+      class="StyledButton-sc-323bzc-0 kpnlyr"
       type="submit"
     >
       Submit
@@ -827,7 +812,6 @@ exports[`Form controlled input lazy 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -843,7 +827,6 @@ exports[`Form controlled input lazy 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -860,7 +843,6 @@ exports[`Form controlled input lazy 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -873,7 +855,6 @@ exports[`Form controlled input lazy 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -908,7 +889,6 @@ exports[`Form controlled input lazy 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -966,7 +946,7 @@ exports[`Form controlled input lazy 1`] = `
       class="c1 "
     >
       <div
-        class="c2"
+        class="c2 "
       >
         <div
           class="c3"
@@ -1001,20 +981,20 @@ exports[`Form controlled input lazy 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 eIRqpH FormField__FormFieldBox-m9hood-0 ddgSii"
+      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cIDibG"
+        class="StyledBox-sc-13pk1d4-0 kGPDbB FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jJdKAu"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 dofnYn"
+              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
               name="test"
               placeholder="test input"
               value="v"
@@ -1024,7 +1004,7 @@ exports[`Form controlled input lazy 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 etKeHw"
+      class="StyledButton-sc-323bzc-0 kpnlyr"
       type="submit"
     >
       Submit
@@ -1039,20 +1019,20 @@ exports[`Form controlled input lazy 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 eIRqpH FormField__FormFieldBox-m9hood-0 ddgSii"
+      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cIDibG"
+        class="StyledBox-sc-13pk1d4-0 kGPDbB FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jJdKAu"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 dofnYn"
+              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
               name="test"
               placeholder="test input"
               value="v"
@@ -1062,7 +1042,7 @@ exports[`Form controlled input lazy 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 etKeHw"
+      class="StyledButton-sc-323bzc-0 kpnlyr"
       type="submit"
     >
       Submit
@@ -1088,7 +1068,6 @@ exports[`Form controlled lazy 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -1104,7 +1083,6 @@ exports[`Form controlled lazy 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1121,7 +1099,6 @@ exports[`Form controlled lazy 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1134,7 +1111,6 @@ exports[`Form controlled lazy 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1169,7 +1145,6 @@ exports[`Form controlled lazy 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1227,7 +1202,7 @@ exports[`Form controlled lazy 1`] = `
       class="c1 "
     >
       <div
-        class="c2"
+        class="c2 "
       >
         <div
           class="c3"
@@ -1262,20 +1237,20 @@ exports[`Form controlled lazy 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 eIRqpH FormField__FormFieldBox-m9hood-0 ddgSii"
+      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cIDibG"
+        class="StyledBox-sc-13pk1d4-0 kGPDbB FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jJdKAu"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 dofnYn"
+              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
               name="test"
               placeholder="test input"
               value="v"
@@ -1285,7 +1260,7 @@ exports[`Form controlled lazy 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 etKeHw"
+      class="StyledButton-sc-323bzc-0 kpnlyr"
       type="submit"
     >
       Submit
@@ -1300,20 +1275,20 @@ exports[`Form controlled lazy 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 eIRqpH FormField__FormFieldBox-m9hood-0 ddgSii"
+      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cIDibG"
+        class="StyledBox-sc-13pk1d4-0 kGPDbB FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jJdKAu"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 dofnYn"
+              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
               name="test"
               placeholder="test input"
               value="v"
@@ -1323,7 +1298,7 @@ exports[`Form controlled lazy 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 etKeHw"
+      class="StyledButton-sc-323bzc-0 kpnlyr"
       type="submit"
     >
       Submit
@@ -1370,7 +1345,6 @@ exports[`Form errors 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -1386,7 +1360,6 @@ exports[`Form errors 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px #FF4040;
   min-width: 0;
@@ -1403,7 +1376,6 @@ exports[`Form errors 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1428,7 +1400,6 @@ exports[`Form errors 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1491,7 +1462,7 @@ exports[`Form errors 1`] = `
       onFocus={[Function]}
     >
       <div
-        className="c2"
+        className="c2 "
       >
         <div
           className="c3"
@@ -1539,7 +1510,6 @@ exports[`Form infos 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -1555,7 +1525,6 @@ exports[`Form infos 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1572,7 +1541,6 @@ exports[`Form infos 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1597,7 +1565,6 @@ exports[`Form infos 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1660,7 +1627,7 @@ exports[`Form infos 1`] = `
       onFocus={[Function]}
     >
       <div
-        className="c2"
+        className="c2 "
       >
         <div
           className="c3"
@@ -1705,7 +1672,6 @@ exports[`Form lazy value 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1737,7 +1703,6 @@ exports[`Form lazy value 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1881,7 +1846,6 @@ exports[`Form uncontrolled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -1897,7 +1861,6 @@ exports[`Form uncontrolled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1914,7 +1877,6 @@ exports[`Form uncontrolled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1927,7 +1889,6 @@ exports[`Form uncontrolled 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1962,7 +1923,6 @@ exports[`Form uncontrolled 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -2020,7 +1980,7 @@ exports[`Form uncontrolled 1`] = `
       class="c1 "
     >
       <div
-        class="c2"
+        class="c2 "
       >
         <div
           class="c3"
@@ -2055,20 +2015,20 @@ exports[`Form uncontrolled 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 eIRqpH FormField__FormFieldBox-m9hood-0 ddgSii"
+      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cIDibG"
+        class="StyledBox-sc-13pk1d4-0 kGPDbB FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jJdKAu"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 dofnYn"
+              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
               name="test"
               placeholder="test input"
               value=""
@@ -2078,7 +2038,7 @@ exports[`Form uncontrolled 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 etKeHw"
+      class="StyledButton-sc-323bzc-0 kpnlyr"
       type="submit"
     >
       Submit
@@ -2093,20 +2053,20 @@ exports[`Form uncontrolled 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 eIRqpH FormField__FormFieldBox-m9hood-0 ddgSii"
+      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cIDibG"
+        class="StyledBox-sc-13pk1d4-0 kGPDbB FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jJdKAu"
+          class="StyledBox-sc-13pk1d4-0 bFwQzJ"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 dofnYn"
+              class="StyledTextInput-sc-1x30a0s-0 cjOhSV"
               name="test"
               placeholder="test input"
               value=""
@@ -2116,7 +2076,7 @@ exports[`Form uncontrolled 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 etKeHw"
+      class="StyledButton-sc-323bzc-0 kpnlyr"
       type="submit"
     >
       Submit
@@ -2142,7 +2102,6 @@ exports[`Form update 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -2158,7 +2117,6 @@ exports[`Form update 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -2175,7 +2133,6 @@ exports[`Form update 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2188,7 +2145,6 @@ exports[`Form update 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2223,7 +2179,6 @@ exports[`Form update 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -2281,7 +2236,7 @@ exports[`Form update 1`] = `
       class="c1 "
     >
       <div
-        class="c2"
+        class="c2 "
       >
         <div
           class="c3"
@@ -2304,7 +2259,7 @@ exports[`Form update 1`] = `
       class="c1 "
     >
       <div
-        class="c2"
+        class="c2 "
       >
         <div
           class="c3"
@@ -2489,7 +2444,6 @@ exports[`Form with field 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -2505,7 +2459,6 @@ exports[`Form with field 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -2522,7 +2475,6 @@ exports[`Form with field 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2537,7 +2489,6 @@ exports[`Form with field 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -2600,7 +2551,7 @@ exports[`Form with field 1`] = `
       onFocus={[Function]}
     >
       <div
-        className="c2"
+        className="c2 "
       >
         <div
           className="c3"

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -26,12 +26,12 @@ const isGrommetInput = comp =>
     grommetInputPadNames.indexOf(comp.displayName) !== -1);
 
 const FormFieldBox = styled(Box)`
-  ${props => props.focus && focusStyle(true)}
+  ${props => props.focus && focusStyle({ justBorder: true })}
   ${props => props.theme.formField && props.theme.formField.extend}
 `;
 
 const FormFieldContentBox = styled(Box)`
-  ${props => props.focus && focusStyle(true)}
+  ${props => props.focus && focusStyle({ justBorder: true })}
 `;
 
 const Message = ({ message, ...rest }) => {

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -9,7 +9,7 @@ import React, {
 import styled, { ThemeContext } from 'styled-components';
 import { defaultProps } from '../../default-props';
 
-import { parseMetricToNum } from '../../utils';
+import { focusStyle, parseMetricToNum } from '../../utils';
 import { Box } from '../Box';
 import { CheckBox } from '../CheckBox';
 import { RadioButtonGroup } from '../RadioButtonGroup';
@@ -26,7 +26,12 @@ const isGrommetInput = comp =>
     grommetInputPadNames.indexOf(comp.displayName) !== -1);
 
 const FormFieldBox = styled(Box)`
+  ${props => props.focus && focusStyle(true)}
   ${props => props.theme.formField && props.theme.formField.extend}
+`;
+
+const FormFieldContentBox = styled(Box)`
+  ${props => props.focus && focusStyle(true)}
 `;
 
 const Message = ({ message, ...rest }) => {
@@ -154,8 +159,8 @@ const FormField = forwardRef(
       );
     };
 
-    const { formField } = theme;
-    const { border } = formField;
+    const { formField: formFieldTheme } = theme;
+    const { border: themeBorder } = formFieldTheme;
 
     // This is here for backwards compatibility. In case the child is a grommet
     // input component, set plain and focusIndicator props, if they aren't
@@ -163,7 +168,7 @@ const FormField = forwardRef(
     let wantContentPad =
       component && (component === CheckBox || component === RadioButtonGroup);
     let contents =
-      (border &&
+      (themeBorder &&
         children &&
         Children.map(children, child => {
           if (
@@ -210,12 +215,13 @@ const FormField = forwardRef(
       }
     }
 
-    const contentProps = pad || wantContentPad ? { ...formField.content } : {};
-    if (border.position === 'inner') {
-      if (normalizedError && formField.error) {
-        contentProps.background = formField.error.background;
-      } else if (disabled && formField.disabled) {
-        contentProps.background = formField.disabled.background;
+    const contentProps =
+      pad || wantContentPad ? { ...formFieldTheme.content } : {};
+    if (themeBorder.position === 'inner') {
+      if (normalizedError && formFieldTheme.error) {
+        contentProps.background = formFieldTheme.error.background;
+      } else if (disabled && formFieldTheme.disabled) {
+        contentProps.background = formFieldTheme.disabled.background;
       }
     }
     contents = <Box {...contentProps}>{contents}</Box>;
@@ -224,21 +230,20 @@ const FormField = forwardRef(
 
     if (disabled) {
       borderColor =
-        formField.disabled.border && formField.disabled.border.color;
-    } else if (focus && !normalizedError) {
-      borderColor = 'focus';
+        formFieldTheme.disabled.border && formFieldTheme.disabled.border.color;
     } else if (normalizedError) {
-      borderColor = (border && border.error.color) || 'status-critical';
+      borderColor =
+        (themeBorder && themeBorder.error.color) || 'status-critical';
     } else {
-      borderColor = (border && border.color) || 'border';
+      borderColor = (themeBorder && themeBorder.color) || 'border';
     }
 
-    const labelStyle = { ...formField.label };
+    const labelStyle = { ...formFieldTheme.label };
 
     if (disabled) {
       labelStyle.color =
-        formField.disabled && formField.disabled.label
-          ? formField.disabled.label.color
+        formFieldTheme.disabled && formFieldTheme.disabled.label
+          ? formFieldTheme.disabled.label.color
           : labelStyle.color;
     }
 
@@ -246,31 +251,31 @@ const FormField = forwardRef(
     let abutMargin;
     let outerStyle = style;
 
-    if (border) {
+    if (themeBorder) {
+      const innerProps =
+        themeBorder.position === 'inner'
+          ? {
+              border: {
+                ...themeBorder,
+                side: themeBorder.side || 'bottom',
+                color: borderColor,
+              },
+              round: formFieldTheme.round,
+              focus,
+            }
+          : {};
       contents = (
-        <Box
-          overflow="hidden"
-          border={
-            border.position === 'inner'
-              ? {
-                  ...border,
-                  side: border.side || 'bottom',
-                  color: borderColor,
-                }
-              : undefined
-          }
-          round={border.position === 'inner' ? formField.round : undefined}
-        >
+        <FormFieldContentBox overflow="hidden" {...innerProps}>
           {contents}
-        </Box>
+        </FormFieldContentBox>
       );
 
-      const mergedMargin = margin || formField.margin;
+      const mergedMargin = margin || formFieldTheme.margin;
       abut =
-        border.position === 'outer' &&
-        (border.side === 'all' ||
-          border.side === 'horizontal' ||
-          !border.side) &&
+        themeBorder.position === 'outer' &&
+        (themeBorder.side === 'all' ||
+          themeBorder.side === 'horizontal' ||
+          !themeBorder.side) &&
         !(
           mergedMargin &&
           ((typeof mergedMargin === 'string' && mergedMargin !== 'none') ||
@@ -282,12 +287,12 @@ const FormField = forwardRef(
         abutMargin = { bottom: '-1px' };
         if (margin) {
           abutMargin = margin;
-        } else if (border.size) {
+        } else if (themeBorder.size) {
           // if the user defines a margin,
           // then the default margin below will be overriden
           abutMargin = {
             bottom: `-${parseMetricToNum(
-              theme.global.borderSize[border.size] || border.size,
+              theme.global.borderSize[themeBorder.size] || themeBorder.size,
             )}px`,
           };
         }
@@ -301,26 +306,30 @@ const FormField = forwardRef(
     }
 
     let outerBackground;
-    if (border.position === 'outer') {
-      if (normalizedError && formField.error) {
-        outerBackground = formField.error.background;
-      } else if (disabled && formField.disabled) {
-        outerBackground = formField.disabled.background;
+    if (themeBorder.position === 'outer') {
+      if (normalizedError && formFieldTheme.error) {
+        outerBackground = formFieldTheme.error.background;
+      } else if (disabled && formFieldTheme.disabled) {
+        outerBackground = formFieldTheme.disabled.background;
       }
     }
+
+    const outerProps =
+      themeBorder && themeBorder.position === 'outer'
+        ? {
+            border: { ...themeBorder, color: borderColor },
+            round: formFieldTheme.round,
+            focus,
+          }
+        : {};
 
     return (
       <FormFieldBox
         ref={ref}
         className={className}
-        border={
-          border && border.position === 'outer'
-            ? { ...border, color: borderColor }
-            : undefined
-        }
         background={outerBackground}
-        margin={abut ? abutMargin : margin || { ...formField.margin }}
-        round={border.position === 'outer' ? formField.round : undefined}
+        margin={abut ? abutMargin : margin || { ...formFieldTheme.margin }}
+        {...outerProps}
         style={outerStyle}
         onFocus={event => {
           setFocus(true);
@@ -340,14 +349,14 @@ const FormField = forwardRef(
                 {label}
               </Text>
             )}
-            <Message message={help} {...formField.help} />
+            <Message message={help} {...formFieldTheme.help} />
           </>
         ) : (
           undefined
         )}
         {contents}
-        <Message message={normalizedError} {...formField.error} />
-        <Message message={normalizedInfo} {...formField.info} />
+        <Message message={normalizedError} {...formFieldTheme.error} />
+        <Message message={normalizedInfo} {...formFieldTheme.info} />
       </FormFieldBox>
     );
   },

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -17,7 +17,6 @@ exports[`FormField abut 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   border: solid 12px rgba(0,0,0,0.33);
@@ -34,7 +33,6 @@ exports[`FormField abut 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -50,7 +48,6 @@ exports[`FormField abut 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -80,7 +77,7 @@ exports[`FormField abut 1`] = `
     onFocus={[Function]}
   >
     <div
-      className="c2"
+      className="c2 "
     >
       <div
         className="c3"
@@ -107,7 +104,6 @@ exports[`FormField abut with margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin: 24px;
   border: solid 12px rgba(0,0,0,0.33);
@@ -124,7 +120,6 @@ exports[`FormField abut with margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -140,7 +135,6 @@ exports[`FormField abut with margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -170,7 +164,7 @@ exports[`FormField abut with margin 1`] = `
     onFocus={[Function]}
   >
     <div
-      className="c2"
+      className="c2 "
     >
       <div
         className="c3"
@@ -197,7 +191,6 @@ exports[`FormField custom formfield 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -213,7 +206,6 @@ exports[`FormField custom formfield 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -230,7 +222,6 @@ exports[`FormField custom formfield 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -264,7 +255,7 @@ exports[`FormField custom formfield 1`] = `
     onFocus={[Function]}
   >
     <div
-      className="c3"
+      className="c3 "
     >
       <div
         className="c4"
@@ -291,7 +282,6 @@ exports[`FormField custom label 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -307,7 +297,6 @@ exports[`FormField custom label 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -324,7 +313,6 @@ exports[`FormField custom label 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -347,7 +335,6 @@ exports[`FormField custom label 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -416,7 +403,7 @@ exports[`FormField custom label 1`] = `
         label
       </label>
       <div
-        className="c3"
+        className="c3 "
       >
         <div
           className="c4"
@@ -457,7 +444,6 @@ exports[`FormField default 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -473,7 +459,6 @@ exports[`FormField default 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -490,7 +475,6 @@ exports[`FormField default 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -505,7 +489,6 @@ exports[`FormField default 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -564,7 +547,7 @@ exports[`FormField default 1`] = `
     onFocus={[Function]}
   >
     <div
-      className="c2"
+      className="c2 "
     >
       <div
         className="c3"
@@ -577,7 +560,7 @@ exports[`FormField default 1`] = `
     onFocus={[Function]}
   >
     <div
-      className="c2"
+      className="c2 "
     >
       <div
         className="c3"
@@ -617,7 +600,6 @@ exports[`FormField disabled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -633,7 +615,6 @@ exports[`FormField disabled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -650,7 +631,6 @@ exports[`FormField disabled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(204,204,204,0.4);
   color: #444444;
@@ -667,7 +647,6 @@ exports[`FormField disabled 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -728,7 +707,7 @@ exports[`FormField disabled 1`] = `
     onFocus={[Function]}
   >
     <div
-      className="c2"
+      className="c2 "
     >
       <div
         className="c3"
@@ -746,7 +725,7 @@ exports[`FormField disabled 1`] = `
       onFocus={[Function]}
     >
       <div
-        className="c2"
+        className="c2 "
       >
         <div
           className="c3"
@@ -788,7 +767,6 @@ exports[`FormField disabled with custom label 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -804,7 +782,6 @@ exports[`FormField disabled with custom label 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -821,7 +798,6 @@ exports[`FormField disabled with custom label 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(204,204,204,0.4);
   color: #444444;
@@ -846,7 +822,6 @@ exports[`FormField disabled with custom label 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -917,7 +892,7 @@ exports[`FormField disabled with custom label 1`] = `
         label
       </label>
       <div
-        className="c3"
+        className="c3 "
       >
         <div
           className="c4"
@@ -959,7 +934,6 @@ exports[`FormField empty margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin: 0px;
   min-width: 0;
@@ -975,7 +949,6 @@ exports[`FormField empty margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -992,7 +965,6 @@ exports[`FormField empty margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1022,7 +994,7 @@ exports[`FormField empty margin 1`] = `
     onFocus={[Function]}
   >
     <div
-      className="c2"
+      className="c2 "
     >
       <div
         className="c3"
@@ -1049,7 +1021,6 @@ exports[`FormField error 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -1065,7 +1036,6 @@ exports[`FormField error 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px #FF4040;
   min-width: 0;
@@ -1082,7 +1052,6 @@ exports[`FormField error 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1122,7 +1091,7 @@ exports[`FormField error 1`] = `
     onFocus={[Function]}
   >
     <div
-      className="c2"
+      className="c2 "
     >
       <div
         className="c3"
@@ -1154,7 +1123,6 @@ exports[`FormField help 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -1170,7 +1138,6 @@ exports[`FormField help 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1187,7 +1154,6 @@ exports[`FormField help 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1229,7 +1195,7 @@ exports[`FormField help 1`] = `
       test help
     </span>
     <div
-      className="c3"
+      className="c3 "
     >
       <div
         className="c4"
@@ -1256,7 +1222,6 @@ exports[`FormField htmlFor 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -1272,7 +1237,6 @@ exports[`FormField htmlFor 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1289,7 +1253,6 @@ exports[`FormField htmlFor 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1319,7 +1282,7 @@ exports[`FormField htmlFor 1`] = `
     onFocus={[Function]}
   >
     <div
-      className="c2"
+      className="c2 "
     >
       <div
         className="c3"
@@ -1346,7 +1309,6 @@ exports[`FormField info 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -1362,7 +1324,6 @@ exports[`FormField info 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1379,7 +1340,6 @@ exports[`FormField info 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1419,7 +1379,7 @@ exports[`FormField info 1`] = `
     onFocus={[Function]}
   >
     <div
-      className="c2"
+      className="c2 "
     >
       <div
         className="c3"
@@ -1451,7 +1411,6 @@ exports[`FormField label 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -1467,7 +1426,6 @@ exports[`FormField label 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1484,7 +1442,6 @@ exports[`FormField label 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1528,7 +1485,7 @@ exports[`FormField label 1`] = `
       test label
     </label>
     <div
-      className="c3"
+      className="c3 "
     >
       <div
         className="c4"
@@ -1555,7 +1512,6 @@ exports[`FormField margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin: 24px;
   min-width: 0;
@@ -1571,7 +1527,6 @@ exports[`FormField margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1588,7 +1543,6 @@ exports[`FormField margin 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1618,7 +1572,7 @@ exports[`FormField margin 1`] = `
     onFocus={[Function]}
   >
     <div
-      className="c2"
+      className="c2 "
     >
       <div
         className="c3"
@@ -1645,7 +1599,6 @@ exports[`FormField pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -1661,7 +1614,6 @@ exports[`FormField pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1678,7 +1630,6 @@ exports[`FormField pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1715,7 +1666,7 @@ exports[`FormField pad 1`] = `
     onFocus={[Function]}
   >
     <div
-      className="c2"
+      className="c2 "
     >
       <div
         className="c3"
@@ -1742,7 +1693,6 @@ exports[`FormField required 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-bottom: 12px;
   min-width: 0;
@@ -1758,7 +1708,6 @@ exports[`FormField required 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1775,7 +1724,6 @@ exports[`FormField required 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1790,7 +1738,6 @@ exports[`FormField required 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1849,7 +1796,7 @@ exports[`FormField required 1`] = `
     onFocus={[Function]}
   >
     <div
-      className="c2"
+      className="c2 "
     >
       <div
         className="c3"
@@ -1867,7 +1814,7 @@ exports[`FormField required 1`] = `
       onFocus={[Function]}
     >
       <div
-        className="c2"
+        className="c2 "
       >
         <div
           className="c3"

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -343,6 +343,7 @@ exports[`FormField custom label 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -497,6 +498,7 @@ exports[`FormField default 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -655,6 +657,7 @@ exports[`FormField disabled 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
   opacity: 0.3;
   cursor: default;
@@ -830,6 +833,7 @@ exports[`FormField disabled with custom label 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
   opacity: 0.3;
   cursor: default;
@@ -1746,6 +1750,7 @@ exports[`FormField required 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 

--- a/src/js/components/InfiniteScroll/__tests__/__snapshots__/InfiniteScroll-test.js.snap
+++ b/src/js/components/InfiniteScroll/__tests__/__snapshots__/InfiniteScroll-test.js.snap
@@ -58,7 +58,6 @@ exports[`InfiniteScroll renderMarker 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -105,7 +104,6 @@ exports[`InfiniteScroll replace 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -150,7 +148,6 @@ exports[`InfiniteScroll show 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -201,7 +198,6 @@ exports[`InfiniteScroll step 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -14,7 +14,7 @@ const StyledList = styled.ul`
   ${props => !props.margin && 'margin: 0;'}
   padding: 0;
   ${genericStyles}
-  ${props => props.focus && focusStyle}
+  ${props => props.focus && focusStyle()}
 `;
 
 const StyledItem = styled(Box)`

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -17,7 +17,6 @@ exports[`List background array 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #6FFFB0;
   color: #444444;
@@ -43,7 +42,6 @@ exports[`List background array 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #FD6FFF;
   color: #444444;
@@ -68,7 +66,6 @@ exports[`List background array 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #6FFFB0;
   color: #444444;
@@ -201,7 +198,6 @@ exports[`List background string 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #6FFFB0;
   color: #444444;
@@ -227,7 +223,6 @@ exports[`List background string 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #6FFFB0;
   color: #444444;
@@ -330,7 +325,6 @@ exports[`List border boolean 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -410,7 +404,6 @@ exports[`List border object 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-top: solid 12px #6FFFB0;
   border-bottom: solid 12px #6FFFB0;
@@ -492,7 +485,6 @@ exports[`List border side 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-top: solid 1px rgba(0,0,0,0.33);
   border-bottom: solid 1px rgba(0,0,0,0.33);
@@ -516,7 +508,6 @@ exports[`List border side 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -617,7 +608,6 @@ exports[`List children render 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-top: solid 1px rgba(0,0,0,0.33);
   border-bottom: solid 1px rgba(0,0,0,0.33);
@@ -641,7 +631,6 @@ exports[`List children render 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -742,7 +731,6 @@ exports[`List data objects 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-top: solid 1px rgba(0,0,0,0.33);
   border-bottom: solid 1px rgba(0,0,0,0.33);
@@ -766,7 +754,6 @@ exports[`List data objects 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -867,7 +854,6 @@ exports[`List data strings 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-top: solid 1px rgba(0,0,0,0.33);
   border-bottom: solid 1px rgba(0,0,0,0.33);
@@ -891,7 +877,6 @@ exports[`List data strings 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1018,7 +1003,6 @@ exports[`List itemProps 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-top: solid 1px rgba(0,0,0,0.33);
   border-bottom: solid 1px rgba(0,0,0,0.33);
@@ -1042,7 +1026,6 @@ exports[`List itemProps 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #6FFFB0;
   color: #444444;
@@ -1136,7 +1119,6 @@ exports[`List margin object 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-top: solid 1px rgba(0,0,0,0.33);
   border-bottom: solid 1px rgba(0,0,0,0.33);
@@ -1160,7 +1142,6 @@ exports[`List margin object 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1262,7 +1243,6 @@ exports[`List margin string 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-top: solid 1px rgba(0,0,0,0.33);
   border-bottom: solid 1px rgba(0,0,0,0.33);
@@ -1286,7 +1266,6 @@ exports[`List margin string 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1387,7 +1366,6 @@ exports[`List onClickItem 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-top: solid 1px rgba(0,0,0,0.33);
   border-bottom: solid 1px rgba(0,0,0,0.33);
@@ -1412,7 +1390,6 @@ exports[`List onClickItem 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1513,13 +1490,13 @@ exports[`List onClickItem 2`] = `
     tabindex="0"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 bJRAgK List__StyledItem-sc-130gdqg-1 fBniOQ"
+      class="StyledBox-sc-13pk1d4-0 hRnMDt List__StyledItem-sc-130gdqg-1 fBniOQ"
       tabindex="-1"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 iWnVHs List__StyledItem-sc-130gdqg-1 fBniOQ"
+      class="StyledBox-sc-13pk1d4-0 fbIRTP List__StyledItem-sc-130gdqg-1 fBniOQ"
       tabindex="-1"
     >
       beta
@@ -1545,7 +1522,6 @@ exports[`List pad object 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-top: solid 1px rgba(0,0,0,0.33);
   border-bottom: solid 1px rgba(0,0,0,0.33);
@@ -1567,7 +1543,6 @@ exports[`List pad object 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1652,7 +1627,6 @@ exports[`List pad string 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-top: solid 1px rgba(0,0,0,0.33);
   border-bottom: solid 1px rgba(0,0,0,0.33);
@@ -1673,7 +1647,6 @@ exports[`List pad string 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1755,7 +1728,6 @@ exports[`List primaryKey 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-top: solid 1px rgba(0,0,0,0.33);
   border-bottom: solid 1px rgba(0,0,0,0.33);
@@ -1779,7 +1751,6 @@ exports[`List primaryKey 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1894,7 +1865,6 @@ exports[`List secondaryKey 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1926,7 +1896,6 @@ exports[`List secondaryKey 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
+++ b/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
@@ -51,7 +51,6 @@ exports[`Markdown renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -69,7 +68,6 @@ exports[`Markdown renders 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
 }
 
 .c6:hover {

--- a/src/js/components/MaskedInput/README.md
+++ b/src/js/components/MaskedInput/README.md
@@ -156,12 +156,52 @@ Defaults to
 
 **global.focus.border.color**
 
-The color around the component when in focus. Expects `string | { dark: string, light: string }`.
+The border color of the component when in focus. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 
 ```
 focus
+```
+
+**global.focus.outline.color**
+
+The outline color around the component when in focus. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+undefined
+```
+
+**global.focus.outline.size**
+
+The size of the outline around the component when in focus. Expects `string`.
+
+Defaults to
+
+```
+undefined
+```
+
+**global.focus.shadow.color**
+
+The shadow color around the component when in focus. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+focus
+```
+
+**global.focus.shadow.size**
+
+The size of the shadow around the component when in focus. Expects `string`.
+
+Defaults to
+
+```
+2px
 ```
 
 **global.colors.placeholder**

--- a/src/js/components/MaskedInput/StyledMaskedInput.js
+++ b/src/js/components/MaskedInput/StyledMaskedInput.js
@@ -37,7 +37,7 @@ export const StyledMaskedInput = styled.input`
     outline: none;
   }
 
-  ${props => props.focus && !props.plain && focusStyle};
+  ${props => props.focus && !props.plain && focusStyle()};
   ${props => props.theme.maskedInput && props.theme.maskedInput.extend};
 `;
 

--- a/src/js/components/MaskedInput/StyledMaskedInput.js
+++ b/src/js/components/MaskedInput/StyledMaskedInput.js
@@ -16,6 +16,7 @@ const sizeStyle = props => {
 };
 
 const plainStyle = css`
+  outline: none;
   border: none;
 `;
 

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -27,6 +27,7 @@ exports[`MaskedInput applies custom global.hover theme to options 1`] = `
   width: 100%;
   font-size: 22px;
   line-height: 28px;
+  outline: none;
   border: none;
 }
 
@@ -106,6 +107,7 @@ exports[`MaskedInput applies custom global.hover theme to options 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -282,6 +284,7 @@ exports[`MaskedInput event target props are available option via mouse 1`] = `
   width: 100%;
   font-size: 22px;
   line-height: 28px;
+  outline: none;
   border: none;
 }
 
@@ -404,6 +407,7 @@ exports[`MaskedInput event target props are available option via mouse 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -517,7 +521,7 @@ exports[`MaskedInput event target props are available option via mouse 4`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 dVJbJT"
+    class="StyledMaskedInput-sc-99vkfa-0 eoUyQk"
     data-testid="test-input"
     id="item"
     name="item"
@@ -913,6 +917,7 @@ exports[`MaskedInput mask 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1169,6 +1174,7 @@ exports[`MaskedInput option via mouse 1`] = `
   width: 100%;
   font-size: 22px;
   line-height: 28px;
+  outline: none;
   border: none;
 }
 
@@ -1291,6 +1297,7 @@ exports[`MaskedInput option via mouse 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1404,7 +1411,7 @@ exports[`MaskedInput option via mouse 4`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 dVJbJT"
+    class="StyledMaskedInput-sc-99vkfa-0 eoUyQk"
     data-testid="test-input"
     id="item"
     name="item"

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -17,7 +17,6 @@ exports[`MaskedInput applies custom global.hover theme to options 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -83,7 +82,6 @@ exports[`MaskedInput applies custom global.hover theme to options 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -100,7 +98,6 @@ exports[`MaskedInput applies custom global.hover theme to options 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -159,7 +156,6 @@ exports[`MaskedInput basic 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -216,7 +212,6 @@ exports[`MaskedInput event target props are available option via keyboard 1`] = 
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -277,7 +272,6 @@ exports[`MaskedInput event target props are available option via mouse 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -339,7 +333,6 @@ exports[`MaskedInput event target props are available option via mouse 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -356,7 +349,6 @@ exports[`MaskedInput event target props are available option via mouse 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -371,7 +363,6 @@ exports[`MaskedInput event target props are available option via mouse 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -389,7 +380,6 @@ exports[`MaskedInput event target props are available option via mouse 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -406,7 +396,6 @@ exports[`MaskedInput event target props are available option via mouse 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -528,7 +517,7 @@ exports[`MaskedInput event target props are available option via mouse 4`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 ePLrXp"
+    class="StyledMaskedInput-sc-99vkfa-0 dVJbJT"
     data-testid="test-input"
     id="item"
     name="item"
@@ -579,7 +568,6 @@ exports[`MaskedInput icon 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -705,7 +693,6 @@ exports[`MaskedInput icon reverse 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -797,7 +784,6 @@ exports[`MaskedInput mask 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -856,7 +842,6 @@ exports[`MaskedInput mask 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -873,7 +858,6 @@ exports[`MaskedInput mask 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -888,7 +872,6 @@ exports[`MaskedInput mask 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -906,7 +889,6 @@ exports[`MaskedInput mask 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -923,7 +905,6 @@ exports[`MaskedInput mask 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1046,7 +1027,6 @@ exports[`MaskedInput next and previous without options 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1104,7 +1084,7 @@ exports[`MaskedInput next and previous without options 2`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 jKiojf"
+    class="StyledMaskedInput-sc-99vkfa-0 jLSwLs"
     data-testid="test-input"
     id="item"
     name="item"
@@ -1121,7 +1101,6 @@ exports[`MaskedInput option via keyboard 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1180,7 +1159,6 @@ exports[`MaskedInput option via mouse 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1242,7 +1220,6 @@ exports[`MaskedInput option via mouse 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1259,7 +1236,6 @@ exports[`MaskedInput option via mouse 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1274,7 +1250,6 @@ exports[`MaskedInput option via mouse 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1292,7 +1267,6 @@ exports[`MaskedInput option via mouse 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1309,7 +1283,6 @@ exports[`MaskedInput option via mouse 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1431,7 +1404,7 @@ exports[`MaskedInput option via mouse 4`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 ePLrXp"
+    class="StyledMaskedInput-sc-99vkfa-0 dVJbJT"
     data-testid="test-input"
     id="item"
     name="item"

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -1089,7 +1089,7 @@ exports[`MaskedInput next and previous without options 2`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 jLSwLs"
+    class="StyledMaskedInput-sc-99vkfa-0 Cfxjk"
     data-testid="test-input"
     id="item"
     name="item"

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -7,7 +7,6 @@ exports[`Menu basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -39,7 +38,6 @@ exports[`Menu basic 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -147,7 +145,6 @@ exports[`Menu close by clicking outside 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -179,7 +176,6 @@ exports[`Menu close by clicking outside 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -292,7 +288,6 @@ exports[`Menu close by clicking outside 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -316,7 +311,6 @@ exports[`Menu close by clicking outside 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -333,7 +327,6 @@ exports[`Menu close by clicking outside 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -348,7 +341,6 @@ exports[`Menu close by clicking outside 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -366,7 +358,6 @@ exports[`Menu close by clicking outside 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -382,7 +373,6 @@ exports[`Menu close by clicking outside 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -410,7 +400,6 @@ exports[`Menu close by clicking outside 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -576,7 +565,7 @@ exports[`Menu close by clicking outside 2`] = `
 
 exports[`Menu close by clicking outside 3`] = `
 "@media only screen and (max-width:768px) {
-  .hYQclW {
+  .hkbjbd {
     padding: 6px;
   }
 }"
@@ -623,7 +612,6 @@ exports[`Menu close on esc 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -655,7 +643,6 @@ exports[`Menu close on esc 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -768,7 +755,6 @@ exports[`Menu close on tab 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -800,7 +786,6 @@ exports[`Menu close on tab 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -913,7 +898,6 @@ exports[`Menu custom a11yTitle 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -945,7 +929,6 @@ exports[`Menu custom a11yTitle 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1059,7 +1042,6 @@ exports[`Menu custom message 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1091,7 +1073,6 @@ exports[`Menu custom message 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1209,7 +1190,6 @@ exports[`Menu disabled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1241,7 +1221,6 @@ exports[`Menu disabled 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1357,7 +1336,6 @@ exports[`Menu gap between icon and label 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1389,7 +1367,6 @@ exports[`Menu gap between icon and label 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1515,7 +1492,6 @@ exports[`Menu justify content 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1539,7 +1515,6 @@ exports[`Menu justify content 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1563,7 +1538,6 @@ exports[`Menu justify content 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1587,7 +1561,6 @@ exports[`Menu justify content 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1611,7 +1584,6 @@ exports[`Menu justify content 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1635,7 +1607,6 @@ exports[`Menu justify content 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1663,7 +1634,6 @@ exports[`Menu justify content 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1991,7 +1961,6 @@ exports[`Menu navigate through suggestions and select 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2023,7 +1992,6 @@ exports[`Menu navigate through suggestions and select 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2136,7 +2104,6 @@ exports[`Menu open and close on click 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2168,7 +2135,6 @@ exports[`Menu open and close on click 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2246,12 +2212,12 @@ exports[`Menu open and close on click 2`] = `
 >
   <button
     aria-label="Open Menu"
-    class="StyledButton-sc-323bzc-0 dnCEuz"
+    class="StyledButton-sc-323bzc-0 ohdLU"
     id="test-menu"
     type="button"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hYQclW"
+      class="StyledBox-sc-13pk1d4-0 hkbjbd"
     >
       <span
         class="StyledText-sc-1sadyjn-0 hUokoe"
@@ -2319,7 +2285,6 @@ exports[`Menu open and close on click 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2343,7 +2308,6 @@ exports[`Menu open and close on click 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2360,7 +2324,6 @@ exports[`Menu open and close on click 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2375,7 +2338,6 @@ exports[`Menu open and close on click 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2393,7 +2355,6 @@ exports[`Menu open and close on click 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2409,7 +2370,6 @@ exports[`Menu open and close on click 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -2437,7 +2397,6 @@ exports[`Menu open and close on click 3`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2617,7 +2576,7 @@ exports[`Menu open and close on click 3`] = `
 
 exports[`Menu open and close on click 4`] = `
 "@media only screen and (max-width:768px) {
-  .hYQclW {
+  .hkbjbd {
     padding: 6px;
   }
 }"
@@ -2664,7 +2623,6 @@ exports[`Menu reverse icon and label 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2696,7 +2654,6 @@ exports[`Menu reverse icon and label 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2822,7 +2779,6 @@ exports[`Menu select an item 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2854,7 +2810,6 @@ exports[`Menu select an item 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2967,7 +2922,6 @@ exports[`Menu tab through menu until it closes 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2999,7 +2953,6 @@ exports[`Menu tab through menu until it closes 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3112,7 +3065,6 @@ exports[`Menu with dropAlign renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -3144,7 +3096,6 @@ exports[`Menu with dropAlign renders 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3257,7 +3208,6 @@ exports[`Menu with dropAlign renders 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -3281,7 +3231,6 @@ exports[`Menu with dropAlign renders 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3298,7 +3247,6 @@ exports[`Menu with dropAlign renders 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3313,7 +3261,6 @@ exports[`Menu with dropAlign renders 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3331,7 +3278,6 @@ exports[`Menu with dropAlign renders 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3347,7 +3293,6 @@ exports[`Menu with dropAlign renders 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -3375,7 +3320,6 @@ exports[`Menu with dropAlign renders 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3541,7 +3485,7 @@ exports[`Menu with dropAlign renders 2`] = `
 
 exports[`Menu with dropAlign renders 3`] = `
 "@media only screen and (max-width:768px) {
-  .hYQclW {
+  .hkbjbd {
     padding: 6px;
   }
 }"

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -46,6 +46,7 @@ exports[`Menu basic 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -184,6 +185,7 @@ exports[`Menu close by clicking outside 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -408,6 +410,7 @@ exports[`Menu close by clicking outside 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -651,6 +654,7 @@ exports[`Menu close on esc 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -794,6 +798,7 @@ exports[`Menu close on tab 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -937,6 +942,7 @@ exports[`Menu custom a11yTitle 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1081,6 +1087,7 @@ exports[`Menu custom message 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1229,6 +1236,7 @@ exports[`Menu disabled 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1375,6 +1383,7 @@ exports[`Menu gap between icon and label 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1642,6 +1651,7 @@ exports[`Menu justify content 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2000,6 +2010,7 @@ exports[`Menu navigate through suggestions and select 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2143,6 +2154,7 @@ exports[`Menu open and close on click 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2212,7 +2224,7 @@ exports[`Menu open and close on click 2`] = `
 >
   <button
     aria-label="Open Menu"
-    class="StyledButton-sc-323bzc-0 ohdLU"
+    class="StyledButton-sc-323bzc-0 bwJeiP"
     id="test-menu"
     type="button"
   >
@@ -2405,6 +2417,7 @@ exports[`Menu open and close on click 3`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2662,6 +2675,7 @@ exports[`Menu reverse icon and label 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2818,6 +2832,7 @@ exports[`Menu select an item 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2961,6 +2976,7 @@ exports[`Menu tab through menu until it closes 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -3104,6 +3120,7 @@ exports[`Menu with dropAlign renders 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -3328,6 +3345,7 @@ exports[`Menu with dropAlign renders 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;

--- a/src/js/components/RadioButton/StyledRadioButton.js
+++ b/src/js/components/RadioButton/StyledRadioButton.js
@@ -60,7 +60,7 @@ StyledRadioButtonIcon.defaultProps = {};
 Object.setPrototypeOf(StyledRadioButtonIcon.defaultProps, defaultProps);
 
 const StyledRadioButtonBox = styled.div`
-  ${props => props.focus && focusStyle};
+  ${props => props.focus && focusStyle()};
   ${props => props.theme.radioButton.check.extend};
 `;
 

--- a/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
+++ b/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
@@ -17,7 +17,6 @@ exports[`RadioButton basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -32,7 +31,6 @@ exports[`RadioButton basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -160,7 +158,6 @@ exports[`RadioButton checked 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -175,7 +172,6 @@ exports[`RadioButton checked 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -301,7 +297,6 @@ exports[`RadioButton children 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -316,7 +311,6 @@ exports[`RadioButton children 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -334,7 +328,6 @@ exports[`RadioButton children 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #6FFFB0;
   color: #444444;
@@ -458,7 +451,6 @@ exports[`RadioButton disabled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -473,7 +465,6 @@ exports[`RadioButton disabled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -500,7 +491,6 @@ exports[`RadioButton disabled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -656,7 +646,6 @@ exports[`RadioButton label 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-right: 12px;
   min-width: 0;
@@ -672,7 +661,6 @@ exports[`RadioButton label 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
+++ b/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
@@ -17,7 +17,6 @@ exports[`RadioButtonGroup adding additional props 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -32,7 +31,6 @@ exports[`RadioButtonGroup adding additional props 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -195,7 +193,6 @@ exports[`RadioButtonGroup children 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -210,7 +207,6 @@ exports[`RadioButtonGroup children 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -362,7 +358,6 @@ exports[`RadioButtonGroup default 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -397,7 +392,6 @@ exports[`RadioButtonGroup object options 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -412,7 +406,6 @@ exports[`RadioButtonGroup object options 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-right: 12px;
   min-width: 0;
@@ -428,7 +421,6 @@ exports[`RadioButtonGroup object options 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -601,7 +593,6 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -616,7 +607,6 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -811,7 +801,6 @@ exports[`RadioButtonGroup object options just value 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -826,7 +815,6 @@ exports[`RadioButtonGroup object options just value 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -853,7 +841,6 @@ exports[`RadioButtonGroup object options just value 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1035,7 +1022,6 @@ exports[`RadioButtonGroup string options 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1050,7 +1036,6 @@ exports[`RadioButtonGroup string options 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-right: 12px;
   min-width: 0;
@@ -1066,7 +1051,6 @@ exports[`RadioButtonGroup string options 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1093,7 +1077,6 @@ exports[`RadioButtonGroup string options 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/js/components/RangeInput/README.md
+++ b/src/js/components/RangeInput/README.md
@@ -81,12 +81,52 @@ input
   
 **global.focus.border.color**
 
-The color around the component when in focus. Expects `string | { dark: string, light: string }`.
+The border color of the component when in focus. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 
 ```
 focus
+```
+
+**global.focus.outline.color**
+
+The outline color around the component when in focus. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+undefined
+```
+
+**global.focus.outline.size**
+
+The size of the outline around the component when in focus. Expects `string`.
+
+Defaults to
+
+```
+undefined
+```
+
+**global.focus.shadow.color**
+
+The shadow color around the component when in focus. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+focus
+```
+
+**global.focus.shadow.size**
+
+The size of the shadow around the component when in focus. Expects `string`.
+
+Defaults to
+
+```
+2px
 ```
 
 **global.spacing**

--- a/src/js/components/RangeInput/StyledRangeInput.js
+++ b/src/js/components/RangeInput/StyledRangeInput.js
@@ -57,10 +57,6 @@ const StyledRangeInput = styled.input`
   cursor: pointer;
   background: transparent;
 
-  &:focus {
-    outline: none;
-  }
-
   &::-moz-focus-inner {
     border: none;
   }
@@ -140,7 +136,7 @@ const StyledRangeInput = styled.input`
     border-color: transparent;
   }
 
-  ${props => props.focus && focusStyle}
+  ${props => props.focus && focusStyle()}
   ${props => props.theme.rangeInput && props.theme.rangeInput.extend}
 `;
 /* eslint-enable max-len */

--- a/src/js/components/RangeInput/__tests__/__snapshots__/RangeInput-test.js.snap
+++ b/src/js/components/RangeInput/__tests__/__snapshots__/RangeInput-test.js.snap
@@ -23,10 +23,6 @@ exports[`RangeInput renders 1`] = `
   background: transparent;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 .c1::-moz-focus-inner {
   border: none;
 }

--- a/src/js/components/RangeSelector/EdgeControl.js
+++ b/src/js/components/RangeSelector/EdgeControl.js
@@ -1,11 +1,11 @@
 import React, { forwardRef, useContext, useState } from 'react';
-import { ThemeContext } from 'styled-components';
+import styled, { ThemeContext } from 'styled-components';
 
 import { defaultProps } from '../../default-props';
 
 import { Box } from '../Box';
 import { Keyboard } from '../Keyboard';
-import { normalizeColor, parseMetricToNum } from '../../utils';
+import { focusStyle, normalizeColor, parseMetricToNum } from '../../utils';
 
 const DIRECTION_PROPS = {
   horizontal: {
@@ -18,13 +18,17 @@ const DIRECTION_PROPS = {
   },
 };
 
+const StyledBox = styled(Box)`
+  ${props => props.focus && focusStyle()}
+`;
+
 const EdgeControl = forwardRef(
   (
     { color, direction, edge, onDecrease, onIncrease, thickness, ...rest },
     ref,
   ) => {
     const theme = useContext(ThemeContext);
-    const [focused, setFocused] = useState(false);
+    const [focus, setFocus] = useState(false);
     const { cursor, fill } = DIRECTION_PROPS[direction];
     const size = parseMetricToNum(theme.global.spacing) / 2;
     const keyboardProps =
@@ -39,29 +43,26 @@ const EdgeControl = forwardRef(
       'disc';
 
     let node;
+    const backgroundColor = normalizeColor(color || 'control', theme);
     if (type === 'bar') {
       node = (
-        <Box
+        <StyledBox
           flex={!thickness}
           justifySelf="stretch"
           width={direction === 'vertical' ? thickness : `${size}px`}
           height={direction === 'vertical' ? `${size}px` : thickness}
-          background={normalizeColor(color || 'control', theme)}
-          border={
-            focused ? { color: normalizeColor('focus', theme) } : undefined
-          }
+          background={backgroundColor}
+          focus={focus}
         />
       );
     } else if (type === 'disc') {
       node = (
-        <Box
-          width={`${size + (focused ? 2 : 0)}px`}
-          height={`${size + (focused ? 2 : 0)}px`}
+        <StyledBox
+          width={`${size}px`}
+          height={`${size}px`}
           round="full"
-          background={normalizeColor(color || 'control', theme)}
-          border={
-            focused ? { color: normalizeColor('focus', theme) } : undefined
-          }
+          background={backgroundColor}
+          focus={focus}
         />
       );
     } else {
@@ -86,13 +87,14 @@ const EdgeControl = forwardRef(
             fill={fill}
             style={{
               cursor,
+              outline: 'none',
               minWidth: size,
               minHeight: size,
               zIndex: 10,
             }}
             tabIndex={0}
-            onFocus={() => setFocused(true)}
-            onBlur={() => setFocused(false)}
+            onFocus={() => setFocus(true)}
+            onBlur={() => setFocus(false)}
             {...rest}
           >
             {node}

--- a/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
+++ b/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
@@ -17,7 +17,6 @@ exports[`RangeSelector basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -38,7 +37,6 @@ exports[`RangeSelector basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -55,7 +53,6 @@ exports[`RangeSelector basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -82,7 +79,6 @@ exports[`RangeSelector basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -108,7 +104,6 @@ exports[`RangeSelector basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -128,7 +123,6 @@ exports[`RangeSelector basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -182,13 +176,14 @@ exports[`RangeSelector basic 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -220,13 +215,14 @@ exports[`RangeSelector basic 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -259,7 +255,6 @@ exports[`RangeSelector color 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -280,7 +275,6 @@ exports[`RangeSelector color 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -297,7 +291,6 @@ exports[`RangeSelector color 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -324,7 +317,6 @@ exports[`RangeSelector color 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -350,7 +342,6 @@ exports[`RangeSelector color 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #6FFFB0;
   color: #444444;
@@ -370,7 +361,6 @@ exports[`RangeSelector color 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(111,255,176,0.4);
   color: #444444;
@@ -424,13 +414,14 @@ exports[`RangeSelector color 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -462,13 +453,14 @@ exports[`RangeSelector color 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -501,7 +493,6 @@ exports[`RangeSelector direction 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -522,7 +513,6 @@ exports[`RangeSelector direction 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -539,7 +529,6 @@ exports[`RangeSelector direction 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -566,7 +555,6 @@ exports[`RangeSelector direction 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -592,7 +580,6 @@ exports[`RangeSelector direction 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -612,7 +599,6 @@ exports[`RangeSelector direction 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -631,7 +617,6 @@ exports[`RangeSelector direction 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -652,7 +637,6 @@ exports[`RangeSelector direction 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -669,7 +653,6 @@ exports[`RangeSelector direction 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -696,7 +679,6 @@ exports[`RangeSelector direction 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -722,7 +704,6 @@ exports[`RangeSelector direction 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -776,13 +757,14 @@ exports[`RangeSelector direction 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -814,13 +796,14 @@ exports[`RangeSelector direction 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -864,13 +847,14 @@ exports[`RangeSelector direction 1`] = `
             "cursor": "row-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -902,13 +886,14 @@ exports[`RangeSelector direction 1`] = `
             "cursor": "row-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -941,7 +926,6 @@ exports[`RangeSelector handle keyboard 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -963,7 +947,6 @@ exports[`RangeSelector handle keyboard 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -980,7 +963,6 @@ exports[`RangeSelector handle keyboard 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -1007,7 +989,6 @@ exports[`RangeSelector handle keyboard 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1033,7 +1014,6 @@ exports[`RangeSelector handle keyboard 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -1053,7 +1033,6 @@ exports[`RangeSelector handle keyboard 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -1091,11 +1070,11 @@ exports[`RangeSelector handle keyboard 1`] = `
       <div
         aria-label="Lower Bounds"
         class="c5"
-        style="cursor: col-resize; min-width: 12px; min-height: 12px; z-index: 10;"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
         tabindex="0"
       >
         <div
-          class="c6"
+          class="c6 "
         />
       </div>
     </div>
@@ -1110,11 +1089,11 @@ exports[`RangeSelector handle keyboard 1`] = `
       <div
         aria-label="Upper Bounds"
         class="c5"
-        style="cursor: col-resize; min-width: 12px; min-height: 12px; z-index: 10;"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
         tabindex="0"
       >
         <div
-          class="c6"
+          class="c6 "
         />
       </div>
     </div>
@@ -1143,7 +1122,6 @@ exports[`RangeSelector handle mouse 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1165,7 +1143,6 @@ exports[`RangeSelector handle mouse 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1182,7 +1159,6 @@ exports[`RangeSelector handle mouse 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -1209,7 +1185,6 @@ exports[`RangeSelector handle mouse 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1235,7 +1210,6 @@ exports[`RangeSelector handle mouse 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -1255,7 +1229,6 @@ exports[`RangeSelector handle mouse 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -1293,11 +1266,11 @@ exports[`RangeSelector handle mouse 1`] = `
       <div
         aria-label="Lower Bounds"
         class="c5"
-        style="cursor: col-resize; min-width: 12px; min-height: 12px; z-index: 10;"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
         tabindex="0"
       >
         <div
-          class="c6"
+          class="c6 "
         />
       </div>
     </div>
@@ -1312,11 +1285,11 @@ exports[`RangeSelector handle mouse 1`] = `
       <div
         aria-label="Upper Bounds"
         class="c5"
-        style="cursor: col-resize; min-width: 12px; min-height: 12px; z-index: 10;"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
         tabindex="0"
       >
         <div
-          class="c6"
+          class="c6 "
         />
       </div>
     </div>
@@ -1345,7 +1318,6 @@ exports[`RangeSelector invert 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1366,7 +1338,6 @@ exports[`RangeSelector invert 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(218,218,218,0.4);
   color: #444444;
@@ -1385,7 +1356,6 @@ exports[`RangeSelector invert 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -1412,7 +1382,6 @@ exports[`RangeSelector invert 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1438,7 +1407,6 @@ exports[`RangeSelector invert 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -1458,7 +1426,6 @@ exports[`RangeSelector invert 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1475,7 +1442,6 @@ exports[`RangeSelector invert 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -1529,13 +1495,14 @@ exports[`RangeSelector invert 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -1567,13 +1534,14 @@ exports[`RangeSelector invert 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -1617,13 +1585,14 @@ exports[`RangeSelector invert 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -1655,13 +1624,14 @@ exports[`RangeSelector invert 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -1694,7 +1664,6 @@ exports[`RangeSelector max 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1715,7 +1684,6 @@ exports[`RangeSelector max 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1732,7 +1700,6 @@ exports[`RangeSelector max 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -1759,7 +1726,6 @@ exports[`RangeSelector max 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1785,7 +1751,6 @@ exports[`RangeSelector max 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -1805,7 +1770,6 @@ exports[`RangeSelector max 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -1859,13 +1823,14 @@ exports[`RangeSelector max 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -1897,13 +1862,14 @@ exports[`RangeSelector max 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -1936,7 +1902,6 @@ exports[`RangeSelector min 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1957,7 +1922,6 @@ exports[`RangeSelector min 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1974,7 +1938,6 @@ exports[`RangeSelector min 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -2001,7 +1964,6 @@ exports[`RangeSelector min 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2027,7 +1989,6 @@ exports[`RangeSelector min 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -2047,7 +2008,6 @@ exports[`RangeSelector min 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -2101,13 +2061,14 @@ exports[`RangeSelector min 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -2139,13 +2100,14 @@ exports[`RangeSelector min 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -2178,7 +2140,6 @@ exports[`RangeSelector opacity 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2199,7 +2160,6 @@ exports[`RangeSelector opacity 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2216,7 +2176,6 @@ exports[`RangeSelector opacity 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -2243,7 +2202,6 @@ exports[`RangeSelector opacity 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2269,7 +2227,6 @@ exports[`RangeSelector opacity 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -2289,7 +2246,6 @@ exports[`RangeSelector opacity 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.1);
   min-width: 0;
@@ -2307,7 +2263,6 @@ exports[`RangeSelector opacity 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -2326,7 +2281,6 @@ exports[`RangeSelector opacity 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.8);
   color: #f8f8f8;
@@ -2380,13 +2334,14 @@ exports[`RangeSelector opacity 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -2418,13 +2373,14 @@ exports[`RangeSelector opacity 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -2468,13 +2424,14 @@ exports[`RangeSelector opacity 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -2506,13 +2463,14 @@ exports[`RangeSelector opacity 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -2556,13 +2514,14 @@ exports[`RangeSelector opacity 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -2594,13 +2553,14 @@ exports[`RangeSelector opacity 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -2633,7 +2593,6 @@ exports[`RangeSelector round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2654,7 +2613,6 @@ exports[`RangeSelector round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2672,7 +2630,6 @@ exports[`RangeSelector round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -2699,7 +2656,6 @@ exports[`RangeSelector round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2725,7 +2681,6 @@ exports[`RangeSelector round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -2745,7 +2700,6 @@ exports[`RangeSelector round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -2765,7 +2719,6 @@ exports[`RangeSelector round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2783,7 +2736,6 @@ exports[`RangeSelector round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -2803,7 +2755,6 @@ exports[`RangeSelector round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2821,7 +2772,6 @@ exports[`RangeSelector round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -2841,7 +2791,6 @@ exports[`RangeSelector round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2859,7 +2808,6 @@ exports[`RangeSelector round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -2879,7 +2827,6 @@ exports[`RangeSelector round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2897,7 +2844,6 @@ exports[`RangeSelector round 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -3000,13 +2946,14 @@ exports[`RangeSelector round 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -3038,13 +2985,14 @@ exports[`RangeSelector round 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -3088,13 +3036,14 @@ exports[`RangeSelector round 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -3126,13 +3075,14 @@ exports[`RangeSelector round 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -3176,13 +3126,14 @@ exports[`RangeSelector round 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -3214,13 +3165,14 @@ exports[`RangeSelector round 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -3264,13 +3216,14 @@ exports[`RangeSelector round 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -3302,13 +3255,14 @@ exports[`RangeSelector round 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -3352,13 +3306,14 @@ exports[`RangeSelector round 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -3390,13 +3345,14 @@ exports[`RangeSelector round 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -3429,7 +3385,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -3450,7 +3405,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3467,7 +3421,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -3494,7 +3447,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3520,7 +3472,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -3540,7 +3491,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -3559,7 +3509,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3576,7 +3525,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -3595,7 +3543,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3612,7 +3559,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -3631,7 +3577,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3648,7 +3593,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -3667,7 +3611,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3684,7 +3627,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -3703,7 +3645,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3720,7 +3661,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -3739,7 +3679,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -3758,7 +3697,6 @@ exports[`RangeSelector size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -3814,13 +3752,14 @@ exports[`RangeSelector size 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -3852,13 +3791,14 @@ exports[`RangeSelector size 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -3902,13 +3842,14 @@ exports[`RangeSelector size 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -3940,13 +3881,14 @@ exports[`RangeSelector size 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -3990,13 +3932,14 @@ exports[`RangeSelector size 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -4028,13 +3971,14 @@ exports[`RangeSelector size 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -4078,13 +4022,14 @@ exports[`RangeSelector size 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -4116,13 +4061,14 @@ exports[`RangeSelector size 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -4166,13 +4112,14 @@ exports[`RangeSelector size 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -4204,13 +4151,14 @@ exports[`RangeSelector size 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -4254,13 +4202,14 @@ exports[`RangeSelector size 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -4292,13 +4241,14 @@ exports[`RangeSelector size 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -4342,13 +4292,14 @@ exports[`RangeSelector size 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -4380,13 +4331,14 @@ exports[`RangeSelector size 1`] = `
             "cursor": "col-resize",
             "minHeight": 12,
             "minWidth": 12,
+            "outline": "none",
             "zIndex": 10,
           }
         }
         tabIndex={0}
       >
         <div
-          className="c6"
+          className="c6 "
         />
       </div>
     </div>
@@ -4419,7 +4371,6 @@ exports[`RangeSelector step renders correct values 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -4441,7 +4392,6 @@ exports[`RangeSelector step renders correct values 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4458,7 +4408,6 @@ exports[`RangeSelector step renders correct values 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
@@ -4485,7 +4434,6 @@ exports[`RangeSelector step renders correct values 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4511,7 +4459,6 @@ exports[`RangeSelector step renders correct values 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -4531,7 +4478,6 @@ exports[`RangeSelector step renders correct values 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background-color: rgba(125,76,219,0.4);
   color: #444444;
@@ -4569,11 +4515,11 @@ exports[`RangeSelector step renders correct values 1`] = `
       <div
         aria-label="Lower Bounds"
         class="c5"
-        style="cursor: col-resize; min-width: 12px; min-height: 12px; z-index: 10;"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
         tabindex="0"
       >
         <div
-          class="c6"
+          class="c6 "
         />
       </div>
     </div>
@@ -4588,11 +4534,11 @@ exports[`RangeSelector step renders correct values 1`] = `
       <div
         aria-label="Upper Bounds"
         class="c5"
-        style="cursor: col-resize; min-width: 12px; min-height: 12px; z-index: 10;"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
         tabindex="0"
       >
         <div
-          class="c6"
+          class="c6 "
         />
       </div>
     </div>

--- a/src/js/components/RoutedAnchor/__tests__/__snapshots__/RoutedAnchor-test.js.snap
+++ b/src/js/components/RoutedAnchor/__tests__/__snapshots__/RoutedAnchor-test.js.snap
@@ -20,7 +20,6 @@ exports[`RoutedAnchor renders 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
 }
 
 .c1:hover {

--- a/src/js/components/RoutedButton/__tests__/__snapshots__/RoutedButton-test.js.snap
+++ b/src/js/components/RoutedButton/__tests__/__snapshots__/RoutedButton-test.js.snap
@@ -5,7 +5,6 @@ exports[`RoutedButton renders 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -107,6 +107,7 @@ exports[`Select 0 value 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -126,6 +127,7 @@ exports[`Select 0 value 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -340,6 +342,7 @@ exports[`Select applies custom global.hover theme to options 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -359,6 +362,7 @@ exports[`Select applies custom global.hover theme to options 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -499,6 +503,7 @@ exports[`Select applies custom global.hover theme to options 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -665,6 +670,7 @@ exports[`Select basic 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -684,6 +690,7 @@ exports[`Select basic 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -897,6 +904,7 @@ exports[`Select complex options and children 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -916,6 +924,7 @@ exports[`Select complex options and children 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -1012,7 +1021,7 @@ exports[`Select complex options and children 1`] = `
 exports[`Select complex options and children 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 ohdLU Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
+  class="StyledButton-sc-323bzc-0 bwJeiP Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
   id="test-select"
   type="button"
 >
@@ -1027,7 +1036,7 @@ exports[`Select complex options and children 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 cjOhSV Select__SelectTextInput-sc-17idtfo-0 hWmVID"
+          class="StyledTextInput-sc-1x30a0s-0 jsQcHW Select__SelectTextInput-sc-17idtfo-0 hWmVID"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -1119,6 +1128,7 @@ exports[`Select complex options and children 3`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1354,6 +1364,7 @@ exports[`Select deselect an option 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1373,6 +1384,7 @@ exports[`Select deselect an option 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -1573,6 +1585,7 @@ exports[`Select disabled 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1594,6 +1607,7 @@ exports[`Select disabled 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -1691,7 +1705,7 @@ exports[`Select disabled 1`] = `
 exports[`Select disabled 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 dBSXPS Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
+  class="StyledButton-sc-323bzc-0 hzhigJ Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
   disabled=""
   id="test-select"
   type="button"
@@ -1707,7 +1721,7 @@ exports[`Select disabled 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 cjOhSV Select__SelectTextInput-sc-17idtfo-0 hWmVID"
+          class="StyledTextInput-sc-1x30a0s-0 jsQcHW Select__SelectTextInput-sc-17idtfo-0 hWmVID"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -1818,6 +1832,7 @@ exports[`Select empty results search 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2083,6 +2098,7 @@ exports[`Select large drop container height 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2306,6 +2322,7 @@ exports[`Select medium drop container height 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2556,6 +2573,7 @@ exports[`Select modifies select control style on open 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2575,6 +2593,7 @@ exports[`Select modifies select control style on open 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -2791,6 +2810,7 @@ exports[`Select multiple 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2810,6 +2830,7 @@ exports[`Select multiple 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -3023,6 +3044,7 @@ exports[`Select multiple onChange toggle with valueKey reduce 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -3042,6 +3064,7 @@ exports[`Select multiple onChange toggle with valueKey reduce 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -3229,6 +3252,7 @@ exports[`Select multiple onChange toggle with valueKey reduce 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -3493,6 +3517,7 @@ exports[`Select multiple onChange with valueKey reduce 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -3512,6 +3537,7 @@ exports[`Select multiple onChange with valueKey reduce 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -3699,6 +3725,7 @@ exports[`Select multiple onChange with valueKey reduce 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -3958,6 +3985,7 @@ exports[`Select multiple onChange with valueKey string 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -3977,6 +4005,7 @@ exports[`Select multiple onChange with valueKey string 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -4164,6 +4193,7 @@ exports[`Select multiple onChange with valueKey string 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -4423,6 +4453,7 @@ exports[`Select multiple onChange without valueKey 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -4442,6 +4473,7 @@ exports[`Select multiple onChange without valueKey 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -4629,6 +4661,7 @@ exports[`Select multiple onChange without valueKey 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -4799,7 +4832,7 @@ exports[`Select multiple onChange without valueKey 4`] = `
       tabindex="-1"
     >
       <button
-        class="StyledButton-sc-323bzc-0 jnQMfE SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
+        class="StyledButton-sc-323bzc-0 gSWBFn SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
         role="menuitem"
         tabindex="-1"
         type="button"
@@ -4815,7 +4848,7 @@ exports[`Select multiple onChange without valueKey 4`] = `
         </div>
       </button>
       <button
-        class="StyledButton-sc-323bzc-0 jnQMfE SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
+        class="StyledButton-sc-323bzc-0 gSWBFn SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
         role="menuitem"
         tabindex="-1"
         type="button"
@@ -4954,6 +4987,7 @@ exports[`Select multiple values 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -4973,6 +5007,7 @@ exports[`Select multiple values 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -5069,7 +5104,7 @@ exports[`Select multiple values 1`] = `
 exports[`Select multiple values 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 ohdLU Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
+  class="StyledButton-sc-323bzc-0 bwJeiP Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
   id="test-select"
   type="button"
 >
@@ -5084,7 +5119,7 @@ exports[`Select multiple values 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 cjOhSV Select__SelectTextInput-sc-17idtfo-0 hWmVID"
+          class="StyledTextInput-sc-1x30a0s-0 jsQcHW Select__SelectTextInput-sc-17idtfo-0 hWmVID"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -5195,6 +5230,7 @@ exports[`Select multiple values 3`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -5459,6 +5495,7 @@ exports[`Select onChange with valueKey string 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -5478,6 +5515,7 @@ exports[`Select onChange with valueKey string 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -5665,6 +5703,7 @@ exports[`Select onChange with valueKey string 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -5924,6 +5963,7 @@ exports[`Select onChange without valueKey 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -5943,6 +5983,7 @@ exports[`Select onChange without valueKey 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -6130,6 +6171,7 @@ exports[`Select onChange without valueKey 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -6389,6 +6431,7 @@ exports[`Select opens 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -6408,6 +6451,7 @@ exports[`Select opens 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -6504,7 +6548,7 @@ exports[`Select opens 1`] = `
 exports[`Select opens 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 ohdLU Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
+  class="StyledButton-sc-323bzc-0 bwJeiP Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
   id="test-select"
   type="button"
 >
@@ -6519,7 +6563,7 @@ exports[`Select opens 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 cjOhSV Select__SelectTextInput-sc-17idtfo-0 hWmVID"
+          class="StyledTextInput-sc-1x30a0s-0 jsQcHW Select__SelectTextInput-sc-17idtfo-0 hWmVID"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -6630,6 +6674,7 @@ exports[`Select opens 3`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -6789,7 +6834,7 @@ exports[`Select opens 5`] = `
   tabindex="-1"
 >
   <button
-    class="StyledButton-sc-323bzc-0 jnQMfE SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
+    class="StyledButton-sc-323bzc-0 gSWBFn SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
     role="menuitem"
     tabindex="-1"
     type="button"
@@ -6805,7 +6850,7 @@ exports[`Select opens 5`] = `
     </div>
   </button>
   <button
-    class="StyledButton-sc-323bzc-0 jnQMfE SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
+    class="StyledButton-sc-323bzc-0 gSWBFn SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
     role="menuitem"
     tabindex="-1"
     type="button"
@@ -6933,6 +6978,7 @@ exports[`Select renders custom icon 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -6952,6 +6998,7 @@ exports[`Select renders custom icon 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -7165,6 +7212,7 @@ exports[`Select renders custom up and down icons 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -7184,6 +7232,7 @@ exports[`Select renders custom up and down icons 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -7295,7 +7344,7 @@ exports[`Select renders custom up and down icons 2`] = `
 >
   <button
     aria-label="Open Drop"
-    class="StyledButton-sc-323bzc-0 ohdLU Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
+    class="StyledButton-sc-323bzc-0 bwJeiP Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
     type="button"
   >
     <div
@@ -7309,7 +7358,7 @@ exports[`Select renders custom up and down icons 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 cjOhSV Select__SelectTextInput-sc-17idtfo-0 hWmVID"
+            class="StyledTextInput-sc-1x30a0s-0 jsQcHW Select__SelectTextInput-sc-17idtfo-0 hWmVID"
             placeholder="Select..."
             readonly=""
             tabindex="-1"
@@ -7498,6 +7547,7 @@ exports[`Select renders default icon 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -7517,6 +7567,7 @@ exports[`Select renders default icon 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -7731,6 +7782,7 @@ exports[`Select renders styled select options backwards compatible with legacy
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -7750,6 +7802,7 @@ exports[`Select renders styled select options backwards compatible with legacy
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -7967,6 +8020,7 @@ exports[`Select renders styled select options combining select.options.box &&
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -7986,6 +8040,7 @@ exports[`Select renders styled select options combining select.options.box &&
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -8201,6 +8256,7 @@ exports[`Select renders styled select options using select.options.container 1`]
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -8220,6 +8276,7 @@ exports[`Select renders styled select options using select.options.container 1`]
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -8382,6 +8439,7 @@ exports[`Select renders without icon 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -8401,6 +8459,7 @@ exports[`Select renders without icon 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -8586,6 +8645,7 @@ exports[`Select search 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -8605,6 +8665,7 @@ exports[`Select search 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -8796,6 +8857,7 @@ exports[`Select search 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -9119,6 +9181,7 @@ exports[`Select select an option 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -9138,6 +9201,7 @@ exports[`Select select an option 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -9338,6 +9402,7 @@ exports[`Select select an option with complex options 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -9494,6 +9559,7 @@ exports[`Select select an option with enter 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -9513,6 +9579,7 @@ exports[`Select select an option with enter 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -9713,6 +9780,7 @@ exports[`Select select another option 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -9732,6 +9800,7 @@ exports[`Select select another option 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
 }
 
@@ -9932,6 +10001,7 @@ exports[`Select size 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -9953,6 +10023,7 @@ exports[`Select size 1`] = `
   width: 100%;
   font-size: 22px;
   line-height: 28px;
+  outline: none;
   border: none;
 }
 
@@ -10140,6 +10211,7 @@ exports[`Select small drop container height 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -41,7 +41,6 @@ exports[`Select 0 value 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -64,7 +63,6 @@ exports[`Select 0 value 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -84,7 +82,6 @@ exports[`Select 0 value 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -102,7 +99,6 @@ exports[`Select 0 value 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -122,7 +118,6 @@ exports[`Select 0 value 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -279,7 +274,6 @@ exports[`Select applies custom global.hover theme to options 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -302,7 +296,6 @@ exports[`Select applies custom global.hover theme to options 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -322,7 +315,6 @@ exports[`Select applies custom global.hover theme to options 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -340,7 +332,6 @@ exports[`Select applies custom global.hover theme to options 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -360,7 +351,6 @@ exports[`Select applies custom global.hover theme to options 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -484,7 +474,6 @@ exports[`Select applies custom global.hover theme to options 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -502,7 +491,6 @@ exports[`Select applies custom global.hover theme to options 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -611,7 +599,6 @@ exports[`Select basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -634,7 +621,6 @@ exports[`Select basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -654,7 +640,6 @@ exports[`Select basic 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -672,7 +657,6 @@ exports[`Select basic 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -692,7 +676,6 @@ exports[`Select basic 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -848,7 +831,6 @@ exports[`Select complex options and children 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -871,7 +853,6 @@ exports[`Select complex options and children 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -891,7 +872,6 @@ exports[`Select complex options and children 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -909,7 +889,6 @@ exports[`Select complex options and children 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -929,7 +908,6 @@ exports[`Select complex options and children 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1034,22 +1012,22 @@ exports[`Select complex options and children 1`] = `
 exports[`Select complex options and children 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 dnCEuz Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
+  class="StyledButton-sc-323bzc-0 ohdLU Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
   id="test-select"
   type="button"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 kDANyu"
+    class="StyledBox-sc-13pk1d4-0 VvbUh"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 fBosDE"
+      class="StyledBox-sc-13pk1d4-0 bVYLzf"
     >
       <div
         class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 dofnYn Select__SelectTextInput-sc-17idtfo-0 hWmVID"
+          class="StyledTextInput-sc-1x30a0s-0 cjOhSV Select__SelectTextInput-sc-17idtfo-0 hWmVID"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -1060,7 +1038,7 @@ exports[`Select complex options and children 2`] = `
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 jUELQZ"
+      class="StyledBox-sc-13pk1d4-0 iCDnTm"
       style="min-width: auto;"
     >
       <svg
@@ -1087,7 +1065,6 @@ exports[`Select complex options and children 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1104,7 +1081,6 @@ exports[`Select complex options and children 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1119,7 +1095,6 @@ exports[`Select complex options and children 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1136,7 +1111,6 @@ exports[`Select complex options and children 3`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1266,7 +1240,7 @@ exports[`Select complex options and children 3`] = `
 
 exports[`Select complex options and children 4`] = `
 "@media only screen and (max-width:768px) {
-  .jUELQZ {
+  .iCDnTm {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -1314,7 +1288,6 @@ exports[`Select deselect an option 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1337,7 +1310,6 @@ exports[`Select deselect an option 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -1357,7 +1329,6 @@ exports[`Select deselect an option 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -1375,7 +1346,6 @@ exports[`Select deselect an option 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1395,7 +1365,6 @@ exports[`Select deselect an option 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1538,7 +1507,6 @@ exports[`Select disabled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1561,7 +1529,6 @@ exports[`Select disabled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -1581,7 +1548,6 @@ exports[`Select disabled 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -1599,7 +1565,6 @@ exports[`Select disabled 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1621,7 +1586,6 @@ exports[`Select disabled 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1727,23 +1691,23 @@ exports[`Select disabled 1`] = `
 exports[`Select disabled 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 cTujh Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
+  class="StyledButton-sc-323bzc-0 dBSXPS Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
   disabled=""
   id="test-select"
   type="button"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 kDANyu"
+    class="StyledBox-sc-13pk1d4-0 VvbUh"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 fBosDE"
+      class="StyledBox-sc-13pk1d4-0 bVYLzf"
     >
       <div
         class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 dofnYn Select__SelectTextInput-sc-17idtfo-0 hWmVID"
+          class="StyledTextInput-sc-1x30a0s-0 cjOhSV Select__SelectTextInput-sc-17idtfo-0 hWmVID"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -1754,7 +1718,7 @@ exports[`Select disabled 2`] = `
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 jUELQZ"
+      class="StyledBox-sc-13pk1d4-0 iCDnTm"
       style="min-width: auto;"
     >
       <svg
@@ -1781,7 +1745,6 @@ exports[`Select empty results search 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1798,7 +1761,6 @@ exports[`Select empty results search 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1813,7 +1775,6 @@ exports[`Select empty results search 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1832,7 +1793,6 @@ exports[`Select empty results search 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -1850,7 +1810,6 @@ exports[`Select empty results search 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1901,7 +1860,6 @@ exports[`Select empty results search 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -2052,7 +2010,6 @@ exports[`Select large drop container height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2069,7 +2026,6 @@ exports[`Select large drop container height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2084,7 +2040,6 @@ exports[`Select large drop container height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -2104,7 +2059,6 @@ exports[`Select large drop container height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2121,7 +2075,6 @@ exports[`Select large drop container height 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2280,7 +2233,6 @@ exports[`Select medium drop container height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2297,7 +2249,6 @@ exports[`Select medium drop container height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2312,7 +2263,6 @@ exports[`Select medium drop container height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -2332,7 +2282,6 @@ exports[`Select medium drop container height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2349,7 +2298,6 @@ exports[`Select medium drop container height 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2542,7 +2490,6 @@ exports[`Select modifies select control style on open 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2565,7 +2512,6 @@ exports[`Select modifies select control style on open 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -2585,7 +2531,6 @@ exports[`Select modifies select control style on open 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -2603,7 +2548,6 @@ exports[`Select modifies select control style on open 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2623,7 +2567,6 @@ exports[`Select modifies select control style on open 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -2782,7 +2725,6 @@ exports[`Select multiple 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2805,7 +2747,6 @@ exports[`Select multiple 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -2825,7 +2766,6 @@ exports[`Select multiple 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -2843,7 +2783,6 @@ exports[`Select multiple 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2863,7 +2802,6 @@ exports[`Select multiple 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -3019,7 +2957,6 @@ exports[`Select multiple onChange toggle with valueKey reduce 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -3042,7 +2979,6 @@ exports[`Select multiple onChange toggle with valueKey reduce 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -3062,7 +2998,6 @@ exports[`Select multiple onChange toggle with valueKey reduce 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -3080,7 +3015,6 @@ exports[`Select multiple onChange toggle with valueKey reduce 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3100,7 +3034,6 @@ exports[`Select multiple onChange toggle with valueKey reduce 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -3223,7 +3156,6 @@ exports[`Select multiple onChange toggle with valueKey reduce 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3240,7 +3172,6 @@ exports[`Select multiple onChange toggle with valueKey reduce 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3255,7 +3186,6 @@ exports[`Select multiple onChange toggle with valueKey reduce 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -3275,7 +3205,6 @@ exports[`Select multiple onChange toggle with valueKey reduce 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3292,7 +3221,6 @@ exports[`Select multiple onChange toggle with valueKey reduce 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3451,7 +3379,7 @@ exports[`Select multiple onChange toggle with valueKey reduce 2`] = `
 
 exports[`Select multiple onChange toggle with valueKey reduce 3`] = `
 "@media only screen and (max-width:768px) {
-  .jUELQZ {
+  .iCDnTm {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -3499,7 +3427,6 @@ exports[`Select multiple onChange with valueKey reduce 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -3522,7 +3449,6 @@ exports[`Select multiple onChange with valueKey reduce 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -3542,7 +3468,6 @@ exports[`Select multiple onChange with valueKey reduce 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -3560,7 +3485,6 @@ exports[`Select multiple onChange with valueKey reduce 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3580,7 +3504,6 @@ exports[`Select multiple onChange with valueKey reduce 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -3703,7 +3626,6 @@ exports[`Select multiple onChange with valueKey reduce 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3720,7 +3642,6 @@ exports[`Select multiple onChange with valueKey reduce 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3735,7 +3656,6 @@ exports[`Select multiple onChange with valueKey reduce 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -3755,7 +3675,6 @@ exports[`Select multiple onChange with valueKey reduce 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -3772,7 +3691,6 @@ exports[`Select multiple onChange with valueKey reduce 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3926,7 +3844,7 @@ exports[`Select multiple onChange with valueKey reduce 2`] = `
 
 exports[`Select multiple onChange with valueKey reduce 3`] = `
 "@media only screen and (max-width:768px) {
-  .jUELQZ {
+  .iCDnTm {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -3974,7 +3892,6 @@ exports[`Select multiple onChange with valueKey string 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -3997,7 +3914,6 @@ exports[`Select multiple onChange with valueKey string 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -4017,7 +3933,6 @@ exports[`Select multiple onChange with valueKey string 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -4035,7 +3950,6 @@ exports[`Select multiple onChange with valueKey string 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4055,7 +3969,6 @@ exports[`Select multiple onChange with valueKey string 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -4178,7 +4091,6 @@ exports[`Select multiple onChange with valueKey string 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4195,7 +4107,6 @@ exports[`Select multiple onChange with valueKey string 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4210,7 +4121,6 @@ exports[`Select multiple onChange with valueKey string 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -4230,7 +4140,6 @@ exports[`Select multiple onChange with valueKey string 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4247,7 +4156,6 @@ exports[`Select multiple onChange with valueKey string 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4401,7 +4309,7 @@ exports[`Select multiple onChange with valueKey string 2`] = `
 
 exports[`Select multiple onChange with valueKey string 3`] = `
 "@media only screen and (max-width:768px) {
-  .jUELQZ {
+  .iCDnTm {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -4449,7 +4357,6 @@ exports[`Select multiple onChange without valueKey 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -4472,7 +4379,6 @@ exports[`Select multiple onChange without valueKey 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -4492,7 +4398,6 @@ exports[`Select multiple onChange without valueKey 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -4510,7 +4415,6 @@ exports[`Select multiple onChange without valueKey 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4530,7 +4434,6 @@ exports[`Select multiple onChange without valueKey 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -4653,7 +4556,6 @@ exports[`Select multiple onChange without valueKey 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4670,7 +4572,6 @@ exports[`Select multiple onChange without valueKey 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4685,7 +4586,6 @@ exports[`Select multiple onChange without valueKey 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -4705,7 +4605,6 @@ exports[`Select multiple onChange without valueKey 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -4722,7 +4621,6 @@ exports[`Select multiple onChange without valueKey 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4876,7 +4774,7 @@ exports[`Select multiple onChange without valueKey 2`] = `
 
 exports[`Select multiple onChange without valueKey 3`] = `
 "@media only screen and (max-width:768px) {
-  .jUELQZ {
+  .iCDnTm {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -4885,14 +4783,14 @@ exports[`Select multiple onChange without valueKey 3`] = `
 
 exports[`Select multiple onChange without valueKey 4`] = `
 <div
-  class="StyledBox-sc-13pk1d4-0 fUuNUq StyledDrop-sc-16s5rx8-0 exrnbV"
+  class="StyledBox-sc-13pk1d4-0 glPSfV StyledDrop-sc-16s5rx8-0 exrnbV"
   data-g-portal-id="0"
   id="test-select__drop"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu StyledSelect__StyledContainer-znp66n-0 evOFkc"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ StyledSelect__StyledContainer-znp66n-0 evOFkc"
     id="test-select__select-drop"
   >
     <div
@@ -4901,13 +4799,13 @@ exports[`Select multiple onChange without valueKey 4`] = `
       tabindex="-1"
     >
       <button
-        class="StyledButton-sc-323bzc-0 iElqND SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
+        class="StyledButton-sc-323bzc-0 jnQMfE SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
         role="menuitem"
         tabindex="-1"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bcEMiq SelectContainer__OptionBox-sc-1wi0ul8-1 cjPAAw"
+          class="StyledBox-sc-13pk1d4-0 lcXThF SelectContainer__OptionBox-sc-1wi0ul8-1 cjPAAw"
         >
           <span
             class="StyledText-sc-1sadyjn-0 bilRua"
@@ -4917,13 +4815,13 @@ exports[`Select multiple onChange without valueKey 4`] = `
         </div>
       </button>
       <button
-        class="StyledButton-sc-323bzc-0 iElqND SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
+        class="StyledButton-sc-323bzc-0 jnQMfE SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
         role="menuitem"
         tabindex="-1"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bcEMiq SelectContainer__OptionBox-sc-1wi0ul8-1 cjPAAw"
+          class="StyledBox-sc-13pk1d4-0 lcXThF SelectContainer__OptionBox-sc-1wi0ul8-1 cjPAAw"
         >
           <span
             class="StyledText-sc-1sadyjn-0 bilRua"
@@ -4933,7 +4831,7 @@ exports[`Select multiple onChange without valueKey 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 fmwxyt"
+        class="StyledBox-sc-13pk1d4-0 bokQlS"
       />
     </div>
   </div>
@@ -4942,7 +4840,7 @@ exports[`Select multiple onChange without valueKey 4`] = `
 
 exports[`Select multiple onChange without valueKey 5`] = `
 "@media only screen and (max-width:768px) {
-  .jUELQZ {
+  .iCDnTm {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -4990,7 +4888,6 @@ exports[`Select multiple values 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -5013,7 +4910,6 @@ exports[`Select multiple values 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -5033,7 +4929,6 @@ exports[`Select multiple values 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -5051,7 +4946,6 @@ exports[`Select multiple values 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -5071,7 +4965,6 @@ exports[`Select multiple values 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -5176,22 +5069,22 @@ exports[`Select multiple values 1`] = `
 exports[`Select multiple values 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 dnCEuz Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
+  class="StyledButton-sc-323bzc-0 ohdLU Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
   id="test-select"
   type="button"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 kDANyu"
+    class="StyledBox-sc-13pk1d4-0 VvbUh"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 fBosDE"
+      class="StyledBox-sc-13pk1d4-0 bVYLzf"
     >
       <div
         class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 dofnYn Select__SelectTextInput-sc-17idtfo-0 hWmVID"
+          class="StyledTextInput-sc-1x30a0s-0 cjOhSV Select__SelectTextInput-sc-17idtfo-0 hWmVID"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -5202,7 +5095,7 @@ exports[`Select multiple values 2`] = `
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 jUELQZ"
+      class="StyledBox-sc-13pk1d4-0 iCDnTm"
       style="min-width: auto;"
     >
       <svg
@@ -5229,7 +5122,6 @@ exports[`Select multiple values 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -5246,7 +5138,6 @@ exports[`Select multiple values 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -5261,7 +5152,6 @@ exports[`Select multiple values 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -5281,7 +5171,6 @@ exports[`Select multiple values 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -5298,7 +5187,6 @@ exports[`Select multiple values 3`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -5457,7 +5345,7 @@ exports[`Select multiple values 3`] = `
 
 exports[`Select multiple values 4`] = `
 "@media only screen and (max-width:768px) {
-  .jUELQZ {
+  .iCDnTm {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -5505,7 +5393,6 @@ exports[`Select onChange with valueKey string 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -5528,7 +5415,6 @@ exports[`Select onChange with valueKey string 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -5548,7 +5434,6 @@ exports[`Select onChange with valueKey string 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -5566,7 +5451,6 @@ exports[`Select onChange with valueKey string 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -5586,7 +5470,6 @@ exports[`Select onChange with valueKey string 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -5709,7 +5592,6 @@ exports[`Select onChange with valueKey string 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -5726,7 +5608,6 @@ exports[`Select onChange with valueKey string 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -5741,7 +5622,6 @@ exports[`Select onChange with valueKey string 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -5761,7 +5641,6 @@ exports[`Select onChange with valueKey string 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -5778,7 +5657,6 @@ exports[`Select onChange with valueKey string 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -5932,7 +5810,7 @@ exports[`Select onChange with valueKey string 2`] = `
 
 exports[`Select onChange with valueKey string 3`] = `
 "@media only screen and (max-width:768px) {
-  .jUELQZ {
+  .iCDnTm {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -5980,7 +5858,6 @@ exports[`Select onChange without valueKey 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -6003,7 +5880,6 @@ exports[`Select onChange without valueKey 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -6023,7 +5899,6 @@ exports[`Select onChange without valueKey 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -6041,7 +5916,6 @@ exports[`Select onChange without valueKey 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -6061,7 +5935,6 @@ exports[`Select onChange without valueKey 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -6184,7 +6057,6 @@ exports[`Select onChange without valueKey 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -6201,7 +6073,6 @@ exports[`Select onChange without valueKey 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -6216,7 +6087,6 @@ exports[`Select onChange without valueKey 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -6236,7 +6106,6 @@ exports[`Select onChange without valueKey 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -6253,7 +6122,6 @@ exports[`Select onChange without valueKey 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -6407,7 +6275,7 @@ exports[`Select onChange without valueKey 2`] = `
 
 exports[`Select onChange without valueKey 3`] = `
 "@media only screen and (max-width:768px) {
-  .jUELQZ {
+  .iCDnTm {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -6455,7 +6323,6 @@ exports[`Select opens 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -6478,7 +6345,6 @@ exports[`Select opens 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -6498,7 +6364,6 @@ exports[`Select opens 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -6516,7 +6381,6 @@ exports[`Select opens 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -6536,7 +6400,6 @@ exports[`Select opens 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -6641,22 +6504,22 @@ exports[`Select opens 1`] = `
 exports[`Select opens 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 dnCEuz Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
+  class="StyledButton-sc-323bzc-0 ohdLU Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
   id="test-select"
   type="button"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 kDANyu"
+    class="StyledBox-sc-13pk1d4-0 VvbUh"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 fBosDE"
+      class="StyledBox-sc-13pk1d4-0 bVYLzf"
     >
       <div
         class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 dofnYn Select__SelectTextInput-sc-17idtfo-0 hWmVID"
+          class="StyledTextInput-sc-1x30a0s-0 cjOhSV Select__SelectTextInput-sc-17idtfo-0 hWmVID"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -6667,7 +6530,7 @@ exports[`Select opens 2`] = `
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 jUELQZ"
+      class="StyledBox-sc-13pk1d4-0 iCDnTm"
       style="min-width: auto;"
     >
       <svg
@@ -6694,7 +6557,6 @@ exports[`Select opens 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -6711,7 +6573,6 @@ exports[`Select opens 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -6726,7 +6587,6 @@ exports[`Select opens 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -6746,7 +6606,6 @@ exports[`Select opens 3`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -6763,7 +6622,6 @@ exports[`Select opens 3`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -6917,7 +6775,7 @@ exports[`Select opens 3`] = `
 
 exports[`Select opens 4`] = `
 "@media only screen and (max-width:768px) {
-  .jUELQZ {
+  .iCDnTm {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -6931,13 +6789,13 @@ exports[`Select opens 5`] = `
   tabindex="-1"
 >
   <button
-    class="StyledButton-sc-323bzc-0 iElqND SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
+    class="StyledButton-sc-323bzc-0 jnQMfE SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
     role="menuitem"
     tabindex="-1"
     type="button"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bcEMiq SelectContainer__OptionBox-sc-1wi0ul8-1 cjPAAw"
+      class="StyledBox-sc-13pk1d4-0 lcXThF SelectContainer__OptionBox-sc-1wi0ul8-1 cjPAAw"
     >
       <span
         class="StyledText-sc-1sadyjn-0 bilRua"
@@ -6947,13 +6805,13 @@ exports[`Select opens 5`] = `
     </div>
   </button>
   <button
-    class="StyledButton-sc-323bzc-0 iElqND SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
+    class="StyledButton-sc-323bzc-0 jnQMfE SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
     role="menuitem"
     tabindex="-1"
     type="button"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bcEMiq SelectContainer__OptionBox-sc-1wi0ul8-1 cjPAAw"
+      class="StyledBox-sc-13pk1d4-0 lcXThF SelectContainer__OptionBox-sc-1wi0ul8-1 cjPAAw"
     >
       <span
         class="StyledText-sc-1sadyjn-0 bilRua"
@@ -6963,7 +6821,7 @@ exports[`Select opens 5`] = `
     </div>
   </button>
   <div
-    class="StyledBox-sc-13pk1d4-0 fmwxyt"
+    class="StyledBox-sc-13pk1d4-0 bokQlS"
   />
 </div>
 `;
@@ -7009,7 +6867,6 @@ exports[`Select renders custom icon 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -7032,7 +6889,6 @@ exports[`Select renders custom icon 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -7052,7 +6908,6 @@ exports[`Select renders custom icon 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -7070,7 +6925,6 @@ exports[`Select renders custom icon 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -7090,7 +6944,6 @@ exports[`Select renders custom icon 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -7246,7 +7099,6 @@ exports[`Select renders custom up and down icons 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -7269,7 +7121,6 @@ exports[`Select renders custom up and down icons 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -7289,7 +7140,6 @@ exports[`Select renders custom up and down icons 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -7307,7 +7157,6 @@ exports[`Select renders custom up and down icons 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -7327,7 +7176,6 @@ exports[`Select renders custom up and down icons 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -7447,21 +7295,21 @@ exports[`Select renders custom up and down icons 2`] = `
 >
   <button
     aria-label="Open Drop"
-    class="StyledButton-sc-323bzc-0 dnCEuz Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
+    class="StyledButton-sc-323bzc-0 ohdLU Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
     type="button"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kDANyu"
+      class="StyledBox-sc-13pk1d4-0 VvbUh"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fBosDE"
+        class="StyledBox-sc-13pk1d4-0 bVYLzf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 dofnYn Select__SelectTextInput-sc-17idtfo-0 hWmVID"
+            class="StyledTextInput-sc-1x30a0s-0 cjOhSV Select__SelectTextInput-sc-17idtfo-0 hWmVID"
             placeholder="Select..."
             readonly=""
             tabindex="-1"
@@ -7471,7 +7319,7 @@ exports[`Select renders custom up and down icons 2`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 jUELQZ"
+        class="StyledBox-sc-13pk1d4-0 iCDnTm"
         style="min-width: auto;"
       >
         .c0 {
@@ -7584,7 +7432,6 @@ exports[`Select renders default icon 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -7607,7 +7454,6 @@ exports[`Select renders default icon 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -7627,7 +7473,6 @@ exports[`Select renders default icon 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -7645,7 +7490,6 @@ exports[`Select renders default icon 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -7665,7 +7509,6 @@ exports[`Select renders default icon 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -7822,7 +7665,6 @@ exports[`Select renders styled select options backwards compatible with legacy
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -7845,7 +7687,6 @@ exports[`Select renders styled select options backwards compatible with legacy
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -7865,7 +7706,6 @@ exports[`Select renders styled select options backwards compatible with legacy
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -7883,7 +7723,6 @@ exports[`Select renders styled select options backwards compatible with legacy
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -7903,7 +7742,6 @@ exports[`Select renders styled select options backwards compatible with legacy
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -8063,7 +7901,6 @@ exports[`Select renders styled select options combining select.options.box &&
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -8086,7 +7923,6 @@ exports[`Select renders styled select options combining select.options.box &&
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -8106,7 +7942,6 @@ exports[`Select renders styled select options combining select.options.box &&
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -8124,7 +7959,6 @@ exports[`Select renders styled select options combining select.options.box &&
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -8144,7 +7978,6 @@ exports[`Select renders styled select options combining select.options.box &&
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -8302,7 +8135,6 @@ exports[`Select renders styled select options using select.options.container 1`]
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -8325,7 +8157,6 @@ exports[`Select renders styled select options using select.options.container 1`]
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -8345,7 +8176,6 @@ exports[`Select renders styled select options using select.options.container 1`]
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -8363,7 +8193,6 @@ exports[`Select renders styled select options using select.options.container 1`]
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -8383,7 +8212,6 @@ exports[`Select renders styled select options using select.options.container 1`]
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -8507,7 +8335,6 @@ exports[`Select renders without icon 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -8530,7 +8357,6 @@ exports[`Select renders without icon 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -8548,7 +8374,6 @@ exports[`Select renders without icon 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -8568,7 +8393,6 @@ exports[`Select renders without icon 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -8696,7 +8520,6 @@ exports[`Select search 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -8719,7 +8542,6 @@ exports[`Select search 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -8739,7 +8561,6 @@ exports[`Select search 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -8757,7 +8578,6 @@ exports[`Select search 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -8777,7 +8597,6 @@ exports[`Select search 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -8886,7 +8705,6 @@ exports[`Select search 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -8903,7 +8721,6 @@ exports[`Select search 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -8918,7 +8735,6 @@ exports[`Select search 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -8937,7 +8753,6 @@ exports[`Select search 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -8957,7 +8772,6 @@ exports[`Select search 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -8974,7 +8788,6 @@ exports[`Select search 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -9029,7 +8842,6 @@ exports[`Select search 2`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -9193,7 +9005,7 @@ exports[`Select search 2`] = `
 
 exports[`Select search 3`] = `
 "@media only screen and (max-width:768px) {
-  .jUELQZ {
+  .iCDnTm {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -9241,7 +9053,6 @@ exports[`Select select an option 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -9264,7 +9075,6 @@ exports[`Select select an option 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -9284,7 +9094,6 @@ exports[`Select select an option 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -9302,7 +9111,6 @@ exports[`Select select an option 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -9322,7 +9130,6 @@ exports[`Select select an option 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -9465,7 +9272,6 @@ exports[`Select select an option with complex options 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -9488,7 +9294,6 @@ exports[`Select select an option with complex options 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -9508,7 +9313,6 @@ exports[`Select select an option with complex options 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -9526,7 +9330,6 @@ exports[`Select select an option with complex options 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -9625,7 +9428,6 @@ exports[`Select select an option with enter 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -9648,7 +9450,6 @@ exports[`Select select an option with enter 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -9668,7 +9469,6 @@ exports[`Select select an option with enter 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -9686,7 +9486,6 @@ exports[`Select select an option with enter 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -9706,7 +9505,6 @@ exports[`Select select an option with enter 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -9849,7 +9647,6 @@ exports[`Select select another option 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -9872,7 +9669,6 @@ exports[`Select select another option 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -9892,7 +9688,6 @@ exports[`Select select another option 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -9910,7 +9705,6 @@ exports[`Select select another option 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -9930,7 +9724,6 @@ exports[`Select select another option 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -10073,7 +9866,6 @@ exports[`Select size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -10096,7 +9888,6 @@ exports[`Select size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -10116,7 +9907,6 @@ exports[`Select size 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -10134,7 +9924,6 @@ exports[`Select size 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -10154,7 +9943,6 @@ exports[`Select size 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -10279,7 +10067,6 @@ exports[`Select small drop container height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -10296,7 +10083,6 @@ exports[`Select small drop container height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -10311,7 +10097,6 @@ exports[`Select small drop container height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -10331,7 +10116,6 @@ exports[`Select small drop container height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -10348,7 +10132,6 @@ exports[`Select small drop container height 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/src/js/components/Sidebar/__tests__/__snapshots__/Sidebar-test.js.snap
+++ b/src/js/components/Sidebar/__tests__/__snapshots__/Sidebar-test.js.snap
@@ -7,7 +7,6 @@ exports[`Sidebar all 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -26,7 +25,6 @@ exports[`Sidebar all 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -55,7 +53,6 @@ exports[`Sidebar all 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -73,7 +70,6 @@ exports[`Sidebar all 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -175,7 +171,6 @@ exports[`Sidebar children 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -192,7 +187,6 @@ exports[`Sidebar children 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -210,7 +204,6 @@ exports[`Sidebar children 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -274,7 +267,6 @@ exports[`Sidebar footer 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -291,7 +283,6 @@ exports[`Sidebar footer 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -309,7 +300,6 @@ exports[`Sidebar footer 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -390,7 +380,6 @@ exports[`Sidebar header 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -407,7 +396,6 @@ exports[`Sidebar header 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -436,7 +424,6 @@ exports[`Sidebar header 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -506,7 +493,6 @@ exports[`Sidebar renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -523,7 +509,6 @@ exports[`Sidebar renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;

--- a/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
+++ b/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
@@ -10,7 +10,6 @@ exports[`SkipLink basic 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
 }
 
 .c1:hover {
@@ -97,7 +96,7 @@ exports[`SkipLink basic 2`] = `
   <div>
     <a
       aria-hidden="true"
-      class="StyledAnchor-sc-1rp7lwl-0 gzrmWK SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
+      class="StyledAnchor-sc-1rp7lwl-0 cfNrRd SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
       id="main"
       tabindex="-1"
     />
@@ -110,7 +109,7 @@ exports[`SkipLink basic 2`] = `
   <footer>
     <a
       aria-hidden="true"
-      class="StyledAnchor-sc-1rp7lwl-0 gzrmWK SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
+      class="StyledAnchor-sc-1rp7lwl-0 cfNrRd SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
       id="footer"
       tabindex="-1"
     />
@@ -129,7 +128,7 @@ exports[`SkipLink basic 3`] = `
   <div>
     <a
       aria-hidden="true"
-      class="StyledAnchor-sc-1rp7lwl-0 gzrmWK SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
+      class="StyledAnchor-sc-1rp7lwl-0 cfNrRd SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
       data-g-tabindex="-1"
       id="main"
       tabindex="-1"
@@ -145,7 +144,7 @@ exports[`SkipLink basic 3`] = `
   <footer>
     <a
       aria-hidden="true"
-      class="StyledAnchor-sc-1rp7lwl-0 gzrmWK SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
+      class="StyledAnchor-sc-1rp7lwl-0 cfNrRd SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
       data-g-tabindex="-1"
       id="footer"
       tabindex="-1"

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -7,7 +7,6 @@ exports[`Tabs Tab 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -22,7 +21,6 @@ exports[`Tabs Tab 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -47,7 +45,6 @@ exports[`Tabs Tab 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -68,7 +65,6 @@ exports[`Tabs Tab 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -87,7 +83,6 @@ exports[`Tabs Tab 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -263,7 +258,6 @@ exports[`Tabs change to second tab 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -278,7 +272,6 @@ exports[`Tabs change to second tab 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -303,7 +296,6 @@ exports[`Tabs change to second tab 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -324,7 +316,6 @@ exports[`Tabs change to second tab 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -343,7 +334,6 @@ exports[`Tabs change to second tab 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -507,21 +497,21 @@ exports[`Tabs change to second tab 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu StyledTabs-a4fwxl-2 gjpnHh"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ StyledTabs-a4fwxl-2 gjpnHh"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 cbhmKY StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
+      class="StyledBox-sc-13pk1d4-0 ewBYLf StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fuNnNM StyledTab-sc-1nnwnsb-0 cuuQmA"
+          class="StyledBox-sc-13pk1d4-0 iwzLzf StyledTab-sc-1nnwnsb-0 cuuQmA"
         >
           <span
             class="StyledText-sc-1sadyjn-0 iBFVwz"
@@ -533,12 +523,12 @@ exports[`Tabs change to second tab 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 hZYEKY StyledTab-sc-1nnwnsb-0 cuuQmA"
+          class="StyledBox-sc-13pk1d4-0 fQtdUH StyledTab-sc-1nnwnsb-0 cuuQmA"
         >
           <span
             class="StyledText-sc-1sadyjn-0 kJdDnV"
@@ -566,7 +556,6 @@ exports[`Tabs complex title 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -581,7 +570,6 @@ exports[`Tabs complex title 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -606,7 +594,6 @@ exports[`Tabs complex title 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -627,7 +614,6 @@ exports[`Tabs complex title 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -646,7 +632,6 @@ exports[`Tabs complex title 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -806,7 +791,6 @@ exports[`Tabs no Tab 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -821,7 +805,6 @@ exports[`Tabs no Tab 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -846,7 +829,6 @@ exports[`Tabs no Tab 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -865,7 +847,6 @@ exports[`Tabs no Tab 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -973,7 +954,6 @@ exports[`Tabs set on hover 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -988,7 +968,6 @@ exports[`Tabs set on hover 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1013,7 +992,6 @@ exports[`Tabs set on hover 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -1034,7 +1012,6 @@ exports[`Tabs set on hover 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -1053,7 +1030,6 @@ exports[`Tabs set on hover 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1217,21 +1193,21 @@ exports[`Tabs set on hover 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu StyledTabs-a4fwxl-2 gjpnHh"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ StyledTabs-a4fwxl-2 gjpnHh"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 cbhmKY StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
+      class="StyledBox-sc-13pk1d4-0 ewBYLf StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 hZYEKY StyledTab-sc-1nnwnsb-0 cuuQmA"
+          class="StyledBox-sc-13pk1d4-0 fQtdUH StyledTab-sc-1nnwnsb-0 cuuQmA"
         >
           <span
             class="StyledText-sc-1sadyjn-0 kJdDnV"
@@ -1243,12 +1219,12 @@ exports[`Tabs set on hover 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fuNnNM StyledTab-sc-1nnwnsb-0 cuuQmA"
+          class="StyledBox-sc-13pk1d4-0 iwzLzf StyledTab-sc-1nnwnsb-0 cuuQmA"
         >
           <span
             class="StyledText-sc-1sadyjn-0 iBFVwz"
@@ -1274,21 +1250,21 @@ exports[`Tabs set on hover 3`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu StyledTabs-a4fwxl-2 gjpnHh"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ StyledTabs-a4fwxl-2 gjpnHh"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 cbhmKY StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
+      class="StyledBox-sc-13pk1d4-0 ewBYLf StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 hZYEKY StyledTab-sc-1nnwnsb-0 cuuQmA"
+          class="StyledBox-sc-13pk1d4-0 fQtdUH StyledTab-sc-1nnwnsb-0 cuuQmA"
         >
           <span
             class="StyledText-sc-1sadyjn-0 kJdDnV"
@@ -1300,12 +1276,12 @@ exports[`Tabs set on hover 3`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 hZYEKY StyledTab-sc-1nnwnsb-0 cuuQmA"
+          class="StyledBox-sc-13pk1d4-0 fQtdUH StyledTab-sc-1nnwnsb-0 cuuQmA"
         >
           <span
             class="StyledText-sc-1sadyjn-0 jvLdFN"
@@ -1331,21 +1307,21 @@ exports[`Tabs set on hover 4`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu StyledTabs-a4fwxl-2 gjpnHh"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ StyledTabs-a4fwxl-2 gjpnHh"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 cbhmKY StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
+      class="StyledBox-sc-13pk1d4-0 ewBYLf StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 hZYEKY StyledTab-sc-1nnwnsb-0 cuuQmA"
+          class="StyledBox-sc-13pk1d4-0 fQtdUH StyledTab-sc-1nnwnsb-0 cuuQmA"
         >
           <span
             class="StyledText-sc-1sadyjn-0 kJdDnV"
@@ -1357,12 +1333,12 @@ exports[`Tabs set on hover 4`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 hZYEKY StyledTab-sc-1nnwnsb-0 cuuQmA"
+          class="StyledBox-sc-13pk1d4-0 fQtdUH StyledTab-sc-1nnwnsb-0 cuuQmA"
         >
           <span
             class="StyledText-sc-1sadyjn-0 jvLdFN"
@@ -1388,21 +1364,21 @@ exports[`Tabs set on hover 5`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 jJdKAu StyledTabs-a4fwxl-2 gjpnHh"
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ StyledTabs-a4fwxl-2 gjpnHh"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 cbhmKY StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
+      class="StyledBox-sc-13pk1d4-0 ewBYLf StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 hZYEKY StyledTab-sc-1nnwnsb-0 cuuQmA"
+          class="StyledBox-sc-13pk1d4-0 fQtdUH StyledTab-sc-1nnwnsb-0 cuuQmA"
         >
           <span
             class="StyledText-sc-1sadyjn-0 kJdDnV"
@@ -1414,12 +1390,12 @@ exports[`Tabs set on hover 5`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 dnCEuz"
+        class="StyledButton-sc-323bzc-0 ohdLU"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fuNnNM StyledTab-sc-1nnwnsb-0 cuuQmA"
+          class="StyledBox-sc-13pk1d4-0 iwzLzf StyledTab-sc-1nnwnsb-0 cuuQmA"
         >
           <span
             class="StyledText-sc-1sadyjn-0 iBFVwz"
@@ -1447,7 +1423,6 @@ exports[`Tabs with icon + reverse 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1462,7 +1437,6 @@ exports[`Tabs with icon + reverse 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1487,7 +1461,6 @@ exports[`Tabs with icon + reverse 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -1516,7 +1489,6 @@ exports[`Tabs with icon + reverse 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   margin-left: 12px;
   margin-right: 12px;
@@ -1553,7 +1525,6 @@ exports[`Tabs with icon + reverse 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -91,6 +91,7 @@ exports[`Tabs Tab 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -342,6 +343,7 @@ exports[`Tabs change to second tab 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -506,7 +508,7 @@ exports[`Tabs change to second tab 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -523,7 +525,7 @@ exports[`Tabs change to second tab 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -640,6 +642,7 @@ exports[`Tabs complex title 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -855,6 +858,7 @@ exports[`Tabs no Tab 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1038,6 +1042,7 @@ exports[`Tabs set on hover 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1202,7 +1207,7 @@ exports[`Tabs set on hover 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -1219,7 +1224,7 @@ exports[`Tabs set on hover 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -1259,7 +1264,7 @@ exports[`Tabs set on hover 3`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -1276,7 +1281,7 @@ exports[`Tabs set on hover 3`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -1316,7 +1321,7 @@ exports[`Tabs set on hover 4`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -1333,7 +1338,7 @@ exports[`Tabs set on hover 4`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -1373,7 +1378,7 @@ exports[`Tabs set on hover 5`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -1390,7 +1395,7 @@ exports[`Tabs set on hover 5`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 ohdLU"
+        class="StyledButton-sc-323bzc-0 bwJeiP"
         role="tab"
         type="button"
       >
@@ -1533,6 +1538,7 @@ exports[`Tabs with icon + reverse 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;

--- a/src/js/components/TextArea/README.md
+++ b/src/js/components/TextArea/README.md
@@ -167,12 +167,52 @@ Defaults to
 
 **global.focus.border.color**
 
-The color around the component when in focus. Expects `string | { dark: string, light: string }`.
+The border color of the component when in focus. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 
 ```
 focus
+```
+
+**global.focus.outline.color**
+
+The outline color around the component when in focus. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+undefined
+```
+
+**global.focus.outline.size**
+
+The size of the outline around the component when in focus. Expects `string`.
+
+Defaults to
+
+```
+undefined
+```
+
+**global.focus.shadow.color**
+
+The shadow color around the component when in focus. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+focus
+```
+
+**global.focus.shadow.size**
+
+The size of the shadow around the component when in focus. Expects `string`.
+
+Defaults to
+
+```
+2px
 ```
 
 **global.colors.placeholder**

--- a/src/js/components/TextArea/StyledTextArea.js
+++ b/src/js/components/TextArea/StyledTextArea.js
@@ -55,7 +55,7 @@ const StyledTextArea = styled.textarea`
     outline: none;
   }
 
-  ${props => props.focus && !props.plain && focusStyle};
+  ${props => props.focus && !props.plain && focusStyle()};
   ${props => props.theme.textArea && props.theme.textArea.extend};
 `;
 

--- a/src/js/components/TextArea/StyledTextArea.js
+++ b/src/js/components/TextArea/StyledTextArea.js
@@ -9,6 +9,7 @@ import {
 import { defaultProps } from '../../default-props';
 
 const plainStyle = css`
+  outline: none;
   border: none;
   width: 100%;
   -webkit-appearance: none;

--- a/src/js/components/TextArea/__tests__/__snapshots__/TextArea-test.js.snap
+++ b/src/js/components/TextArea/__tests__/__snapshots__/TextArea-test.js.snap
@@ -17,7 +17,6 @@ exports[`TextArea basic 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -81,7 +80,6 @@ exports[`TextArea disabled 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -151,7 +149,6 @@ exports[`TextArea fill 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -216,7 +213,6 @@ exports[`TextArea focusIndicator 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -280,7 +276,6 @@ exports[`TextArea placeholder 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -345,7 +340,6 @@ exports[`TextArea plain 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -412,7 +406,6 @@ exports[`TextArea resize false 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -477,7 +470,6 @@ exports[`TextArea resize horizontal 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -542,7 +534,6 @@ exports[`TextArea resize true 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -607,7 +598,6 @@ exports[`TextArea resize vertical 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -672,7 +662,6 @@ exports[`TextArea size large 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -739,7 +728,6 @@ exports[`TextArea size medium 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -806,7 +794,6 @@ exports[`TextArea size small 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;

--- a/src/js/components/TextArea/__tests__/__snapshots__/TextArea-test.js.snap
+++ b/src/js/components/TextArea/__tests__/__snapshots__/TextArea-test.js.snap
@@ -88,6 +88,7 @@ exports[`TextArea disabled 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
   width: 100%;
   -webkit-appearance: none;
@@ -348,6 +349,7 @@ exports[`TextArea plain 1`] = `
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
   width: 100%;
+  outline: none;
   border: none;
   width: 100%;
   -webkit-appearance: none;

--- a/src/js/components/TextInput/README.md
+++ b/src/js/components/TextInput/README.md
@@ -359,12 +359,52 @@ Defaults to
 
 **global.focus.border.color**
 
-The color around the component when in focus. Expects `string | { dark: string, light: string }`.
+The border color of the component when in focus. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 
 ```
 focus
+```
+
+**global.focus.outline.color**
+
+The outline color around the component when in focus. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+undefined
+```
+
+**global.focus.outline.size**
+
+The size of the outline around the component when in focus. Expects `string`.
+
+Defaults to
+
+```
+undefined
+```
+
+**global.focus.shadow.color**
+
+The shadow color around the component when in focus. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+focus
+```
+
+**global.focus.shadow.size**
+
+The size of the shadow around the component when in focus. Expects `string`.
+
+Defaults to
+
+```
+2px
 ```
 
 **global.colors.placeholder**

--- a/src/js/components/TextInput/StyledTextInput.js
+++ b/src/js/components/TextInput/StyledTextInput.js
@@ -40,7 +40,7 @@ const StyledTextInput = styled.input`
     outline: none;
   }
 
-  ${props => props.focus && !props.plain && focusStyle};
+  ${props => props.focus && !props.plain && focusStyle()};
   ${props =>
     props.disabled &&
     disabledStyle(

--- a/src/js/components/TextInput/StyledTextInput.js
+++ b/src/js/components/TextInput/StyledTextInput.js
@@ -19,6 +19,7 @@ const sizeStyle = props => {
 };
 
 const plainStyle = css`
+  outline: none;
   border: none;
 `;
 

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -189,6 +189,7 @@ exports[`TextInput calls onSuggestionsClose 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -392,6 +393,7 @@ exports[`TextInput calls onSuggestionsOpen 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -647,6 +649,7 @@ exports[`TextInput close suggestion drop 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -902,6 +905,7 @@ exports[`TextInput complex suggestions 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1468,6 +1472,7 @@ exports[`TextInput large drop height 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1652,6 +1657,7 @@ exports[`TextInput medium drop height 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1871,6 +1877,7 @@ exports[`TextInput select suggestion 1`] = `
   width: 100%;
   font-size: 22px;
   line-height: 28px;
+  outline: none;
   border: none;
 }
 
@@ -1981,6 +1988,7 @@ exports[`TextInput select suggestion 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2111,7 +2119,7 @@ exports[`TextInput select suggestion 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 gUyRkk"
+      class="StyledTextInput-sc-1x30a0s-0 cWvRjL"
       data-testid="test-input"
       id="item"
       name="item"
@@ -2184,6 +2192,7 @@ exports[`TextInput small drop height 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2425,6 +2434,7 @@ exports[`TextInput suggestions 2`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -320,7 +320,7 @@ exports[`TextInput calls onSuggestionsClose 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 cjwPmn"
+      class="StyledTextInput-sc-1x30a0s-0 ieaeUD"
       data-testid="test-input"
       id="item"
       name="item"
@@ -780,7 +780,7 @@ exports[`TextInput close suggestion drop 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 cjwPmn"
+      class="StyledTextInput-sc-1x30a0s-0 ieaeUD"
       data-testid="test-input"
       id="item"
       name="item"

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -7,7 +7,6 @@ exports[`TextInput basic 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -73,7 +72,6 @@ exports[`TextInput calls onSuggestionsClose 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -135,7 +133,6 @@ exports[`TextInput calls onSuggestionsClose 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -152,7 +149,6 @@ exports[`TextInput calls onSuggestionsClose 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -168,7 +164,6 @@ exports[`TextInput calls onSuggestionsClose 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -186,7 +181,6 @@ exports[`TextInput calls onSuggestionsClose 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -325,7 +319,7 @@ exports[`TextInput calls onSuggestionsClose 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 infNeI"
+      class="StyledTextInput-sc-1x30a0s-0 cjwPmn"
       data-testid="test-input"
       id="item"
       name="item"
@@ -342,7 +336,6 @@ exports[`TextInput calls onSuggestionsOpen 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -359,7 +352,6 @@ exports[`TextInput calls onSuggestionsOpen 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -375,7 +367,6 @@ exports[`TextInput calls onSuggestionsOpen 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -393,7 +384,6 @@ exports[`TextInput calls onSuggestionsOpen 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -540,7 +530,6 @@ exports[`TextInput close suggestion drop 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -602,7 +591,6 @@ exports[`TextInput close suggestion drop 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -619,7 +607,6 @@ exports[`TextInput close suggestion drop 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -635,7 +622,6 @@ exports[`TextInput close suggestion drop 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -653,7 +639,6 @@ exports[`TextInput close suggestion drop 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -792,7 +777,7 @@ exports[`TextInput close suggestion drop 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 infNeI"
+      class="StyledTextInput-sc-1x30a0s-0 cjwPmn"
       data-testid="test-input"
       id="item"
       name="item"
@@ -819,7 +804,6 @@ exports[`TextInput complex suggestions 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -881,7 +865,6 @@ exports[`TextInput complex suggestions 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -898,7 +881,6 @@ exports[`TextInput complex suggestions 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -912,7 +894,6 @@ exports[`TextInput complex suggestions 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1035,7 +1016,6 @@ exports[`TextInput disabled 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1104,7 +1084,6 @@ exports[`TextInput handles next and previous without suggestion 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1168,7 +1147,7 @@ exports[`TextInput handles next and previous without suggestion 2`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 kQqgOI"
+      class="StyledTextInput-sc-1x30a0s-0 dcnGDe"
       data-testid="test-input"
       id="item"
       name="item"
@@ -1219,7 +1198,6 @@ exports[`TextInput icon 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1344,7 +1322,6 @@ exports[`TextInput icon reverse 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1435,7 +1412,6 @@ exports[`TextInput large drop height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1452,7 +1428,6 @@ exports[`TextInput large drop height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1468,7 +1443,6 @@ exports[`TextInput large drop height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -1486,7 +1460,6 @@ exports[`TextInput large drop height 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1623,7 +1596,6 @@ exports[`TextInput medium drop height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1640,7 +1612,6 @@ exports[`TextInput medium drop height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1656,7 +1627,6 @@ exports[`TextInput medium drop height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -1674,7 +1644,6 @@ exports[`TextInput medium drop height 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1821,7 +1790,6 @@ exports[`TextInput select a suggestion 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1893,7 +1861,6 @@ exports[`TextInput select suggestion 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -1958,7 +1925,6 @@ exports[`TextInput select suggestion 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1975,7 +1941,6 @@ exports[`TextInput select suggestion 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1991,7 +1956,6 @@ exports[`TextInput select suggestion 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -2009,7 +1973,6 @@ exports[`TextInput select suggestion 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2148,7 +2111,7 @@ exports[`TextInput select suggestion 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 bFsRze"
+      class="StyledTextInput-sc-1x30a0s-0 gUyRkk"
       data-testid="test-input"
       id="item"
       name="item"
@@ -2165,7 +2128,6 @@ exports[`TextInput small drop height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2182,7 +2144,6 @@ exports[`TextInput small drop height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2198,7 +2159,6 @@ exports[`TextInput small drop height 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -2216,7 +2176,6 @@ exports[`TextInput small drop height 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2353,7 +2312,6 @@ exports[`TextInput suggestions 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   padding: 11px;
@@ -2411,7 +2369,6 @@ exports[`TextInput suggestions 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2428,7 +2385,6 @@ exports[`TextInput suggestions 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2444,7 +2400,6 @@ exports[`TextInput suggestions 2`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -2462,7 +2417,6 @@ exports[`TextInput suggestions 2`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -148,6 +148,7 @@ exports[`Video autoPlay renders 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -172,6 +173,7 @@ exports[`Video autoPlay renders 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -643,6 +645,7 @@ exports[`Video controls renders 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -667,6 +670,7 @@ exports[`Video controls renders 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1242,6 +1246,7 @@ exports[`Video fit renders 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1266,6 +1271,7 @@ exports[`Video fit renders 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1851,6 +1857,7 @@ exports[`Video loop renders 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -1875,6 +1882,7 @@ exports[`Video loop renders 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2290,6 +2298,7 @@ exports[`Video mute renders 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2314,6 +2323,7 @@ exports[`Video mute renders 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2729,6 +2739,7 @@ exports[`Video renders 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
@@ -2753,6 +2764,7 @@ exports[`Video renders 1`] = `
   overflow: visible;
   text-transform: none;
   color: inherit;
+  outline: none;
   border: none;
   padding: 0;
   text-align: inherit;

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -41,7 +41,6 @@ exports[`Video autoPlay renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -66,7 +65,6 @@ exports[`Video autoPlay renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -88,7 +86,6 @@ exports[`Video autoPlay renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -106,7 +103,6 @@ exports[`Video autoPlay renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -123,7 +119,6 @@ exports[`Video autoPlay renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -145,7 +140,6 @@ exports[`Video autoPlay renders 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -170,7 +164,6 @@ exports[`Video autoPlay renders 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -521,7 +514,6 @@ exports[`Video controls renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -546,7 +538,6 @@ exports[`Video controls renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -568,7 +559,6 @@ exports[`Video controls renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -586,7 +576,6 @@ exports[`Video controls renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -603,7 +592,6 @@ exports[`Video controls renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -627,7 +615,6 @@ exports[`Video controls renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -648,7 +635,6 @@ exports[`Video controls renders 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -673,7 +659,6 @@ exports[`Video controls renders 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1150,7 +1135,6 @@ exports[`Video fit renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1175,7 +1159,6 @@ exports[`Video fit renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1197,7 +1180,6 @@ exports[`Video fit renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1215,7 +1197,6 @@ exports[`Video fit renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1232,7 +1213,6 @@ exports[`Video fit renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1254,7 +1234,6 @@ exports[`Video fit renders 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1279,7 +1258,6 @@ exports[`Video fit renders 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1766,7 +1744,6 @@ exports[`Video loop renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1791,7 +1768,6 @@ exports[`Video loop renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1813,7 +1789,6 @@ exports[`Video loop renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1831,7 +1806,6 @@ exports[`Video loop renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -1848,7 +1822,6 @@ exports[`Video loop renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1870,7 +1843,6 @@ exports[`Video loop renders 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1895,7 +1867,6 @@ exports[`Video loop renders 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2212,7 +2183,6 @@ exports[`Video mute renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2237,7 +2207,6 @@ exports[`Video mute renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2259,7 +2228,6 @@ exports[`Video mute renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2277,7 +2245,6 @@ exports[`Video mute renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2294,7 +2261,6 @@ exports[`Video mute renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2316,7 +2282,6 @@ exports[`Video mute renders 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2341,7 +2306,6 @@ exports[`Video mute renders 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2658,7 +2622,6 @@ exports[`Video renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2683,7 +2646,6 @@ exports[`Video renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2705,7 +2667,6 @@ exports[`Video renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2723,7 +2684,6 @@ exports[`Video renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -2740,7 +2700,6 @@ exports[`Video renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2762,7 +2721,6 @@ exports[`Video renders 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2787,7 +2745,6 @@ exports[`Video renders 1`] = `
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
-  outline: none;
   font: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -601,12 +601,52 @@ Defaults to
 
 **global.focus.border.color**
 
-The color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+The border color of the component when in focus. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 
 \`\`\`
 focus
+\`\`\`
+
+**global.focus.outline.color**
+
+The outline color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**global.focus.outline.size**
+
+The size of the outline around the component when in focus. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**global.focus.shadow.color**
+
+The shadow color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+focus
+\`\`\`
+
+**global.focus.shadow.size**
+
+The size of the shadow around the component when in focus. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+2px
 \`\`\`
 
 **global.edgeSize**
@@ -2462,12 +2502,52 @@ undefined
 
 **global.focus.border.color**
 
-The color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+The border color of the component when in focus. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 
 \`\`\`
 focus
+\`\`\`
+
+**global.focus.outline.color**
+
+The outline color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**global.focus.outline.size**
+
+The size of the outline around the component when in focus. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**global.focus.shadow.color**
+
+The shadow color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+focus
+\`\`\`
+
+**global.focus.shadow.size**
+
+The size of the shadow around the component when in focus. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+2px
 \`\`\`
 
 **global.control.disabled.opacity**
@@ -8918,12 +8998,52 @@ Defaults to
 
 **global.focus.border.color**
 
-The color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+The border color of the component when in focus. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 
 \`\`\`
 focus
+\`\`\`
+
+**global.focus.outline.color**
+
+The outline color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**global.focus.outline.size**
+
+The size of the outline around the component when in focus. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**global.focus.shadow.color**
+
+The shadow color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+focus
+\`\`\`
+
+**global.focus.shadow.size**
+
+The size of the shadow around the component when in focus. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+2px
 \`\`\`
 
 **global.colors.placeholder**
@@ -10264,12 +10384,52 @@ input
   
 **global.focus.border.color**
 
-The color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+The border color of the component when in focus. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 
 \`\`\`
 focus
+\`\`\`
+
+**global.focus.outline.color**
+
+The outline color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**global.focus.outline.size**
+
+The size of the outline around the component when in focus. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**global.focus.shadow.color**
+
+The shadow color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+focus
+\`\`\`
+
+**global.focus.shadow.size**
+
+The size of the shadow around the component when in focus. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+2px
 \`\`\`
 
 **global.spacing**
@@ -12947,12 +13107,52 @@ Defaults to
 
 **global.focus.border.color**
 
-The color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+The border color of the component when in focus. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 
 \`\`\`
 focus
+\`\`\`
+
+**global.focus.outline.color**
+
+The outline color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**global.focus.outline.size**
+
+The size of the outline around the component when in focus. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**global.focus.shadow.color**
+
+The shadow color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+focus
+\`\`\`
+
+**global.focus.shadow.size**
+
+The size of the shadow around the component when in focus. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+2px
 \`\`\`
 
 **global.colors.placeholder**
@@ -13389,12 +13589,52 @@ Defaults to
 
 **global.focus.border.color**
 
-The color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+The border color of the component when in focus. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 
 \`\`\`
 focus
+\`\`\`
+
+**global.focus.outline.color**
+
+The outline color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**global.focus.outline.size**
+
+The size of the outline around the component when in focus. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**global.focus.shadow.color**
+
+The shadow color around the component when in focus. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+focus
+\`\`\`
+
+**global.focus.shadow.size**
+
+The size of the shadow around the component when in focus. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+2px
 \`\`\`
 
 **global.colors.placeholder**

--- a/src/js/contexts/ThemeContext/stories/ThemeContextExtend.js
+++ b/src/js/contexts/ThemeContext/stories/ThemeContextExtend.js
@@ -11,6 +11,9 @@ const customTheme = deepMerge(grommet, {
       border: {
         color: 'red',
       },
+      shadow: {
+        color: 'red',
+      },
     },
   },
 });

--- a/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
+++ b/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
@@ -109,7 +109,6 @@ exports[`Grommet custom theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   min-width: 0;
   min-height: 0;
@@ -124,7 +123,6 @@ exports[`Grommet custom theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -143,7 +141,6 @@ exports[`Grommet custom theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #333333;
   color: #f8f8f8;
@@ -173,7 +170,6 @@ exports[`Grommet custom theme 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
 }
 
 .c2:hover {
@@ -190,7 +186,6 @@ exports[`Grommet custom theme 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
 }
 
 .c6:hover {
@@ -207,7 +202,6 @@ exports[`Grommet custom theme 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
 }
 
 .c9:hover {
@@ -221,7 +215,6 @@ exports[`Grommet custom theme 1`] = `
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   line-height: 50px;
@@ -431,7 +424,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #FD6FFF;
   color: #444444;
@@ -448,7 +440,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #60EB9F;
   color: #444444;
@@ -465,7 +456,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #60EBE1;
   color: #444444;
@@ -482,7 +472,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #333333;
   color: #eeeeee;
@@ -499,7 +488,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #555555;
   color: #eeeeee;
@@ -516,7 +504,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #777777;
   color: #eeeeee;
@@ -533,7 +520,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #999999;
   color: #444444;
@@ -550,7 +536,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #FFCA58;
   color: #444444;
@@ -567,7 +552,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #F8F8F8;
   color: #444444;
@@ -584,7 +568,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #F2F2F2;
   color: #444444;
@@ -601,7 +584,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #EDEDED;
   color: #444444;
@@ -618,7 +600,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #DADADA;
   color: #444444;
@@ -635,7 +616,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #EB6060;
   color: #444444;
@@ -652,7 +632,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #01C781;
   color: #444444;
@@ -669,7 +648,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #6095EB;
   color: #444444;
@@ -686,7 +664,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #FF3333;
   color: #eeeeee;
@@ -703,7 +680,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #a8a8a8;
   color: #444444;
@@ -720,7 +696,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7DD892;
   color: #444444;
@@ -737,7 +712,6 @@ exports[`Grommet dark theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #F7E464;
   color: #444444;
@@ -1004,7 +978,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #6FFFB0;
   color: #444444;
@@ -1021,7 +994,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #FD6FFF;
   color: #444444;
@@ -1038,7 +1010,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #81FCED;
   color: #444444;
@@ -1055,7 +1026,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #7D4CDB;
   color: #f8f8f8;
@@ -1072,7 +1042,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #333333;
   color: #f8f8f8;
@@ -1089,7 +1058,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #555555;
   color: #f8f8f8;
@@ -1106,7 +1074,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #777777;
   color: #f8f8f8;
@@ -1123,7 +1090,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #999999;
   color: #444444;
@@ -1140,7 +1106,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #F8F8F8;
   color: #444444;
@@ -1157,7 +1122,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #F2F2F2;
   color: #444444;
@@ -1174,7 +1138,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #EDEDED;
   color: #444444;
@@ -1191,7 +1154,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #DADADA;
   color: #444444;
@@ -1208,7 +1170,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #00873D;
   color: #f8f8f8;
@@ -1225,7 +1186,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #3D138D;
   color: #f8f8f8;
@@ -1242,7 +1202,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #00739D;
   color: #f8f8f8;
@@ -1259,7 +1218,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #FF4040;
   color: #f8f8f8;
@@ -1276,7 +1234,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #CCCCCC;
   color: #444444;
@@ -1293,7 +1250,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #00C781;
   color: #444444;
@@ -1310,7 +1266,6 @@ exports[`Grommet default theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #FFAA15;
   color: #444444;
@@ -1574,7 +1529,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #6FFFB0;
   color: #333333;
@@ -1591,7 +1545,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #FD6FFF;
   color: #333333;
@@ -1608,7 +1561,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #81FCED;
   color: #333333;
@@ -1625,7 +1577,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #01A982;
   color: #EEEEEE;
@@ -1642,7 +1593,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #333333;
   color: #EEEEEE;
@@ -1659,7 +1609,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #555555;
   color: #EEEEEE;
@@ -1676,7 +1625,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #777777;
   color: #EEEEEE;
@@ -1693,7 +1641,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #999999;
   color: #333333;
@@ -1710,7 +1657,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #F8F8F8;
   color: #333333;
@@ -1727,7 +1673,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #F2F2F2;
   color: #333333;
@@ -1744,7 +1689,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #EDEDED;
   color: #333333;
@@ -1761,7 +1705,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #DADADA;
   color: #333333;
@@ -1778,7 +1721,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #00873D;
   color: #EEEEEE;
@@ -1795,7 +1737,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #3D138D;
   color: #EEEEEE;
@@ -1812,7 +1753,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #00739D;
   color: #EEEEEE;
@@ -1829,7 +1769,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #FF4040;
   color: #EEEEEE;
@@ -1846,7 +1785,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #CCCCCC;
   color: #333333;
@@ -1863,7 +1801,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #00C781;
   color: #333333;
@@ -1880,7 +1817,6 @@ exports[`Grommet hpe theme 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  outline: none;
   max-width: 100%;
   background: #FFAA15;
   color: #333333;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -184,6 +184,14 @@ export interface ThemeType {
       border?: {
         color?: ColorType;
       };
+      outline?: {
+        color?: ColorType;
+        size?: string;
+      };
+      shadow?: {
+        color?: ColorType;
+        size?: string;
+      };
     };
     font?: {
       face?: string;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -256,8 +256,15 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         },
       },
       focus: {
+        // shodow or outline are required for accessibility
         border: {
+          // remove to only have shadow
           color: 'focus',
+        },
+        // outline: { color: undefined, size: undefined },
+        shadow: {
+          color: 'focus',
+          size: '2px',
         },
       },
       font: {

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -208,72 +208,68 @@ export const fillStyle = fillProp => {
   return undefined;
 };
 
-export const focusStyle = justBorder => css`
-  ${props =>
-    // focus also supports clickable elements inside svg
-    props.theme.global.focus &&
-    props.theme.global.focus.border &&
-    props.theme.global.focus.border.color &&
-    `> circle,
-    > ellipse,
-    > line,
-    > path,
-    > polygon,
-    > polyline,
-    > rect {
-      outline: ${normalizeColor(
-        props.theme.global.focus.border.color,
+const focusStyles = (props, { justBorder } = {}) => {
+  const {
+    theme: {
+      global: { focus },
+    },
+  } = props;
+  if (!focus) return ''; // native
+  if (focus.shadow && (!focus.border || !justBorder)) {
+    if (typeof focus.shadow === 'object') {
+      const color = normalizeColor(
+        // If there is a focus.border.color, use that for shadow too.
+        // This is for backwards compatibility in v2.
+        (focus.border && focus.border.color) || focus.shadow.color || 'focus',
         props.theme,
-      )}
-        solid 2px;
-    }`}
-  ${props => {
-    const {
-      theme: {
-        global: { focus },
-      },
-    } = props;
-    if (!focus) return ''; // native
-    if (focus.shadow && (!focus.border || !justBorder)) {
-      if (typeof focus.shadow === 'object') {
-        const color = normalizeColor(
-          focus.shadow.color || 'focus',
-          props.theme,
-        );
-        const size = focus.shadow.size || '2px'; // backwards compatible default
-        return `
-          outline: none;
-          box-shadow: 0 0 ${size} ${size} ${color};
-        `;
-      }
+      );
+      const size = focus.shadow.size || '2px'; // backwards compatible default
       return `
         outline: none;
-        box-shadow: ${focus.shadow};
+        box-shadow: 0 0 ${size} ${size} ${color};
       `;
     }
-    if (focus.outline && (!focus.border || !justBorder)) {
-      if (typeof focus.outline === 'object') {
-        const color = normalizeColor(
-          focus.outline.color || 'focus',
-          props.theme,
-        );
-        const size = focus.outline.size || '2px';
-        return `
-          outline-offset: 0px;
-          outline: ${size} solid ${color};
-        `;
-      }
-      return `outline: ${focus.outline};`;
-    }
-    if (focus.border) {
-      const color = normalizeColor(focus.border.color || 'focus', props.theme);
+    return `
+      outline: none;
+      box-shadow: ${focus.shadow};
+    `;
+  }
+  if (focus.outline && (!focus.border || !justBorder)) {
+    if (typeof focus.outline === 'object') {
+      const color = normalizeColor(focus.outline.color || 'focus', props.theme);
+      const size = focus.outline.size || '2px';
       return `
-        outline: none;
-        border-color: ${color};
+        outline-offset: 0px;
+        outline: ${size} solid ${color};
       `;
     }
-    return ''; // defensive
-  }}
+    return `outline: ${focus.outline};`;
+  }
+  if (focus.border) {
+    const color = normalizeColor(focus.border.color || 'focus', props.theme);
+    return `
+      outline: none;
+      border-color: ${color};
+    `;
+  }
+  return ''; // defensive
+};
+
+// focus also supports clickable elements inside svg
+export const focusStyle = ({ justBorder, skipSvgChildren } = {}) => css`
+  ${props =>
+    !skipSvgChildren &&
+    `
+  > circle,
+  > ellipse,
+  > line,
+  > path,
+  > polygon,
+  > polyline,
+  > rect {
+    ${focusStyles(props)}
+  }`}
+  ${props => focusStyles(props, { justBorder })}
   ::-moz-focus-inner {
     border: 0;
   }

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -208,27 +208,72 @@ export const fillStyle = fillProp => {
   return undefined;
 };
 
-// focus also supports clickable elements inside svg
-export const focusStyle = css`
-  > circle,
-  > ellipse,
-  > line,
-  > path,
-  > polygon,
-  > polyline,
-  > rect {
-    outline: ${props =>
-        normalizeColor(props.theme.global.focus.border.color, props.theme)}
-      solid 2px;
-  }
-  outline-color: ${props =>
-    normalizeColor(props.theme.global.focus.border.color, props.theme)};
-  border-color: ${props =>
-    normalizeColor(props.theme.global.focus.border.color, props.theme)};
-  box-shadow: 0 0 2px 2px
-    ${props =>
-      normalizeColor(props.theme.global.focus.border.color, props.theme)};
-
+export const focusStyle = justBorder => css`
+  ${props =>
+    // focus also supports clickable elements inside svg
+    props.theme.global.focus &&
+    props.theme.global.focus.border &&
+    props.theme.global.focus.border.color &&
+    `> circle,
+    > ellipse,
+    > line,
+    > path,
+    > polygon,
+    > polyline,
+    > rect {
+      outline: ${normalizeColor(
+        props.theme.global.focus.border.color,
+        props.theme,
+      )}
+        solid 2px;
+    }`}
+  ${props => {
+    const {
+      theme: {
+        global: { focus },
+      },
+    } = props;
+    if (!focus) return ''; // native
+    if (focus.shadow && (!focus.border || !justBorder)) {
+      if (typeof focus.shadow === 'object') {
+        const color = normalizeColor(
+          focus.shadow.color || 'focus',
+          props.theme,
+        );
+        const size = focus.shadow.size || '2px'; // backwards compatible default
+        return `
+          outline: none;
+          box-shadow: 0 0 ${size} ${size} ${color};
+        `;
+      }
+      return `
+        outline: none;
+        box-shadow: ${focus.shadow};
+      `;
+    }
+    if (focus.outline && (!focus.border || !justBorder)) {
+      if (typeof focus.outline === 'object') {
+        const color = normalizeColor(
+          focus.outline.color || 'focus',
+          props.theme,
+        );
+        const size = focus.outline.size || '2px';
+        return `
+          outline-offset: 0px;
+          outline: ${size} solid ${color};
+        `;
+      }
+      return `outline: ${focus.outline};`;
+    }
+    if (focus.border) {
+      const color = normalizeColor(focus.border.color || 'focus', props.theme);
+      return `
+        outline: none;
+        border-color: ${color};
+      `;
+    }
+    return ''; // defensive
+  }}
   ::-moz-focus-inner {
     border: 0;
   }
@@ -278,7 +323,6 @@ export const inputStyle = css`
   font-family: inherit;
   border: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   color: inherit;
   ${props =>
@@ -309,11 +353,7 @@ export const inputStyle = css`
       font-weight: ${props.theme.global.input.weight ||
         props.theme.global.input.font.weight};
     `} margin: 0;
-
-  ${props =>
-    props.focus &&
-    (!props.plain || props.focusIndicator) &&
-    focusStyle} ${controlBorderStyle}
+  ${controlBorderStyle}
 
   ::-webkit-search-decoration {
     -webkit-appearance: none;

--- a/src/js/utils/themeDocUtils.js
+++ b/src/js/utils/themeDocUtils.js
@@ -70,9 +70,28 @@ export const themeDocUtils = {
   }),
   focusStyle: {
     'global.focus.border.color': {
-      description: 'The color around the component when in focus.',
+      description: 'The border color of the component when in focus.',
       type: 'string | { dark: string, light: string }',
       defaultValue: 'focus',
+    },
+    'global.focus.outline.color': {
+      description: 'The outline color around the component when in focus.',
+      type: 'string | { dark: string, light: string }',
+    },
+    'global.focus.outline.size': {
+      description:
+        'The size of the outline around the component when in focus.',
+      type: 'string',
+    },
+    'global.focus.shadow.color': {
+      description: 'The shadow color around the component when in focus.',
+      type: 'string | { dark: string, light: string }',
+      defaultValue: 'focus',
+    },
+    'global.focus.shadow.size': {
+      description: 'The size of the shadow around the component when in focus.',
+      type: 'string',
+      defaultValue: '2px',
     },
   },
   iconColor: {


### PR DESCRIPTION
#### What does this PR do?

Enhanced ability to style focus with theme.

`theme.global.focus` now supports `outline` and `shadow` as keys, each with `color` and `size` keys.

`FormField` and `EdgeControl` no longer embed focus styling within them. Everywhere we use `focusStyle()` now.

`focusStyle` is now a function that is called with `focusStyle(true)` from FormField to indicate that the focus should only affect the border color if the theme has `global.focus.border`.

The most notable change in the snapshots is removing `outline: none;` as a base style. This allows the theme to control the focus behavior using outline as an option. Now, we only set `outline: none;` when a component has focus and doesn't want it to use an outline.

#### Where should the reviewer start?

base.d.ts to see the theme structure
`focusStyle` in styles.js for the core changes

#### What testing has been done on this PR?

Added the anticipated HPE NEXT focus theme to the AllComponents story. This allows switching themes and then tabbing through the various components to observe the focus behavior. This story was extremely helpful for making these changes.

#### How should this be manually tested?

AllComponents story

#### What are the relevant issues?

#### Do the grommet docs need to be updated?

yes, automatic from `themeDocUtils`

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

mostly backwards compatible

The one visual difference is that the grommet theme no longer changes the border color of Button, TextInput, CheckBox, and TextArea. The Select component already behaved this way, so grommet was inconsistent. This unifies the behavior around how Select behaved.
