### PR TITLE
TS: Add extend type to text

### DIFF
--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -984,6 +984,7 @@ export interface ThemeType {
     };
   };
   text?: {
+    extend?: ExtendType;
     xsmall?: {
       size?: string;
       height?: string;


### PR DESCRIPTION
`text.extend` is not defined in the `ThemeType` definition, causing TS compile to throw an error.

#### What does this PR do?

Adds type definition for the themes `text.extend` 

#### Where should the reviewer start?

`src/js/themes/base.d.ts` -> `ThemeType`

#### What testing has been done on this PR?

Tested locally

#### How should this be manually tested?

Using typescript, attempt to add the following theme:

```
 {
  text: {
    extend: (props: any) => {
      const { value } = props.theme.global.breakpoints.small;
      return `
        @media (max-width: ${value}px) {
          font-size: 16px
        }
      `;
    },
  },
};
```

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

they already reference this property, so no

https://v2.grommet.io/text#text.extend

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Should be backwards compatible
