### PR TITLE
Add flex={false} to RadioButton

### DIFF
--- a/src/js/components/RadioButton/RadioButton.js
+++ b/src/js/components/RadioButton/RadioButton.js
@@ -44,6 +44,7 @@ const RadioButton = forwardRef(
       >
         <StyledRadioButton
           as={Box}
+          flex={false}
           margin={
             label ? { right: theme.radioButton.gap || 'small' } : undefined
           }

--- a/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
+++ b/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
@@ -23,6 +23,9 @@ exports[`RadioButton basic 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c4 {
@@ -164,6 +167,9 @@ exports[`RadioButton checked 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c4 {
@@ -303,6 +309,9 @@ exports[`RadioButton children 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c4 {
@@ -457,6 +466,9 @@ exports[`RadioButton disabled 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c4 {
@@ -653,6 +665,9 @@ exports[`RadioButton label 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c4 {

--- a/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
+++ b/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
@@ -25,7 +25,24 @@ exports[`RadioButtonGroup adding additional props 1`] = `
   flex-direction: column;
 }
 
-.c4 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -51,7 +68,7 @@ exports[`RadioButtonGroup adding additional props 1`] = `
   border-radius: 100%;
 }
 
-.c5 {
+.c6 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -88,7 +105,7 @@ exports[`RadioButtonGroup adding additional props 1`] = `
   border-color: #000000;
 }
 
-.c3 {
+.c4 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -98,13 +115,13 @@ exports[`RadioButtonGroup adding additional props 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     height: 6px;
   }
 }
@@ -123,11 +140,11 @@ exports[`RadioButtonGroup adding additional props 1`] = `
       onMouseLeave={[Function]}
     >
       <div
-        className="c1 "
+        className="c3 "
       >
         <input
           checked={false}
-          className="c3"
+          className="c4"
           data-testid="testid-1"
           id="ONE"
           name="test"
@@ -138,12 +155,12 @@ exports[`RadioButtonGroup adding additional props 1`] = `
           value="1"
         />
         <div
-          className="c4 "
+          className="c5 "
         />
       </div>
     </label>
     <div
-      className="c5"
+      className="c6"
     />
     <label
       className="c2"
@@ -153,11 +170,11 @@ exports[`RadioButtonGroup adding additional props 1`] = `
       onMouseLeave={[Function]}
     >
       <div
-        className="c1 "
+        className="c3 "
       >
         <input
           checked={false}
-          className="c3"
+          className="c4"
           data-testid="testid-2"
           id="TWO"
           name="test"
@@ -168,7 +185,7 @@ exports[`RadioButtonGroup adding additional props 1`] = `
           value="2"
         />
         <div
-          className="c4 "
+          className="c5 "
         />
       </div>
     </label>
@@ -201,7 +218,24 @@ exports[`RadioButtonGroup children 1`] = `
   flex-direction: column;
 }
 
-.c4 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -218,7 +252,7 @@ exports[`RadioButtonGroup children 1`] = `
   padding: 12px;
 }
 
-.c5 {
+.c6 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -255,7 +289,7 @@ exports[`RadioButtonGroup children 1`] = `
   border-color: #000000;
 }
 
-.c3 {
+.c4 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -265,13 +299,13 @@ exports[`RadioButtonGroup children 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     height: 6px;
   }
 }
@@ -290,11 +324,11 @@ exports[`RadioButtonGroup children 1`] = `
       onMouseLeave={[Function]}
     >
       <div
-        className="c1 "
+        className="c3 "
       >
         <input
           checked={true}
-          className="c3"
+          className="c4"
           id="one"
           name="test"
           onBlur={[Function]}
@@ -304,12 +338,12 @@ exports[`RadioButtonGroup children 1`] = `
           value="one"
         />
         <div
-          className="c4"
+          className="c5"
         />
       </div>
     </label>
     <div
-      className="c5"
+      className="c6"
     />
     <label
       className="c2"
@@ -319,11 +353,11 @@ exports[`RadioButtonGroup children 1`] = `
       onMouseLeave={[Function]}
     >
       <div
-        className="c1 "
+        className="c3 "
       >
         <input
           checked={false}
-          className="c3"
+          className="c4"
           id="two"
           name="test"
           onBlur={[Function]}
@@ -333,7 +367,7 @@ exports[`RadioButtonGroup children 1`] = `
           value="two"
         />
         <div
-          className="c4"
+          className="c5"
         />
       </div>
     </label>
@@ -413,6 +447,9 @@ exports[`RadioButtonGroup number options 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c5 {
@@ -610,6 +647,9 @@ exports[`RadioButtonGroup object options 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c5 {
@@ -798,7 +838,24 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   flex-direction: column;
 }
 
-.c4 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -824,7 +881,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   border-radius: 100%;
 }
 
-.c5 {
+.c6 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -862,7 +919,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   border-color: #000000;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -884,12 +941,12 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   cursor: pointer;
 }
 
-.c6:hover input:not([disabled]) + div,
-.c6:hover input:not([disabled]) + span {
+.c7:hover input:not([disabled]) + div,
+.c7:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c3 {
+.c4 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -897,7 +954,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   margin: 0;
 }
 
-.c7 {
+.c8 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -907,13 +964,13 @@ exports[`RadioButtonGroup object options disabled 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     height: 6px;
   }
 }
@@ -932,11 +989,11 @@ exports[`RadioButtonGroup object options disabled 1`] = `
       onMouseLeave={[Function]}
     >
       <div
-        className="c1 "
+        className="c3 "
       >
         <input
           checked={false}
-          className="c3"
+          className="c4"
           disabled={true}
           name="test"
           onBlur={[Function]}
@@ -946,25 +1003,25 @@ exports[`RadioButtonGroup object options disabled 1`] = `
           value="one"
         />
         <div
-          className="c4 "
+          className="c5 "
         />
       </div>
     </label>
     <div
-      className="c5"
+      className="c6"
     />
     <label
-      className="c6"
+      className="c7"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
     >
       <div
-        className="c1 "
+        className="c3 "
       >
         <input
           checked={false}
-          className="c7"
+          className="c8"
           name="test"
           onBlur={[Function]}
           onChange={[Function]}
@@ -973,7 +1030,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
           value="two"
         />
         <div
-          className="c4 "
+          className="c5 "
         />
       </div>
     </label>
@@ -1006,7 +1063,24 @@ exports[`RadioButtonGroup object options just value 1`] = `
   flex-direction: column;
 }
 
-.c4 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1032,7 +1106,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
   border-radius: 100%;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1058,7 +1132,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
   border-radius: 100%;
 }
 
-.c5 {
+.c6 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -1095,7 +1169,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
   border-color: #000000;
 }
 
-.c3 {
+.c4 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -1104,7 +1178,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
   cursor: pointer;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   width: 24px;
   height: 24px;
@@ -1112,19 +1186,19 @@ exports[`RadioButtonGroup object options just value 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c7 {
     border: solid 2px #7D4CDB;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     height: 6px;
   }
 }
@@ -1142,11 +1216,11 @@ exports[`RadioButtonGroup object options just value 1`] = `
       onMouseLeave={[Function]}
     >
       <div
-        className="c1 "
+        className="c3 "
       >
         <input
           checked={false}
-          className="c3"
+          className="c4"
           name="test"
           onBlur={[Function]}
           onChange={[Function]}
@@ -1155,12 +1229,12 @@ exports[`RadioButtonGroup object options just value 1`] = `
           value="one"
         />
         <div
-          className="c4 "
+          className="c5 "
         />
       </div>
     </label>
     <div
-      className="c5"
+      className="c6"
     />
     <label
       className="c2"
@@ -1169,11 +1243,11 @@ exports[`RadioButtonGroup object options just value 1`] = `
       onMouseLeave={[Function]}
     >
       <div
-        className="c1 "
+        className="c3 "
       >
         <input
           checked={true}
-          className="c3"
+          className="c4"
           name="test"
           onBlur={[Function]}
           onChange={[Function]}
@@ -1182,10 +1256,10 @@ exports[`RadioButtonGroup object options just value 1`] = `
           value="two"
         />
         <div
-          className="c6 "
+          className="c7 "
         >
           <svg
-            className="c7"
+            className="c8"
             preserveAspectRatio="xMidYMid meet"
             viewBox="0 0 24 24"
           >
@@ -1240,6 +1314,9 @@ exports[`RadioButtonGroup string options 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c5 {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds flex={false} to the Box surrounding the RadioButton indicator. In cases where radiobuttons had long labels/restricted widths, the indicator was getting squished.

#### Where should the reviewer start?
src/js/components/RadioButton/RadioButton.js

#### What testing has been done on this PR?
Before this change. Long labels were placed on RadioButton, and a Box of width="medium" wrapped the RadioButtonGroup, causing this:
<img width="339" alt="Screen Shot 2020-06-10 at 11 24 32 AM" src="https://user-images.githubusercontent.com/12522275/84305189-78a20f80-ab0e-11ea-8aba-fda0f4fbc8a8.png">

After this change, the radiobutton indicator does not get squished, and instead the label adapt to accommodate the width restriction:
<img width="350" alt="Screen Shot 2020-06-10 at 11 24 40 AM" src="https://user-images.githubusercontent.com/12522275/84305225-8bb4df80-ab0e-11ea-8235-4bac9109633b.png">

#### How should this be manually tested? 
Same as above.

#### Any background context you want to provide?
RadioButton indicator was getting squished when there wasn't adequate space.
#### What are the relevant issues?

#### Screenshots (if appropriate)
See above.

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.