### PR TITLE
Fix Button propTypes for the target property to allow string

### DIFF
--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -327,6 +327,7 @@ _self
 _blank
 _parent
 _top
+string
 ```
 
 **type**

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -110,7 +110,10 @@ with plain Buttons.`,
       padding, border radius, text size and line height. 
       'size' will not impact any icon related sizing.`,
     ),
-    target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']).description(
+    target: PropTypes.oneOfType([
+      PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
+      PropTypes.string,
+    ]).description(
       `Specifies where to display the URL defined in the href property.`,
     ),
     type: PropTypes.oneOf(['button', 'reset', 'submit'])

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -25,7 +25,7 @@ export interface ButtonProps {
   gap?: GapType;
   hoverIndicator?: BackgroundType | boolean;
   href?: string;
-  target?: "_self" | "_blank" | "_parent" | "_top";
+  target?: "_self" | "_blank" | "_parent" | "_top" | string;
   icon?: JSX.Element;
   label?: React.ReactNode;
   plain?: boolean;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -2175,6 +2175,7 @@ _self
 _blank
 _parent
 _top
+string
 \`\`\`
 
 **type**

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1354,7 +1354,8 @@ large",
         "format": "_self
 _blank
 _parent
-_top",
+_top
+string",
         "name": "target",
       },
       Object {


### PR DESCRIPTION

<!--- Provide a general summary of the PR in the Title above -->
The Button propTypes currently complain about specifying
something other than _self, _blank, _parent, _top. In
html the anchor tag actually allows any string in target
to create a named tab/window. The names above that start
with _ are special names but it is perfectly fine to
create a named window.

#### What does this PR do?
Changes Button propTypes for the target prop to allow any string
and not just _self, _blank, _parent, _top

#### Where should the reviewer start?

#### What testing has been done on this PR?
Manually tested with a temporary tweak in the storybook for Button.
Ran jest tests.

#### How should this be manually tested?
Just add a target="somename" to a Button with an href.

#### Any background context you want to provide?
Setting target to some string like quakehelp is something we often do for help links. That way, when the user selects any links with the same target window name, the help always ends up in the same window rather than continually creating new windows/tabs.

#### What are the relevant issues?
#4097 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Done

#### Should this PR be mentioned in the release notes?
Don't think this needs to be mentioned

#### Is this change backwards compatible or is it a breaking change?
It is backwards compatible