### PR TITLE
Changed RadioButtonGroup to support numeric values

### DIFF
--- a/src/js/components/RadioButtonGroup/README.md
+++ b/src/js/components/RadioButtonGroup/README.md
@@ -76,6 +76,7 @@ Currently selected option value.
 
 ```
 string
+number
 object
 ```
   

--- a/src/js/components/RadioButtonGroup/README.md
+++ b/src/js/components/RadioButtonGroup/README.md
@@ -57,13 +57,16 @@ Required. Options can be either a string or an object.
 
 ```
 [string]
+[number]
 [{
   disabled: boolean,
   id: string,
   label: 
     string
     element,
-  value: string
+  value: 
+    string
+    number
 }]
 ```
 

--- a/src/js/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/js/components/RadioButtonGroup/RadioButtonGroup.js
@@ -32,10 +32,10 @@ const RadioButtonGroup = forwardRef(
     const options = useMemo(
       () =>
         optionsProp.map(o =>
-          typeof o === 'string'
+          typeof o !== 'object'
             ? {
                 disabled,
-                id: rest.id ? `${rest.id}-${o}` : o,
+                id: rest.id ? `${rest.id}-${o}` : `${o}`, // force string
                 label: o,
                 value: o,
               }
@@ -131,7 +131,7 @@ const RadioButtonGroup = forwardRef(
                 onFocus={onFocus}
                 onBlur={onBlur}
                 onChange={event => {
-                  setValue(event.target.value);
+                  setValue(optionValue);
                   if (onChange) onChange(event);
                 }}
                 {...optionRest}

--- a/src/js/components/RadioButtonGroup/__tests__/RadioButtonGroup-test.js
+++ b/src/js/components/RadioButtonGroup/__tests__/RadioButtonGroup-test.js
@@ -27,6 +27,16 @@ describe('RadioButtonGroup', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  test('number options', () => {
+    const component = renderer.create(
+      <Grommet>
+        <RadioButtonGroup name="test" options={[1, 2]} value="one" />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   test('object options just value', () => {
     const component = renderer.create(
       <Grommet>

--- a/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
+++ b/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
@@ -375,6 +375,203 @@ exports[`RadioButtonGroup default 1`] = `
 </div>
 `;
 
+exports[`RadioButtonGroup number options 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-right: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px rgba(0,0,0,0.15);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 100%;
+}
+
+.c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: pointer;
+}
+
+.c2:hover input:not([disabled]) + div,
+.c2:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c4 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    border: solid 2px rgba(0,0,0,0.15);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    height: 6px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <label
+      className="c2"
+      htmlFor="1"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="c3 "
+      >
+        <input
+          checked={false}
+          className="c4"
+          id="1"
+          name="test"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          type="radio"
+          value={1}
+        />
+        <div
+          className="c5 "
+        />
+      </div>
+      1
+    </label>
+    <div
+      className="c6"
+    />
+    <label
+      className="c2"
+      htmlFor="2"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="c3 "
+      >
+        <input
+          checked={false}
+          className="c4"
+          id="2"
+          name="test"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          type="radio"
+          value={2}
+        />
+        <div
+          className="c5 "
+        />
+      </div>
+      2
+    </label>
+  </div>
+</div>
+`;
+
 exports[`RadioButtonGroup object options 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/RadioButtonGroup/doc.js
+++ b/src/js/components/RadioButtonGroup/doc.js
@@ -48,6 +48,7 @@ export const doc = RadioButtonGroup => {
     Each option is rendered as a single RadioButton.`).isRequired,
     value: PropTypes.oneOfType([
       PropTypes.string,
+      PropTypes.number,
       PropTypes.object,
     ]).description(`Currently selected option value.`),
   };

--- a/src/js/components/RadioButtonGroup/doc.js
+++ b/src/js/components/RadioButtonGroup/doc.js
@@ -34,12 +34,14 @@ export const doc = RadioButtonGroup => {
     ),
     options: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.string),
+      PropTypes.arrayOf(PropTypes.number),
       PropTypes.arrayOf(
         PropTypes.shape({
           disabled: PropTypes.bool,
           id: PropTypes.string,
           label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-          value: PropTypes.string.isRequired,
+          value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+            .isRequired,
         }),
       ),
     ]).description(`Options can be either a string or an object. 

--- a/src/js/components/RadioButtonGroup/index.d.ts
+++ b/src/js/components/RadioButtonGroup/index.d.ts
@@ -5,7 +5,7 @@ export interface RadioButtonGroupProps {
   disabled?: boolean;
   name: string;
   onChange?: ((event: React.ChangeEvent<HTMLInputElement>) => void);
-  options: (string | { disabled?: boolean, id?: string, label?: (string | React.ReactNode), value: string | number })[];
+  options: (string | number | { disabled?: boolean, id?: string, label?: (string | React.ReactNode), value: string | number })[];
   value?: string | number | object;
 }
 

--- a/src/js/components/RadioButtonGroup/index.d.ts
+++ b/src/js/components/RadioButtonGroup/index.d.ts
@@ -5,8 +5,8 @@ export interface RadioButtonGroupProps {
   disabled?: boolean;
   name: string;
   onChange?: ((event: React.ChangeEvent<HTMLInputElement>) => void);
-  options: (string | { disabled?: boolean, id?: string, label?: (string | React.ReactNode), value: string})[];
-  value?: string | object;
+  options: (string | { disabled?: boolean, id?: string, label?: (string | React.ReactNode), value: string | number })[];
+  value?: string | number | object;
 }
 
 declare const RadioButtonGroup: React.ComponentClass<RadioButtonGroupProps & BoxProps & JSX.IntrinsicElements['div']>;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11394,13 +11394,16 @@ Required. Options can be either a string or an object.
 
 \`\`\`
 [string]
+[number]
 [{
   disabled: boolean,
   id: string,
   label: 
     string
     element,
-  value: string
+  value: 
+    string
+    number
 }]
 \`\`\`
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11413,6 +11413,7 @@ Currently selected option value.
 
 \`\`\`
 string
+number
 object
 \`\`\`
   

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -4935,6 +4935,7 @@ with the same name so form submissions work.",
       Object {
         "description": "Currently selected option value.",
         "format": "string
+number
 object",
         "name": "value",
       },

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -4918,13 +4918,16 @@ with the same name so form submissions work.",
         "description": "Options can be either a string or an object. 
     Each option is rendered as a single RadioButton.",
         "format": "[string]
+[number]
 [{
   disabled: boolean,
   id: string,
   label: 
     string
     element,
-  value: string
+  value: 
+    string
+    number
 }]",
         "name": "options",
         "required": true,


### PR DESCRIPTION
#### What does this PR do?

Changed RadioButtonGroup to support numeric values.

This allows setting something to `5` instead of `"5"`.

#### Where should the reviewer start?

doc.js

#### What testing has been done on this PR?

added unit test

#### How should this be manually tested?

see unit test

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
