### PR TITLE
Storybook - add dual color track story for RangeInput

### DIFF
--- a/src/js/components/RangeInput/stories/TrackDualColor.js
+++ b/src/js/components/RangeInput/stories/TrackDualColor.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { Box, Grommet, RangeInput } from 'grommet';
+
+const rangeTheme = {
+  rangeInput: {
+    track: {
+      height: '12px',
+      extend: ({ max, value }) => {
+        const lowerTrack = 'lightgreen';
+        const upperTrack = 'lightgrey';
+        const thumbPosition = `${(value / max) * 100}%`;
+
+        return `background: linear-gradient(
+        to right, 
+        ${lowerTrack}, 
+        ${lowerTrack} ${thumbPosition},
+        ${upperTrack} ${thumbPosition},
+        ${upperTrack}
+      );`;
+      },
+    },
+  },
+};
+
+const TrackDualColor = () => {
+  const [value, setValue] = React.useState(40);
+
+  const onChange = event => setValue(event.target.value);
+
+  return (
+    <Grommet theme={rangeTheme}>
+      <Box align="center" pad="large" width="medium">
+        <RangeInput value={value} max={100} onChange={onChange} />
+      </Box>
+    </Grommet>
+  );
+};
+
+storiesOf('RangeInput', module).add('Dual Color Track', () => (
+  <TrackDualColor />
+));


### PR DESCRIPTION
Signed-off-by: Matt Glissmann <mdglissmann@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds Storybook story to illustrate how to style `<RangeInput>`'s track so that track can have different colors on either side of the thumb.

#### Where should the reviewer start?
Storybook - `RangeInput/stories/TrackDualColor.js`

#### What testing has been done on this PR?
Storybook

#### How should this be manually tested?
Storybook

#### Any background context you want to provide?
Discussed adding this story with @ShimiSun 

#### What are the relevant issues?
None.

#### Screenshots (if appropriate)
![Screen Shot 2020-05-15 at 12 25 45 PM](https://user-images.githubusercontent.com/1756948/82083601-3d472900-96a7-11ea-8d9c-dcb52f945b7d.png)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
