### PR TITLE
add extend to datatable body

### DIFF
--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -611,6 +611,16 @@ Defaults to
 { dark: 'white', light: 'black' }
 ```
 
+**dataTable.body.extend**
+
+Any additional style for an DataTable Body Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```
+
 **dataTable.groupHeader.background**
 
 The background color of the group header. Expects `string | { dark: string, light: string }`.

--- a/src/js/components/DataTable/StyledDataTable.js
+++ b/src/js/components/DataTable/StyledDataTable.js
@@ -18,7 +18,10 @@ const StyledDataTable = styled(Table)`
   border-collapse: collapse;
   height: auto; /* helps Firefox to get table contents to not overflow */
 
-  ${genericStyles};
+  ${genericStyles} ${props =>
+    props.theme.dataTable &&
+    props.theme.dataTable.body &&
+    props.theme.dataTable.body.extend};
 `;
 
 StyledDataTable.defaultProps = {};

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -1832,7 +1832,7 @@ exports[`DataTable click 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 hJcOxq"
+    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 dqmKUB"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 kdPLsZ StyledDataTable__StyledDataTableHeader-xrlyjm-3 hOGMbn"
@@ -2488,7 +2488,7 @@ exports[`DataTable groupBy 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 hJcOxq"
+    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 dqmKUB"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 kdPLsZ StyledDataTable__StyledDataTableHeader-xrlyjm-3 hOGMbn"
@@ -3402,7 +3402,7 @@ exports[`DataTable groupBy property 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 hJcOxq"
+    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 dqmKUB"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 kdPLsZ StyledDataTable__StyledDataTableHeader-xrlyjm-3 hOGMbn"
@@ -3798,7 +3798,7 @@ exports[`DataTable onSort 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 hJcOxq"
+    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 dqmKUB"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 kdPLsZ StyledDataTable__StyledDataTableHeader-xrlyjm-3 hOGMbn"
@@ -5881,7 +5881,7 @@ exports[`DataTable search 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 hJcOxq"
+    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 dqmKUB"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 kdPLsZ StyledDataTable__StyledDataTableHeader-xrlyjm-3 hOGMbn"
@@ -6310,7 +6310,7 @@ exports[`DataTable sortable 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 hJcOxq"
+    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 dqmKUB"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 kdPLsZ StyledDataTable__StyledDataTableHeader-xrlyjm-3 hOGMbn"

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -249,6 +249,11 @@ export const themeDoc = {
     type: 'string | { dark: string, light: string }',
     defaultValue: "{ dark: 'white', light: 'black' }",
   },
+  'dataTable.body.extend': {
+    description: 'Any additional style for an DataTable Body',
+    type: 'string | (props) => {}',
+    defaultValue: undefined,
+  },
   'dataTable.groupHeader.background': {
     description: 'The background color of the group header.',
     type: 'string | { dark: string, light: string }',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -6177,6 +6177,16 @@ Defaults to
 { dark: 'white', light: 'black' }
 \`\`\`
 
+**dataTable.body.extend**
+
+Any additional style for an DataTable Body Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
 **dataTable.groupHeader.background**
 
 The background color of the group header. Expects \`string | { dark: string, light: string }\`.

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -518,6 +518,9 @@ export interface ThemeType {
     baseline?: number;
   };
   dataTable?: {
+    body?:{
+      extend?: ExtendType;
+    }
     header?: {};
     groupHeader?: {
       border?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -640,6 +640,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       baseline: 500,
     },
     dataTable: {
+      // body: {
+      //   extend: undefined,
+      // },
       groupHeader: {
         background: {
           dark: 'dark-2',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds to extend for DataTable Body 
Closes #3792 
#### Where should the reviewer start?
StyledDataTable.js
#### What testing has been done on this PR?
Storybook
Took code from CodeSandBox and tested it in local storybook 

https://codesandbox.io/s/grommet-v2-template-55rdu?file=/index.js
use `const theme2 = {
  dataTable: { body: { extend: `min-height: 800px;` } },
};
`
#### How should this be manually tested?
Use a custom theme to set height of table body 
```

const theme2 = {
  dataTable: { body: { extend: `min-height: 800px;` } },
};

```
#### Any background context you want to provide?

#### What are the relevant issues?
Issue #3792 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
auto
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible