### PR TITLE
Refactored backgroundStyle to split out backgroundAndTextColors

### DIFF
--- a/src/js/__tests__/__snapshots__/default-props-test.js.snap
+++ b/src/js/__tests__/__snapshots__/default-props-test.js.snap
@@ -8,7 +8,7 @@ exports[`default theme is used 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -30,7 +30,7 @@ exports[`extends default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: red;
+  background-color: red;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -52,7 +52,7 @@ exports[`extends default theme twice 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: red;
+  background-color: red;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -74,7 +74,7 @@ exports[`extends default theme twice 2`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: blue;
+  background-color: blue;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -106,7 +106,7 @@ exports[`uses Grommet theme instead of default 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -119,7 +119,7 @@ exports[`uses Grommet theme instead of default 1`] = `
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Arial,sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 18px;
   line-height: 24px;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;

--- a/src/js/__tests__/__snapshots__/default-props-test.js.snap
+++ b/src/js/__tests__/__snapshots__/default-props-test.js.snap
@@ -30,8 +30,8 @@ exports[`extends default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: red;
-  color: #444444;
+  background-color: #ff0000;
+  color: #f8f8f8;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -52,8 +52,8 @@ exports[`extends default theme twice 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: red;
-  color: #444444;
+  background-color: #ff0000;
+  color: #f8f8f8;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -74,8 +74,8 @@ exports[`extends default theme twice 2`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: blue;
-  color: #444444;
+  background-color: #0000ff;
+  color: #f8f8f8;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;

--- a/src/js/__tests__/default-props-test.js
+++ b/src/js/__tests__/default-props-test.js
@@ -19,19 +19,19 @@ test('default theme is used', () => {
 });
 
 test('extends default theme', () => {
-  extendDefaultTheme({ global: { colors: { brand: 'red' } } });
+  extendDefaultTheme({ global: { colors: { brand: '#ff0000' } } });
   const component = renderer.create(<Box background="brand" />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
 
 test('extends default theme twice', () => {
-  extendDefaultTheme({ global: { colors: { brand: 'red' } } });
+  extendDefaultTheme({ global: { colors: { brand: '#ff0000' } } });
   let component = renderer.create(<Box background="brand" />);
   let tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 
-  extendDefaultTheme({ global: { colors: { brand: 'blue' } } });
+  extendDefaultTheme({ global: { colors: { brand: '#0000ff' } } });
 
   component = renderer.create(<Box background="brand" />);
   tree = component.toJSON();

--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -1847,7 +1847,7 @@ exports[`Accordion complex title 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #333333;
+  background-color: #333333;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;

--- a/src/js/components/Avatar/__tests__/__snapshots__/Avatar-test.js.snap
+++ b/src/js/components/Avatar/__tests__/__snapshots__/Avatar-test.js.snap
@@ -12,7 +12,7 @@ exports[`Avatar icon renders 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #FFCA58;
+  background-color: #FFCA58;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -647,7 +647,7 @@ exports[`Avatar text renders 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #555555;
+  background-color: #555555;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -675,7 +675,7 @@ exports[`Avatar text renders 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -707,7 +707,7 @@ exports[`Box background 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -723,7 +723,7 @@ exports[`Box background 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #6FFFB0;
+  background-color: #6FFFB0;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -739,7 +739,7 @@ exports[`Box background 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #00873D;
+  background-color: #00873D;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -755,7 +755,7 @@ exports[`Box background 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #F8F8F8;
+  background-color: #F8F8F8;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -771,7 +771,7 @@ exports[`Box background 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #333333;
+  background-color: #333333;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -787,7 +787,7 @@ exports[`Box background 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #FF4040;
+  background-color: #FF4040;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -803,7 +803,7 @@ exports[`Box background 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #aabbcc;
+  background-color: #aabbcc;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -819,7 +819,7 @@ exports[`Box background 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #def;
+  background-color: #def;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -835,7 +835,7 @@ exports[`Box background 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: rgb(90,80,50);
+  background-color: rgb(90,80,50);
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -851,7 +851,7 @@ exports[`Box background 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: rgba(200,100,150,0.8);
+  background-color: rgba(200,100,150,0.8);
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -867,7 +867,7 @@ exports[`Box background 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: hsl(10,50%,20%);
+  background-color: hsl(10,50%,20%);
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -883,7 +883,7 @@ exports[`Box background 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: hsla(10,50%,70%,0.7);
+  background-color: hsla(10,50%,70%,0.7);
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -920,7 +920,6 @@ exports[`Box background 1`] = `
   background-position: center center;
   background-size: cover;
   color: #444444;
-  color: #444444;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -940,7 +939,6 @@ exports[`Box background 1`] = `
   background-position: center center;
   background-size: cover;
   color: #f8f8f8;
-  color: #f8f8f8;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -959,7 +957,6 @@ exports[`Box background 1`] = `
   background-repeat: no-repeat;
   background-position: top center;
   background-size: cover;
-  color: inherit;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -978,7 +975,6 @@ exports[`Box background 1`] = `
   background-repeat: no-repeat;
   background-position: center center;
   background-size: cover;
-  color: inherit;
   background-color: rgba(111,255,176,1);
   color: #444444;
   min-width: 0;
@@ -999,7 +995,6 @@ exports[`Box background 1`] = `
   background-repeat: no-repeat;
   background-position: center center;
   background-size: contain;
-  color: inherit;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1018,7 +1013,6 @@ exports[`Box background 1`] = `
   background-repeat: repeat;
   background-position: center center;
   background-size: cover;
-  color: inherit;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1037,7 +1031,6 @@ exports[`Box background 1`] = `
   background-repeat: no-repeat;
   background-position: center center;
   background-size: cover;
-  color: inherit;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -2131,7 +2124,7 @@ exports[`Box elevation 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #333333;
+  background-color: #333333;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -18,7 +18,7 @@ exports[`Button active + primary 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   border-radius: 18px;
   background-color: rgba(221,221,221,0.4);
@@ -343,7 +343,7 @@ exports[`Button color 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  background: #6FFFB0;
+  background-color: #6FFFB0;
   color: #444444;
   border-radius: 18px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -375,7 +375,7 @@ exports[`Button color 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  background: #111111;
+  background-color: #111111;
   color: #f8f8f8;
   border-radius: 18px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -407,7 +407,7 @@ exports[`Button color 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  background: #123;
+  background-color: #123;
   color: #f8f8f8;
   border-radius: 18px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -559,7 +559,7 @@ exports[`Button disabled 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   border-radius: 18px;
   opacity: 0.3;
@@ -1263,7 +1263,7 @@ exports[`Button hoverIndicator color 1`] = `
 }
 
 .c1:hover {
-  background: #777777;
+  background-color: #777777;
   color: #FFFFFF;
 }
 
@@ -1463,7 +1463,7 @@ exports[`Button primary 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   border-radius: 18px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -1807,7 +1807,7 @@ exports[`Button size 1`] = `
   padding: 4px 20px;
   font-size: 14px;
   line-height: 20px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   border-radius: 18px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -1839,7 +1839,7 @@ exports[`Button size 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   border-radius: 18px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -1871,7 +1871,7 @@ exports[`Button size 1`] = `
   padding: 8px 32px;
   font-size: 22px;
   line-height: 28px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   border-radius: 24px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -1902,7 +1902,7 @@ exports[`Button size 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   border-radius: 18px;
   line-height: 0;

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -241,7 +241,7 @@ exports[`Calendar date 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
 }
@@ -1517,7 +1517,7 @@ exports[`Calendar dates 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
 }
@@ -2793,7 +2793,7 @@ exports[`Calendar daysOfWeek 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
 }
@@ -4136,7 +4136,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
 }
@@ -6362,7 +6362,7 @@ exports[`Calendar header 1`] = `
   align-items: center;
   width: 27.428571428571427px;
   height: 27.428571428571427px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
 }
@@ -8911,7 +8911,7 @@ exports[`Calendar select date 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
 }
@@ -10084,7 +10084,7 @@ exports[`Calendar select date 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 eaIdgx"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gBUPeV"
                 >
                   17
                 </div>
@@ -10735,7 +10735,7 @@ exports[`Calendar select dates 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
 }
@@ -12669,7 +12669,7 @@ exports[`Calendar size 1`] = `
   align-items: center;
   width: 27.428571428571427px;
   height: 27.428571428571427px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
 }
@@ -12724,7 +12724,7 @@ exports[`Calendar size 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
 }
@@ -12779,7 +12779,7 @@ exports[`Calendar size 1`] = `
   align-items: center;
   width: 109.71428571428571px;
   height: 109.71428571428571px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
 }

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -560,7 +560,7 @@ exports[`DataTable background 1`] = `
   text-align: inherit;
   height: 100%;
   text-align: start;
-  background: #6FFFB0;
+  background-color: #6FFFB0;
   color: #444444;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
@@ -576,7 +576,7 @@ exports[`DataTable background 1`] = `
   text-align: inherit;
   height: 100%;
   text-align: start;
-  background: #6FFFB0;
+  background-color: #6FFFB0;
   color: #444444;
   padding-left: 12px;
   padding-right: 12px;
@@ -591,7 +591,7 @@ exports[`DataTable background 1`] = `
   text-align: inherit;
   height: 100%;
   text-align: start;
-  background: #6FFFB0;
+  background-color: #6FFFB0;
   color: #444444;
   border-top: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
@@ -621,7 +621,7 @@ exports[`DataTable background 1`] = `
   text-align: inherit;
   height: 100%;
   text-align: start;
-  background: #FD6FFF;
+  background-color: #FD6FFF;
   color: #444444;
   padding-left: 12px;
   padding-right: 12px;
@@ -650,7 +650,7 @@ exports[`DataTable background 1`] = `
   text-align: inherit;
   height: 100%;
   text-align: start;
-  background: #81FCED;
+  background-color: #81FCED;
   color: #444444;
   border-top: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
@@ -5356,7 +5356,7 @@ exports[`DataTable rowProps 1`] = `
   text-align: inherit;
   height: 100%;
   text-align: start;
-  background: #6FFFB0;
+  background-color: #6FFFB0;
   color: #444444;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   padding: 48px;

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -29,7 +29,7 @@ exports[`Drop align left left 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: bottom left;
@@ -83,7 +83,7 @@ exports[`Drop align left left 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -125,7 +125,7 @@ exports[`Drop align left right top bottom 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -178,7 +178,7 @@ exports[`Drop align left right top bottom 2`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.exrnbV {
+.kQAKuZ {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -190,7 +190,7 @@ exports[`Drop align left right top bottom 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -203,7 +203,7 @@ exports[`Drop align left right top bottom 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -245,7 +245,7 @@ exports[`Drop align right left top top 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top right;
@@ -299,7 +299,7 @@ exports[`Drop align right left top top 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -341,7 +341,7 @@ exports[`Drop align right right 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top right;
@@ -395,7 +395,7 @@ exports[`Drop align right right 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -437,7 +437,7 @@ exports[`Drop align right right bottom top 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: bottom right;
@@ -491,7 +491,7 @@ exports[`Drop align right right bottom top 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -533,7 +533,7 @@ exports[`Drop align right right bottom top 3`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: bottom right;
@@ -587,7 +587,7 @@ exports[`Drop align right right bottom top 4`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -629,7 +629,7 @@ exports[`Drop basic 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -682,7 +682,7 @@ exports[`Drop basic 2`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.exrnbV {
+.kQAKuZ {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -694,7 +694,7 @@ exports[`Drop basic 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -707,7 +707,7 @@ exports[`Drop basic 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -749,7 +749,7 @@ exports[`Drop close 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -802,7 +802,7 @@ exports[`Drop close 2`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.exrnbV {
+.kQAKuZ {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -814,7 +814,7 @@ exports[`Drop close 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -827,7 +827,7 @@ exports[`Drop close 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -869,7 +869,7 @@ exports[`Drop default elevation renders 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -922,7 +922,7 @@ exports[`Drop default elevation renders 2`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.exrnbV {
+.kQAKuZ {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -934,7 +934,7 @@ exports[`Drop default elevation renders 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -947,7 +947,7 @@ exports[`Drop default elevation renders 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -989,7 +989,7 @@ exports[`Drop invalid align 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1042,7 +1042,7 @@ exports[`Drop invalid align 2`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.exrnbV {
+.kQAKuZ {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1054,7 +1054,7 @@ exports[`Drop invalid align 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1067,7 +1067,7 @@ exports[`Drop invalid align 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1109,7 +1109,7 @@ exports[`Drop invoke onClickOutside 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1162,7 +1162,7 @@ exports[`Drop invoke onClickOutside 2`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.exrnbV {
+.kQAKuZ {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1174,7 +1174,7 @@ exports[`Drop invoke onClickOutside 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1187,7 +1187,7 @@ exports[`Drop invoke onClickOutside 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1229,7 +1229,7 @@ exports[`Drop no stretch 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1282,7 +1282,7 @@ exports[`Drop no stretch 2`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.exrnbV {
+.kQAKuZ {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1294,7 +1294,7 @@ exports[`Drop no stretch 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1307,7 +1307,7 @@ exports[`Drop no stretch 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1384,7 +1384,7 @@ exports[`Drop plain renders 1`] = `
 
 exports[`Drop plain renders 2`] = `
 "@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1426,7 +1426,7 @@ exports[`Drop props elevation renders 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1463,7 +1463,7 @@ exports[`Drop props elevation renders 1`] = `
 `;
 
 exports[`Drop props elevation renders 2`] = `
-".exrnbV {
+".kQAKuZ {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1475,7 +1475,7 @@ exports[`Drop props elevation renders 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1488,7 +1488,7 @@ exports[`Drop props elevation renders 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1530,7 +1530,7 @@ exports[`Drop resize 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1583,7 +1583,7 @@ exports[`Drop resize 2`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.exrnbV {
+.kQAKuZ {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1595,7 +1595,7 @@ exports[`Drop resize 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1608,7 +1608,7 @@ exports[`Drop resize 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1650,7 +1650,7 @@ exports[`Drop restrict focus 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1688,7 +1688,7 @@ exports[`Drop restrict focus 1`] = `
 
 exports[`Drop restrict focus 2`] = `
 <div
-  class="StyledBox-sc-13pk1d4-0 glPSfV StyledDrop-sc-16s5rx8-0 exrnbV"
+  class="StyledBox-sc-13pk1d4-0 glPSfV StyledDrop-sc-16s5rx8-0 kQAKuZ"
   data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -1715,7 +1715,7 @@ exports[`Drop restrict focus 3`] = `
   box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
 }
 
-.exrnbV {
+.kQAKuZ {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1727,7 +1727,7 @@ exports[`Drop restrict focus 3`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1740,7 +1740,7 @@ exports[`Drop restrict focus 3`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1790,7 +1790,7 @@ exports[`Drop theme elevation renders 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1827,7 +1827,7 @@ exports[`Drop theme elevation renders 1`] = `
 `;
 
 exports[`Drop theme elevation renders 2`] = `
-".exrnbV {
+".kQAKuZ {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1839,7 +1839,7 @@ exports[`Drop theme elevation renders 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1852,7 +1852,7 @@ exports[`Drop theme elevation renders 2`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .exrnbV {
+  .kQAKuZ {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test.js.snap
@@ -73,7 +73,7 @@ exports[`Form controlled 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   border-radius: 18px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -210,7 +210,7 @@ exports[`Form controlled 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 kpnlyr"
+      class="StyledButton-sc-323bzc-0 kIXxtf"
       type="submit"
     >
       Submit
@@ -248,7 +248,7 @@ exports[`Form controlled 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 kpnlyr"
+      class="StyledButton-sc-323bzc-0 kIXxtf"
       type="submit"
     >
       Submit
@@ -339,7 +339,7 @@ exports[`Form controlled FormField deprecated 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   border-radius: 18px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -488,7 +488,7 @@ exports[`Form controlled FormField deprecated 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 kpnlyr"
+      class="StyledButton-sc-323bzc-0 kIXxtf"
       type="submit"
     >
       Submit
@@ -532,7 +532,7 @@ exports[`Form controlled FormField deprecated 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 kpnlyr"
+      class="StyledButton-sc-323bzc-0 kIXxtf"
       type="submit"
     >
       Submit
@@ -614,7 +614,7 @@ exports[`Form controlled input 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   border-radius: 18px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -751,7 +751,7 @@ exports[`Form controlled input 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 kpnlyr"
+      class="StyledButton-sc-323bzc-0 kIXxtf"
       type="submit"
     >
       Submit
@@ -789,7 +789,7 @@ exports[`Form controlled input 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 kpnlyr"
+      class="StyledButton-sc-323bzc-0 kIXxtf"
       type="submit"
     >
       Submit
@@ -871,7 +871,7 @@ exports[`Form controlled input lazy 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   border-radius: 18px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -1008,7 +1008,7 @@ exports[`Form controlled input lazy 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 kpnlyr"
+      class="StyledButton-sc-323bzc-0 kIXxtf"
       type="submit"
     >
       Submit
@@ -1046,7 +1046,7 @@ exports[`Form controlled input lazy 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 kpnlyr"
+      class="StyledButton-sc-323bzc-0 kIXxtf"
       type="submit"
     >
       Submit
@@ -1128,7 +1128,7 @@ exports[`Form controlled lazy 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   border-radius: 18px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -1265,7 +1265,7 @@ exports[`Form controlled lazy 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 kpnlyr"
+      class="StyledButton-sc-323bzc-0 kIXxtf"
       type="submit"
     >
       Submit
@@ -1303,7 +1303,7 @@ exports[`Form controlled lazy 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 kpnlyr"
+      class="StyledButton-sc-323bzc-0 kIXxtf"
       type="submit"
     >
       Submit
@@ -1909,7 +1909,7 @@ exports[`Form uncontrolled 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   border-radius: 18px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -2046,7 +2046,7 @@ exports[`Form uncontrolled 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 kpnlyr"
+      class="StyledButton-sc-323bzc-0 kIXxtf"
       type="submit"
     >
       Submit
@@ -2084,7 +2084,7 @@ exports[`Form uncontrolled 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 kpnlyr"
+      class="StyledButton-sc-323bzc-0 kIXxtf"
       type="submit"
     >
       Submit
@@ -2166,7 +2166,7 @@ exports[`Form update 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   border-radius: 18px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;

--- a/src/js/components/Grommet/__tests__/Grommet-test.js
+++ b/src/js/components/Grommet/__tests__/Grommet-test.js
@@ -85,7 +85,7 @@ describe('Grommet', () => {
 
   test('background', () => {
     const component = renderer.create(
-      <Grommet full background="blue">
+      <Grommet full background="#0000ff">
         Grommet App
       </Grommet>,
     );

--- a/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
+++ b/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
@@ -40,8 +40,8 @@ exports[`Grommet background 1`] = `
 .c0 {
   font-size: 18px;
   line-height: 24px;
-  background-color: blue;
-  color: #444444;
+  background-color: #0000ff;
+  color: #f8f8f8;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;

--- a/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
+++ b/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
@@ -40,7 +40,7 @@ exports[`Grommet background 1`] = `
 .c0 {
   font-size: 18px;
   line-height: 24px;
-  background: blue;
+  background-color: blue;
   color: #444444;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
@@ -161,7 +161,7 @@ exports[`Grommet grommet theme 1`] = `
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Arial,sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 18px;
   line-height: 24px;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
@@ -180,7 +180,7 @@ exports[`Grommet hpe theme 1`] = `
   font-family: 'Metric',Arial,sans-serif;
   font-size: 18px;
   line-height: 24px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #333333;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
@@ -312,7 +312,7 @@ exports[`Grommet themeMode 1`] = `
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Arial,sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 18px;
   line-height: 24px;
-  background: #000000;
+  background-color: #000000;
   color: #f8f8f8;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -27,7 +27,7 @@ exports[`Layer animation fadeIn 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -41,7 +41,7 @@ exports[`Layer animation fadeIn 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -154,13 +154,13 @@ exports[`Layer animation fadeIn 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -207,7 +207,7 @@ exports[`Layer animation false 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -221,7 +221,7 @@ exports[`Layer animation false 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -332,13 +332,13 @@ exports[`Layer animation false 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -385,7 +385,7 @@ exports[`Layer animation slide 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -399,7 +399,7 @@ exports[`Layer animation slide 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -512,13 +512,13 @@ exports[`Layer animation slide 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -565,7 +565,7 @@ exports[`Layer animation true 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -579,7 +579,7 @@ exports[`Layer animation true 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -692,13 +692,13 @@ exports[`Layer animation true 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -745,7 +745,7 @@ exports[`Layer custom margin 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -759,7 +759,7 @@ exports[`Layer custom margin 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -872,13 +872,13 @@ exports[`Layer custom margin 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -915,7 +915,7 @@ exports[`Layer dark context 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -984,13 +984,13 @@ exports[`Layer dark context 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1020,7 +1020,7 @@ exports[`Layer focus on layer 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -1113,7 +1113,7 @@ exports[`Layer full false 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -1127,7 +1127,7 @@ exports[`Layer full false 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -1240,13 +1240,13 @@ exports[`Layer full false 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1293,7 +1293,7 @@ exports[`Layer full horizontal 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -1307,7 +1307,7 @@ exports[`Layer full horizontal 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -1421,13 +1421,13 @@ exports[`Layer full horizontal 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1474,7 +1474,7 @@ exports[`Layer full true 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -1488,7 +1488,7 @@ exports[`Layer full true 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -1600,13 +1600,13 @@ exports[`Layer full true 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1653,7 +1653,7 @@ exports[`Layer full vertical 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -1667,7 +1667,7 @@ exports[`Layer full vertical 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -1781,13 +1781,13 @@ exports[`Layer full vertical 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1833,7 +1833,7 @@ exports[`Layer hidden 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -1847,7 +1847,7 @@ exports[`Layer hidden 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -1924,13 +1924,13 @@ exports[`Layer hidden 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1957,10 +1957,10 @@ exports[`Layer hidden 3`] = `
   tabindex="-1"
 >
   <div
-    class="StyledLayer__StyledOverlay-rmtehz-1 bnUvKb"
+    class="StyledLayer__StyledOverlay-rmtehz-1 TgNMj"
   />
   <div
-    class="StyledLayer__StyledContainer-rmtehz-2 cUgmNe"
+    class="StyledLayer__StyledContainer-rmtehz-2 hyqqbS"
     id="hidden-test"
   >
     <a
@@ -2004,13 +2004,13 @@ exports[`Layer hidden 4`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2114,7 +2114,7 @@ exports[`Layer margin large 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -2128,7 +2128,7 @@ exports[`Layer margin large 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -2241,13 +2241,13 @@ exports[`Layer margin large 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2294,7 +2294,7 @@ exports[`Layer margin medium 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -2308,7 +2308,7 @@ exports[`Layer margin medium 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -2421,13 +2421,13 @@ exports[`Layer margin medium 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2474,7 +2474,7 @@ exports[`Layer margin none 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -2488,7 +2488,7 @@ exports[`Layer margin none 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -2601,13 +2601,13 @@ exports[`Layer margin none 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2654,7 +2654,7 @@ exports[`Layer margin small 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -2668,7 +2668,7 @@ exports[`Layer margin small 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -2781,13 +2781,13 @@ exports[`Layer margin small 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2834,7 +2834,7 @@ exports[`Layer margin xsmall 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -2848,7 +2848,7 @@ exports[`Layer margin xsmall 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -2961,13 +2961,13 @@ exports[`Layer margin xsmall 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3004,7 +3004,7 @@ exports[`Layer non-modal 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -3073,13 +3073,13 @@ exports[`Layer non-modal 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3109,7 +3109,7 @@ exports[`Layer not steal focus from an autofocus focusable element 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -3332,13 +3332,13 @@ exports[`Layer plain 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3385,7 +3385,7 @@ exports[`Layer position bottom 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -3399,7 +3399,7 @@ exports[`Layer position bottom 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -3512,13 +3512,13 @@ exports[`Layer position bottom 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3565,7 +3565,7 @@ exports[`Layer position center 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -3579,7 +3579,7 @@ exports[`Layer position center 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -3692,13 +3692,13 @@ exports[`Layer position center 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3745,7 +3745,7 @@ exports[`Layer position end 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -3759,7 +3759,7 @@ exports[`Layer position end 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -3872,13 +3872,13 @@ exports[`Layer position end 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3925,7 +3925,7 @@ exports[`Layer position left 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -3939,7 +3939,7 @@ exports[`Layer position left 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -4052,13 +4052,13 @@ exports[`Layer position left 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4105,7 +4105,7 @@ exports[`Layer position right 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -4119,7 +4119,7 @@ exports[`Layer position right 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -4232,13 +4232,13 @@ exports[`Layer position right 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4285,7 +4285,7 @@ exports[`Layer position start 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -4299,7 +4299,7 @@ exports[`Layer position start 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -4412,13 +4412,13 @@ exports[`Layer position start 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4465,7 +4465,7 @@ exports[`Layer position top 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -4479,7 +4479,7 @@ exports[`Layer position top 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -4592,13 +4592,13 @@ exports[`Layer position top 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4645,7 +4645,7 @@ exports[`Layer target 1`] = `
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: rgba(0,0,0,0.5);
+  background-color: rgba(0,0,0,0.5);
   color: #f8f8f8;
   pointer-events: all;
 }
@@ -4659,7 +4659,7 @@ exports[`Layer target 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -4756,13 +4756,13 @@ exports[`Layer target 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4799,7 +4799,7 @@ exports[`Layer target not modal 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   min-height: 48px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #444444;
   outline: none;
   pointer-events: all;
@@ -4872,13 +4872,13 @@ exports[`Layer target not modal 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .bnUvKb {
+  .TgNMj {
     position: relative;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .ckZaHQ {
+  .fYgBNY {
     position: relative;
     max-height: none;
     max-width: none;

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -18,7 +18,7 @@ exports[`List background array 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #6FFFB0;
+  background-color: #6FFFB0;
   color: #444444;
   border-top: solid 1px rgba(0,0,0,0.33);
   border-bottom: solid 1px rgba(0,0,0,0.33);
@@ -43,7 +43,7 @@ exports[`List background array 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #FD6FFF;
+  background-color: #FD6FFF;
   color: #444444;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -67,7 +67,7 @@ exports[`List background array 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #6FFFB0;
+  background-color: #6FFFB0;
   color: #444444;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -199,7 +199,7 @@ exports[`List background string 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #6FFFB0;
+  background-color: #6FFFB0;
   color: #444444;
   border-top: solid 1px rgba(0,0,0,0.33);
   border-bottom: solid 1px rgba(0,0,0,0.33);
@@ -224,7 +224,7 @@ exports[`List background string 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #6FFFB0;
+  background-color: #6FFFB0;
   color: #444444;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
@@ -1027,7 +1027,7 @@ exports[`List itemProps 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #6FFFB0;
+  background-color: #6FFFB0;
   color: #444444;
   border-top: solid 2px rgba(0,0,0,0.33);
   border-bottom: solid 2px rgba(0,0,0,0.33);

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -430,7 +430,7 @@ exports[`MaskedInput event target props are available option via mouse 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -940,7 +940,7 @@ exports[`MaskedInput mask 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1320,7 +1320,7 @@ exports[`MaskedInput option via mouse 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -438,7 +438,7 @@ exports[`Menu close by clicking outside 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -2445,7 +2445,7 @@ exports[`Menu open and close on click 3`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -3373,7 +3373,7 @@ exports[`Menu with dropAlign renders 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top right;

--- a/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
+++ b/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
@@ -312,7 +312,7 @@ exports[`RadioButton children 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -329,7 +329,7 @@ exports[`RadioButton children 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #6FFFB0;
+  background-color: #6FFFB0;
   color: #444444;
   min-width: 0;
   min-height: 0;

--- a/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
+++ b/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
@@ -208,7 +208,7 @@ exports[`RadioButtonGroup children 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;

--- a/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
+++ b/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
@@ -105,7 +105,7 @@ exports[`RangeSelector basic 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -343,7 +343,7 @@ exports[`RangeSelector color 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #6FFFB0;
+  background-color: #6FFFB0;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -581,7 +581,7 @@ exports[`RangeSelector direction 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -1015,7 +1015,7 @@ exports[`RangeSelector handle keyboard 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -1211,7 +1211,7 @@ exports[`RangeSelector handle mouse 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -1408,7 +1408,7 @@ exports[`RangeSelector invert 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -1752,7 +1752,7 @@ exports[`RangeSelector max 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -1990,7 +1990,7 @@ exports[`RangeSelector min 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -2228,7 +2228,7 @@ exports[`RangeSelector opacity 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -2248,6 +2248,7 @@ exports[`RangeSelector opacity 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   background-color: rgba(125,76,219,0.1);
+  color: #444444;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -2682,7 +2683,7 @@ exports[`RangeSelector round 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -3473,7 +3474,7 @@ exports[`RangeSelector size 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -4460,7 +4461,7 @@ exports[`RangeSelector step renders correct values 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;

--- a/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
+++ b/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
@@ -2248,7 +2248,6 @@ exports[`RangeSelector opacity 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   background-color: rgba(125,76,219,0.1);
-  color: #444444;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -1151,7 +1151,7 @@ exports[`Select complex options and children 3`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1857,7 +1857,7 @@ exports[`Select empty results search 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -2127,7 +2127,7 @@ exports[`Select large drop container height 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -2351,7 +2351,7 @@ exports[`Select medium drop container height 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -3281,7 +3281,7 @@ exports[`Select multiple onChange toggle with valueKey reduce 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -3307,7 +3307,7 @@ exports[`Select multiple onChange toggle with valueKey reduce 2`] = `
 }
 
 .c8 {
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #FFFFFF;
 }
 
@@ -3754,7 +3754,7 @@ exports[`Select multiple onChange with valueKey reduce 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -4222,7 +4222,7 @@ exports[`Select multiple onChange with valueKey string 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -4690,7 +4690,7 @@ exports[`Select multiple onChange without valueKey 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -4816,7 +4816,7 @@ exports[`Select multiple onChange without valueKey 3`] = `
 
 exports[`Select multiple onChange without valueKey 4`] = `
 <div
-  class="StyledBox-sc-13pk1d4-0 glPSfV StyledDrop-sc-16s5rx8-0 exrnbV"
+  class="StyledBox-sc-13pk1d4-0 glPSfV StyledDrop-sc-16s5rx8-0 kQAKuZ"
   data-g-portal-id="0"
   id="test-select__drop"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
@@ -5259,7 +5259,7 @@ exports[`Select multiple values 3`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -5285,7 +5285,7 @@ exports[`Select multiple values 3`] = `
 }
 
 .c8 {
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #FFFFFF;
 }
 
@@ -5732,7 +5732,7 @@ exports[`Select onChange with valueKey string 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -6200,7 +6200,7 @@ exports[`Select onChange without valueKey 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -6703,7 +6703,7 @@ exports[`Select opens 3`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -8886,7 +8886,7 @@ exports[`Select search 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -10240,7 +10240,7 @@ exports[`Select small drop container height 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;

--- a/src/js/components/Sidebar/__tests__/__snapshots__/Sidebar-test.js.snap
+++ b/src/js/components/Sidebar/__tests__/__snapshots__/Sidebar-test.js.snap
@@ -8,7 +8,7 @@ exports[`Sidebar all 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -218,7 +218,7 @@ exports[`TextInput calls onSuggestionsClose 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -422,7 +422,7 @@ exports[`TextInput calls onSuggestionsOpen 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -678,7 +678,7 @@ exports[`TextInput close suggestion drop 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -934,7 +934,7 @@ exports[`TextInput complex suggestions 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1501,7 +1501,7 @@ exports[`TextInput large drop height 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -1686,7 +1686,7 @@ exports[`TextInput medium drop height 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -2017,7 +2017,7 @@ exports[`TextInput select suggestion 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -2221,7 +2221,7 @@ exports[`TextInput small drop height 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -2463,7 +2463,7 @@ exports[`TextInput suggestions 2`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #ffffff;
+  background-color: #ffffff;
   color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -158,7 +158,7 @@ exports[`Video autoPlay renders 1`] = `
 
 .c5:hover {
   background-color: rgba(221,221,221,0.4);
-  color: #000000;
+  color: #FFFFFF;
 }
 
 .c16 {
@@ -476,7 +476,7 @@ exports[`Video controls renders 1`] = `
   stroke: none;
 }
 
-.c21 {
+.c22 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -487,25 +487,25 @@ exports[`Video controls renders 1`] = `
   stroke: #666666;
 }
 
-.c21 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c21 *:not([stroke])[fill="none"] {
+.c22 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c21 *[stroke*="#"],
-.c21 *[STROKE*="#"] {
+.c22 *[stroke*="#"],
+.c22 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c21 *[fill-rule],
-.c21 *[FILL-RULE],
-.c21 *[fill*="#"],
-.c21 *[FILL*="#"] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*="#"],
+.c22 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -655,7 +655,7 @@ exports[`Video controls renders 1`] = `
 
 .c5:hover {
   background-color: rgba(221,221,221,0.4);
-  color: #000000;
+  color: #FFFFFF;
 }
 
 .c16 {
@@ -674,6 +674,31 @@ exports[`Video controls renders 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+}
+
+.c21 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c21:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
 .c15 {
@@ -986,7 +1011,7 @@ exports[`Video controls renders 1`] = `
         className="c20"
       >
         <button
-          className="c5"
+          className="c21"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -996,7 +1021,7 @@ exports[`Video controls renders 1`] = `
         >
           <svg
             aria-label="Play"
-            className="c21"
+            className="c22"
             viewBox="0 0 24 24"
           >
             <polygon
@@ -1080,7 +1105,7 @@ exports[`Video controls renders 1`] = `
             />
             <svg
               aria-label="Actions"
-              className="c21"
+              className="c22"
               viewBox="0 0 24 24"
             >
               <path
@@ -1256,7 +1281,7 @@ exports[`Video fit renders 1`] = `
 
 .c5:hover {
   background-color: rgba(221,221,221,0.4);
-  color: #000000;
+  color: #FFFFFF;
 }
 
 .c16 {
@@ -1867,7 +1892,7 @@ exports[`Video loop renders 1`] = `
 
 .c5:hover {
   background-color: rgba(221,221,221,0.4);
-  color: #000000;
+  color: #FFFFFF;
 }
 
 .c16 {
@@ -2308,7 +2333,7 @@ exports[`Video mute renders 1`] = `
 
 .c5:hover {
   background-color: rgba(221,221,221,0.4);
-  color: #000000;
+  color: #FFFFFF;
 }
 
 .c16 {
@@ -2749,7 +2774,7 @@ exports[`Video renders 1`] = `
 
 .c5:hover {
   background-color: rgba(221,221,221,0.4);
-  color: #000000;
+  color: #FFFFFF;
 }
 
 .c16 {

--- a/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
+++ b/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
@@ -142,7 +142,7 @@ exports[`Grommet custom theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #333333;
+  background-color: #333333;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -425,7 +425,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #FD6FFF;
+  background-color: #FD6FFF;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -441,7 +441,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #60EB9F;
+  background-color: #60EB9F;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -457,7 +457,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #60EBE1;
+  background-color: #60EBE1;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -473,7 +473,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #333333;
+  background-color: #333333;
   color: #eeeeee;
   min-width: 0;
   min-height: 0;
@@ -489,7 +489,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #555555;
+  background-color: #555555;
   color: #eeeeee;
   min-width: 0;
   min-height: 0;
@@ -505,7 +505,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #777777;
+  background-color: #777777;
   color: #eeeeee;
   min-width: 0;
   min-height: 0;
@@ -521,7 +521,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #999999;
+  background-color: #999999;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -537,7 +537,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #FFCA58;
+  background-color: #FFCA58;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -553,7 +553,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #F8F8F8;
+  background-color: #F8F8F8;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -569,7 +569,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #F2F2F2;
+  background-color: #F2F2F2;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -585,7 +585,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #EDEDED;
+  background-color: #EDEDED;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -601,7 +601,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #DADADA;
+  background-color: #DADADA;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -617,7 +617,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #EB6060;
+  background-color: #EB6060;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -633,7 +633,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #01C781;
+  background-color: #01C781;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -649,7 +649,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #6095EB;
+  background-color: #6095EB;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -665,7 +665,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #FF3333;
+  background-color: #FF3333;
   color: #eeeeee;
   min-width: 0;
   min-height: 0;
@@ -681,7 +681,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #a8a8a8;
+  background-color: #a8a8a8;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -697,7 +697,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7DD892;
+  background-color: #7DD892;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -713,7 +713,7 @@ exports[`Grommet dark theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #F7E464;
+  background-color: #F7E464;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -731,7 +731,7 @@ exports[`Grommet dark theme 1`] = `
   font-family: Arial;
   font-size: 18px;
   line-height: 24px;
-  background: #111111;
+  background-color: #111111;
   color: #eeeeee;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;
@@ -979,7 +979,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #6FFFB0;
+  background-color: #6FFFB0;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -995,7 +995,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #FD6FFF;
+  background-color: #FD6FFF;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -1011,7 +1011,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #81FCED;
+  background-color: #81FCED;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -1027,7 +1027,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #7D4CDB;
+  background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -1043,7 +1043,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #333333;
+  background-color: #333333;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -1059,7 +1059,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #555555;
+  background-color: #555555;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -1075,7 +1075,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #777777;
+  background-color: #777777;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -1091,7 +1091,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #999999;
+  background-color: #999999;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -1107,7 +1107,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #F8F8F8;
+  background-color: #F8F8F8;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -1123,7 +1123,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #F2F2F2;
+  background-color: #F2F2F2;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -1139,7 +1139,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #EDEDED;
+  background-color: #EDEDED;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -1155,7 +1155,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #DADADA;
+  background-color: #DADADA;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -1171,7 +1171,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #00873D;
+  background-color: #00873D;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -1187,7 +1187,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #3D138D;
+  background-color: #3D138D;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -1203,7 +1203,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #00739D;
+  background-color: #00739D;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -1219,7 +1219,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #FF4040;
+  background-color: #FF4040;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -1235,7 +1235,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #CCCCCC;
+  background-color: #CCCCCC;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -1251,7 +1251,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #00C781;
+  background-color: #00C781;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -1267,7 +1267,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #FFAA15;
+  background-color: #FFAA15;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -1530,7 +1530,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #6FFFB0;
+  background-color: #6FFFB0;
   color: #333333;
   min-width: 0;
   min-height: 0;
@@ -1546,7 +1546,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #FD6FFF;
+  background-color: #FD6FFF;
   color: #333333;
   min-width: 0;
   min-height: 0;
@@ -1562,7 +1562,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #81FCED;
+  background-color: #81FCED;
   color: #333333;
   min-width: 0;
   min-height: 0;
@@ -1578,7 +1578,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #01A982;
+  background-color: #01A982;
   color: #EEEEEE;
   min-width: 0;
   min-height: 0;
@@ -1594,7 +1594,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #333333;
+  background-color: #333333;
   color: #EEEEEE;
   min-width: 0;
   min-height: 0;
@@ -1610,7 +1610,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #555555;
+  background-color: #555555;
   color: #EEEEEE;
   min-width: 0;
   min-height: 0;
@@ -1626,7 +1626,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #777777;
+  background-color: #777777;
   color: #EEEEEE;
   min-width: 0;
   min-height: 0;
@@ -1642,7 +1642,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #999999;
+  background-color: #999999;
   color: #333333;
   min-width: 0;
   min-height: 0;
@@ -1658,7 +1658,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #F8F8F8;
+  background-color: #F8F8F8;
   color: #333333;
   min-width: 0;
   min-height: 0;
@@ -1674,7 +1674,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #F2F2F2;
+  background-color: #F2F2F2;
   color: #333333;
   min-width: 0;
   min-height: 0;
@@ -1690,7 +1690,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #EDEDED;
+  background-color: #EDEDED;
   color: #333333;
   min-width: 0;
   min-height: 0;
@@ -1706,7 +1706,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #DADADA;
+  background-color: #DADADA;
   color: #333333;
   min-width: 0;
   min-height: 0;
@@ -1722,7 +1722,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #00873D;
+  background-color: #00873D;
   color: #EEEEEE;
   min-width: 0;
   min-height: 0;
@@ -1738,7 +1738,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #3D138D;
+  background-color: #3D138D;
   color: #EEEEEE;
   min-width: 0;
   min-height: 0;
@@ -1754,7 +1754,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #00739D;
+  background-color: #00739D;
   color: #EEEEEE;
   min-width: 0;
   min-height: 0;
@@ -1770,7 +1770,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #FF4040;
+  background-color: #FF4040;
   color: #EEEEEE;
   min-width: 0;
   min-height: 0;
@@ -1786,7 +1786,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #CCCCCC;
+  background-color: #CCCCCC;
   color: #333333;
   min-width: 0;
   min-height: 0;
@@ -1802,7 +1802,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #00C781;
+  background-color: #00C781;
   color: #333333;
   min-width: 0;
   min-height: 0;
@@ -1818,7 +1818,7 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #FFAA15;
+  background-color: #FFAA15;
   color: #333333;
   min-width: 0;
   min-height: 0;
@@ -1836,7 +1836,7 @@ exports[`Grommet hpe theme 1`] = `
   font-family: 'Metric',Arial,sans-serif;
   font-size: 18px;
   line-height: 24px;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   color: #333333;
   box-sizing: border-box;
   -webkit-text-size-adjust: 100%;

--- a/src/js/utils/background.js
+++ b/src/js/utils/background.js
@@ -92,7 +92,7 @@ export const backgroundAndTextColors = (backgroundArg, textArg, theme) => {
       // If we don't have a textColor already, and we aren't too translucent,
       // set the textColor to have the best contrast against the background
       // color.
-      if (!textColor && opacity !== 'weak') {
+      if (!textColor && (opacity === undefined || opacity > 0.3)) {
         const shade = darkContext(backgroundColor, theme);
         textColor = normalizeColor((shade && text[shade]) || text, theme);
       }

--- a/src/js/utils/background.js
+++ b/src/js/utils/background.js
@@ -154,8 +154,10 @@ export const backgroundStyle = (backgroundArg, theme, textColorArg) => {
   }
 
   if (typeof background === 'string')
+    // This case takes care of gradients
+    // or theme colors that use CSS names like 'red' that we don't parse
     return css`
-      background: ${background};
+      background: ${normalizeColor(background, theme)};
     `;
 
   return undefined;

--- a/src/js/utils/background.js
+++ b/src/js/utils/background.js
@@ -56,89 +56,91 @@ export const backgroundIsDark = (backgroundArg, theme) => {
   return result;
 };
 
-export const backgroundStyle = (backgroundArg, theme, textColorArg) => {
-  // for Grommet component, if the background isn't defined, don't set it
-  if (backgroundArg === undefined) {
-    return undefined;
-  }
+const darkContext = (backgroundColor, theme) => {
+  const isDark = colorIsDark(backgroundColor);
+  return isDark || (isDark === undefined && theme.dark) ? 'dark' : 'light';
+};
 
-  // If the background has a light or dark object, use that
+// Returns an array of two CSS colors: [background, color]
+// Either could be undefined.
+export const backgroundAndTextColors = (backgroundArg, textArg, theme) => {
+  const { global } = theme;
   const background = normalizeBackground(backgroundArg, theme);
-  const textColor = textColorArg || theme.global.colors.text;
+  const text = textArg || global.colors.text;
 
+  let backgroundColor;
+  let textColor;
   if (typeof background === 'object') {
-    const styles = [];
-    if (background.image) {
-      let color;
-      if (background.dark === false) {
-        color = normalizeColor(textColor.light || textColor, theme);
-      } else if (background.dark) {
-        color = normalizeColor(textColor.dark || textColor, theme);
-      } else if (!textColorArg) {
-        color = 'inherit';
-      }
-      styles.push(css`
-        background-image: ${background.image};
-        background-repeat: ${background.repeat || 'no-repeat'};
-        background-position: ${background.position || 'center center'};
-        background-size: ${background.size || 'cover'};
-        color: ${color};
-      `);
+    if (background.dark === false) {
+      textColor = text.light || text;
+    } else if (background.dark) {
+      textColor = text.dark || text;
     }
     if (background.color) {
       const color = normalizeColor(background.color, theme, background.dark);
-      const backgroundColor =
-        getRGBA(
-          color,
-          background.opacity === true
-            ? theme.global.opacity.medium
-            : theme.global.opacity[background.opacity] || background.opacity,
-        ) || color;
-      styles.push(css`
-        background-color: ${backgroundColor};
-        ${(!background.opacity || background.opacity !== 'weak') &&
-          `color: ${normalizeColor(
-            textColor[
-              background.dark || colorIsDark(backgroundColor) ? 'dark' : 'light'
-            ] || textColor,
-            theme,
-          )};`}
-      `);
+      const opacity =
+        background.opacity === true
+          ? global.opacity.medium
+          : global.opacity[background.opacity] || background.opacity;
+      backgroundColor = getRGBA(color, opacity) || color;
+
+      // If we don't have a textColor already, and we aren't too translucent,
+      // set the textColor to have the best contrast against the background
+      // color.
+      if (backgroundColor && !textColor && opacity !== 'weak') {
+        const shade = darkContext(backgroundColor, theme);
+        textColor = normalizeColor(text[shade] || text, theme);
+      }
     }
-    if (background.dark === false) {
-      styles.push(css`
-        color: ${textColor.light || textColor};
-      `);
-    } else if (background.dark) {
-      styles.push(css`
-        color: ${textColor.dark || textColor};
-      `);
+  } else {
+    backgroundColor = normalizeColor(background, theme);
+    if (backgroundColor) {
+      const shade = darkContext(backgroundColor, theme);
+      textColor = normalizeColor(text[shade] || text, theme);
     }
-    return styles;
   }
 
-  if (background) {
-    if (background.lastIndexOf('url', 0) === 0) {
-      return css`
-        background: ${background} no-repeat center center;
-        background-size: cover;
-      `;
-    }
-    const backgroundColor = normalizeColor(background, theme);
-    if (backgroundColor) {
-      const backgroundDark = colorIsDark(backgroundColor);
-      return css`
-        background: ${backgroundColor};
-        color: ${normalizeColor(
-          textColor[
-            backgroundDark || (backgroundDark === undefined && theme.dark)
-              ? 'dark'
-              : 'light'
-          ] || textColor,
-          theme,
-        )};
-      `;
-    }
+  return [backgroundColor, textColor];
+};
+
+export const backgroundStyle = (backgroundArg, theme, textColorArg) => {
+  // for Grommet component, if the background isn't defined, don't set it
+  if (backgroundArg === undefined) return undefined;
+
+  const background = normalizeBackground(backgroundArg, theme);
+
+  if (
+    typeof background === 'string' &&
+    background.lastIndexOf('url', 0) === 0
+  ) {
+    return css`
+      background: ${background} no-repeat center center;
+      background-size: cover;
+    `;
+  }
+
+  const [backgroundColor, textColor] = backgroundAndTextColors(
+    background,
+    textColorArg,
+    theme,
+  );
+
+  if (background.image) {
+    return css`
+      background-image: ${background.image};
+      background-repeat: ${background.repeat || 'no-repeat'};
+      background-position: ${background.position || 'center center'};
+      background-size: ${background.size || 'cover'};
+      ${backgroundColor ? `background-color: ${backgroundColor};` : ''}
+      ${textColor ? `color: ${textColor};` : ''}
+    `;
+  }
+
+  if (backgroundColor) {
+    return css`
+      background-color: ${backgroundColor};
+      ${textColor ? `color: ${textColor};` : ''}
+    `;
   }
 
   return undefined;

--- a/src/js/utils/colors.js
+++ b/src/js/utils/colors.js
@@ -1,5 +1,6 @@
 // Returns the specific color that should be used according to the theme.
 // If 'dark' is supplied, it takes precedence over 'theme.dark'.
+// Can return undefined.
 export const normalizeColor = (color, theme, dark) => {
   const colorSpec =
     theme.global && theme.global.colors[color] !== undefined
@@ -105,13 +106,16 @@ const getRGBArray = color => {
 };
 
 export const colorIsDark = color => {
-  const [red, green, blue, alpha] = getRGBArray(color);
-  // if there is an alpha and it's greater than 50%, we can't really tell
-  if (alpha < 0.5) return undefined;
-  const brightness = (299 * red + 587 * green + 114 * blue) / 1000;
-  // From: http://www.had2know.com/technology/color-contrast-calculator-web-design.html
-  // Above domain is no longer registered.
-  return brightness < 125;
+  if (color && canExtractRGBArray(color)) {
+    const [red, green, blue, alpha] = getRGBArray(color);
+    // if there is an alpha and it's greater than 50%, we can't really tell
+    if (alpha < 0.5) return undefined;
+    const brightness = (299 * red + 587 * green + 114 * blue) / 1000;
+    // From: http://www.had2know.com/technology/color-contrast-calculator-web-design.html
+    // Above domain is no longer registered.
+    return brightness < 125;
+  }
+  return undefined;
 };
 
 export const getRGBA = (color, opacity) => {


### PR DESCRIPTION
#### What does this PR do?

Refactored backgroundStyle to split out backgroundAndTextColors.
This will make it easier to share the colors between properties and styles.
The snapshot changes are primarily due to the new code only setting `background-color` instead of `background` when we are only providing a color value.

#### What testing has been done on this PR?

Storybook

#### How should this be manually tested?

Storybook

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
