### PR TITLE
Changed core components that use Button to apply 'plain' for theme.button.default

### DIFF
--- a/src/js/components/AccordionPanel/AccordionPanel.js
+++ b/src/js/components/AccordionPanel/AccordionPanel.js
@@ -91,7 +91,7 @@ const AccordionPanel = forwardRef(
           role="tab"
           aria-selected={active}
           aria-expanded={active}
-          plain={theme.button.default}
+          plain={!!theme.button.default}
           onClick={onPanelChange}
           onMouseOver={event => {
             setHover(headingColor);

--- a/src/js/components/AccordionPanel/AccordionPanel.js
+++ b/src/js/components/AccordionPanel/AccordionPanel.js
@@ -53,8 +53,8 @@ const AccordionPanel = forwardRef(
         use accordion.hover.heading.color instead.`,
       );
 
-    // accordion.hover.heading.color will trump accordion.hover.color in case 
-    // the user sets its value to be any other value than the 
+    // accordion.hover.heading.color will trump accordion.hover.color in case
+    // the user sets its value to be any other value than the
     // default value (defaultHoverColor).
     // accordion.hover.color will be deprecated in v3.
     const headingColor =
@@ -91,6 +91,7 @@ const AccordionPanel = forwardRef(
           role="tab"
           aria-selected={active}
           aria-expanded={active}
+          plain={theme.button.default}
           onClick={onPanelChange}
           onMouseOver={event => {
             setHover(headingColor);

--- a/src/js/components/AccordionPanel/AccordionPanel.js
+++ b/src/js/components/AccordionPanel/AccordionPanel.js
@@ -91,7 +91,7 @@ const AccordionPanel = forwardRef(
           role="tab"
           aria-selected={active}
           aria-expanded={active}
-          plain={!!theme.button.default}
+          plain={theme.button.default ? true : undefined}
           onClick={onPanelChange}
           onMouseOver={event => {
             setHover(headingColor);

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -261,7 +261,7 @@ const Menu = forwardRef((props, ref) => {
                       active={activeItemIndex === index}
                       hoverIndicator="background"
                       focusIndicator={false}
-                      plain={theme.button.default}
+                      plain={!!theme.button.default}
                       {...{ ...item, icon: undefined, label: undefined }}
                       onClick={(...args) => {
                         if (item.onClick) {

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -261,6 +261,7 @@ const Menu = forwardRef((props, ref) => {
                       active={activeItemIndex === index}
                       hoverIndicator="background"
                       focusIndicator={false}
+                      plain={theme.button.default}
                       {...{ ...item, icon: undefined, label: undefined }}
                       onClick={(...args) => {
                         if (item.onClick) {

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -217,9 +217,6 @@ const Menu = forwardRef((props, ref) => {
       </Button>
     </Box>
   );
-  console.log(theme.button.default);
-  console.log(!theme.button.default);
-  console.log(!!theme.button.default);
 
   return (
     <Keyboard

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -217,6 +217,9 @@ const Menu = forwardRef((props, ref) => {
       </Button>
     </Box>
   );
+  console.log(theme.button.default);
+  console.log(!theme.button.default);
+  console.log(!!theme.button.default);
 
   return (
     <Keyboard
@@ -261,7 +264,7 @@ const Menu = forwardRef((props, ref) => {
                       active={activeItemIndex === index}
                       hoverIndicator="background"
                       focusIndicator={false}
-                      plain={!!theme.button.default}
+                      plain={theme.button.default ? true : undefined}
                       {...{ ...item, icon: undefined, label: undefined }}
                       onClick={(...args) => {
                         if (item.onClick) {


### PR DESCRIPTION

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
With the new button.default theme assignment, the core components that use Button are being impacted by the new styles.
This PR is assigning the `plain` prop for those Buttons in case theme.button.default is defined.

#### Where should the reviewer start?
Any changed file.
#### What testing has been done on this PR?
jest
#### How should this be manually tested?
with the design system
#### Any background context you want to provide?

#### What are the relevant issues?
#4077 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
nope
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible 