### PR TITLE
fix: header should include JSX div types

### DIFF
--- a/src/js/components/Header/index.d.ts
+++ b/src/js/components/Header/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { BoxProps } from '../Box' 
+import { BoxTypes } from '../Box' 
 
-declare const Header: React.FC<BoxProps>;
+declare const Header: React.FC<BoxTypes>;
 
 export { Header };


### PR DESCRIPTION
The header was set to use `BoxProps` for the type, but it should use `BoxTypes` so that it inherits the JSX `div` types.

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes an issue where the Header component did not extend the general `div` types

#### Where should the reviewer start?

#### What testing has been done on this PR?
I made the type change on my machine and verified that the header props extended div props.

#### How should this be manually tested?
Use the Header component and verify it now extends `div` props.

#### Any background context you want to provide?
I was trying to customize the Header and noticed it only had the Box props, without also having div props.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Probably not

#### Should this PR be mentioned in the release notes?
Probably not necessary

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
