### PR TITLE
Updated documenation for TextInput a11yTitle

### DIFF
--- a/src/js/components/TextInput/README.md
+++ b/src/js/components/TextInput/README.md
@@ -11,6 +11,14 @@ import { TextInput } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+```
+string
+```
+
 **dropAlign**
 
 How to align the drop. Defaults to `{

--- a/src/js/components/TextInput/doc.js
+++ b/src/js/components/TextInput/doc.js
@@ -15,6 +15,9 @@ export const doc = TextInput => {
     .intrinsicElement('input');
 
   DocumentedTextInput.propTypes = {
+    a11yTitle: PropTypes.string.description(
+      'Custom title to be used by screen readers.',
+    ),
     dropAlign: PropTypes.shape({
       top: PropTypes.oneOf(['top', 'bottom']),
       bottom: PropTypes.oneOf(['top', 'bottom']),

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -14490,6 +14490,14 @@ import { TextInput } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom title to be used by screen readers.
+
+\`\`\`
+string
+\`\`\`
+
 **dropAlign**
 
 How to align the drop. Defaults to \`{

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -6333,6 +6333,11 @@ string",
     "name": "TextInput",
     "properties": Array [
       Object {
+        "description": "Custom title to be used by screen readers.",
+        "format": "string",
+        "name": "a11yTitle",
+      },
+      Object {
         "defaultValue": Object {
           "left": "left",
           "top": "bottom",


### PR DESCRIPTION
### What does this PR do?
Updates the TextInput documentation to include the a11yTitle

#### Where should the reviewer start?
TextInput/doc.js

#### What testing has been done on this PR?
`yarn test`

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
#4244 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Updated

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
