### PR TITLE
Applies default disabled component styling to StyledButtonKind

### DIFF
--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -2,6 +2,7 @@ import styled, { css } from 'styled-components';
 
 import {
   backgroundStyle,
+  disabledStyle,
   focusStyle,
   genericStyles,
   normalizeColor,
@@ -242,6 +243,8 @@ const StyledButtonKind = styled.button`
   text-align: ${props.align};
   `}
   ${props => props.hoverIndicator && hoverIndicatorStyle(props)}
+  ${props =>
+    props.disabled && disabledStyle(props.theme.button.disabled.opacity)}
   ${props =>
     props.focus && (!props.plain || props.focusIndicator) && focusStyle()}
   ${props =>

--- a/src/js/components/Button/__tests__/Button-kind-test.js
+++ b/src/js/components/Button/__tests__/Button-kind-test.js
@@ -274,4 +274,23 @@ describe('Button kind', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test(`disabled state cursor should indicate the button cannot be 
+  clicked`, () => {
+    const { getByText } = render(
+      <Grommet
+        theme={{
+          button: { default: {} },
+        }}
+      >
+        <Button disabled label="Button" />
+      </Grommet>,
+    );
+
+    const button = getByText('Button');
+    // eslint-disable-next-line no-underscore-dangle
+    const cursorStyle = window.getComputedStyle(button)._values.cursor;
+    expect(cursorStyle).not.toBe('pointer');
+    expect(cursorStyle).toBe('default');
+  });
 });

--- a/src/js/components/Button/__tests__/Button-test.js
+++ b/src/js/components/Button/__tests__/Button-test.js
@@ -300,4 +300,19 @@ describe('Button', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  test(`disabled state cursor should indicate the button cannot be 
+  clicked`, () => {
+    const { getByText } = render(
+      <Grommet>
+        <Button disabled label="Button" />
+      </Grommet>,
+    );
+
+    const button = getByText('Button');
+    // eslint-disable-next-line no-underscore-dangle
+    const cursorStyle = window.getComputedStyle(button)._values.cursor;
+    expect(cursorStyle).not.toBe('pointer');
+    expect(cursorStyle).toBe('default');
+  });
 });


### PR DESCRIPTION
Signed-off-by: Matt Glissmann <mdglissmann@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Applies the default disabled component styling to `<StyledButtonKind />` for backwards compatibility.

Specifically, ensures a disabled Button does not receive a cursor treatment indicating the Button can be interacted with in a disabled state.

#### Where should the reviewer start?

StyledButtonKind.js

#### What testing has been done on this PR?

Storybook - Button --> 'Custom' story
Additional Jest tests

#### How should this be manually tested?

Storybook - Button --> 'Custom' story is a good one

#### Any background context you want to provide?

Original issue surfaced: https://github.com/hpe-design/design-system/issues/920

This compliments https://github.com/grommet/grommet/pull/4232


#### What are the relevant issues?

https://github.com/hpe-design/design-system/issues/920

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Not necessarily.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.