### PR TITLE
Documentation for RadioButton `control` color

### DIFF
--- a/src/js/components/RadioButton/README.md
+++ b/src/js/components/RadioButton/README.md
@@ -88,7 +88,8 @@ input
   
 **global.colors.control**
 
-The default color to use for the button border. Expects `string | { dark: string, light: string }`.
+The default color of the border surrounding 
+    the checked icon in RadioButton checked state. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 

--- a/src/js/components/RadioButton/README.md
+++ b/src/js/components/RadioButton/README.md
@@ -86,6 +86,16 @@ input
 ```
 ## Theme
   
+**global.colors.control**
+
+The default color to use for the button border. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+{ dark: 'accent-1', light: 'brand'}
+```
+
 **radioButton.border.color**
 
 The color of the border of the Radio Button. Expects `string | { dark: string, light: string }`.

--- a/src/js/components/RadioButton/doc.js
+++ b/src/js/components/RadioButton/doc.js
@@ -51,6 +51,11 @@ with the same name so form submissions work.`,
 };
 
 export const themeDoc = {
+  'global.colors.control': {
+    description: `The default color to use for the button border.`,
+    type: 'string | { dark: string, light: string }',
+    defaultValue: `{ dark: 'accent-1', light: 'brand'}`,
+  },
   'radioButton.border.color': {
     description: 'The color of the border of the Radio Button.',
     type: 'string | { dark: string, light: string }',

--- a/src/js/components/RadioButton/doc.js
+++ b/src/js/components/RadioButton/doc.js
@@ -52,7 +52,8 @@ with the same name so form submissions work.`,
 
 export const themeDoc = {
   'global.colors.control': {
-    description: `The default color to use for the button border.`,
+    description: `The default color of the border surrounding 
+    the checked icon in RadioButton checked state.`,
     type: 'string | { dark: string, light: string }',
     defaultValue: `{ dark: 'accent-1', light: 'brand'}`,
   },

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11228,7 +11228,8 @@ input
   
 **global.colors.control**
 
-The default color to use for the button border. Expects \`string | { dark: string, light: string }\`.
+The default color of the border surrounding 
+    the checked icon in RadioButton checked state. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11226,6 +11226,16 @@ input
 \`\`\`
 ## Theme
   
+**global.colors.control**
+
+The default color to use for the button border. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+{ dark: 'accent-1', light: 'brand'}
+\`\`\`
+
 **radioButton.border.color**
 
 The color of the border of the Radio Button. Expects \`string | { dark: string, light: string }\`.


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds documentation for the `control` color as part of the theme docs for RadioButton

#### Where should the reviewer start?
RadioButton/doc.js

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
closes #4159 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Updated

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
