### PR TITLE
Changed DropContainer to use a constant default prop value

### DIFF
--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -31,15 +31,13 @@ const preventLayerClose = event => {
   }
 };
 
+const defaultAlign = { top: 'top', left: 'left' };
 const defaultPortalContext = [];
 
 const DropContainer = forwardRef(
   (
     {
-      align = {
-        top: 'top',
-        left: 'left',
-      },
+      align = defaultAlign,
       children,
       dropTarget,
       elevation,


### PR DESCRIPTION
#### What does this PR do?

Changed DropContainer to use a constant default prop value.
I've found this to help reduce re-rendering in general. It isn't fixing a particular issue.

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
