### PR TITLE
Changed DataChart to improve axes

### DIFF
--- a/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
+++ b/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
@@ -9,6 +9,7 @@ Object {
     ],
     Array [
       3.2,
+      0.8,
     ],
   ],
   "bounds": Array [
@@ -23,7 +24,7 @@ Object {
   ],
   "dimensions": Array [
     2,
-    2.4000000000000004,
+    2.4,
   ],
   "pad": "large",
   "thickness": "xlarge",

--- a/src/js/components/Chart/calcs.js
+++ b/src/js/components/Chart/calcs.js
@@ -8,6 +8,9 @@ const thicknessPad = {
   xsmall: 'xxsmall',
 };
 
+export const round = (value, decimals) =>
+  Number(`${Math.round(`${value}e${decimals}`)}e-${decimals}`);
+
 export const calcs = (values, options = {}) => {
   // coarseness influences the rounding of the bounds, the smaller the
   // number, the more the bounds will be rounded. e.g. 111 -> 110 -> 100
@@ -73,14 +76,19 @@ export const calcs = (values, options = {}) => {
         [min, max],
       ]
     : [[], []];
-  const dimensions = [bounds[0][1] - bounds[0][0], bounds[1][1] - bounds[1][0]];
+  const dimensions = [
+    round(bounds[0][1] - bounds[0][0], 2),
+    round(bounds[1][1] - bounds[1][0], 2),
+  ];
 
   // Calculate x and y axis values across the specfied number of steps.
   const yAxis = [];
   let y = bounds[1][1];
-  const yStepInterval = dimensions[1] / steps[1];
-  while (y >= bounds[1][0]) {
-    yAxis.push(y);
+  // To deal with javascript math limitations, round the step with 4 decimal
+  // places and then push the values with 2 decimal places
+  const yStepInterval = round(dimensions[1] / steps[1], 4);
+  while (round(y, 2) >= bounds[1][0]) {
+    yAxis.push(round(y, 2));
     y -= yStepInterval;
   }
 

--- a/src/js/components/Chart/index.js
+++ b/src/js/components/Chart/index.js
@@ -1,2 +1,2 @@
 export { Chart } from './Chart';
-export { calcs } from './calcs';
+export { calcs, round } from './calcs';

--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -190,7 +190,11 @@ const DataChart = forwardRef(
           {axis[1].map((axisValue, i) => {
             let content;
             if (yAxis.render) content = yAxis.render(axisValue, i);
-            else content = axisValue;
+            else {
+              content = axisValue;
+              if (yAxis.prefix) content = `${yAxis.prefix}${content}`;
+              if (yAxis.suffix) content = `${content}${yAxis.suffix}`;
+            }
             return (
               <Box key={i} align="end">
                 {content}

--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -16,6 +16,15 @@ const halfPad = {
   large: 'medium',
   medium: 'small',
   small: 'xsmall',
+  xsmall: 'xxsmall',
+};
+
+const doublePad = {
+  large: 'xlarge',
+  medium: 'large',
+  small: 'medium',
+  xsmall: 'small',
+  xxsmall: 'xsmall',
 };
 
 const checkDateFormat = (firstValue, lastValue, full) => {
@@ -167,8 +176,9 @@ const DataChart = forwardRef(
       const allSides =
         charts.filter(({ type }) => type && type !== 'bar').length > 0;
       if (allSides) return padSize;
+      if (yAxis) return { horizontal: padSize, vertical: halfPad.medium };
       return { horizontal: padSize };
-    }, [charts, padProp, thickness]);
+    }, [charts, padProp, thickness, yAxis]);
 
     const xGuide = useMemo(
       () =>
@@ -233,7 +243,6 @@ const DataChart = forwardRef(
             if (xAxis.render)
               content = xAxis.render(content, data, Math.floor(dataIndex), i);
             else if (dateFormat) {
-              if (xAxis.key === 'b') console.log('!!!!', xAxis.key, content);
               content = dateFormat(new Date(content));
             }
             return (
@@ -261,6 +270,15 @@ const DataChart = forwardRef(
           unit = 'K';
         }
       }
+
+      // Set basis to match double the vertical pad, so we can align the
+      // text with the guides
+      let basis;
+      if (axis[0].length === numValues) {
+        const edgeSize = doublePad[pad.vertical || pad];
+        basis = theme.global.edgeSize[edgeSize] || edgeSize;
+      }
+
       yAxisElement = (
         <Box gridArea="yAxis" justify="between" flex>
           {axis[1].map((axisValue, i) => {
@@ -276,7 +294,12 @@ const DataChart = forwardRef(
                 content = `${content}${yAxis.suffix || unit}`;
             }
             return (
-              <Box key={i} align="end">
+              <Box
+                key={i}
+                align="end"
+                basis={basis}
+                justify={basis ? 'center' : undefined}
+              >
                 {content}
               </Box>
             );

--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -167,11 +167,12 @@ const DataChart = forwardRef(
       }
       xAxisElement = (
         <Box ref={xRef} gridArea="xAxis" direction="row" justify="between">
-          {axis[0].map((a, i) => {
-            let content;
-            if (xAxis.render) content = xAxis.render(a, i);
-            else if (xAxis.key) content = data[i][xAxis.key];
-            else content = a;
+          {axis[0].map((dataIndex, i) => {
+            let content = xAxis.key
+              ? data[Math.floor(dataIndex)][xAxis.key]
+              : dataIndex;
+            if (xAxis.render)
+              content = xAxis.render(content, data, Math.floor(dataIndex), i);
             return (
               <Box key={i} basis={basis} align={basis ? 'center' : undefined}>
                 {content}
@@ -186,10 +187,10 @@ const DataChart = forwardRef(
     if (yAxis) {
       yAxisElement = (
         <Box gridArea="yAxis" justify="between" flex>
-          {axis[1].map((a, i) => {
+          {axis[1].map((axisValue, i) => {
             let content;
-            if (yAxis.render) content = yAxis.render(a, i);
-            else content = a;
+            if (yAxis.render) content = yAxis.render(axisValue, i);
+            else content = axisValue;
             return (
               <Box key={i} align="end">
                 {content}

--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -18,6 +18,52 @@ const halfPad = {
   small: 'xsmall',
 };
 
+const checkDateFormat = (firstValue, lastValue, full) => {
+  let dateFormat;
+  const startDate = new Date(firstValue);
+  const endDate = new Date(lastValue);
+  if (
+    // check for valid dates, this is the fastest way
+    !Number.isNaN(startDate.getTime()) &&
+    !Number.isNaN(endDate.getTime())
+  ) {
+    const delta = Math.abs(endDate - startDate);
+    let options;
+    if (delta < 60000)
+      // less than 1 minute
+      options = full
+        ? {
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            day: undefined,
+          }
+        : { second: '2-digit', day: undefined };
+    else if (delta < 3600000)
+      // less than 1 hour
+      options = full
+        ? { hour: 'numeric', minute: '2-digit', day: undefined }
+        : { minute: '2-digit', day: undefined };
+    else if (delta < 86400000)
+      // less than 1 day
+      options = { hour: 'numeric' };
+    else if (delta < 2592000000)
+      // less than 30 days
+      options = {
+        month: full ? 'short' : 'numeric',
+        day: 'numeric',
+      };
+    else if (delta < 31557600000)
+      // less than 1 year
+      options = { month: full ? 'long' : 'short' };
+    // 1 year or more
+    else options = { year: 'numeric' };
+    if (options)
+      dateFormat = new Intl.DateTimeFormat(undefined, options).format;
+  }
+  return dateFormat;
+};
+
 const DataChart = forwardRef(
   (
     {
@@ -171,51 +217,11 @@ const DataChart = forwardRef(
       // of values
       let dateFormat;
       if (!xAxis.render && xAxis.key && axis[0].length > 1) {
-        const startDate = new Date(data[Math.floor(axis[0][0])][xAxis.key]);
-        const endDate = new Date(
+        dateFormat = checkDateFormat(
+          data[Math.floor(axis[0][0])][xAxis.key],
           data[Math.floor(axis[0][axis[0].length - 1])][xAxis.key],
+          axis[0].length <= 2,
         );
-        if (
-          // check for valid dates, this is the fastest way
-          !Number.isNaN(startDate.getTime()) &&
-          !Number.isNaN(endDate.getTime())
-        ) {
-          const delta = Math.abs(endDate - startDate);
-          let options;
-          if (delta < 60000)
-            // less than 1 minute
-            options =
-              axis[0].length <= 2
-                ? {
-                    hour: '2-digit',
-                    minute: '2-digit',
-                    second: '2-digit',
-                    day: undefined,
-                  }
-                : { second: '2-digit', day: undefined };
-          else if (delta < 3600000)
-            // less than 1 hour
-            options =
-              axis[0].length <= 2
-                ? { hour: 'numeric', minute: '2-digit', day: undefined }
-                : { minute: '2-digit', day: undefined };
-          else if (delta < 86400000)
-            // less than 1 day
-            options = { hour: 'numeric' };
-          else if (delta < 2592000000)
-            // less than 30 days
-            options = {
-              month: axis[0].length <= 2 ? 'short' : 'numeric',
-              day: 'numeric',
-            };
-          else if (delta < 31557600000)
-            // less than 1 year
-            options = { month: axis[0].length <= 2 ? 'long' : 'short' };
-          // 1 year or more
-          else options = { year: 'numeric' };
-          if (options)
-            dateFormat = new Intl.DateTimeFormat(undefined, options).format;
-        }
       }
 
       xAxisElement = (

--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -322,14 +322,20 @@ const DataChart = forwardRef(
     const stackElement = (
       <Stack gridArea="charts" guidingChild="last" fill={stackFill}>
         {xAxis && xAxis.guide && (
-          <Box fill direction="row" justify="between" pad={pad}>
+          <Box
+            fill
+            direction="row"
+            justify="between"
+            pad={pad}
+            responsive={false}
+          >
             {xGuide.map((_, i) => (
               <Box key={i} border="left" />
             ))}
           </Box>
         )}
         {yAxis && yAxis.guide && (
-          <Box fill justify="between" pad={pad}>
+          <Box fill justify="between" pad={pad} responsive={false}>
             {yGuide.map((_, i) => (
               <Box key={i} border="top" />
             ))}

--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import { ThemeContext } from 'styled-components';
 import { Box } from '../Box';
-import { Chart, calcs } from '../Chart';
+import { Chart, calcs, round } from '../Chart';
 import { Grid } from '../Grid';
 import { Stack } from '../Stack';
 
@@ -185,6 +185,19 @@ const DataChart = forwardRef(
 
     let yAxisElement;
     if (yAxis) {
+      let divideBy;
+      let unit;
+      if (!yAxis.render && !yAxis.suffix) {
+        // figure out how many digits to show
+        const maxValue = Math.max(...axis[1].map(v => Math.abs(v)));
+        if (maxValue > 10000000) {
+          divideBy = 1000000;
+          unit = 'M';
+        } else if (maxValue > 10000) {
+          divideBy = 1000;
+          unit = 'K';
+        }
+      }
       yAxisElement = (
         <Box gridArea="yAxis" justify="between" flex>
           {axis[1].map((axisValue, i) => {
@@ -192,8 +205,12 @@ const DataChart = forwardRef(
             if (yAxis.render) content = yAxis.render(axisValue, i);
             else {
               content = axisValue;
+              if (divideBy) {
+                content = round(content / divideBy, 0);
+              }
               if (yAxis.prefix) content = `${yAxis.prefix}${content}`;
-              if (yAxis.suffix) content = `${content}${yAxis.suffix}`;
+              if (yAxis.suffix || unit)
+                content = `${content}${yAxis.suffix || unit}`;
             }
             return (
               <Box key={i} align="end">

--- a/src/js/components/DataChart/README.md
+++ b/src/js/components/DataChart/README.md
@@ -437,7 +437,9 @@ boolean
 {
   guide: boolean,
   labels: number,
-  render: function
+  prefix: string,
+  render: function,
+  suffix: string
 }
 ```
   

--- a/src/js/components/DataChart/README.md
+++ b/src/js/components/DataChart/README.md
@@ -275,7 +275,7 @@ string
 **pad**
 
 Spacing around the outer edge of
-    the drawing coordinate area for bars and points to overflow into. Defaults to `none`.
+    the drawing coordinate area for the graphic elements to overflow into. Defaults to `none`.
 
 ```
 none

--- a/src/js/components/DataChart/__tests__/DataChart-test.js
+++ b/src/js/components/DataChart/__tests__/DataChart-test.js
@@ -6,8 +6,8 @@ import { Grommet } from '../../Grommet';
 import { DataChart } from '..';
 
 const data = [
-  { a: 1, b: 'one' },
-  { a: 2, b: 'two' },
+  { a: 1, b: 'one', c: 111111 },
+  { a: 2, b: 'two', c: 222222 },
 ];
 
 describe('DataChart', () => {
@@ -25,7 +25,12 @@ describe('DataChart', () => {
     const component = renderer.create(
       <Grommet>
         {['xsmall', 'small', 'medium', 'large', 'xlarge'].map(thickness => (
-          <DataChart data={data} chart={{ key: 'a' }} thickness={thickness} />
+          <DataChart
+            key={thickness}
+            data={data}
+            chart={{ key: 'a' }}
+            thickness={thickness}
+          />
         ))}
       </Grommet>,
     );
@@ -37,7 +42,7 @@ describe('DataChart', () => {
     const component = renderer.create(
       <Grommet>
         {['small', 'medium', 'large'].map(gap => (
-          <DataChart data={data} chart={{ key: 'a' }} gap={gap} />
+          <DataChart key={gap} data={data} chart={{ key: 'a' }} gap={gap} />
         ))}
       </Grommet>,
     );
@@ -49,7 +54,7 @@ describe('DataChart', () => {
     const component = renderer.create(
       <Grommet>
         {['small', 'medium', 'large'].map(pad => (
-          <DataChart data={data} chart={{ key: 'a' }} pad={pad} />
+          <DataChart key={pad} data={data} chart={{ key: 'a' }} pad={pad} />
         ))}
       </Grommet>,
     );
@@ -68,8 +73,9 @@ describe('DataChart', () => {
           'xlarge',
           { width: 'fill' },
           { width: 'auto' },
-        ].map(size => (
-          <DataChart data={data} chart={{ key: 'a' }} size={size} />
+        ].map((size, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <DataChart key={i} data={data} chart={{ key: 'a' }} size={size} />
         ))}
       </Grommet>,
     );
@@ -87,8 +93,9 @@ describe('DataChart', () => {
           { key: 'b' },
           { labels: 2 },
           { key: 'b', render: b => b },
-        ].map(xAxis => (
-          <DataChart data={data} chart={{ key: 'a' }} xAxis={xAxis} />
+        ].map((xAxis, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <DataChart key={i} data={data} chart={{ key: 'a' }} xAxis={xAxis} />
         ))}
       </Grommet>,
     );
@@ -104,11 +111,26 @@ describe('DataChart', () => {
           false,
           { guide: true },
           { labels: 2 },
+          { labels: 5 },
           { render: v => v },
           { prefix: '$' },
           { suffix: '%' },
-        ].map(yAxis => (
-          <DataChart data={data} chart={{ key: 'a' }} yAxis={yAxis} />
+        ].map((yAxis, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <DataChart key={i} data={data} chart={{ key: 'a' }} yAxis={yAxis} />
+        ))}
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('yAxis rounding', () => {
+    const component = renderer.create(
+      <Grommet>
+        {[true, { labels: 4 }].map((yAxis, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <DataChart key={i} data={data} chart={{ key: 'c' }} yAxis={yAxis} />
         ))}
       </Grommet>,
     );

--- a/src/js/components/DataChart/__tests__/DataChart-test.js
+++ b/src/js/components/DataChart/__tests__/DataChart-test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
@@ -96,6 +96,42 @@ describe('DataChart', () => {
         ].map((xAxis, i) => (
           // eslint-disable-next-line react/no-array-index-key
           <DataChart key={i} data={data} chart={{ key: 'a' }} xAxis={xAxis} />
+        ))}
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('xAxis dates', () => {
+    const dateData = [];
+    for (let i = 0; i < 4; i += 1) {
+      dateData.push({
+        second: `2020-05-15T08:04:${((i % 12) + 1).toString().padStart(2, 0)}`,
+        minute: `2020-05-15T08:${((i % 12) + 1).toString().padStart(2, 0)}:00`,
+        hour: `2020-05-15T${((i % 12) + 1).toString().padStart(2, 0)}:00:00`,
+        day: `2020-05-${((i % 12) + 1).toString().padStart(2, 0)}`,
+        month: `2020-${((i % 12) + 1).toString().padStart(2, 0)}-15`,
+        year: `20${((i % 12) + 1).toString().padStart(2, 0)}-01-15`,
+        percent: Math.abs(i * 10),
+        amount: i * 111111,
+      });
+    }
+    const component = renderer.create(
+      <Grommet>
+        {['second', 'minute', 'hour', 'day', 'month', 'year'].map(key => (
+          <Fragment key={key}>
+            <DataChart
+              data={dateData}
+              chart={{ key: 'amount' }}
+              xAxis={{ key, labels: 2 }}
+            />
+            <DataChart
+              data={dateData}
+              chart={{ key: 'percent' }}
+              xAxis={{ key }}
+            />
+          </Fragment>
         ))}
       </Grommet>,
     );

--- a/src/js/components/DataChart/__tests__/DataChart-test.js
+++ b/src/js/components/DataChart/__tests__/DataChart-test.js
@@ -99,11 +99,17 @@ describe('DataChart', () => {
   test('yAxis', () => {
     const component = renderer.create(
       <Grommet>
-        {[true, false, { guide: true }, { labels: 2 }, { render: v => v }].map(
-          yAxis => (
-            <DataChart data={data} chart={{ key: 'a' }} yAxis={yAxis} />
-          ),
-        )}
+        {[
+          true,
+          false,
+          { guide: true },
+          { labels: 2 },
+          { render: v => v },
+          { prefix: '$' },
+          { suffix: '%' },
+        ].map(yAxis => (
+          <DataChart data={data} chart={{ key: 'a' }} yAxis={yAxis} />
+        ))}
       </Grommet>,
     );
     const tree = component.toJSON();

--- a/src/js/components/DataChart/__tests__/DataChart-test.js
+++ b/src/js/components/DataChart/__tests__/DataChart-test.js
@@ -105,7 +105,7 @@ describe('DataChart', () => {
 
   test('xAxis dates', () => {
     const dateData = [];
-    for (let i = 0; i < 4; i += 1) {
+    for (let i = 2; i < 6; i += 1) {
       dateData.push({
         second: `2020-05-15T08:04:${((i % 12) + 1).toString().padStart(2, 0)}`,
         minute: `2020-05-15T08:${((i % 12) + 1).toString().padStart(2, 0)}:00`,

--- a/src/js/components/DataChart/__tests__/DataChart-test.js
+++ b/src/js/components/DataChart/__tests__/DataChart-test.js
@@ -86,7 +86,7 @@ describe('DataChart', () => {
           { guide: true },
           { key: 'b' },
           { labels: 2 },
-          { render: i => data[i].b },
+          { key: 'b', render: b => b },
         ].map(xAxis => (
           <DataChart data={data} chart={{ key: 'a' }} xAxis={xAxis} />
         ))}

--- a/src/js/components/DataChart/__tests__/DataChart-test.js
+++ b/src/js/components/DataChart/__tests__/DataChart-test.js
@@ -105,14 +105,15 @@ describe('DataChart', () => {
 
   test('xAxis dates', () => {
     const dateData = [];
-    for (let i = 2; i < 6; i += 1) {
+    for (let i = 0; i < 4; i += 1) {
+      const digits = ((i % 12) + 1).toString().padStart(2, 0);
       dateData.push({
-        second: `2020-05-15T08:04:${((i % 12) + 1).toString().padStart(2, 0)}`,
-        minute: `2020-05-15T08:${((i % 12) + 1).toString().padStart(2, 0)}:00`,
-        hour: `2020-05-15T${((i % 12) + 1).toString().padStart(2, 0)}:00:00`,
-        day: `2020-05-${((i % 12) + 1).toString().padStart(2, 0)}`,
-        month: `2020-${((i % 12) + 1).toString().padStart(2, 0)}-15`,
-        year: `20${((i % 12) + 1).toString().padStart(2, 0)}-01-15`,
+        second: `2020-05-15T08:04:${digits}`,
+        minute: `2020-05-15T08:${digits}:00`,
+        hour: `2020-05-15T${digits}:00:00`,
+        day: `2020-05-${digits}T08:00:00`,
+        month: `2020-${digits}-15`,
+        year: `20${digits}-01-15`,
         percent: Math.abs(i * 10),
         amount: i * 111111,
       });

--- a/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
+++ b/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
@@ -754,7 +754,7 @@ exports[`DataChart thickness 1`] = `
         className="c3"
         height={192}
         preserveAspectRatio="none"
-        viewBox="0 0 384 192"
+        viewBox="-3 0 390 192"
         width={384}
       >
         <g
@@ -2536,7 +2536,6 @@ exports[`DataChart yAxis 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  max-width: 100%;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
@@ -2546,6 +2545,13 @@ exports[`DataChart yAxis 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex-basis: 24px;
+  -ms-flex-preferred-size: 24px;
+  flex-basis: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c5 {
@@ -2585,6 +2591,8 @@ exports[`DataChart yAxis 1`] = `
   justify-content: space-between;
   padding-left: 48px;
   padding-right: 48px;
+  padding-top: 12px;
+  padding-bottom: 12px;
 }
 
 .c11 {
@@ -2634,6 +2642,13 @@ exports[`DataChart yAxis 1`] = `
 }
 
 @media only screen and (max-width:768px) {
+  .c10 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
   .c11 {
     border-top: solid 1px rgba(0,0,0,0.33);
   }
@@ -2676,7 +2691,7 @@ exports[`DataChart yAxis 1`] = `
           className="c8"
           height={192}
           preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
+          viewBox="-48 -12 480 216"
           width={384}
         >
           <g
@@ -2795,7 +2810,7 @@ exports[`DataChart yAxis 1`] = `
           className="c8"
           height={192}
           preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
+          viewBox="-48 -12 480 216"
           width={384}
         >
           <g
@@ -2860,7 +2875,7 @@ exports[`DataChart yAxis 1`] = `
           className="c8"
           height={192}
           preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
+          viewBox="-48 -12 480 216"
           width={384}
         >
           <g
@@ -2940,7 +2955,7 @@ exports[`DataChart yAxis 1`] = `
           className="c8"
           height={192}
           preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
+          viewBox="-48 -12 480 216"
           width={384}
         >
           <g
@@ -3005,7 +3020,7 @@ exports[`DataChart yAxis 1`] = `
           className="c8"
           height={192}
           preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
+          viewBox="-48 -12 480 216"
           width={384}
         >
           <g
@@ -3070,7 +3085,7 @@ exports[`DataChart yAxis 1`] = `
           className="c8"
           height={192}
           preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
+          viewBox="-48 -12 480 216"
           width={384}
         >
           <g
@@ -3135,7 +3150,7 @@ exports[`DataChart yAxis 1`] = `
           className="c8"
           height={192}
           preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
+          viewBox="-48 -12 480 216"
           width={384}
         >
           <g
@@ -3236,7 +3251,6 @@ exports[`DataChart yAxis rounding 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  max-width: 100%;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
@@ -3246,6 +3260,13 @@ exports[`DataChart yAxis rounding 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex-basis: 24px;
+  -ms-flex-preferred-size: 24px;
+  flex-basis: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c5 {
@@ -3318,7 +3339,7 @@ exports[`DataChart yAxis rounding 1`] = `
           className="c8"
           height={192}
           preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
+          viewBox="-48 -12 480 216"
           width={384}
         >
           <g
@@ -3393,7 +3414,7 @@ exports[`DataChart yAxis rounding 1`] = `
           className="c8"
           height={192}
           preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
+          viewBox="-48 -12 480 216"
           width={384}
         >
           <g

--- a/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
+++ b/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
@@ -1874,6 +1874,86 @@ exports[`DataChart yAxis 1`] = `
         <div
           className="c4"
         >
+          1.7
+        </div>
+        <div
+          className="c4"
+        >
+          1.4
+        </div>
+        <div
+          className="c4"
+        >
+          1.1
+        </div>
+        <div
+          className="c4"
+        >
+          0.8
+        </div>
+      </div>
+      <div
+        className="c5"
+      />
+    </div>
+    <div
+      className="c6"
+    >
+      <div
+        className="c7"
+      >
+        <svg
+          className="c8"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,0"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <div
+          className="c4"
+        >
+          2
+        </div>
+        <div
+          className="c4"
+        >
           0.8
         </div>
       </div>
@@ -2045,6 +2125,264 @@ exports[`DataChart yAxis 1`] = `
               <title />
               <path
                 d="M 384,192 L 384,0"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataChart yAxis rounding 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: yAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c8 {
+  display: block;
+  max-width: 100%;
+  overflow: visible;
+}
+
+.c6 {
+  position: relative;
+  grid-area: charts;
+}
+
+.c7 {
+  position: relative;
+  display: block;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <div
+          className="c4"
+        >
+          240K
+        </div>
+        <div
+          className="c4"
+        >
+          100K
+        </div>
+      </div>
+      <div
+        className="c5"
+      />
+    </div>
+    <div
+      className="c6"
+    >
+      <div
+        className="c7"
+      >
+        <svg
+          className="c8"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,176.76205714285715"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,24.38125714285715"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <div
+          className="c4"
+        >
+          240K
+        </div>
+        <div
+          className="c4"
+        >
+          193K
+        </div>
+        <div
+          className="c4"
+        >
+          147K
+        </div>
+        <div
+          className="c4"
+        >
+          100K
+        </div>
+      </div>
+      <div
+        className="c5"
+      />
+    </div>
+    <div
+      className="c6"
+    >
+      <div
+        className="c7"
+      >
+        <svg
+          className="c8"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,176.76205714285715"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,24.38125714285715"
               />
             </g>
           </g>

--- a/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
+++ b/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
@@ -1922,5 +1922,135 @@ exports[`DataChart yAxis 1`] = `
       </div>
     </div>
   </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <div
+          className="c4"
+        >
+          $2
+        </div>
+        <div
+          className="c4"
+        >
+          $0.8
+        </div>
+      </div>
+      <div
+        className="c5"
+      />
+    </div>
+    <div
+      className="c6"
+    >
+      <div
+        className="c7"
+      >
+        <svg
+          className="c8"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,0"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <div
+          className="c4"
+        >
+          2%
+        </div>
+        <div
+          className="c4"
+        >
+          0.8%
+        </div>
+      </div>
+      <div
+        className="c5"
+      />
+    </div>
+    <div
+      className="c6"
+    >
+      <div
+        className="c7"
+      >
+        <svg
+          className="c8"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,0"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
+++ b/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
@@ -1073,13 +1073,6 @@ exports[`DataChart xAxis 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
-    padding-left: 24px;
-    padding-right: 24px;
-  }
-}
-
-@media only screen and (max-width:768px) {
   .c9 {
     border-left: solid 1px rgba(0,0,0,0.33);
   }
@@ -1546,7 +1539,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 0,192 L 0,185.29536"
+                d="M 0,192 L 0,192"
               />
             </g>
             <g
@@ -1554,7 +1547,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 128,192 L 128,124.34304"
+                d="M 128,192 L 128,131.04768"
               />
             </g>
             <g
@@ -1562,7 +1555,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 256,192 L 256,63.390720000000016"
+                d="M 256,192 L 256,70.09536000000001"
               />
             </g>
             <g
@@ -1570,7 +1563,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 384,192 L 384,2.4384000000000015"
+                d="M 384,192 L 384,9.143040000000013"
               />
             </g>
           </g>
@@ -1583,12 +1576,12 @@ exports[`DataChart xAxis dates 1`] = `
       <div
         className="c1"
       >
-        08:04:03 AM
+        08:04:01 AM
       </div>
       <div
         className="c1"
       >
-        08:04:06 AM
+        08:04:04 AM
       </div>
     </div>
   </div>
@@ -1620,7 +1613,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 0,192 L 0,181.33333333333334"
+                d="M 0,192 L 0,192"
               />
             </g>
             <g
@@ -1628,7 +1621,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 128,192 L 128,128"
+                d="M 128,192 L 128,138.66666666666669"
               />
             </g>
             <g
@@ -1636,7 +1629,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 256,192 L 256,74.66666666666667"
+                d="M 256,192 L 256,85.33333333333334"
               />
             </g>
             <g
@@ -1644,7 +1637,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 384,192 L 384,21.333333333333343"
+                d="M 384,192 L 384,32"
               />
             </g>
           </g>
@@ -1654,6 +1647,16 @@ exports[`DataChart xAxis dates 1`] = `
     <div
       className="c5"
     >
+      <div
+        className="c6"
+      >
+        1
+      </div>
+      <div
+        className="c6"
+      >
+        2
+      </div>
       <div
         className="c6"
       >
@@ -1664,15 +1667,79 @@ exports[`DataChart xAxis dates 1`] = `
       >
         4
       </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
       <div
-        className="c6"
+        className="c3"
       >
-        5
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c1"
+      >
+        8:01 AM
       </div>
       <div
-        className="c6"
+        className="c1"
       >
-        6
+        8:04 AM
       </div>
     </div>
   </div>
@@ -1704,7 +1771,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 0,192 L 0,185.29536"
+                d="M 0,192 L 0,192"
               />
             </g>
             <g
@@ -1712,7 +1779,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 128,192 L 128,124.34304"
+                d="M 128,192 L 128,138.66666666666669"
               />
             </g>
             <g
@@ -1720,7 +1787,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 256,192 L 256,63.390720000000016"
+                d="M 256,192 L 256,85.33333333333334"
               />
             </g>
             <g
@@ -1728,7 +1795,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 384,192 L 384,2.4384000000000015"
+                d="M 384,192 L 384,32"
               />
             </g>
           </g>
@@ -1739,79 +1806,15 @@ exports[`DataChart xAxis dates 1`] = `
       className="c5"
     >
       <div
-        className="c1"
+        className="c6"
       >
-        8:03 AM
+        1
       </div>
       <div
-        className="c1"
+        className="c6"
       >
-        8:06 AM
+        2
       </div>
-    </div>
-  </div>
-  <div
-    className="c1"
-  >
-    <div
-      className="c2"
-    >
-      <div
-        className="c3"
-      >
-        <svg
-          className="c4"
-          height={192}
-          preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
-          width={384}
-        >
-          <g
-            fill="none"
-            stroke="#6FFFB0"
-            strokeLinecap="butt"
-            strokeLinejoin="miter"
-            strokeWidth={96}
-          >
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 0,192 L 0,181.33333333333334"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 128,192 L 128,128"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 256,192 L 256,74.66666666666667"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 384,192 L 384,21.333333333333343"
-              />
-            </g>
-          </g>
-        </svg>
-      </div>
-    </div>
-    <div
-      className="c5"
-    >
       <div
         className="c6"
       >
@@ -1822,15 +1825,79 @@ exports[`DataChart xAxis dates 1`] = `
       >
         4
       </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
       <div
-        className="c6"
+        className="c3"
       >
-        5
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c1"
+      >
+        1 AM
       </div>
       <div
-        className="c6"
+        className="c1"
       >
-        6
+        4 AM
       </div>
     </div>
   </div>
@@ -1862,7 +1929,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 0,192 L 0,185.29536"
+                d="M 0,192 L 0,192"
               />
             </g>
             <g
@@ -1870,7 +1937,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 128,192 L 128,124.34304"
+                d="M 128,192 L 128,138.66666666666669"
               />
             </g>
             <g
@@ -1878,7 +1945,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 256,192 L 256,63.390720000000016"
+                d="M 256,192 L 256,85.33333333333334"
               />
             </g>
             <g
@@ -1886,7 +1953,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 384,192 L 384,2.4384000000000015"
+                d="M 384,192 L 384,32"
               />
             </g>
           </g>
@@ -1897,79 +1964,15 @@ exports[`DataChart xAxis dates 1`] = `
       className="c5"
     >
       <div
-        className="c1"
+        className="c6"
       >
-        3 AM
+        1 AM
       </div>
       <div
-        className="c1"
+        className="c6"
       >
-        6 AM
+        2 AM
       </div>
-    </div>
-  </div>
-  <div
-    className="c1"
-  >
-    <div
-      className="c2"
-    >
-      <div
-        className="c3"
-      >
-        <svg
-          className="c4"
-          height={192}
-          preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
-          width={384}
-        >
-          <g
-            fill="none"
-            stroke="#6FFFB0"
-            strokeLinecap="butt"
-            strokeLinejoin="miter"
-            strokeWidth={96}
-          >
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 0,192 L 0,181.33333333333334"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 128,192 L 128,128"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 256,192 L 256,74.66666666666667"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 384,192 L 384,21.333333333333343"
-              />
-            </g>
-          </g>
-        </svg>
-      </div>
-    </div>
-    <div
-      className="c5"
-    >
       <div
         className="c6"
       >
@@ -1980,15 +1983,79 @@ exports[`DataChart xAxis dates 1`] = `
       >
         4 AM
       </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
       <div
-        className="c6"
+        className="c3"
       >
-        5 AM
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c1"
+      >
+        May 1
       </div>
       <div
-        className="c6"
+        className="c1"
       >
-        6 AM
+        May 4
       </div>
     </div>
   </div>
@@ -2020,7 +2087,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 0,192 L 0,185.29536"
+                d="M 0,192 L 0,192"
               />
             </g>
             <g
@@ -2028,7 +2095,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 128,192 L 128,124.34304"
+                d="M 128,192 L 128,138.66666666666669"
               />
             </g>
             <g
@@ -2036,7 +2103,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 256,192 L 256,63.390720000000016"
+                d="M 256,192 L 256,85.33333333333334"
               />
             </g>
             <g
@@ -2044,7 +2111,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 384,192 L 384,2.4384000000000015"
+                d="M 384,192 L 384,32"
               />
             </g>
           </g>
@@ -2055,79 +2122,10 @@ exports[`DataChart xAxis dates 1`] = `
       className="c5"
     >
       <div
-        className="c1"
+        className="c6"
       >
-        May 2
+        5/1
       </div>
-      <div
-        className="c1"
-      >
-        May 5
-      </div>
-    </div>
-  </div>
-  <div
-    className="c1"
-  >
-    <div
-      className="c2"
-    >
-      <div
-        className="c3"
-      >
-        <svg
-          className="c4"
-          height={192}
-          preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
-          width={384}
-        >
-          <g
-            fill="none"
-            stroke="#6FFFB0"
-            strokeLinecap="butt"
-            strokeLinejoin="miter"
-            strokeWidth={96}
-          >
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 0,192 L 0,181.33333333333334"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 128,192 L 128,128"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 256,192 L 256,74.66666666666667"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 384,192 L 384,21.333333333333343"
-              />
-            </g>
-          </g>
-        </svg>
-      </div>
-    </div>
-    <div
-      className="c5"
-    >
       <div
         className="c6"
       >
@@ -2143,149 +2141,154 @@ exports[`DataChart xAxis dates 1`] = `
       >
         5/4
       </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c1"
+      >
+        January
+      </div>
+      <div
+        className="c1"
+      >
+        April
+      </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,138.66666666666669"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,85.33333333333334"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,32"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
       <div
         className="c6"
       >
-        5/5
-      </div>
-    </div>
-  </div>
-  <div
-    className="c1"
-  >
-    <div
-      className="c2"
-    >
-      <div
-        className="c3"
-      >
-        <svg
-          className="c4"
-          height={192}
-          preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
-          width={384}
-        >
-          <g
-            fill="none"
-            stroke="#6FFFB0"
-            strokeLinecap="butt"
-            strokeLinejoin="miter"
-            strokeWidth={96}
-          >
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 0,192 L 0,185.29536"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 128,192 L 128,124.34304"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 256,192 L 256,63.390720000000016"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 384,192 L 384,2.4384000000000015"
-              />
-            </g>
-          </g>
-        </svg>
-      </div>
-    </div>
-    <div
-      className="c5"
-    >
-      <div
-        className="c1"
-      >
-        March
+        Jan
       </div>
       <div
-        className="c1"
+        className="c6"
       >
-        June
+        Feb
       </div>
-    </div>
-  </div>
-  <div
-    className="c1"
-  >
-    <div
-      className="c2"
-    >
-      <div
-        className="c3"
-      >
-        <svg
-          className="c4"
-          height={192}
-          preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
-          width={384}
-        >
-          <g
-            fill="none"
-            stroke="#6FFFB0"
-            strokeLinecap="butt"
-            strokeLinejoin="miter"
-            strokeWidth={96}
-          >
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 0,192 L 0,181.33333333333334"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 128,192 L 128,128"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 256,192 L 256,74.66666666666667"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 384,192 L 384,21.333333333333343"
-              />
-            </g>
-          </g>
-        </svg>
-      </div>
-    </div>
-    <div
-      className="c5"
-    >
       <div
         className="c6"
       >
@@ -2296,15 +2299,79 @@ exports[`DataChart xAxis dates 1`] = `
       >
         Apr
       </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
       <div
-        className="c6"
+        className="c3"
       >
-        May
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c1"
+      >
+        2001
       </div>
       <div
-        className="c6"
+        className="c1"
       >
-        Jun
+        2004
       </div>
     </div>
   </div>
@@ -2336,7 +2403,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 0,192 L 0,185.29536"
+                d="M 0,192 L 0,192"
               />
             </g>
             <g
@@ -2344,7 +2411,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 128,192 L 128,124.34304"
+                d="M 128,192 L 128,138.66666666666669"
               />
             </g>
             <g
@@ -2352,7 +2419,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 256,192 L 256,63.390720000000016"
+                d="M 256,192 L 256,85.33333333333334"
               />
             </g>
             <g
@@ -2360,7 +2427,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 384,192 L 384,2.4384000000000015"
+                d="M 384,192 L 384,32"
               />
             </g>
           </g>
@@ -2371,79 +2438,15 @@ exports[`DataChart xAxis dates 1`] = `
       className="c5"
     >
       <div
-        className="c1"
+        className="c6"
       >
-        2003
+        2001
       </div>
       <div
-        className="c1"
+        className="c6"
       >
-        2006
+        2002
       </div>
-    </div>
-  </div>
-  <div
-    className="c1"
-  >
-    <div
-      className="c2"
-    >
-      <div
-        className="c3"
-      >
-        <svg
-          className="c4"
-          height={192}
-          preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
-          width={384}
-        >
-          <g
-            fill="none"
-            stroke="#6FFFB0"
-            strokeLinecap="butt"
-            strokeLinejoin="miter"
-            strokeWidth={96}
-          >
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 0,192 L 0,181.33333333333334"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 128,192 L 128,128"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 256,192 L 256,74.66666666666667"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 384,192 L 384,21.333333333333343"
-              />
-            </g>
-          </g>
-        </svg>
-      </div>
-    </div>
-    <div
-      className="c5"
-    >
       <div
         className="c6"
       >
@@ -2453,16 +2456,6 @@ exports[`DataChart xAxis dates 1`] = `
         className="c6"
       >
         2004
-      </div>
-      <div
-        className="c6"
-      >
-        2005
-      </div>
-      <div
-        className="c6"
-      >
-        2006
       </div>
     </div>
   </div>
@@ -2632,20 +2625,6 @@ exports[`DataChart yAxis 1`] = `
   left: 0;
   bottom: 0;
   right: 0;
-}
-
-@media only screen and (max-width:768px) {
-  .c10 {
-    padding-left: 24px;
-    padding-right: 24px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c10 {
-    padding-top: 6px;
-    padding-bottom: 6px;
-  }
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
+++ b/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
@@ -1435,6 +1435,1040 @@ exports[`DataChart xAxis 1`] = `
 </div>
 `;
 
+exports[`DataChart xAxis dates 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: xAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex-basis: 96px;
+  -ms-flex-preferred-size: 96px;
+  flex-basis: 96px;
+}
+
+.c4 {
+  display: block;
+  max-width: 100%;
+  overflow: visible;
+}
+
+.c2 {
+  position: relative;
+  grid-area: charts;
+}
+
+.c3 {
+  position: relative;
+  display: block;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c1"
+      >
+        08:04:01 AM
+      </div>
+      <div
+        className="c1"
+      >
+        08:04:04 AM
+      </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,138.66666666666669"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,85.33333333333334"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,32"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c6"
+      >
+        1
+      </div>
+      <div
+        className="c6"
+      >
+        2
+      </div>
+      <div
+        className="c6"
+      >
+        3
+      </div>
+      <div
+        className="c6"
+      >
+        4
+      </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c1"
+      >
+        8:01 AM
+      </div>
+      <div
+        className="c1"
+      >
+        8:04 AM
+      </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,138.66666666666669"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,85.33333333333334"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,32"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c6"
+      >
+        1
+      </div>
+      <div
+        className="c6"
+      >
+        2
+      </div>
+      <div
+        className="c6"
+      >
+        3
+      </div>
+      <div
+        className="c6"
+      >
+        4
+      </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c1"
+      >
+        1 AM
+      </div>
+      <div
+        className="c1"
+      >
+        4 AM
+      </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,138.66666666666669"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,85.33333333333334"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,32"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c6"
+      >
+        1 AM
+      </div>
+      <div
+        className="c6"
+      >
+        2 AM
+      </div>
+      <div
+        className="c6"
+      >
+        3 AM
+      </div>
+      <div
+        className="c6"
+      >
+        4 AM
+      </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c1"
+      >
+        Apr 30
+      </div>
+      <div
+        className="c1"
+      >
+        May 3
+      </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,138.66666666666669"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,85.33333333333334"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,32"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c6"
+      >
+        4/30
+      </div>
+      <div
+        className="c6"
+      >
+        5/1
+      </div>
+      <div
+        className="c6"
+      >
+        5/2
+      </div>
+      <div
+        className="c6"
+      >
+        5/3
+      </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c1"
+      >
+        January
+      </div>
+      <div
+        className="c1"
+      >
+        April
+      </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,138.66666666666669"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,85.33333333333334"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,32"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c6"
+      >
+        Jan
+      </div>
+      <div
+        className="c6"
+      >
+        Feb
+      </div>
+      <div
+        className="c6"
+      >
+        Mar
+      </div>
+      <div
+        className="c6"
+      >
+        Apr
+      </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c1"
+      >
+        2001
+      </div>
+      <div
+        className="c1"
+      >
+        2004
+      </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,138.66666666666669"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,85.33333333333334"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,32"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
+      <div
+        className="c6"
+      >
+        2001
+      </div>
+      <div
+        className="c6"
+      >
+        2002
+      </div>
+      <div
+        className="c6"
+      >
+        2003
+      </div>
+      <div
+        className="c6"
+      >
+        2004
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DataChart yAxis 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
+++ b/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
@@ -1546,7 +1546,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 0,192 L 0,192"
+                d="M 0,192 L 0,185.29536"
               />
             </g>
             <g
@@ -1554,7 +1554,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 128,192 L 128,131.04768"
+                d="M 128,192 L 128,124.34304"
               />
             </g>
             <g
@@ -1562,7 +1562,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 256,192 L 256,70.09536000000001"
+                d="M 256,192 L 256,63.390720000000016"
               />
             </g>
             <g
@@ -1570,7 +1570,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 384,192 L 384,9.143040000000013"
+                d="M 384,192 L 384,2.4384000000000015"
               />
             </g>
           </g>
@@ -1583,12 +1583,12 @@ exports[`DataChart xAxis dates 1`] = `
       <div
         className="c1"
       >
-        08:04:01 AM
+        08:04:03 AM
       </div>
       <div
         className="c1"
       >
-        08:04:04 AM
+        08:04:06 AM
       </div>
     </div>
   </div>
@@ -1620,7 +1620,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 0,192 L 0,192"
+                d="M 0,192 L 0,181.33333333333334"
               />
             </g>
             <g
@@ -1628,7 +1628,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 128,192 L 128,138.66666666666669"
+                d="M 128,192 L 128,128"
               />
             </g>
             <g
@@ -1636,7 +1636,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 256,192 L 256,85.33333333333334"
+                d="M 256,192 L 256,74.66666666666667"
               />
             </g>
             <g
@@ -1644,7 +1644,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 384,192 L 384,32"
+                d="M 384,192 L 384,21.333333333333343"
               />
             </g>
           </g>
@@ -1654,16 +1654,6 @@ exports[`DataChart xAxis dates 1`] = `
     <div
       className="c5"
     >
-      <div
-        className="c6"
-      >
-        1
-      </div>
-      <div
-        className="c6"
-      >
-        2
-      </div>
       <div
         className="c6"
       >
@@ -1674,79 +1664,15 @@ exports[`DataChart xAxis dates 1`] = `
       >
         4
       </div>
-    </div>
-  </div>
-  <div
-    className="c1"
-  >
-    <div
-      className="c2"
-    >
       <div
-        className="c3"
+        className="c6"
       >
-        <svg
-          className="c4"
-          height={192}
-          preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
-          width={384}
-        >
-          <g
-            fill="none"
-            stroke="#6FFFB0"
-            strokeLinecap="butt"
-            strokeLinejoin="miter"
-            strokeWidth={96}
-          >
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 0,192 L 0,192"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 128,192 L 128,131.04768"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 256,192 L 256,70.09536000000001"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 384,192 L 384,9.143040000000013"
-              />
-            </g>
-          </g>
-        </svg>
-      </div>
-    </div>
-    <div
-      className="c5"
-    >
-      <div
-        className="c1"
-      >
-        8:01 AM
+        5
       </div>
       <div
-        className="c1"
+        className="c6"
       >
-        8:04 AM
+        6
       </div>
     </div>
   </div>
@@ -1778,7 +1704,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 0,192 L 0,192"
+                d="M 0,192 L 0,185.29536"
               />
             </g>
             <g
@@ -1786,7 +1712,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 128,192 L 128,138.66666666666669"
+                d="M 128,192 L 128,124.34304"
               />
             </g>
             <g
@@ -1794,7 +1720,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 256,192 L 256,85.33333333333334"
+                d="M 256,192 L 256,63.390720000000016"
               />
             </g>
             <g
@@ -1802,7 +1728,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 384,192 L 384,32"
+                d="M 384,192 L 384,2.4384000000000015"
               />
             </g>
           </g>
@@ -1813,15 +1739,79 @@ exports[`DataChart xAxis dates 1`] = `
       className="c5"
     >
       <div
-        className="c6"
+        className="c1"
       >
-        1
+        8:03 AM
       </div>
       <div
-        className="c6"
+        className="c1"
       >
-        2
+        8:06 AM
       </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,181.33333333333334"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,128"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,74.66666666666667"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,21.333333333333343"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
       <div
         className="c6"
       >
@@ -1832,79 +1822,15 @@ exports[`DataChart xAxis dates 1`] = `
       >
         4
       </div>
-    </div>
-  </div>
-  <div
-    className="c1"
-  >
-    <div
-      className="c2"
-    >
       <div
-        className="c3"
+        className="c6"
       >
-        <svg
-          className="c4"
-          height={192}
-          preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
-          width={384}
-        >
-          <g
-            fill="none"
-            stroke="#6FFFB0"
-            strokeLinecap="butt"
-            strokeLinejoin="miter"
-            strokeWidth={96}
-          >
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 0,192 L 0,192"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 128,192 L 128,131.04768"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 256,192 L 256,70.09536000000001"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 384,192 L 384,9.143040000000013"
-              />
-            </g>
-          </g>
-        </svg>
-      </div>
-    </div>
-    <div
-      className="c5"
-    >
-      <div
-        className="c1"
-      >
-        1 AM
+        5
       </div>
       <div
-        className="c1"
+        className="c6"
       >
-        4 AM
+        6
       </div>
     </div>
   </div>
@@ -1936,7 +1862,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 0,192 L 0,192"
+                d="M 0,192 L 0,185.29536"
               />
             </g>
             <g
@@ -1944,7 +1870,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 128,192 L 128,138.66666666666669"
+                d="M 128,192 L 128,124.34304"
               />
             </g>
             <g
@@ -1952,7 +1878,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 256,192 L 256,85.33333333333334"
+                d="M 256,192 L 256,63.390720000000016"
               />
             </g>
             <g
@@ -1960,7 +1886,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 384,192 L 384,32"
+                d="M 384,192 L 384,2.4384000000000015"
               />
             </g>
           </g>
@@ -1971,15 +1897,79 @@ exports[`DataChart xAxis dates 1`] = `
       className="c5"
     >
       <div
-        className="c6"
+        className="c1"
       >
-        1 AM
+        3 AM
       </div>
       <div
-        className="c6"
+        className="c1"
       >
-        2 AM
+        6 AM
       </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,181.33333333333334"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,128"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,74.66666666666667"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,21.333333333333343"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
       <div
         className="c6"
       >
@@ -1990,79 +1980,15 @@ exports[`DataChart xAxis dates 1`] = `
       >
         4 AM
       </div>
-    </div>
-  </div>
-  <div
-    className="c1"
-  >
-    <div
-      className="c2"
-    >
       <div
-        className="c3"
+        className="c6"
       >
-        <svg
-          className="c4"
-          height={192}
-          preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
-          width={384}
-        >
-          <g
-            fill="none"
-            stroke="#6FFFB0"
-            strokeLinecap="butt"
-            strokeLinejoin="miter"
-            strokeWidth={96}
-          >
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 0,192 L 0,192"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 128,192 L 128,131.04768"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 256,192 L 256,70.09536000000001"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 384,192 L 384,9.143040000000013"
-              />
-            </g>
-          </g>
-        </svg>
-      </div>
-    </div>
-    <div
-      className="c5"
-    >
-      <div
-        className="c1"
-      >
-        Apr 30
+        5 AM
       </div>
       <div
-        className="c1"
+        className="c6"
       >
-        May 3
+        6 AM
       </div>
     </div>
   </div>
@@ -2094,7 +2020,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 0,192 L 0,192"
+                d="M 0,192 L 0,185.29536"
               />
             </g>
             <g
@@ -2102,7 +2028,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 128,192 L 128,138.66666666666669"
+                d="M 128,192 L 128,124.34304"
               />
             </g>
             <g
@@ -2110,7 +2036,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 256,192 L 256,85.33333333333334"
+                d="M 256,192 L 256,63.390720000000016"
               />
             </g>
             <g
@@ -2118,7 +2044,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 384,192 L 384,32"
+                d="M 384,192 L 384,2.4384000000000015"
               />
             </g>
           </g>
@@ -2129,15 +2055,79 @@ exports[`DataChart xAxis dates 1`] = `
       className="c5"
     >
       <div
-        className="c6"
+        className="c1"
       >
-        4/30
+        May 2
       </div>
       <div
-        className="c6"
+        className="c1"
       >
-        5/1
+        May 5
       </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,181.33333333333334"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,128"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,74.66666666666667"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,21.333333333333343"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
       <div
         className="c6"
       >
@@ -2148,79 +2138,15 @@ exports[`DataChart xAxis dates 1`] = `
       >
         5/3
       </div>
-    </div>
-  </div>
-  <div
-    className="c1"
-  >
-    <div
-      className="c2"
-    >
       <div
-        className="c3"
+        className="c6"
       >
-        <svg
-          className="c4"
-          height={192}
-          preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
-          width={384}
-        >
-          <g
-            fill="none"
-            stroke="#6FFFB0"
-            strokeLinecap="butt"
-            strokeLinejoin="miter"
-            strokeWidth={96}
-          >
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 0,192 L 0,192"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 128,192 L 128,131.04768"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 256,192 L 256,70.09536000000001"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 384,192 L 384,9.143040000000013"
-              />
-            </g>
-          </g>
-        </svg>
-      </div>
-    </div>
-    <div
-      className="c5"
-    >
-      <div
-        className="c1"
-      >
-        January
+        5/4
       </div>
       <div
-        className="c1"
+        className="c6"
       >
-        April
+        5/5
       </div>
     </div>
   </div>
@@ -2252,7 +2178,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 0,192 L 0,192"
+                d="M 0,192 L 0,185.29536"
               />
             </g>
             <g
@@ -2260,7 +2186,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 128,192 L 128,138.66666666666669"
+                d="M 128,192 L 128,124.34304"
               />
             </g>
             <g
@@ -2268,7 +2194,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 256,192 L 256,85.33333333333334"
+                d="M 256,192 L 256,63.390720000000016"
               />
             </g>
             <g
@@ -2276,7 +2202,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 384,192 L 384,32"
+                d="M 384,192 L 384,2.4384000000000015"
               />
             </g>
           </g>
@@ -2287,15 +2213,79 @@ exports[`DataChart xAxis dates 1`] = `
       className="c5"
     >
       <div
-        className="c6"
+        className="c1"
       >
-        Jan
+        March
       </div>
       <div
-        className="c6"
+        className="c1"
       >
-        Feb
+        June
       </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,181.33333333333334"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,128"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,74.66666666666667"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,21.333333333333343"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
       <div
         className="c6"
       >
@@ -2306,79 +2296,15 @@ exports[`DataChart xAxis dates 1`] = `
       >
         Apr
       </div>
-    </div>
-  </div>
-  <div
-    className="c1"
-  >
-    <div
-      className="c2"
-    >
       <div
-        className="c3"
+        className="c6"
       >
-        <svg
-          className="c4"
-          height={192}
-          preserveAspectRatio="none"
-          viewBox="-48 0 480 192"
-          width={384}
-        >
-          <g
-            fill="none"
-            stroke="#6FFFB0"
-            strokeLinecap="butt"
-            strokeLinejoin="miter"
-            strokeWidth={96}
-          >
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 0,192 L 0,192"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 128,192 L 128,131.04768"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 256,192 L 256,70.09536000000001"
-              />
-            </g>
-            <g
-              fill="none"
-            >
-              <title />
-              <path
-                d="M 384,192 L 384,9.143040000000013"
-              />
-            </g>
-          </g>
-        </svg>
-      </div>
-    </div>
-    <div
-      className="c5"
-    >
-      <div
-        className="c1"
-      >
-        2001
+        May
       </div>
       <div
-        className="c1"
+        className="c6"
       >
-        2004
+        Jun
       </div>
     </div>
   </div>
@@ -2410,7 +2336,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 0,192 L 0,192"
+                d="M 0,192 L 0,185.29536"
               />
             </g>
             <g
@@ -2418,7 +2344,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 128,192 L 128,138.66666666666669"
+                d="M 128,192 L 128,124.34304"
               />
             </g>
             <g
@@ -2426,7 +2352,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 256,192 L 256,85.33333333333334"
+                d="M 256,192 L 256,63.390720000000016"
               />
             </g>
             <g
@@ -2434,7 +2360,7 @@ exports[`DataChart xAxis dates 1`] = `
             >
               <title />
               <path
-                d="M 384,192 L 384,32"
+                d="M 384,192 L 384,2.4384000000000015"
               />
             </g>
           </g>
@@ -2445,15 +2371,79 @@ exports[`DataChart xAxis dates 1`] = `
       className="c5"
     >
       <div
-        className="c6"
+        className="c1"
       >
-        2001
+        2003
       </div>
       <div
-        className="c6"
+        className="c1"
       >
-        2002
+        2006
       </div>
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={192}
+          preserveAspectRatio="none"
+          viewBox="-48 0 480 192"
+          width={384}
+        >
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            strokeWidth={96}
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 0,192 L 0,181.33333333333334"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 128,192 L 128,128"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 256,192 L 256,74.66666666666667"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 384,192 L 384,21.333333333333343"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+    <div
+      className="c5"
+    >
       <div
         className="c6"
       >
@@ -2463,6 +2453,16 @@ exports[`DataChart xAxis dates 1`] = `
         className="c6"
       >
         2004
+      </div>
+      <div
+        className="c6"
+      >
+        2005
+      </div>
+      <div
+        className="c6"
+      >
+        2006
       </div>
     </div>
   </div>

--- a/src/js/components/DataChart/doc.js
+++ b/src/js/components/DataChart/doc.js
@@ -88,7 +88,7 @@ export const doc = DataChart => {
       PropTypes.string,
     ]).description(`The spacing between the axes and the Charts.`),
     pad: padPropType.description(`Spacing around the outer edge of
-    the drawing coordinate area for bars and points to overflow into.`),
+    the drawing coordinate area for the graphic elements to overflow into.`),
     size: PropTypes.oneOfType([
       PropTypes.oneOf(['fill']),
       PropTypes.shape({

--- a/src/js/components/DataChart/doc.js
+++ b/src/js/components/DataChart/doc.js
@@ -132,7 +132,9 @@ export const doc = DataChart => {
         guide: PropTypes.bool,
         key: PropTypes.string,
         labels: PropTypes.number, // default undefined, all data points
-        render: PropTypes.func, // (dataIndex, axisIndex) => element
+        // (value, data, dataIndex, axisIndex) => element
+        // value is only defined when a 'key' is provided.
+        render: PropTypes.func,
       }),
     ]).description(`x-axis configuration. 'guide' specifies that vertical
     guide lines should be drawn under the Chart, one per label.

--- a/src/js/components/DataChart/doc.js
+++ b/src/js/components/DataChart/doc.js
@@ -148,7 +148,9 @@ export const doc = DataChart => {
       PropTypes.shape({
         guide: PropTypes.bool,
         labels: PropTypes.number, // default 2, top and bottom
+        prefix: PropTypes.string,
         render: PropTypes.func, // (value, axisIndex) => element
+        suffix: PropTypes.string,
       }),
     ]).description(`y-axis configuration. 'guide' specifies that horizontal
     guide lines should be drawn under the Chart, one per label.

--- a/src/js/components/DataChart/index.d.ts
+++ b/src/js/components/DataChart/index.d.ts
@@ -34,7 +34,7 @@ export interface DataChartProps {
   size?: ChartProps["size"];
   thickness?: ChartProps["thickness"];
   xAxis?: boolean | { guide?: boolean, key?: string, labels?: number, render?: (dataIndex: number, axisIndex: number) => (void) };
-  yAxis?: boolean | { guide?: boolean, labels?: number, render?: (value:any, data:{}[], dataIndex: number, axisIndex: number) => (void) };
+  yAxis?: boolean | { guide?: boolean, labels?: number, prefix?: string, render?: (value:any, data:{}[], dataIndex: number, axisIndex: number) => (void), suffix?: string };
 }
 
 declare const DataChart: React.FC<DataChartProps>;

--- a/src/js/components/DataChart/index.d.ts
+++ b/src/js/components/DataChart/index.d.ts
@@ -34,7 +34,7 @@ export interface DataChartProps {
   size?: ChartProps["size"];
   thickness?: ChartProps["thickness"];
   xAxis?: boolean | { guide?: boolean, key?: string, labels?: number, render?: (dataIndex: number, axisIndex: number) => (void) };
-  yAxis?: boolean | { guide?: boolean, labels?: number, render?: (value: (number|string), axisIndex: number) => (void) };
+  yAxis?: boolean | { guide?: boolean, labels?: number, render?: (value:any, data:{}[], dataIndex: number, axisIndex: number) => (void) };
 }
 
 declare const DataChart: React.FC<DataChartProps>;

--- a/src/js/components/DataChart/stories/Axes.js
+++ b/src/js/components/DataChart/stories/Axes.js
@@ -1,16 +1,25 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import { Box, DataChart, Grommet, Text } from 'grommet';
+import { Box, DataChart, Grommet } from 'grommet';
 import { grommet } from 'grommet/themes';
 
 const data = [];
 for (let i = 0; i < 8; i += 1) {
   const v = Math.sin(i / 2.0);
   data.push({
-    date: `2020-${((i % 12) + 1).toString().padStart(2, 0)}-01`,
-    percent: Math.abs(v * 100),
-    amount: i * 111111,
+    // explore variations in date format by changing the xAxis key to
+    // the timer period you are interested in
+    second: `2020-05-15T08:04:${((i % 12) + 1).toString().padStart(2, 0)}`,
+    minute: `2020-05-15T08:${((i % 12) + 1).toString().padStart(2, 0)}:00`,
+    hour: `2020-05-15T${((i % 12) + 1).toString().padStart(2, 0)}:00:00`,
+    day: `2020-05-${((i % 12) + 1).toString().padStart(2, 0)}`,
+    month: `2020-${((i % 12) + 1).toString().padStart(2, 0)}-15`,
+    year: `20${((i % 12) + 1).toString().padStart(2, 0)}-01-15`,
+    // explore variations in yAxis value handling by changing the chart key
+    // to one of these
+    percent: Math.abs(v * 100), // make yAxis suffix '%'
+    amount: i * 111111, // make yAxis prefix '$'
   });
 }
 
@@ -20,17 +29,7 @@ const AxesDataChart = () => (
       <DataChart
         data={data}
         chart={{ key: 'percent' }}
-        xAxis={{
-          key: 'date',
-          guide: true,
-          render: date => (
-            <Text margin={{ horizontal: 'small' }}>
-              {new Date(date).toLocaleDateString('en-US', {
-                month: 'narrow',
-              })}
-            </Text>
-          ),
-        }}
+        xAxis={{ key: 'day', guide: true }}
         yAxis={{ guide: true, labels: 3, suffix: '%' }}
       />
     </Box>

--- a/src/js/components/DataChart/stories/Axes.js
+++ b/src/js/components/DataChart/stories/Axes.js
@@ -10,6 +10,7 @@ for (let i = 0; i < 8; i += 1) {
   data.push({
     date: `2020-${((i % 12) + 1).toString().padStart(2, 0)}-01`,
     percent: Math.abs(v * 100),
+    amount: i * 111111,
   });
 }
 

--- a/src/js/components/DataChart/stories/Axes.js
+++ b/src/js/components/DataChart/stories/Axes.js
@@ -30,7 +30,7 @@ const AxesDataChart = () => (
             </Text>
           ),
         }}
-        yAxis={{ guide: true, labels: 3 }}
+        yAxis={{ guide: true, labels: 3, suffix: '%' }}
       />
     </Box>
   </Grommet>

--- a/src/js/components/DataChart/stories/Axes.js
+++ b/src/js/components/DataChart/stories/Axes.js
@@ -28,7 +28,7 @@ const AxesDataChart = () => (
     <Box align="center" justify="start" pad="large">
       <DataChart
         data={data}
-        chart={{ key: 'percent' }}
+        chart={{ key: 'percent', type: 'bar' }}
         xAxis={{ key: 'day', guide: true }}
         yAxis={{ guide: true, labels: 3, suffix: '%' }}
       />

--- a/src/js/components/DataChart/stories/Axes.js
+++ b/src/js/components/DataChart/stories/Axes.js
@@ -7,15 +7,16 @@ import { grommet } from 'grommet/themes';
 const data = [];
 for (let i = 0; i < 8; i += 1) {
   const v = Math.sin(i / 2.0);
+  const digits = ((i % 12) + 1).toString().padStart(2, 0);
   data.push({
     // explore variations in date format by changing the xAxis key to
     // the timer period you are interested in
-    second: `2020-05-15T08:04:${((i % 12) + 1).toString().padStart(2, 0)}`,
-    minute: `2020-05-15T08:${((i % 12) + 1).toString().padStart(2, 0)}:00`,
-    hour: `2020-05-15T${((i % 12) + 1).toString().padStart(2, 0)}:00:00`,
-    day: `2020-05-${((i % 12) + 1).toString().padStart(2, 0)}`,
-    month: `2020-${((i % 12) + 1).toString().padStart(2, 0)}-15`,
-    year: `20${((i % 12) + 1).toString().padStart(2, 0)}-01-15`,
+    second: `2020-05-15T08:04:${digits}`,
+    minute: `2020-05-15T08:${digits}:00`,
+    hour: `2020-05-15T${digits}:00:00`,
+    day: `2020-05-${digits}`,
+    month: `2020-${digits}-15`,
+    year: `20${digits}-01-15`,
     // explore variations in yAxis value handling by changing the chart key
     // to one of these
     percent: Math.abs(v * 100), // make yAxis suffix '%'

--- a/src/js/components/DataChart/stories/Axes.js
+++ b/src/js/components/DataChart/stories/Axes.js
@@ -22,9 +22,9 @@ const AxesDataChart = () => (
         xAxis={{
           key: 'date',
           guide: true,
-          render: i => (
+          render: date => (
             <Text margin={{ horizontal: 'small' }}>
-              {new Date(data[i].date).toLocaleDateString('en-US', {
+              {new Date(date).toLocaleDateString('en-US', {
                 month: 'narrow',
               })}
             </Text>

--- a/src/js/components/DataChart/stories/Multiple.js
+++ b/src/js/components/DataChart/stories/Multiple.js
@@ -31,10 +31,11 @@ const MultipleDataChart = () => (
         ]}
         xAxis={{
           labels: 2,
-          render: i => (
+          key: 'date',
+          render: date => (
             <Box pad="xsmall" align="start">
               <Text>
-                {new Date(data[i].date).toLocaleDateString('en-US', {
+                {new Date(date).toLocaleDateString('en-US', {
                   month: 'short',
                   day: 'numeric',
                 })}

--- a/src/js/components/DataChart/stories/StackedBars.js
+++ b/src/js/components/DataChart/stories/StackedBars.js
@@ -28,9 +28,10 @@ const Example = () => (
           },
         ]}
         xAxis={{
-          render: i => (
+          key: 'date',
+          render: date => (
             <Text margin={{ horizontal: 'xsmall' }}>
-              {new Date(data[Math.floor(i)].date).toLocaleDateString('en-US', {
+              {new Date(date).toLocaleDateString('en-US', {
                 month: 'numeric',
                 day: 'numeric',
               })}

--- a/src/js/components/DataChart/stories/typescript/Size.tsx
+++ b/src/js/components/DataChart/stories/typescript/Size.tsx
@@ -28,11 +28,10 @@ const Example = () => (
         ]}
         xAxis={{
           guide: true,
-          render: i => (
+          key: 'date',
+          render: date => (
             <Text margin={{ horizontal: 'xsmall' }}>
-              {new Date(data[Math.floor(i)].date).toLocaleDateString('en-US', {
-                month: 'short',
-              })}
+              {new Date(date).toLocaleDateString('en-US', { month: 'short' })}
             </Text>
           ),
         }}

--- a/src/js/components/Grid/README.md
+++ b/src/js/components/Grid/README.md
@@ -322,7 +322,7 @@ stretch
 **pad**
 
 Spacing around the outer edge of
-    the drawing coordinate area for bars and points to overflow into. Defaults to `none`.
+    the drawing coordinate area for the graphic elements to overflow into. Defaults to `none`.
 
 ```
 none

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5537,7 +5537,9 @@ boolean
 {
   guide: boolean,
   labels: number,
-  render: function
+  prefix: string,
+  render: function,
+  suffix: string
 }
 \`\`\`
   

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5375,7 +5375,7 @@ string
 **pad**
 
 Spacing around the outer edge of
-    the drawing coordinate area for bars and points to overflow into. Defaults to \`none\`.
+    the drawing coordinate area for the graphic elements to overflow into. Defaults to \`none\`.
 
 \`\`\`
 none
@@ -7993,7 +7993,7 @@ stretch
 **pad**
 
 Spacing around the outer edge of
-    the drawing coordinate area for bars and points to overflow into. Defaults to \`none\`.
+    the drawing coordinate area for the graphic elements to overflow into. Defaults to \`none\`.
 
 \`\`\`
 none

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -908,7 +908,7 @@ string",
       Object {
         "defaultValue": "none",
         "description": "Spacing around the outer edge of
-    the drawing coordinate area for bars and points to overflow into.",
+    the drawing coordinate area for the graphic elements to overflow into.",
         "format": "none
 xxsmall
 xsmall
@@ -1816,7 +1816,7 @@ string",
       Object {
         "defaultValue": "none",
         "description": "Spacing around the outer edge of
-    the drawing coordinate area for bars and points to overflow into.",
+    the drawing coordinate area for the graphic elements to overflow into.",
         "format": "none
 xxsmall
 xsmall
@@ -2601,7 +2601,7 @@ string",
       Object {
         "defaultValue": "none",
         "description": "Spacing around the outer edge of
-    the drawing coordinate area for bars and points to overflow into.",
+    the drawing coordinate area for the graphic elements to overflow into.",
         "format": "none
 xxsmall
 xsmall

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2750,7 +2750,9 @@ string",
 {
   guide: boolean,
   labels: number,
-  render: function
+  prefix: string,
+  render: function,
+  suffix: string
 }",
         "name": "yAxis",
       },

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -6366,5 +6366,6 @@ boolean",
   },
   "__esModule": true,
   "calcs": [Function],
+  "round": [Function],
 }
 `;


### PR DESCRIPTION
#### What does this PR do?

Changed DataChart to improve axes.

- truncate y-axis values to avoid long fractions
- added prefix and suffix for axis values, to avoid the need for a custom renderer in typical situations
- y-axis with key will check for a date format and use “right” default date format for the span of dates
- align y-axis labels better with guide lines

#### Where should the reviewer start?

DataChart.js

#### What testing has been done on this PR?

enhanced unit tests, enhanced stories

#### How should this be manually tested?

storybook

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

This has a breaking change for the `yAxis.render()` signature. It is now called with `(content, data, dataIndex, axisIndex)` instead of `(dataIndex, axisIndex)`.