### PR TITLE
Add missing `formField.info` type definition

### DIFF
--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -588,6 +588,10 @@ export interface ThemeType {
       color?: ColorType;
       margin?: MarginType;
     };
+    info?: {
+      color?: ColorType;
+      margin?: MarginType;
+    };
     label?: TextProps;
     margin?: MarginType;
     round?: RoundType;


### PR DESCRIPTION


#### What does this PR do?

Adds missing type definition for `formField.info`

#### Where should the reviewer start?

`themes/base.d.ts` -> `ThemeType`

#### What testing has been done on this PR?

Manually tested

#### How should this be manually tested?

Verify you can add an `info` key to a type theme object.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

They already have this: https://v2.grommet.io/formfield#formField.info.color

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible