### PR TITLE
Allow disabled styling to affect MaskedInput

### DIFF
--- a/src/js/components/MaskedInput/README.md
+++ b/src/js/components/MaskedInput/README.md
@@ -161,6 +161,16 @@ The opacity when the MaskedInput is disabled. Expects `number`.
 Defaults to
 
 ```
+global.control.disabled.opacity
+```
+
+**global.control.disabled.opacity**
+
+The opacity when a component is disabled. Expects `number`.
+
+Defaults to
+
+```
 0.3
 ```
 

--- a/src/js/components/MaskedInput/README.md
+++ b/src/js/components/MaskedInput/README.md
@@ -156,12 +156,12 @@ Defaults to
 
 **maskedInput.disabled.opacity**
 
-The opacity when the MaskedInput is disabled. Expects `number`.
+The opacity when the MaskedInput is disabled. Expects `number | string`.
 
 Defaults to
 
 ```
-global.control.disabled.opacity
+undefined
 ```
 
 **global.control.disabled.opacity**

--- a/src/js/components/MaskedInput/README.md
+++ b/src/js/components/MaskedInput/README.md
@@ -154,6 +154,16 @@ Defaults to
 18px
 ```
 
+**maskedInput.disabled.opacity**
+
+The opacity when the MaskedInput is disabled. Expects `number`.
+
+Defaults to
+
+```
+0.3
+```
+
 **global.focus.border.color**
 
 The border color of the component when in focus. Expects `string | { dark: string, light: string }`.

--- a/src/js/components/MaskedInput/StyledMaskedInput.js
+++ b/src/js/components/MaskedInput/StyledMaskedInput.js
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 
 import {
+  disabledStyle,
   focusStyle,
   getInputPadBySide,
   inputStyle,
@@ -39,6 +40,12 @@ export const StyledMaskedInput = styled.input`
   }
 
   ${props => props.focus && !props.plain && focusStyle()};
+  ${props =>
+    props.disabled &&
+    disabledStyle(
+      props.theme.maskedInput.disabled &&
+        props.theme.maskedInput.disabled.opacity,
+    )}
   ${props => props.theme.maskedInput && props.theme.maskedInput.extend};
 `;
 

--- a/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
+++ b/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
@@ -38,6 +38,11 @@ describe('MaskedInput', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('disabled', () => {
+    const { container } = render(<MaskedInput disabled name="item" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('mask', async () => {
     const onChange = jest.fn();
     const onFocus = jest.fn();

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -207,6 +207,65 @@ exports[`MaskedInput basic 1`] = `
 </div>
 `;
 
+exports[`MaskedInput disabled 1`] = `
+.c1 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  width: 100%;
+  opacity: 0.3;
+  cursor: default;
+}
+
+.c1::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c1::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c1:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c1::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c0 {
+  position: relative;
+  width: 100%;
+}
+
+<div
+  class="c0"
+>
+  <input
+    autocomplete="off"
+    class="c1"
+    disabled=""
+    name="item"
+    placeholder=""
+    value=""
+  />
+</div>
+`;
+
 exports[`MaskedInput event target props are available option via keyboard 1`] = `
 .c1 {
   box-sizing: border-box;
@@ -521,7 +580,7 @@ exports[`MaskedInput event target props are available option via mouse 4`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 eoUyQk"
+    class="StyledMaskedInput-sc-99vkfa-0 iiIkNh"
     data-testid="test-input"
     id="item"
     name="item"
@@ -1089,7 +1148,7 @@ exports[`MaskedInput next and previous without options 2`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 Cfxjk"
+    class="StyledMaskedInput-sc-99vkfa-0 kTqDsx"
     data-testid="test-input"
     id="item"
     name="item"
@@ -1411,7 +1470,7 @@ exports[`MaskedInput option via mouse 4`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 eoUyQk"
+    class="StyledMaskedInput-sc-99vkfa-0 iiIkNh"
     data-testid="test-input"
     id="item"
     name="item"

--- a/src/js/components/MaskedInput/doc.js
+++ b/src/js/components/MaskedInput/doc.js
@@ -87,8 +87,9 @@ export const themeDoc = {
   'maskedInput.disabled.opacity': {
     description: 'The opacity when the MaskedInput is disabled.',
     type: 'number',
-    defaultValue: 0.3,
+    defaultValue: 'global.control.disabled.opacity',
   },
+  ...themeDocUtils.disabledStyle,
   ...themeDocUtils.focusStyle,
   ...themeDocUtils.placeholderStyle,
   ...themeDocUtils.inputStyle,

--- a/src/js/components/MaskedInput/doc.js
+++ b/src/js/components/MaskedInput/doc.js
@@ -86,8 +86,8 @@ export const themeDoc = {
   },
   'maskedInput.disabled.opacity': {
     description: 'The opacity when the MaskedInput is disabled.',
-    type: 'number',
-    defaultValue: 'global.control.disabled.opacity',
+    type: 'number | string',
+    defaultValue: undefined,
   },
   ...themeDocUtils.disabledStyle,
   ...themeDocUtils.focusStyle,

--- a/src/js/components/MaskedInput/doc.js
+++ b/src/js/components/MaskedInput/doc.js
@@ -84,6 +84,11 @@ export const themeDoc = {
     type: 'string',
     defaultValue: '18px',
   },
+  'maskedInput.disabled.opacity': {
+    description: 'The opacity when the MaskedInput is disabled.',
+    type: 'number',
+    defaultValue: 0.3,
+  },
   ...themeDocUtils.focusStyle,
   ...themeDocUtils.placeholderStyle,
   ...themeDocUtils.inputStyle,

--- a/src/js/components/TextInput/README.md
+++ b/src/js/components/TextInput/README.md
@@ -354,7 +354,7 @@ The opacity when the textInput is disabled. Expects `number`.
 Defaults to
 
 ```
-0.3
+global.control.disabled.opacity
 ```
 
 **global.focus.border.color**

--- a/src/js/components/TextInput/README.md
+++ b/src/js/components/TextInput/README.md
@@ -349,12 +349,12 @@ undefined
 
 **textInput.disabled.opacity**
 
-The opacity when the textInput is disabled. Expects `number`.
+The opacity when the textInput is disabled. Expects `number | string`.
 
 Defaults to
 
 ```
-global.control.disabled.opacity
+undefined
 ```
 
 **global.focus.border.color**

--- a/src/js/components/TextInput/doc.js
+++ b/src/js/components/TextInput/doc.js
@@ -199,7 +199,7 @@ export const themeDoc = {
   'textInput.disabled.opacity': {
     description: 'The opacity when the textInput is disabled.',
     type: 'number',
-    defaultValue: 0.3,
+    defaultValue: 'global.control.disabled.opacity',
   },
   ...themeDocUtils.focusStyle,
   ...themeDocUtils.placeholderStyle,

--- a/src/js/components/TextInput/doc.js
+++ b/src/js/components/TextInput/doc.js
@@ -198,8 +198,8 @@ export const themeDoc = {
   },
   'textInput.disabled.opacity': {
     description: 'The opacity when the textInput is disabled.',
-    type: 'number',
-    defaultValue: 'global.control.disabled.opacity',
+    type: 'number | string',
+    defaultValue: undefined,
   },
   ...themeDocUtils.focusStyle,
   ...themeDocUtils.placeholderStyle,

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -9036,6 +9036,16 @@ The opacity when the MaskedInput is disabled. Expects \`number\`.
 Defaults to
 
 \`\`\`
+global.control.disabled.opacity
+\`\`\`
+
+**global.control.disabled.opacity**
+
+The opacity when a component is disabled. Expects \`number\`.
+
+Defaults to
+
+\`\`\`
 0.3
 \`\`\`
 
@@ -13637,7 +13647,7 @@ The opacity when the textInput is disabled. Expects \`number\`.
 Defaults to
 
 \`\`\`
-0.3
+global.control.disabled.opacity
 \`\`\`
 
 **global.focus.border.color**

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -9031,12 +9031,12 @@ Defaults to
 
 **maskedInput.disabled.opacity**
 
-The opacity when the MaskedInput is disabled. Expects \`number\`.
+The opacity when the MaskedInput is disabled. Expects \`number | string\`.
 
 Defaults to
 
 \`\`\`
-global.control.disabled.opacity
+undefined
 \`\`\`
 
 **global.control.disabled.opacity**
@@ -13642,12 +13642,12 @@ undefined
 
 **textInput.disabled.opacity**
 
-The opacity when the textInput is disabled. Expects \`number\`.
+The opacity when the textInput is disabled. Expects \`number | string\`.
 
 Defaults to
 
 \`\`\`
-global.control.disabled.opacity
+undefined
 \`\`\`
 
 **global.focus.border.color**

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -9029,6 +9029,16 @@ Defaults to
 18px
 \`\`\`
 
+**maskedInput.disabled.opacity**
+
+The opacity when the MaskedInput is disabled. Expects \`number\`.
+
+Defaults to
+
+\`\`\`
+0.3
+\`\`\`
+
 **global.focus.border.color**
 
 The border color of the component when in focus. Expects \`string | { dark: string, light: string }\`.

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -763,6 +763,9 @@ export interface ThemeType {
   };
   maskedInput?: {
     extend?: ExtendType;
+    disabled?: {
+      opacity?: OpacityType;
+    };
   };
   menu?: {
     background?: BackgroundType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -769,6 +769,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     },
     maskedInput: {
       // extend: undefined,
+      // disabled: { opacity: undefined },
     },
     menu: {
       // background: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds disabledStyle to MaskedInput. Currently, disabled styling is not being applied to maskedinput like it is for other inputs such as TextInput.

#### Where should the reviewer start?
src/js/components/MaskedInput/StyledMaskedInput.js

#### What testing has been done on this PR?
disabled was applied to a storybook to ensure the opacity changed the same way that TextInput opacity does by default. A jest test was added for future.

#### How should this be manually tested?
Add `disabled` to MaskedInput -- if using `grommet theme`, or base.js, the disabledStyle should default to opacity 0.3.

#### Any background context you want to provide?
When working on MaskedInput examples for the HPE Design System, I noticed that the placeholder text of the MaskedInput was not being toggled in opacity the same that TextInput was.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, they're updated here.

#### Should this PR be mentioned in the release notes?
[Shimi] Yes - Added `disabled` theme styling to MaskedInput.

#### Is this change backwards compatible or is it a breaking change?
This will now toggle opacity to 0.3 for disabled maskedinputs by default, which wasn't in place before but is needed to align with other inputs. It wouldn't be backwards compatible -- suggestions on what to do here?