### PR TITLE
Add a11yTitle support to RadioButton component

### DIFF
--- a/src/js/components/RadioButton/README.md
+++ b/src/js/components/RadioButton/README.md
@@ -14,6 +14,15 @@ import { RadioButton } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom label to be used by screen readers.
+      When provided, an aria-label will be added to the element.
+
+```
+string
+```
+
 **checked**
 
 Same as React <input checked={} />

--- a/src/js/components/RadioButton/RadioButton.js
+++ b/src/js/components/RadioButton/RadioButton.js
@@ -16,7 +16,18 @@ import {
 
 const RadioButton = forwardRef(
   (
-    { checked, children, disabled, focus, id, label, name, onChange, ...rest },
+    {
+      a11yTitle,
+      checked,
+      children,
+      disabled,
+      focus,
+      id,
+      label,
+      name,
+      onChange,
+      ...rest
+    },
     ref,
   ) => {
     const theme = useContext(ThemeContext) || defaultProps.theme;
@@ -55,6 +66,7 @@ const RadioButton = forwardRef(
           }
         >
           <StyledRadioButtonInput
+            aria-label={a11yTitle}
             {...rest}
             ref={ref}
             type="radio"

--- a/src/js/components/RadioButton/__tests__/RadioButton-test.js
+++ b/src/js/components/RadioButton/__tests__/RadioButton-test.js
@@ -1,12 +1,30 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import 'jest-styled-components';
+import 'jest-axe/extend-expect';
+import 'regenerator-runtime/runtime';
 
+import { axe } from 'jest-axe';
+import { cleanup, render } from '@testing-library/react';
 import { Grommet } from '../../Grommet';
 import { Box } from '../../Box';
 import { RadioButton } from '..';
 
 describe('RadioButton', () => {
+  afterEach(cleanup);
+
+  test('should have no accessibility violations', async () => {
+    const { container } = render(
+      <Grommet>
+        <RadioButton name="test" a11yTitle="test" />
+      </Grommet>,
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+    expect(container).toMatchSnapshot();
+  });
+
   test('basic', () => {
     const component = renderer.create(
       <Grommet>

--- a/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
+++ b/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
@@ -934,3 +934,124 @@ exports[`RadioButton label themed 1`] = `
   </label>
 </div>
 `;
+
+exports[`RadioButton should have no accessibility violations 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px rgba(0,0,0,0.15);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 100%;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: pointer;
+}
+
+.c1:hover input:not([disabled]) + div,
+.c1:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c3 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    border: solid 2px rgba(0,0,0,0.15);
+  }
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <label
+      class="c1"
+    >
+      <div
+        class="c2 "
+      >
+        <input
+          aria-label="test"
+          class="c3"
+          name="test"
+          type="radio"
+        />
+        <div
+          class="c4 "
+        />
+      </div>
+    </label>
+  </div>
+</div>
+`;

--- a/src/js/components/RadioButton/doc.js
+++ b/src/js/components/RadioButton/doc.js
@@ -17,6 +17,10 @@ export const doc = RadioButton => {
     .intrinsicElement('input');
 
   DocumentedRadioButton.propTypes = {
+    a11yTitle: PropTypes.string.description(
+      `Custom label to be used by screen readers.
+      When provided, an aria-label will be added to the element.`,
+    ),
     checked: PropTypes.bool.description('Same as React <input checked={} />'),
     children: PropTypes.func.description(
       `Function that will be called to render the visual representation.

--- a/src/js/components/RadioButton/index.d.ts
+++ b/src/js/components/RadioButton/index.d.ts
@@ -1,6 +1,8 @@
 import * as React from "react";
+import { A11yTitleType } from "../../utils";
 
 export interface RadioButtonProps {
+  a11yTitle?: A11yTitleType;
   checked?: boolean;
   disabled?: boolean;
   id?: string;

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11299,6 +11299,15 @@ import { RadioButton } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom label to be used by screen readers.
+      When provided, an aria-label will be added to the element.
+
+\`\`\`
+string
+\`\`\`
+
 **checked**
 
 Same as React <input checked={} />

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -5284,6 +5284,12 @@ end",
     "name": "RadioButton",
     "properties": Array [
       Object {
+        "description": "Custom label to be used by screen readers.
+      When provided, an aria-label will be added to the element.",
+        "format": "string",
+        "name": "a11yTitle",
+      },
+      Object {
         "description": "Same as React <input checked={} />",
         "format": "boolean",
         "name": "checked",


### PR DESCRIPTION
#### What does this PR do?
Adds the `a11yTitle` prop to RadioButton

#### Where should the reviewer start?
RadioButton.js

#### What testing has been done on this PR?
`yarn test`
added an accessibility test

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #4287
#4284

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Updated in this PR

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards comaptible