### PR TITLE
Layer constantly updates fix

### DIFF
--- a/src/js/components/FocusedContainer.js
+++ b/src/js/components/FocusedContainer.js
@@ -23,7 +23,6 @@ export const FocusedContainer = ({
       getBodyChildElements()
         .filter(isNotAncestorOf(child))
         .forEach(makeNodeFocusable);
-      // bodyOverflowStyle is causing the layer to constantly update
       if (restrictScroll) {
         document.body.style.overflow = bodyOverflowStyle;
       }
@@ -35,7 +34,7 @@ export const FocusedContainer = ({
         .filter(isNotAncestorOf(child))
         .forEach(makeNodeUnfocusable);
 
-      if (restrictScroll) {
+      if (restrictScroll && bodyOverflowStyle !== 'hidden') {
         setBodyOverflowStyle(document.body.style.overflow);
         document.body.style.overflow = 'hidden';
       }

--- a/src/js/components/FocusedContainer.js
+++ b/src/js/components/FocusedContainer.js
@@ -23,6 +23,7 @@ export const FocusedContainer = ({
       getBodyChildElements()
         .filter(isNotAncestorOf(child))
         .forEach(makeNodeFocusable);
+      // bodyOverflowStyle is causing the layer to constantly update
       if (restrictScroll) {
         document.body.style.overflow = bodyOverflowStyle;
       }

--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -118,7 +118,6 @@ const LayerContainer = forwardRef(
         {children}
       </StyledContainer>
     );
-    // why are there two checks for modal?
     if (modal) {
       content = (
         <StyledLayer
@@ -155,7 +154,6 @@ const LayerContainer = forwardRef(
         );
       }
     }
-    // won't this override the previous modal check?
     if (modal) {
       content = (
         <FocusedContainer hidden={position === 'hidden'} restrictScroll>

--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -118,7 +118,7 @@ const LayerContainer = forwardRef(
         {children}
       </StyledContainer>
     );
-
+    // why are there two checks for modal?
     if (modal) {
       content = (
         <StyledLayer
@@ -155,7 +155,7 @@ const LayerContainer = forwardRef(
         );
       }
     }
-
+    // won't this override the previous modal check?
     if (modal) {
       content = (
         <FocusedContainer hidden={position === 'hidden'} restrictScroll>


### PR DESCRIPTION
What does this PR do?
closes #3964 

In FocusedContainer.js bodyOverflowStyle was constantly changing from undefined to 'hidden' causing the useEffect to run over and over again. With the conditional, only runs on mount.

I have a question about LayerContainer.js. There are two checks for modal, wouldn't one override the other?

```javascript
// first modal check line 121
    if (modal) {
      content = (
        <StyledLayer
          ref={layerRef}
          id={id}
          targetBounds={targetBounds}
          plain={plain}
          position={position}
          responsive={responsive}
          tabIndex="-1"
          dir={theme.dir}
        >
          <StyledOverlay
            plain={plain}
            onMouseDown={onClickOutside}
            responsive={responsive}
          />
          {content}
        </StyledLayer>
      );
    }
```

```javascript
// second modal check line 157
    if (modal) {
      content = (
        <FocusedContainer hidden={position === 'hidden'} restrictScroll>
          {content}
        </FocusedContainer>
      );
    }
```

Where should the reviewer start?
FocusedContainer.js

What testing has been done on this PR?
Storybook layer examples.

How should this be manually tested?
Same as above

Do the grommet docs need to be updated?
No

Is this change backwards compatible or is it a breaking change?
Backwards compatible