### PR TITLE
Changed DropButton to fix an issue with caller controlling state

### DIFF
--- a/src/js/components/DropButton/DropButton.js
+++ b/src/js/components/DropButton/DropButton.js
@@ -41,11 +41,12 @@ const DropButton = forwardRef(
           node = node.parentNode;
         }
         if (node !== buttonRef.current) {
-          setShow(false);
+          // don't change internal state if caller is driving
+          if (open === undefined) setShow(false);
           if (onClose) onClose(event);
         }
       },
-      [buttonRef, onClose],
+      [buttonRef, onClose, open],
     );
 
     const onClickInternal = useCallback(


### PR DESCRIPTION
#### What does this PR do?

Changed DropButton to fix an issue with caller controlling state.
Specifically, if the caller is explicitly setting `open`, don't set the internal `show` state to false, only to have the effect checking the `open` value to reset it immediately.

#### Where should the reviewer start?

DropButton.js

#### What testing has been done on this PR?

grommet designer

#### How should this be manually tested?

you would need to create a caller controlled DropButton

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
