### PR TITLE
Removed curly braces around file extension in collectCoverageForm in …

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,11 +141,11 @@
       "lcov"
     ],
     "collectCoverageFrom": [
-      "src/js/components/**/*.{js}",
-      "src/js/contexts/**/*.{js}",
-      "src/js/themes/**/*.{js}",
-      "src/js/utils/**/*.{js}",
-      "!src/js/components/**/*.{stories.js}",
+      "src/js/components/**/*.js",
+      "src/js/contexts/**/*.js",
+      "src/js/themes/**/*.js",
+      "src/js/utils/**/*.js",
+      "!src/js/components/**/*.stories.js",
       "!src/js/components/**/stories/*.js"
     ],
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
…package.json to generate code coverage report with jest

Signed-off-by: Jessica Filben <jessica.cheyenne.filben@hpe.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Normally jest testing is setup to display testing coverage when the command `yarn test --coverage` is run. However, when the command was run the coverage was not being shown. The cause of this problem is in the jest configuration settings in package.json under collectCoverageFrom. The curly braces around the file extensions need to be removed for the testing coverage to work properly.

#### Where should the reviewer start?
Look at the following issue explaining the curly braces problem in jest.
Relevant documentation of issue:  https://github.com/facebook/jest/issues/6654
Then look at the package.json file and see the changes that were made. Test out the `yarn test --coverage` command.

#### What testing has been done on this PR?
All tests passed and I manually tested the `yarn test --coverage` command by opening the `index.html` file found in the `coverage/lcov-report` folder.

#### How should this be manually tested?
Run `yarn test --coverage` and open the `index.html` file found in the `coverage/lcov-report` folder to view the test coverage report.

#### Any background context you want to provide?
N/A
#### What are the relevant issues?
N/A
#### Screenshots (if appropriate)
How the test coverage report looks before the curly braces in collectCoverageFrom were removed:
<img width="1792" alt="Screen Shot 2020-05-22 at 11 49 28 AM" src="https://user-images.githubusercontent.com/54560994/82696060-878a5600-9c23-11ea-9819-4aa9778d7598.png">
How the test coverage report looks after:
<img width="1792" alt="Screen Shot 2020-05-22 at 10 46 37 AM" src="https://user-images.githubusercontent.com/54560994/82696087-94a74500-9c23-11ea-9558-247b3bf7754d.png">

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
It is backwards compatible