### PR TITLE
Changed Select to fix an issue with onSearch being called multiple times

### DIFF
--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -173,7 +173,7 @@ const Button = forwardRef(
         }
       }
       return result;
-    }, [active, disabled, kind, plain]);
+    }, [active, disabled, kind, plain, selected]);
 
     // only used when theme does not have button.default
     const isDarkBackground = () => {

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -72,17 +72,10 @@ const SelectContainer = forwardRef(
 
     // adjust activeIndex when options change
     useEffect(() => {
-      if (onSearch) {
-        if (activeIndex === -1 && !search && options && optionIndexesInValue) {
-          const nextActiveIndex = optionIndexesInValue.length
-            ? optionIndexesInValue[0]
-            : -1;
-          setActiveIndex(nextActiveIndex);
-        } else if (activeIndex === -1 && search) {
-          setActiveIndex(0);
-        }
+      if (activeIndex === -1 && search && optionIndexesInValue.length) {
+        setActiveIndex(optionIndexesInValue[0]);
       }
-    }, [activeIndex, optionIndexesInValue, options, onSearch, search]);
+    }, [activeIndex, optionIndexesInValue, search]);
 
     // set initial focus
     useEffect(() => {
@@ -176,27 +169,6 @@ const SelectContainer = forwardRef(
       },
       [optionValue, selected, value, valueKey],
     );
-
-    const onSearchChange = useCallback(
-      event => {
-        const nextSearch = event.target.value;
-        setSearch(nextSearch);
-        setActiveIndex(-1);
-        onSearch(nextSearch);
-      },
-      [onSearch],
-    );
-
-    useEffect(() => {
-      if (search !== undefined && onSearch) {
-        const timer = setTimeout(
-          () => onSearch(search),
-          theme.global.debounceDelay,
-        );
-        return () => clearTimeout(timer);
-      }
-      return undefined;
-    }, [onSearch, search, theme.global]);
 
     const selectOption = useCallback(
       index => event => {
@@ -315,7 +287,12 @@ const SelectContainer = forwardRef(
                 type="search"
                 value={search || ''}
                 placeholder={searchPlaceholder}
-                onChange={onSearchChange}
+                onChange={event => {
+                  const nextSearch = event.target.value;
+                  setSearch(nextSearch);
+                  setActiveIndex(-1);
+                  onSearch(nextSearch);
+                }}
               />
             </Box>
           )}


### PR DESCRIPTION
#### What does this PR do?

Changed Select to fix an issue with onSearch being called multiple times.

The management of `activeIndex` was too convoluted and too different between onSearch and no onSearch cases. Previously, if onSearch was specified, an effect would initialize activeIndex differently than if it wasn't. So, keyboard navigation was inconsistent. Now, we only set activeIndex based on any `search` text, which aligns the keyboard behavior better.

Also, uncovered that `onSearch` was being called repeatedly due to the effect with a dependency on it. So, callers that didn't use `useCallback()` would see repeated calls. Now, we only call `onSearch` directly in the onChange handler.

Also fixed a linter warning in Button.

#### Where should the reviewer start?

Button.js, for a lightweight warm up ;)

#### What testing has been done on this PR?

whitebox by adding onSearch to Select in All Components story
Also ran through Select stories.

#### How should this be manually tested?

Storybook

#### What are the relevant issues?

#4178 

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
