### PR TITLE
propagate onKeyDown from container to StyledTextArea via Keyboard; up…

### DIFF
--- a/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
+++ b/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
@@ -1599,12 +1599,12 @@ exports[`DataChart xAxis dates 1`] = `
       <div
         className="c6"
       >
-        08:04:01 AM
+        8:04:01 AM
       </div>
       <div
         className="c6"
       >
-        08:04:04 AM
+        8:04:04 AM
       </div>
     </div>
   </div>

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -581,10 +581,12 @@ exports[`MaskedInput event target props are available option via mouse 4`] = `
   <input
     autocomplete="off"
     class="StyledMaskedInput-sc-99vkfa-0 iiIkNh"
+    data-g-tabindex="none"
     data-testid="test-input"
     id="item"
     name="item"
     placeholder="!"
+    tabindex="-1"
     value=""
   />
 </div>
@@ -1471,10 +1473,12 @@ exports[`MaskedInput option via mouse 4`] = `
   <input
     autocomplete="off"
     class="StyledMaskedInput-sc-99vkfa-0 iiIkNh"
+    data-g-tabindex="none"
     data-testid="test-input"
     id="item"
     name="item"
     placeholder="!"
+    tabindex="-1"
     value=""
   />
 </div>

--- a/src/js/components/TextArea/TextArea.js
+++ b/src/js/components/TextArea/TextArea.js
@@ -7,7 +7,16 @@ import { StyledTextArea } from './StyledTextArea';
 
 const TextArea = forwardRef(
   (
-    { fill, name, onBlur, onChange, onFocus, value: valueProp, ...rest },
+    {
+      fill,
+      name,
+      onBlur,
+      onChange,
+      onFocus,
+      onKeyDown,
+      value: valueProp,
+      ...rest
+    },
     ref,
   ) => {
     const formContext = useContext(FormContext);
@@ -22,6 +31,7 @@ const TextArea = forwardRef(
           event.stopPropagation();
           event.nativeEvent.stopImmediatePropagation();
         }}
+        onKeyDown={onKeyDown}
       >
         <StyledTextArea
           ref={ref}

--- a/src/js/components/TextArea/__tests__/TextArea-test.js
+++ b/src/js/components/TextArea/__tests__/TextArea-test.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
 import { TextArea } from '..';
-
-jest.mock('react-dom');
 
 describe('TextArea', () => {
   test('basic', () => {
@@ -89,6 +88,65 @@ describe('TextArea', () => {
       );
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe('Event tests', () => {
+    afterEach(cleanup);
+    const keyEvent = {
+      key: 'Backspace',
+      keyCode: 8,
+      which: 8,
+    };
+
+    test(`onKeyDown`, () => {
+      let capturedEvent = null;
+      const callback = event => {
+        const { key, keyCode, which } = event;
+        capturedEvent = { key, keyCode, which };
+      };
+
+      const component = render(
+        <Grommet>
+          <TextArea
+            id="item"
+            name="item"
+            placeholder="item"
+            onKeyDown={callback}
+          />
+        </Grommet>,
+      );
+
+      const textArea = component.getByPlaceholderText('item');
+
+      fireEvent.keyDown(textArea, keyEvent);
+
+      expect(capturedEvent).toEqual(expect.objectContaining(keyEvent));
+    });
+
+    test(`onKeyUp`, () => {
+      let capturedEvent = null;
+      const callback = event => {
+        const { key, keyCode, which } = event;
+        capturedEvent = { key, keyCode, which };
+      };
+
+      const component = render(
+        <Grommet>
+          <TextArea
+            id="item"
+            name="item"
+            placeholder="item"
+            onKeyUp={callback}
+          />
+        </Grommet>,
+      );
+
+      const textArea = component.getByPlaceholderText('item');
+
+      fireEvent.keyUp(textArea, keyEvent);
+
+      expect(capturedEvent).toEqual(expect.objectContaining(keyEvent));
     });
   });
 });


### PR DESCRIPTION
#### What does this PR do?

* Allows the TextArea component to receive an onKeyDown handler
* Add tests for TextArea receiving onKeyDown and onKeyUp events

#### Where should the reviewer start?

Take a look at the TextArea component. Strangely the onKeyUp handler was already getting called with no additional changes but the onKeyDown handler needed to be passed to the Keyboard component in order for it to work.

#### What testing has been done on this PR?

Added two unit tests for the TextArea to the existing test file.

#### How should this be manually tested?

Pass in a handler to `TextArea`'s `onKeyDown` prop and verify in dev console that it's being fired.

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/3664

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Possibly counts as a bug fix

#### Is this change backwards compatible or is it a breaking change?

AFAIK this shouldn't break any existing code
