### PR TITLE
Adjust wording of time docs

### DIFF
--- a/src/js/components/Clock/README.md
+++ b/src/js/components/Clock/README.md
@@ -181,7 +181,7 @@ string
 
 ISO8601 time or duration. For example: 'PT8H12M23S',
       'T08:12:23', or '2015-02-22T08:12:23'. Any included date
-      portion will be ignored for an analog clock. If not provided, the
+      portion will be ignored. If not provided, the
       current browser time will be used.
 
 ```

--- a/src/js/components/Clock/doc.js
+++ b/src/js/components/Clock/doc.js
@@ -42,7 +42,7 @@ export const doc = Clock => {
     time: PropTypes.string.description(
       `ISO8601 time or duration. For example: 'PT8H12M23S',
       'T08:12:23', or '2015-02-22T08:12:23'. Any included date
-      portion will be ignored for an analog clock. If not provided, the
+      portion will be ignored. If not provided, the
       current browser time will be used.`,
     ),
     type: PropTypes.oneOf(['analog', 'digital'])

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4986,7 +4986,7 @@ string
 
 ISO8601 time or duration. For example: 'PT8H12M23S',
       'T08:12:23', or '2015-02-22T08:12:23'. Any included date
-      portion will be ignored for an analog clock. If not provided, the
+      portion will be ignored. If not provided, the
       current browser time will be used.
 
 \`\`\`

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2324,7 +2324,7 @@ string",
       Object {
         "description": "ISO8601 time or duration. For example: 'PT8H12M23S',
       'T08:12:23', or '2015-02-22T08:12:23'. Any included date
-      portion will be ignored for an analog clock. If not provided, the
+      portion will be ignored. If not provided, the
       current browser time will be used.",
         "format": "string",
         "name": "time",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adjusts clock docs. While looking to resolve the `onChange` docs, I noticed that this wording needed to be updated as well. Regardless of if a clock is analog or digital, if the time provided includes a date then the date gets stripped off.

#### Where should the reviewer start?
src/js/components/Clock/doc.js

#### What testing has been done on this PR?
Updated README etc

#### How should this be manually tested?

#### Any background context you want to provide?
Finding related to closing https://github.com/grommet/grommet/issues/4251

#### What are the relevant issues?
#4251 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Updated here.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
backwards compatible.