### PR TITLE
List - prevent misfire of onClickItem handler

### DIFF
--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -186,12 +186,14 @@ const List = React.forwardRef(
                   tabIndex: -1,
                   active: active === index,
                   onClick: event => {
-                    // extract from React's synthetic event pool
-                    event.persist();
-                    const adjustedEvent = event;
-                    adjustedEvent.item = item;
-                    adjustedEvent.index = index;
-                    onClickItem(adjustedEvent);
+                    if (event.type === 'click') {
+                      // extract from React's synthetic event pool
+                      event.persist();
+                      const adjustedEvent = event;
+                      adjustedEvent.item = item;
+                      adjustedEvent.index = index;
+                      onClickItem(adjustedEvent);
+                    }
                   },
                   onMouseOver: () => setActive(index),
                   onMouseOut: () => setActive(undefined),

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -59,17 +59,6 @@ const List = React.forwardRef(
 
     return (
       <Keyboard
-        onEnter={
-          onClickItem && active >= 0
-            ? event => {
-                event.persist();
-                const adjustedEvent = event;
-                adjustedEvent.item = data[active];
-                adjustedEvent.index = active;
-                onClickItem(adjustedEvent);
-              }
-            : undefined
-        }
         onUp={
           onClickItem && active
             ? () => {
@@ -186,14 +175,12 @@ const List = React.forwardRef(
                   tabIndex: -1,
                   active: active === index,
                   onClick: event => {
-                    if (event.type === 'click') {
-                      // extract from React's synthetic event pool
-                      event.persist();
-                      const adjustedEvent = event;
-                      adjustedEvent.item = item;
-                      adjustedEvent.index = index;
-                      onClickItem(adjustedEvent);
-                    }
+                    // extract from React's synthetic event pool
+                    event.persist();
+                    const adjustedEvent = event;
+                    adjustedEvent.item = data[active];
+                    adjustedEvent.index = active;
+                    onClickItem(adjustedEvent);
                   },
                   onMouseOver: () => setActive(index),
                   onMouseOut: () => setActive(undefined),

--- a/src/js/components/List/__tests__/List-test.js
+++ b/src/js/components/List/__tests__/List-test.js
@@ -70,7 +70,9 @@ describe('List', () => {
       </Grommet>,
     );
     expect(container.firstChild).toMatchSnapshot();
-    fireEvent.click(getByText('beta'));
+    const item = getByText('beta');
+    fireEvent.mouseOver(item);
+    fireEvent.click(item);
     expect(onClickItem).toBeCalledWith(
       expect.objectContaining({ item: { a: 'beta' } }),
     );

--- a/src/js/components/List/__tests__/List-test.js
+++ b/src/js/components/List/__tests__/List-test.js
@@ -256,10 +256,7 @@ describe('List events', () => {
       keyCode: 13,
       which: 13,
     });
-    // Reported bug: onEnter calls onClickItem twice instead of once.
-    // Issue #4173. Once fixed it should be
-    // `expect(onClickItem).toHaveBeenCalledTimes(2);`
-    expect(onClickItem).toHaveBeenCalledTimes(3);
+    expect(onClickItem).toHaveBeenCalledTimes(2);
     // Both focus and active should be placed on 'beta'
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -2454,7 +2454,7 @@ exports[`List onClickItem 2`] = `
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 fbIRTP List__StyledItem-sc-130gdqg-1 fBniOQ"
+      class="StyledBox-sc-13pk1d4-0 hEstNb List__StyledItem-sc-130gdqg-1 fBniOQ"
       tabindex="-1"
     >
       beta


### PR DESCRIPTION
Signed-off-by: Matt Glissmann <mdglissmann@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Prevents extraneous call to `List`'s `onClickItem` handler.

Closes: https://github.com/grommet/grommet/issues/4173

**Steps to replicate**
Occurs in the following scenario where both mouse and keyboard are used:
- Go to Storybook --> List --> onClickItem https://storybook.grommet.io/?path=/story/list--onclickitem
  - To see the multiple calls, modify the story's `onClickItem` handler to log the event to console
- Mouse over an item, then click. That item is the active item index and now has focus.
- Leave mouse cursor over item (if cursor leaves that item, the onMouseLeave function will set active to undefined and the multiple calls will not occur)
- Use keyboard. Press Enter. Two calls to `onClickItem` will occur.
  - Optionally, use arrow keys to move active item, then press enter. Two calls to `onClickItem` will occur.

In this scenario, a single enter keydown event is triggering calls from both `List`'s `<Keyboard onEnter />` and `<StyledItem onClick />`.

~The approach to this fix is to check that the `event.type` is appropriate.~

Modified approach to remove onEnter function, then needed to update onClick function to account for active item being set by keyboard interaction in addition to mouse events.

#### Where should the reviewer start?
- Review replication scenario
- List.js 

**Jest test needed to be modified to include setting an active item with an onMouseOver event prior to firing the click event. Snapshot: Including the mouseOver interaction triggers active state styling of the item which results in a change to the snapshot.**

#### What testing has been done on this PR?
Storybook, plus passes 'Enter key' Jest test which was previously failing.

#### How should this be manually tested?
Storybook

#### Any background context you want to provide?
https://github.com/grommet/grommet/issues/4173 & Replication steps described above

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/4173

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible