### PR TITLE
Include RadioButton color reference in basejs and documentation

### DIFF
--- a/src/js/components/RadioButton/README.md
+++ b/src/js/components/RadioButton/README.md
@@ -136,6 +136,17 @@ Defaults to
 100%
 ```
 
+**radioButton.color**
+
+The color of the border surrounding the checked 
+    icon in RadioButton checked state. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+undefined
+```
+
 **radioButton.extend**
 
 Any additional style for the RadioButton. Expects `string | (props) => {}`.

--- a/src/js/components/RadioButton/doc.js
+++ b/src/js/components/RadioButton/doc.js
@@ -76,6 +76,12 @@ export const themeDoc = {
     type: 'string',
     defaultValue: '100%',
   },
+  'radioButton.color': {
+    description: `The color of the border surrounding the checked 
+    icon in RadioButton checked state.`,
+    type: 'string | { dark: string, light: string }',
+    defaultValue: 'undefined',
+  },
   'radioButton.extend': {
     description: 'Any additional style for the RadioButton.',
     type: 'string | (props) => {}',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11275,6 +11275,17 @@ Defaults to
 100%
 \`\`\`
 
+**radioButton.color**
+
+The color of the border surrounding the checked 
+    icon in RadioButton checked state. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
 **radioButton.extend**
 
 Any additional style for the RadioButton. Expects \`string | (props) => {}\`.

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -836,6 +836,7 @@ export interface ThemeType {
     check?: {
       radius?: string;
     };
+    color?: ColorType;
     hover?: {
       border?: {
         color?: ColorType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -858,6 +858,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // color: { dark: undefined, light: undefined },
         // extend: undefined,
       },
+      // color: undefined,
       hover: {
         border: {
           color: {


### PR DESCRIPTION
Signed-off-by: Matt Glissmann <mdglissmann@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds missing documentation for `radioButton.color` in docs and base.js. `radioButton.color` is referenced in implementation here: https://github.com/grommet/grommet/blob/6219ed0086c8673692ff78ca6a31d710f550ed79/src/js/components/RadioButton/RadioButton.js#L29

#### Where should the reviewer start?
base.js & RadioButton/doc.js

#### What testing has been done on this PR?
local env

#### How should this be manually tested?

#### Any background context you want to provide?
Surfaced when implementing theming for https://github.com/hpe-design/design-system/issues/518#issuecomment-639097244

#### What are the relevant issues?
https://github.com/hpe-design/design-system/issues/518

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes.

#### Should this PR be mentioned in the release notes?
Not needed.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.
