### PR TITLE
Fix/form on submit property event type

### DIFF
--- a/src/js/components/Form/index.d.ts
+++ b/src/js/components/Form/index.d.ts
@@ -1,11 +1,16 @@
 import * as React from "react";
 
+export interface FormExtendedEvent<T = Element> extends React.FormEvent<T> {
+  value: Record<string, any>;
+  touched: Record<string, boolean>;
+}
+
 export interface FormProps<T> {
   errors?: {};
   infos?: {};
   messages?: {invalid?: string,required?: string};
   onChange?: (value: T) => void;
-  onSubmit?: ((event: React.FormEvent) => void);
+  onSubmit?: ((event: FormExtendedEvent) => void);
   onReset?: ((event: React.SyntheticEvent) => any);
   validate?: 'blur' | 'submit';
   value?: {};

--- a/src/js/components/Form/stories/typescript/Submit.tsx
+++ b/src/js/components/Form/stories/typescript/Submit.tsx
@@ -15,7 +15,7 @@ import {
   TextArea,
 } from 'grommet';
 import { grommet } from 'grommet/themes';
-import { TypedForm } from '../../Form';
+import { FormExtendedEvent } from '../../Form';
 
 interface FormState {
   name?: string;
@@ -33,7 +33,10 @@ const Example = () => (
       <Box width="medium">
         <Form
           onReset={event => console.log(event)}
-          onChange={(value: FormState) => console.log('Submit', value)}
+          onChange={(value: FormState) => console.log('onChange', value)}
+          onSubmit={(event: FormExtendedEvent) =>
+            console.log('onSubmit', event.value, event.touched)
+          }
         >
           <FormField
             label="Name"

--- a/src/js/components/FormField/README.md
+++ b/src/js/components/FormField/README.md
@@ -15,8 +15,8 @@ import { FormField } from 'grommet';
 
 **component**
 
-The component to insert in the FormField. Grommet will add update the 
-      form values when this field changes. Any additional properties 
+The component to insert in the FormField. Grommet will add update the
+      form values when this field changes. Any additional properties
       (such as initial value) you pass to FormField will be forwarded to this
       component. The component may be custom as long it supports the properties
       of name, value, onChange (event => {}), while event has either event.value
@@ -199,7 +199,7 @@ Validation rule when used within a grommet Form. Provide an object
 
 ```
 {
-  regexp: object,
+  regexp: new RegExp(...),
   message: 
     string
     node,
@@ -210,7 +210,7 @@ Validation rule when used within a grommet Form. Provide an object
 function
 [
   {
-    regexp: object,
+    regexp: new RegExp(...),
     message: 
       string
       node,

--- a/src/js/components/FormField/doc.js
+++ b/src/js/components/FormField/doc.js
@@ -21,8 +21,8 @@ export const doc = FormField => {
       PropTypes.func,
       PropTypes.object,
     ]).description(
-      `The component to insert in the FormField. Grommet will add update the 
-      form values when this field changes. Any additional properties 
+      `The component to insert in the FormField. Grommet will add update the
+      form values when this field changes. Any additional properties
       (such as initial value) you pass to FormField will be forwarded to this
       component. The component may be custom as long it supports the properties
       of name, value, onChange (event => {}), while event has either event.value
@@ -57,7 +57,7 @@ export const doc = FormField => {
     required: PropTypes.bool.description('Whether the field is required.'),
     validate: PropTypes.oneOfType([
       PropTypes.shape({
-        regexp: PropTypes.object, // regular expression
+        regexp: PropTypes.instanceOf(RegExp), // regular expression
         message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
         status: PropTypes.oneOf(['error', 'info']),
       }),
@@ -65,7 +65,7 @@ export const doc = FormField => {
       PropTypes.arrayOf(
         PropTypes.oneOfType([
           PropTypes.shape({
-            regexp: PropTypes.object, // regular expression
+            regexp: PropTypes.instanceOf(RegExp), // regular expression
             message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
             status: PropTypes.oneOf(['error', 'info']),
           }),

--- a/src/js/components/TextInput/README.md
+++ b/src/js/components/TextInput/README.md
@@ -102,7 +102,7 @@ boolean
 
 **messages**
 
-Custom messages for TextInput. Used for accessibility by screen 
+Custom messages for TextInput. Used for accessibility by screen
         readers. Defaults to `{
   "enterSelect": "(Press Enter to Select)",
   "suggestionsCount": "suggestions available",
@@ -281,7 +281,7 @@ Defaults to
 
 **text**
 
-The possible sizes of the text in terms of its font-size and 
+The possible sizes of the text in terms of its font-size and
     line-height. Expects `object`.
 
 Defaults to

--- a/src/js/components/TextInput/doc.js
+++ b/src/js/components/TextInput/doc.js
@@ -55,7 +55,7 @@ export const doc = TextInput => {
       suggestionIsOpen: PropTypes.string,
     })
       .description(
-        `Custom messages for TextInput. Used for accessibility by screen 
+        `Custom messages for TextInput. Used for accessibility by screen
         readers.`,
       )
       .defaultValue({
@@ -101,7 +101,8 @@ Only use this when the containing context provides sufficient affordance`,
       PropTypes.oneOfType([
         PropTypes.shape({
           label: PropTypes.node,
-          value: PropTypes.any,
+          // eslint-disable-next-line
+          value: PropTypes.any, // this is intentional any
         }),
         PropTypes.string,
       ]),
@@ -148,7 +149,7 @@ export const themeDoc = {
     defaultValue: 20,
   },
   text: {
-    description: `The possible sizes of the text in terms of its font-size and 
+    description: `The possible sizes of the text in terms of its font-size and
     line-height.`,
     type: 'object',
     defaultValue: `{

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -7215,8 +7215,8 @@ import { FormField } from 'grommet';
 
 **component**
 
-The component to insert in the FormField. Grommet will add update the 
-      form values when this field changes. Any additional properties 
+The component to insert in the FormField. Grommet will add update the
+      form values when this field changes. Any additional properties
       (such as initial value) you pass to FormField will be forwarded to this
       component. The component may be custom as long it supports the properties
       of name, value, onChange (event => {}), while event has either event.value
@@ -7399,7 +7399,7 @@ Validation rule when used within a grommet Form. Provide an object
 
 \`\`\`
 {
-  regexp: object,
+  regexp: new RegExp(...),
   message: 
     string
     node,
@@ -7410,7 +7410,7 @@ Validation rule when used within a grommet Form. Provide an object
 function
 [
   {
-    regexp: object,
+    regexp: new RegExp(...),
     message: 
       string
       node,
@@ -14616,7 +14616,7 @@ boolean
 
 **messages**
 
-Custom messages for TextInput. Used for accessibility by screen 
+Custom messages for TextInput. Used for accessibility by screen
         readers. Defaults to \`{
   \\"enterSelect\\": \\"(Press Enter to Select)\\",
   \\"suggestionsCount\\": \\"suggestions available\\",
@@ -14795,7 +14795,7 @@ Defaults to
 
 **text**
 
-The possible sizes of the text in terms of its font-size and 
+The possible sizes of the text in terms of its font-size and
     line-height. Expects \`object\`.
 
 Defaults to

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -3287,8 +3287,8 @@ submit",
     "name": "FormField",
     "properties": Array [
       Object {
-        "description": "The component to insert in the FormField. Grommet will add update the 
-      form values when this field changes. Any additional properties 
+        "description": "The component to insert in the FormField. Grommet will add update the
+      form values when this field changes. Any additional properties
       (such as initial value) you pass to FormField will be forwarded to this
       component. The component may be custom as long it supports the properties
       of name, value, onChange (event => {}), while event has either event.value
@@ -3436,7 +3436,7 @@ string",
       describing the validation issue, if any, or an object with 'message'
       and 'status' properties.",
         "format": "{
-  regexp: object,
+  regexp: new RegExp(...),
   message: 
     string
     node,
@@ -3447,7 +3447,7 @@ string",
 function
 [
   {
-    regexp: object,
+    regexp: new RegExp(...),
     message: 
       string
       node,
@@ -6423,7 +6423,7 @@ string",
           "suggestionsCount": "suggestions available",
           "suggestionsExist": "This input has suggestions use arrow keys to navigate",
         },
-        "description": "Custom messages for TextInput. Used for accessibility by screen 
+        "description": "Custom messages for TextInput. Used for accessibility by screen
         readers.",
         "format": "{
   enterSelect: string,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fix form component onSubmit property event type to enriched with value and touched properties.

Besides small fix for lint errors of usage PropTypes.any and PropTypes.object in docs

#### Where should the reviewer start?

Reviewer should start from index.d.ts and then follow to submit.tsx story, after they should check both doc.js files. Other was generated. 

#### What testing has been done on this PR?

Storybook

#### How should this be manually tested?

Storybook, typescript - form - all form controls

#### Any background context you want to provide?

Second commit with fixes in doc.js I made just because pre-commit hook failed on this, so somehow it was in master.

#### What are the relevant issues?

Fixes https://github.com/grommet/grommet/issues/4264

#### Do the grommet docs need to be updated?

I don't think so

#### Should this PR be mentioned in the release notes?

I think yes, this should be very common issue for all typescript and Form users

#### Is this change backwards compatible or is it a breaking change?

It is backwards compatible, because it is a fix
