### PR TITLE
Tests no longer skipped in MaskedInput

### DIFF
--- a/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
+++ b/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
@@ -342,7 +342,7 @@ describe('MaskedInput', () => {
     expect(optionButton).toMatchSnapshot();
   });
 
-  test.only('with no mask', async () => {
+  test('with no mask', async () => {
     const onChange = jest.fn(event => event.target.value);
     const { getByTestId, container } = render(
       <MaskedInput


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
12 tests were being skipped in MaskedInput-test.js this PR fixes it so that all the tests are being run

#### Where should the reviewer start?
MaskedInput-test.js

#### What testing has been done on this PR?
`yarn test --verbose`

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
closes #4239

#### Screenshots (if appropriate)
![](https://user-images.githubusercontent.com/54560994/86030576-e5b01300-b9f1-11ea-9ce9-320a5cbe0844.png)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
