### PR TITLE
Fix Calendar onSelect type

### DIFF
--- a/src/js/components/Calendar/index.d.ts
+++ b/src/js/components/Calendar/index.d.ts
@@ -24,6 +24,6 @@ export interface CalendarProps {
 }
 
 declare const Calendar: React.ComponentClass<CalendarProps & JSX.IntrinsicElements['div']>;
-export type CalendarType = CalendarProps & JSX.IntrinsicElements['div'];
+export type CalendarType = CalendarProps & Omit<JSX.IntrinsicElements['div'], 'onSelect'>;
 
 export { Calendar };

--- a/src/js/components/Calendar/index.d.ts
+++ b/src/js/components/Calendar/index.d.ts
@@ -16,7 +16,7 @@ export interface CalendarProps {
   header?: ((...args: any[]) => any);
   locale?: string;
   onReference?: ((reference: string) => void);
-  onSelect?: ((select: string[]) => any);
+  onSelect?: ((select: string | string[]) => any);
   range?: boolean;
   reference?: string;
   showAdjacentDays?: boolean;


### PR DESCRIPTION
Signed-off-by: Llorenç Muntaner <llorenc.muntaner@gmail.com>

#### What does this PR do?

Improve typings for Calendar component

#### Where should the reviewer start?

`src/js/components/Calendar/index.d.ts

#### What testing has been done on this PR?

No extra tests added.

#### How should this be manually tested?

No manual testing.

#### Any background context you want to provide?

When Calendar is used with single option select, the parameter passed to the handler is a string, not an array of strings.

#### What are the relevant issues?

No issue found.

#### Screenshots (if appropriate)

Not applicable.

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No need.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
