### PR TITLE
Changed Button to fix an issue with plain + icon

### DIFF
--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -201,13 +201,15 @@ const Button = forwardRef(
 
     let buttonIcon = icon;
     // only change color if user did not specify the color themselves...
-    if (icon && !icon.props.color && !plain) {
+    if (icon && !icon.props.color) {
       if (kind) {
-        // match what the label will use
-        const iconColor =
-          (hover && getIconColor(themePaths.hover, theme)) ||
-          getIconColor(themePaths.base, theme, color);
-        if (iconColor) buttonIcon = cloneElement(icon, { color: iconColor });
+        if (!plain) {
+          // match what the label will use
+          const iconColor =
+            (hover && getIconColor(themePaths.hover, theme)) ||
+            getIconColor(themePaths.base, theme, color);
+          if (iconColor) buttonIcon = cloneElement(icon, { color: iconColor });
+        }
       } else if (primary) {
         buttonIcon = cloneElement(icon, {
           color:

--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -201,7 +201,7 @@ const Button = forwardRef(
 
     let buttonIcon = icon;
     // only change color if user did not specify the color themselves...
-    if (icon && !icon.props.color) {
+    if (icon && !icon.props.color && !plain) {
       if (kind) {
         // match what the label will use
         const iconColor =


### PR DESCRIPTION
#### What does this PR do?

Changed Button to fix an issue with plain + icon.
This only occurs when a Button has `plain`, `icon`, and the theme has `button.default`.

#### Where should the reviewer start?

Button.js

#### What testing has been done on this PR?

whitebox

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

no

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
