### PR TITLE
Testing for CheckBoxGroup

### DIFF
--- a/src/js/components/Accordion/__tests__/Accordion-test.js
+++ b/src/js/components/Accordion/__tests__/Accordion-test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import 'jest-styled-components';
 import renderer from 'react-test-renderer';
-import { cleanup, render, fireEvent } from '@testing-library/react';
+import { cleanup, render, fireEvent, act } from '@testing-library/react';
 
 import { Accordion, AccordionPanel, Box, Grommet } from '../..';
 
@@ -74,7 +74,8 @@ describe('Accordion', () => {
     expect(component.toJSON()).toMatchSnapshot();
   });
 
-  test('change to second Panel', done => {
+  test('change to second Panel', () => {
+    jest.useFakeTimers();
     const onActive = jest.fn();
     const { getByText, container } = render(
       <Grommet>
@@ -89,13 +90,12 @@ describe('Accordion', () => {
     fireEvent.click(getByText('Panel 2'));
 
     // wait for panel animation to finish
-    setTimeout(() => {
-      expect(onActive).toBeCalled();
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
 
-      expect(container.firstChild).toMatchSnapshot();
-
-      done();
-    }, 500);
+    expect(onActive).toBeCalled();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('change to second Panel without onActive', () => {
@@ -198,6 +198,7 @@ describe('Accordion', () => {
   });
 
   test('focus and hover styles', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const { getByText, container } = render(
       <Grommet theme={{ accordion: { hover: { color: 'red' } } }}>
         <Accordion>
@@ -216,9 +217,12 @@ describe('Accordion', () => {
 
     fireEvent.focus(getByText('Panel 1'));
     expect(container.firstChild).toMatchSnapshot();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   test('backward compatibility of hover.color = undefined', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const { getByText, container } = render(
       <Grommet
         theme={{
@@ -244,6 +248,8 @@ describe('Accordion', () => {
     fireEvent.focus(getByText('Panel 1'));
     // hover color should be undefined
     expect(container.firstChild).toMatchSnapshot();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   test('theme hover of hover.heading.color', () => {

--- a/src/js/components/CheckBoxGroup/__tests__/CheckBoxGroup-test.js
+++ b/src/js/components/CheckBoxGroup/__tests__/CheckBoxGroup-test.js
@@ -1,12 +1,27 @@
 import React from 'react';
-import { cleanup } from '@testing-library/react';
 import renderer from 'react-test-renderer';
 
+import 'jest-axe/extend-expect';
+import 'regenerator-runtime/runtime';
+
+import { cleanup, render, fireEvent } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import { Grommet } from '../../Grommet';
 import { CheckBoxGroup } from '..';
 
 describe('CheckBoxGroup', () => {
   afterEach(cleanup);
+
+  test('should have no accessibility violations', async () => {
+    const { container } = render(
+      <Grommet>
+        <CheckBoxGroup options={['First', 'Second']} />
+      </Grommet>,
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
 
   test('options renders', () => {
     const component = renderer.create(
@@ -55,5 +70,90 @@ describe('CheckBoxGroup', () => {
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  test('onChange', () => {
+    const onChange = jest.fn();
+    const { container, getByText } = render(
+      <Grommet>
+        <CheckBoxGroup
+          options={[
+            { label: 'first-label', value: 'First' },
+            { label: 'second-label', value: 'Second' },
+          ]}
+          onChange={onChange}
+        />
+      </Grommet>,
+    );
+    fireEvent.click(getByText('first-label'));
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('onClick', () => {
+    const { container, getByText } = render(
+      <Grommet>
+        <CheckBoxGroup
+          options={[
+            { label: 'first-label', value: 'First' },
+            { label: 'second-label', value: 'Second' },
+          ]}
+        />
+      </Grommet>,
+    );
+    fireEvent.click(getByText('first-label'));
+    expect(container.firstChild).toMatchSnapshot();
+    fireEvent.click(getByText('first-label'));
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('labelKey', () => {
+    const { container } = render(
+      <Grommet>
+        <CheckBoxGroup
+          labelKey="labelKeyTest"
+          options={[
+            { labelKeyTest: 'first-label', value: 'First' },
+            { labelKeyTest: 'second-label', value: 'Second' },
+          ]}
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('valueKey', () => {
+    const { container } = render(
+      <Grommet>
+        <CheckBoxGroup
+          valueKey="valueKeyTest"
+          options={[
+            { label: 'first-label', valueKeyTest: 'First' },
+            { label: 'second-label', valueKeyTest: 'Second' },
+          ]}
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('checked warning', () => {
+    console.warn = jest.fn();
+    const warnSpy = jest.spyOn(console, 'warn');
+
+    render(
+      <Grommet>
+        <CheckBoxGroup
+          options={[
+            { label: 'first-label', value: 'First', checked: true },
+            { label: 'second-label', value: 'Second' },
+          ]}
+        />
+      </Grommet>,
+    );
+
+    expect(warnSpy).toBeCalled();
+    warnSpy.mockReset();
+    warnSpy.mockRestore();
+    console.warn.mockReset();
   });
 });

--- a/src/js/components/CheckBoxGroup/__tests__/CheckBoxGroup-test.js
+++ b/src/js/components/CheckBoxGroup/__tests__/CheckBoxGroup-test.js
@@ -86,10 +86,12 @@ describe('CheckBoxGroup', () => {
       </Grommet>,
     );
     fireEvent.click(getByText('first-label'));
+    expect(onChange).toBeCalledTimes(1);
     expect(container.firstChild).toMatchSnapshot();
   });
 
   test('onClick', () => {
+    const onClick = jest.fn();
     const { container, getByText } = render(
       <Grommet>
         <CheckBoxGroup
@@ -97,12 +99,15 @@ describe('CheckBoxGroup', () => {
             { label: 'first-label', value: 'First' },
             { label: 'second-label', value: 'Second' },
           ]}
+          onClick={onClick}
         />
       </Grommet>,
     );
     fireEvent.click(getByText('first-label'));
+    expect(onClick).toBeCalledTimes(1);
     expect(container.firstChild).toMatchSnapshot();
     fireEvent.click(getByText('first-label'));
+    expect(onClick).toBeCalledTimes(2);
     expect(container.firstChild).toMatchSnapshot();
   });
 

--- a/src/js/components/CheckBoxGroup/__tests__/CheckBoxGroup-test.js
+++ b/src/js/components/CheckBoxGroup/__tests__/CheckBoxGroup-test.js
@@ -90,7 +90,7 @@ describe('CheckBoxGroup', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('onClick', () => {
+  test('onClick for check and uncheck a CheckBox', () => {
     const onClick = jest.fn();
     const { container, getByText } = render(
       <Grommet>

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
@@ -372,7 +372,7 @@ exports[`CheckBoxGroup onChange 1`] = `
 </div>
 `;
 
-exports[`CheckBoxGroup onClick 1`] = `
+exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
 <div
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
@@ -434,7 +434,7 @@ exports[`CheckBoxGroup onClick 1`] = `
 </div>
 `;
 
-exports[`CheckBoxGroup onClick 2`] = `
+exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
 <div
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
@@ -261,6 +261,228 @@ exports[`CheckBoxGroup initial value renders 1`] = `
 </div>
 `;
 
+exports[`CheckBoxGroup labelKey 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+>
+  <div
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+  >
+    <label
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+      >
+        <input
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
+          type="checkbox"
+        />
+        <div
+          class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+        />
+      </div>
+      <span>
+        first-label
+      </span>
+    </label>
+    <div
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 liuKJs"
+    />
+    <label
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+      >
+        <input
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
+          type="checkbox"
+        />
+        <div
+          class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+        />
+      </div>
+      <span>
+        second-label
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`CheckBoxGroup onChange 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+>
+  <div
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+  >
+    <label
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+      >
+        <input
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
+          type="checkbox"
+        />
+        <div
+          class="StyledBox-sc-13pk1d4-0 KsQmP StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+        >
+          <svg
+            class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 gHRhNW"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6,11.3 L10.3,16 L18,6.2"
+              fill="none"
+            />
+          </svg>
+        </div>
+      </div>
+      <span>
+        first-label
+      </span>
+    </label>
+    <div
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 liuKJs"
+    />
+    <label
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+      >
+        <input
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
+          type="checkbox"
+        />
+        <div
+          class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+        />
+      </div>
+      <span>
+        second-label
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`CheckBoxGroup onClick 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+>
+  <div
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+  >
+    <label
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+      >
+        <input
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
+          type="checkbox"
+        />
+        <div
+          class="StyledBox-sc-13pk1d4-0 KsQmP StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+        >
+          <svg
+            class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 gHRhNW"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6,11.3 L10.3,16 L18,6.2"
+              fill="none"
+            />
+          </svg>
+        </div>
+      </div>
+      <span>
+        first-label
+      </span>
+    </label>
+    <div
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 liuKJs"
+    />
+    <label
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+      >
+        <input
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
+          type="checkbox"
+        />
+        <div
+          class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+        />
+      </div>
+      <span>
+        second-label
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`CheckBoxGroup onClick 2`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+>
+  <div
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+  >
+    <label
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+      >
+        <input
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
+          type="checkbox"
+        />
+        <div
+          class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+        />
+      </div>
+      <span>
+        first-label
+      </span>
+    </label>
+    <div
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 liuKJs"
+    />
+    <label
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+      >
+        <input
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
+          type="checkbox"
+        />
+        <div
+          class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+        />
+      </div>
+      <span>
+        second-label
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
 exports[`CheckBoxGroup options renders 1`] = `
 <div
   className="StyledGrommet-sc-19lkkz7-0 lcXYAf"
@@ -399,6 +621,56 @@ exports[`CheckBoxGroup value renders 1`] = `
       </div>
       <span>
         Second
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`CheckBoxGroup valueKey 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+>
+  <div
+    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+  >
+    <label
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+      >
+        <input
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
+          type="checkbox"
+        />
+        <div
+          class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+        />
+      </div>
+      <span>
+        first-label
+      </span>
+    </label>
+    <div
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 liuKJs"
+    />
+    <label
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+      >
+        <input
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
+          type="checkbox"
+        />
+        <div
+          class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+        />
+      </div>
+      <span>
+        second-label
       </span>
     </label>
   </div>

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
@@ -377,7 +377,8 @@ exports[`CheckBoxGroup onClick 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 iDvhFF"
+    tabindex="0"
   >
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
@@ -438,7 +439,8 @@ exports[`CheckBoxGroup onClick 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 iDvhFF"
+    tabindex="0"
   >
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"


### PR DESCRIPTION
#### What does this PR do?
Increases testing coverage for CheckBoxGroup:

| Type | Before | After |
| --- | --- | --- |
| Statements | 58.82% | 100% |
| Branches | 47.62% | 85.71% |
| Functions | 66.67% | 100% |
| Lines | 60.61%  | 100% |


Increases repository coverage:
| Type | Before | After |
| --- | --- | --- |
| Statements | 80.9% | 81.16% |
| Branches | 70.65% | 70.82% |
| Functions | 78.58% | 78.73% |
| Lines | 82.11%  | 82.34% |

#### Where should the reviewer start?
CheckBoxGroup-test.js

#### What testing has been done on this PR?
I looked through the snapshots to make sure the tests were working and I looked at the coverage report to see line by line what was being covered for CheckBoxGroup.js to maximize coverage without any unnecessary tests.

#### How should this be manually tested?
Run `yarn test` and look at the coverage report and snapshots.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
<img width="1773" alt="Screen Shot 2020-06-18 at 2 13 39 PM" src="https://user-images.githubusercontent.com/54560994/85067447-edf48c80-b16d-11ea-9bed-c60591c8ca6a.png">

<img width="1771" alt="Screen Shot 2020-06-18 at 2 15 15 PM" src="https://user-images.githubusercontent.com/54560994/85067574-25633900-b16e-11ea-8349-9a2398039e28.png">

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible

#### NOTE:
In line 154 I had to use `expect(warnSpy).toBeCalled();` instead of `expect(warnSpy).toBeCalledWith();` because the error message was too long and wouldn't match if it was broken into a multi-line string.
