### PR TITLE
DataTable - update docs for prop type on size to accept string

### DIFF
--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -461,35 +461,40 @@ string
     small
     medium
     large
-    xlarge,
+    xlarge
+    string,
   vertical: 
     xxsmall
     xsmall
     small
     medium
     large
-    xlarge,
+    xlarge
+    string,
   top: 
     xxsmall
     xsmall
     small
     medium
     large
-    xlarge,
+    xlarge
+    string,
   bottom: 
     xxsmall
     xsmall
     small
     medium
     large
-    xlarge,
+    xlarge
+    string,
   left: 
     xxsmall
     xsmall
     small
     medium
     large
-    xlarge,
+    xlarge
+    string,
   right: 
     xxsmall
     xsmall
@@ -497,6 +502,7 @@ string
     medium
     large
     xlarge
+    string
 }
 {
   header: custom,

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -8,7 +8,10 @@ const parts = ['header', 'body', 'footer'];
 
 const padShapeSides = {};
 sides.forEach(side => {
-  padShapeSides[side] = PropTypes.oneOf(sizes);
+  padShapeSides[side] = PropTypes.oneOfType([
+    PropTypes.oneOf(sizes),
+    PropTypes.string,
+  ]);
 });
 
 const padShapeParts = {};

--- a/src/js/components/DataTable/stories/Simple.js
+++ b/src/js/components/DataTable/stories/Simple.js
@@ -11,7 +11,13 @@ import { columns, DATA } from './data';
 const SimpleDataTable = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
-      <DataTable columns={columns} data={DATA} step={10} />
+      <DataTable
+        pad={{ vertical: '100px', horizontal: '80px' }}
+        // pad={{ vertical: "medium", horizontal: "small" }}
+        columns={columns}
+        data={DATA}
+        step={10}
+      />
     </Box>
   </Grommet>
 );

--- a/src/js/components/DataTable/stories/Simple.js
+++ b/src/js/components/DataTable/stories/Simple.js
@@ -11,13 +11,7 @@ import { columns, DATA } from './data';
 const SimpleDataTable = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
-      <DataTable
-        pad={{ vertical: '100px', horizontal: '80px' }}
-        // pad={{ vertical: "medium", horizontal: "small" }}
-        columns={columns}
-        data={DATA}
-        step={10}
-      />
+      <DataTable columns={columns} data={DATA} step={10} />
     </Box>
   </Grommet>
 );

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -6027,35 +6027,40 @@ string
     small
     medium
     large
-    xlarge,
+    xlarge
+    string,
   vertical: 
     xxsmall
     xsmall
     small
     medium
     large
-    xlarge,
+    xlarge
+    string,
   top: 
     xxsmall
     xsmall
     small
     medium
     large
-    xlarge,
+    xlarge
+    string,
   bottom: 
     xxsmall
     xsmall
     small
     medium
     large
-    xlarge,
+    xlarge
+    string,
   left: 
     xxsmall
     xsmall
     small
     medium
     large
-    xlarge,
+    xlarge
+    string,
   right: 
     xxsmall
     xsmall
@@ -6063,6 +6068,7 @@ string
     medium
     large
     xlarge
+    string
 }
 {
   header: custom,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds to PropTypes for size of pad to also accept a string

Closes #4268 
#### Where should the reviewer start?
DataTable/doc.js
#### What testing has been done on this PR?
storybook 
add this to the simple story to test and check console warning 
```
     pad={{ vertical: '100px', horizontal: '80px' }}

```
#### How should this be manually tested?
`pad={{ vertical: '100px', horizontal: '80px' }}`
#### Any background context you want to provide?
issue #4268 
#### What are the relevant issues?
issue #4268 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
auto
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible