### PR TITLE
fixed warnings in Anchor test

### DIFF
--- a/src/js/components/Anchor/__tests__/Anchor-test.js
+++ b/src/js/components/Anchor/__tests__/Anchor-test.js
@@ -32,41 +32,43 @@ describe('Anchor', () => {
   });
 
   test('warns about invalid label render', () => {
+    console.warn = jest.fn();
     const warnSpy = jest.spyOn(console, 'warn');
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Anchor href="#" label="Test">
           invalid
         </Anchor>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
     expect(warnSpy).toHaveBeenCalledWith(
       'Anchor should not have children if icon or label is provided',
     );
 
     warnSpy.mockReset();
     warnSpy.mockRestore();
+    console.warn.mockReset();
   });
 
   test('warns about invalid icon render', () => {
+    console.warn = jest.fn();
     const warnSpy = jest.spyOn(console, 'warn');
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Anchor href="#" icon={<svg />}>
           invalid
         </Anchor>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
     expect(warnSpy).toHaveBeenCalledWith(
       'Anchor should not have children if icon or label is provided',
     );
 
     warnSpy.mockReset();
     warnSpy.mockRestore();
+    console.warn.mockReset();
   });
 
   test('primary renders', () => {

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
@@ -452,13 +452,11 @@ exports[`Anchor warns about invalid icon render 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <a
-    className="c1"
+    class="c1"
     href="#"
-    onBlur={[Function]}
-    onFocus={[Function]}
   >
     <svg
       color="#7D4CDB"
@@ -495,13 +493,11 @@ exports[`Anchor warns about invalid label render 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <a
-    className="c1"
+    class="c1"
     href="#"
-    onBlur={[Function]}
-    onFocus={[Function]}
   >
     Test
   </a>


### PR DESCRIPTION
### What does this PR do?
Fixes warnings on `yarn test` for Anchor-test.js. This PR has no effect on the overall testing coverage. Also updated the tests to use render instead of renderer.create which is what causes the changes in the snapshots.

#### Where should the reviewer start?
Look at the warnings that were previously being generated from running yarn test. Run this command again on this PR and there won't be warnings for Anchor-test.js.

#### What testing has been done on this PR?
Running yarn test, looking at the snapshots for 'warns about invalid icon' and 'warns about invalid label', and checking that the coverage stayed the same.

#### How should this be manually tested?
^ see above

#### Any background context you want to provide?

#### What are the relevant issues?
#4177

#### Screenshots (if appropriate)
<img width="693" alt="Screen Shot 2020-06-17 at 11 33 54 AM" src="https://user-images.githubusercontent.com/54560994/84930428-7dc30980-b08e-11ea-944e-0f4a52fc5a36.png">


#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
