### PR TITLE
Support clicking inside drops in a shadow root

### DIFF
--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -242,11 +242,21 @@ const DropContainer = forwardRef(
       const onClickDocument = event => {
         // determine which portal id the target is in, if any
         let clickedPortalId = null;
-        let node = event.target;
+        // using the first node in composedPath (if available) allows getting
+        // the real target if it is in a shadow root (as long as the shadow
+        // root mode is set to open)
+        let node = event.composedPath ? event.composedPath()[0] : event.target;
         while (clickedPortalId === null && node !== document) {
-          const attr = node.getAttribute('data-g-portal-id');
-          if (attr !== null) clickedPortalId = parseInt(attr, 10);
-          node = node.parentNode;
+          if (!node.getAttribute) {
+            // node is a DocumentFragment, continue to host element
+            // DocumentFragment is not defined in IE which prevents using
+            // an instanceof check
+            node = node.host;
+          } else {
+            const attr = node.getAttribute('data-g-portal-id');
+            if (attr !== null) clickedPortalId = parseInt(attr, 10);
+            node = node.parentNode;
+          }
         }
         if (
           clickedPortalId === null ||

--- a/src/js/components/Drop/__tests__/Drop-test.js
+++ b/src/js/components/Drop/__tests__/Drop-test.js
@@ -129,6 +129,36 @@ describe('Drop', () => {
     expect(onClickOutside).toBeCalled();
   });
 
+  test('clicking in a shadow root drop does not invoke onClickOutside', () => {
+    const onClickOutside = jest.fn();
+    const host = document.createElement('div');
+    const shadowRoot = host.attachShadow({ mode: 'open' });
+    const container = document.createElement('div');
+    shadowRoot.appendChild(container);
+    const containerTarget = document.createElement('div');
+    shadowRoot.appendChild(containerTarget);
+    document.body.appendChild(host);
+    try {
+      render(
+        <TestInput
+          onClickOutside={onClickOutside}
+          containerTarget={containerTarget}
+          showDrop
+        />,
+        { container },
+      );
+      const event = new MouseEvent('mousedown', {
+        bubbles: true,
+        cancelable: true,
+      });
+      event.composedPath = () => [shadowRoot.querySelector('#drop-node')];
+      fireEvent(host, event);
+      expect(onClickOutside).not.toBeCalled();
+    } finally {
+      document.body.removeChild(host);
+    }
+  });
+
   test('resize', () => {
     render(<TestInput />);
     global.window.innerWidth = 1000;


### PR DESCRIPTION
If a drop is rendered inside a shadow root, clicks in the drop were still triggering `onClickOutside`. This is is because the host element for the shadow root is the target on the document `mousedown` event making it appear to be outside of the drop.

#### What does this PR do?

When a shadow root is attached in open mode, it is possible to get the real target by using `event.composedPath()`. This change uses `composedPath` to get the target if it is supported, and gracefully falls back to `event.target` when it isn't supported.

#### What testing has been done on this PR?

This has been tested in storybook with components that use a drop with `onClickOutside` and in my application that uses drops in a shadow root. This commit also includes a new test to cover this. 

#### How should this be manually tested?

The biggest thing is ensuring no existing functionality with `onClickOutside` is broken. If you would like to test with a shadow root you can set up a `containerTarget` that is in a shadow root and render a `Menu` making sure `onClick` for the items is still triggering.

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Maybe?

#### Is this change backwards compatible or is it a breaking change?

Yes
