### PR TITLE
add color for plain button

### DIFF
--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -203,7 +203,8 @@ const fillStyle = fillContainer => {
   return undefined;
 };
 
-const plainStyle = () => css`
+const plainStyle = props => css`
+  color: ${normalizeColor(props.colorValue || 'inherit', props.theme)};
   outline: none;
   border: none;
   padding: 0;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds color to the plain styled button
#### Where should the reviewer start?
styledbuttonkind.js
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
Add hpe theme from hpe next stable branch 

```
    <Grommet theme={hpe}>
      <Box background="dark-1" {...rest}>
        <Accordion animate={animate} multiple={multiple}>
          <AccordionPanel label="Panel 1">
            <Box background="light-2" overflow="auto" height="medium">
              <Box height="large" flex={false}>
                Panel 1 contents
              </Box>
            </Box>
          </AccordionPanel>
        </Accordion>
      </Box>
    </Grommet>


```
#### Any background context you want to provide?
With the new default button there was some issues that come up
with having to add plain to `button` that is being used to build other components
For example:

Accordion under the hood uses `button` so it needed to look to see if `button.deafult` was used in theme then add plain prop to the `button` used in accordion. This caused issues with Text color. 
The text color was not respecting the dark and light background. Since there was no color being applied to the PlainStyle

https://design-system.hpe.design/components/accordion
![Screen Shot 2020-05-18 at 3 34 28 PM](https://user-images.githubusercontent.com/42451602/82261881-14c86480-991d-11ea-9928-c034fe824684.png)

https://design-system.hpe.design/components/menu

![Screen Shot 2020-05-18 at 3 34 50 PM](https://user-images.githubusercontent.com/42451602/82261904-2447ad80-991d-11ea-9d91-e4bddf2fd505.png)

* The text color on these should be white in dark mode

#### What are the relevant issues?
issue #4077 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible