### PR TITLE
Changed Button to make Kind and size work together (#4134)

### DIFF
--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -30,11 +30,11 @@ const padStyle = ({ sizeProp: size, theme }) => {
     size &&
     theme.button.size &&
     theme.button.size[size] &&
-    theme.button.size[size].padding
+    theme.button.size[size].pad
   ) {
     return css`
-      padding: ${theme.button.size[size].padding.vertical}
-        ${theme.button.size[size].padding.horizontal};
+      padding: ${theme.button.size[size].pad.vertical}
+        ${theme.button.size[size].pad.horizontal};
     `;
   }
 

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -581,12 +581,10 @@ exports[`MaskedInput event target props are available option via mouse 4`] = `
   <input
     autocomplete="off"
     class="StyledMaskedInput-sc-99vkfa-0 iiIkNh"
-    data-g-tabindex="none"
     data-testid="test-input"
     id="item"
     name="item"
     placeholder="!"
-    tabindex="-1"
     value=""
   />
 </div>
@@ -1473,12 +1471,10 @@ exports[`MaskedInput option via mouse 4`] = `
   <input
     autocomplete="off"
     class="StyledMaskedInput-sc-99vkfa-0 iiIkNh"
-    data-g-tabindex="none"
     data-testid="test-input"
     id="item"
     name="item"
     placeholder="!"
-    tabindex="-1"
     value=""
   />
 </div>

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -581,10 +581,12 @@ exports[`MaskedInput event target props are available option via mouse 4`] = `
   <input
     autocomplete="off"
     class="StyledMaskedInput-sc-99vkfa-0 iiIkNh"
+    data-g-tabindex="none"
     data-testid="test-input"
     id="item"
     name="item"
     placeholder="!"
+    tabindex="-1"
     value=""
   />
 </div>
@@ -1471,10 +1473,12 @@ exports[`MaskedInput option via mouse 4`] = `
   <input
     autocomplete="off"
     class="StyledMaskedInput-sc-99vkfa-0 iiIkNh"
+    data-g-tabindex="none"
     data-testid="test-input"
     id="item"
     name="item"
     placeholder="!"
+    tabindex="-1"
     value=""
   />
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR fixes a bug in Button component due to which Size and Kind (primary, secondary) won't work together. For KindButton the padding values are being read from a `theme.button.size[size].padding` path, which is not present in the theme.

#### Where should the reviewer start?

src/js/components/Button/StyledButtonKind.js

#### What testing has been done on this PR?

#### How should this be manually tested?

create a theme with button kind (default, primary) definitions in theme

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/4134

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no

#### Should this PR be mentioned in the release notes?
no

#### Is this change backwards compatible or is it a breaking change?
yes
