### PR TITLE
Create TabsContext to fix Tab issue

### DIFF
--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -32,12 +32,7 @@ const Tab = forwardRef(
     useEffect(() => {
       if (active) {
         setActiveContent(children);
-        let activeTitle;
-        if (typeof title === 'string') {
-          activeTitle = title;
-        } else {
-          activeTitle = activeIndex + 1;
-        }
+       const activeTitle = typeof title === 'string' ? title : activeIndex + 1;
         setActiveTitle(activeTitle);
       }
     }, [

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -1,4 +1,4 @@
-import React, { forwardRef, useContext, useState } from 'react';
+import React, { forwardRef, useContext, useEffect, useState } from 'react';
 import { ThemeContext } from 'styled-components';
 
 import { defaultProps } from '../../default-props';
@@ -7,29 +7,47 @@ import { Box } from '../Box';
 import { Button } from '../Button';
 import { Text } from '../Text';
 import { normalizeColor } from '../../utils';
+import { TabsContext } from '../Tabs/TabsContext';
 
 import { StyledTab } from './StyledTab';
 
 const Tab = forwardRef(
   (
-    {
-      active,
-      icon,
-      plain,
-      title,
-      onActivate,
-      onMouseOver,
-      onMouseOut,
-      reverse,
-      ...rest
-    },
+    { children, icon, plain, title, onMouseOver, onMouseOut, reverse, ...rest },
     ref,
   ) => {
+    const {
+      active,
+      activeIndex,
+      setActiveContent,
+      setActiveTitle,
+      onActivate,
+    } = useContext(TabsContext);
     const theme = useContext(ThemeContext) || defaultProps.theme;
     const [over, setOver] = useState(undefined);
     const [focus, setFocus] = useState(undefined);
     let normalizedTitle = title;
     const tabStyles = {};
+
+    useEffect(() => {
+      if (active) {
+        setActiveContent(children);
+        let activeTitle;
+        if (typeof title === 'string') {
+          activeTitle = title;
+        } else {
+          activeTitle = activeIndex + 1;
+        }
+        setActiveTitle(activeTitle);
+      }
+    }, [
+      active,
+      activeIndex,
+      children,
+      setActiveContent,
+      setActiveTitle,
+      title,
+    ]);
 
     const onMouseOverTab = event => {
       setOver(true);

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -19,9 +19,9 @@ const Tab = forwardRef(
     const {
       active,
       activeIndex,
+      onActivate,
       setActiveContent,
       setActiveTitle,
-      onActivate,
     } = useContext(TabsContext);
     const theme = useContext(ThemeContext) || defaultProps.theme;
     const [over, setOver] = useState(undefined);

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -6,8 +6,8 @@ import { defaultProps } from '../../default-props';
 import { Box } from '../Box';
 import { Button } from '../Button';
 import { Text } from '../Text';
-import { normalizeColor } from '../../utils';
 import { TabsContext } from '../Tabs/TabsContext';
+import { normalizeColor } from '../../utils';
 
 import { StyledTab } from './StyledTab';
 

--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -1,16 +1,10 @@
-import React, {
-  forwardRef,
-  cloneElement,
-  Children,
-  useContext,
-  useState,
-} from 'react';
+import React, { forwardRef, useContext, useState } from 'react';
 import { ThemeContext } from 'styled-components';
 
 import { defaultProps } from '../../default-props';
 
 import { Box } from '../Box';
-
+import { TabsContext } from './TabsContext';
 import { StyledTabPanel, StyledTabs, StyledTabsHeader } from './StyledTabs';
 import { normalizeColor } from '../../utils';
 
@@ -30,6 +24,7 @@ const Tabs = forwardRef(
     const theme = useContext(ThemeContext) || defaultProps.theme;
     const { activeIndex: propsActiveIndex, onActive } = rest;
     const [activeIndex, setActiveIndex] = useState(rest.activeIndex || 0);
+    const [activeContent, setActiveContent] = useState();
 
     if (activeIndex !== propsActiveIndex && propsActiveIndex !== undefined) {
       setActiveIndex(propsActiveIndex);
@@ -49,33 +44,7 @@ const Tabs = forwardRef(
     delete rest.onActive;
     /* eslint-enable no-param-reassign */
 
-    let activeContent;
-    let activeTitle;
-    const tabs = Children.map(
-      children,
-      (tab, index) => {
-        if (!tab) return undefined;
-
-        const tabProps = tab.props || {};
-
-        const isTabActive = index === activeIndex;
-
-        if (isTabActive) {
-          activeContent = tabProps.children;
-          if (typeof tabProps.title === 'string') {
-            activeTitle = tabProps.title;
-          } else {
-            activeTitle = index + 1;
-          }
-        }
-
-        return cloneElement(tab, {
-          active: isTabActive,
-          onActivate: () => activateTab(index),
-        });
-      },
-      this,
-    );
+    const [activeTitle, setActiveTitle] = useState();
 
     const tabsHeaderStyles = {};
     if (theme.tabs.header && theme.tabs.header.border) {
@@ -114,7 +83,21 @@ const Tabs = forwardRef(
           gap={theme.tabs.gap}
           {...tabsHeaderStyles}
         >
-          {tabs}
+          {React.Children.map(children, (child, index) => (
+            <TabsContext.Provider
+              // eslint-disable-next-line react/no-array-index-key
+              key={index}
+              value={{
+                activeIndex,
+                active: activeIndex === index,
+                onActivate: () => activateTab(index),
+                setActiveContent,
+                setActiveTitle,
+              }}
+            >
+              {child}
+            </TabsContext.Provider>
+          ))}
         </StyledTabsHeader>
         <StyledTabPanel
           flex={flex}

--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -25,6 +25,7 @@ const Tabs = forwardRef(
     const { activeIndex: propsActiveIndex, onActive } = rest;
     const [activeIndex, setActiveIndex] = useState(rest.activeIndex || 0);
     const [activeContent, setActiveContent] = useState();
+    const [activeTitle, setActiveTitle] = useState();
 
     if (activeIndex !== propsActiveIndex && propsActiveIndex !== undefined) {
       setActiveIndex(propsActiveIndex);
@@ -44,7 +45,19 @@ const Tabs = forwardRef(
     delete rest.onActive;
     /* eslint-enable no-param-reassign */
 
-    const [activeTitle, setActiveTitle] = useState();
+    const tabs = React.Children.map(children, (child, index) => (
+      <TabsContext.Provider
+        value={{
+          activeIndex,
+          active: activeIndex === index,
+          onActivate: () => activateTab(index),
+          setActiveContent,
+          setActiveTitle,
+        }}
+      >
+        {child}
+      </TabsContext.Provider>
+    ));
 
     const tabsHeaderStyles = {};
     if (theme.tabs.header && theme.tabs.header.border) {
@@ -83,21 +96,7 @@ const Tabs = forwardRef(
           gap={theme.tabs.gap}
           {...tabsHeaderStyles}
         >
-          {React.Children.map(children, (child, index) => (
-            <TabsContext.Provider
-              // eslint-disable-next-line react/no-array-index-key
-              key={index}
-              value={{
-                activeIndex,
-                active: activeIndex === index,
-                onActivate: () => activateTab(index),
-                setActiveContent,
-                setActiveTitle,
-              }}
-            >
-              {child}
-            </TabsContext.Provider>
-          ))}
+          {tabs}
         </StyledTabsHeader>
         <StyledTabPanel
           flex={flex}

--- a/src/js/components/Tabs/TabsContext.js
+++ b/src/js/components/Tabs/TabsContext.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const TabsContext = React.createContext({});

--- a/src/js/components/Tabs/__tests__/Tabs-test.js
+++ b/src/js/components/Tabs/__tests__/Tabs-test.js
@@ -71,6 +71,20 @@ describe('Tabs', () => {
     expect(component.toJSON()).toMatchSnapshot();
   });
 
+  test('Custom Tab component', () => {
+    const CustomTab = () => <Tab title="Tab 1">Tab body 1</Tab>;
+    const { container } = render(
+      <Grommet>
+        <Tabs>
+          <CustomTab />
+          <Tab title="Tab 2">Tab body 2</Tab>
+        </Tabs>
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('change to second tab', () => {
     const onActive = jest.fn();
     const { getByText, container } = render(

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -1,5 +1,247 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Tabs Custom Tab component 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
+  border-bottom: solid 2px #000000;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
+  border-bottom: solid 2px #7D4CDB;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 6px;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  color: #444444;
+}
+
+.c8 {
+  font-size: 18px;
+  line-height: 24px;
+  color: #7D4CDB;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c5 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
+}
+
+.c5:hover {
+  color: #000000;
+}
+
+.c9 {
+  min-height: 0;
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    margin-top: 2px;
+    margin-bottom: 2px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    border-bottom: solid 2px #000000;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    margin-top: 2px;
+    margin-bottom: 2px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    border-bottom: solid 2px #7D4CDB;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding-bottom: 3px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 "
+    role="tablist"
+  >
+    <div
+      class="c2 "
+    >
+      <button
+        aria-expanded="true"
+        aria-selected="true"
+        class="c3"
+        role="tab"
+        type="button"
+      >
+        <div
+          class="c4 c5"
+        >
+          <span
+            class="c6"
+          >
+            Tab 1
+          </span>
+        </div>
+      </button>
+      <button
+        aria-expanded="false"
+        aria-selected="false"
+        class="c3"
+        role="tab"
+        type="button"
+      >
+        <div
+          class="c7 c5"
+        >
+          <span
+            class="c8"
+          >
+            Tab 2
+          </span>
+        </div>
+      </button>
+    </div>
+    <div
+      aria-label="Tab 1 Tab Contents"
+      class="c9"
+      role="tabpanel"
+    >
+      Tab body 1
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Tabs Tab 1`] = `
 .c1 {
   display: -webkit-box;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Creates `TabsContext` which stores the `activeIndex` (needed to properly assign `activeTitle`), if tab is `active` (previously passed to Tab as a prop via clone child), `onActivate` (previously passed to individual Tab as a prop via clone child), `setActiveContent` (allows Tab to assign its children as the active content to be rendered by Tabs, and `setActiveTitle` (for screen reader accessibility).

Previously, Tabs was looking into its children to find what should be the active content displayed. If `Tab` was not the direct descendant of `Tabs`, it wouldn't render the child properly. Now, `Tab` takes more control by assigning its children to the activeContent. This hand-off is done using `TabsContext`.

Closes #4224 

#### Where should the reviewer start?
src/js/components/Tabs/Tabs.js

#### What testing has been done on this PR?
In local storybook, I recreated the setup causing the bug in the filed issue:

```
const MyTabComponent = props => (
  <Tab title="Tab 2" {...props}>
      <Text>Content for the Second tab</Text>
  </Tab>
);
...
...
<Tabs>
      <Tab title="Tab 1">
         <Text>Content for the First tab</Text>
      </Tab>
      <MyTabComponent />
</Tabs>
```

Prior to this change, the content inside of `MyTabComponent` wasn't rendering, but after this change it renders properly.

#### How should this be manually tested?
Same as above.

#### Any background context you want to provide?
Solves [this issue](https://github.com/grommet/grommet/issues/4224), when users created custom Tab component, the tab itself would render but its child content wouldn't.

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/4224

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, this is backwards compatible.