### PR TITLE
Fixed display of non-string values on RadioButtonGroup

### DIFF
--- a/src/js/components/RadioButtonGroup/README.md
+++ b/src/js/components/RadioButtonGroup/README.md
@@ -52,8 +52,8 @@ function
 
 **options**
 
-Required. Options can be either a string or an object. 
-    Each option is rendered as a single RadioButton.
+Required. Options can be either a string, boolean, number 
+      or an object. Each option is rendered as a single RadioButton.
 
 ```
 [string]

--- a/src/js/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/js/components/RadioButtonGroup/RadioButtonGroup.js
@@ -36,7 +36,7 @@ const RadioButtonGroup = forwardRef(
             ? {
                 disabled,
                 id: rest.id ? `${rest.id}-${o}` : `${o}`, // force string
-                label: o,
+                label: typeof o !== 'string' ? JSON.stringify(o) : o,
                 value: o,
               }
             : { disabled, ...o },

--- a/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
+++ b/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
@@ -269,23 +269,6 @@ exports[`RadioButtonGroup boolean options 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -371,7 +354,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c8 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
@@ -425,6 +408,9 @@ exports[`RadioButtonGroup boolean options 1`] = `
           </svg>
         </div>
       </div>
+      <span>
+        true
+      </span>
     </label>
     <div
       className="c7"
@@ -437,7 +423,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
       onMouseLeave={[Function]}
     >
       <div
-        className="c8 "
+        className="c3 "
       >
         <input
           checked={false}
@@ -451,9 +437,12 @@ exports[`RadioButtonGroup boolean options 1`] = `
           value={false}
         />
         <div
-          className="c9 "
+          className="c8 "
         />
       </div>
+      <span>
+        false
+      </span>
     </label>
   </div>
 </div>
@@ -890,7 +879,9 @@ exports[`RadioButtonGroup number options 1`] = `
           </svg>
         </div>
       </div>
-      1
+      <span>
+        1
+      </span>
     </label>
     <div
       className="c7"
@@ -920,7 +911,9 @@ exports[`RadioButtonGroup number options 1`] = `
           className="c8 "
         />
       </div>
-      2
+      <span>
+        2
+      </span>
     </label>
   </div>
 </div>

--- a/src/js/components/RadioButtonGroup/doc.js
+++ b/src/js/components/RadioButtonGroup/doc.js
@@ -48,8 +48,9 @@ export const doc = RadioButtonGroup => {
           ]).isRequired,
         }),
       ),
-    ]).description(`Options can be either a string or an object. 
-    Each option is rendered as a single RadioButton.`).isRequired,
+    ]).description(`Options can be either a string, boolean, number 
+      or an object. Each option is rendered as a single RadioButton.`)
+      .isRequired,
     value: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11400,8 +11400,8 @@ function
 
 **options**
 
-Required. Options can be either a string or an object. 
-    Each option is rendered as a single RadioButton.
+Required. Options can be either a string, boolean, number 
+      or an object. Each option is rendered as a single RadioButton.
 
 \`\`\`
 [string]

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -5358,8 +5358,8 @@ with the same name so form submissions work.",
         "name": "onChange",
       },
       Object {
-        "description": "Options can be either a string or an object. 
-    Each option is rendered as a single RadioButton.",
+        "description": "Options can be either a string, boolean, number 
+      or an object. Each option is rendered as a single RadioButton.",
         "format": "[string]
 [number]
 [boolean]


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Resolving all non-string types of options to a string for the `label` prop.
Regarding the snapshot changes, I noticed that now all non-string label values (boolean and numbers) are now wrapped with span on the DOM which is consistent with how label strings are rendered.
#### Where should the reviewer start?
doc.js
#### What testing has been done on this PR?
tested locally with storybook examples and made sure the jest snapshots are up to date as expected.
#### How should this be manually tested?
go over snapshots.
#### Any background context you want to provide?
This issue was revealed during tests clean-ups.
#### What are the relevant issues?
https://github.com/grommet/grommet/pull/4208
#4180 
https://github.com/grommet/grommet-site/pull/174

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, done on https://github.com/grommet/grommet-site/pull/174
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible