### PR TITLE
add proper documentation for tab.extend

### DIFF
--- a/src/js/components/Tab/README.md
+++ b/src/js/components/Tab/README.md
@@ -138,6 +138,16 @@ Defaults to
 undefined
 ```
 
+**tab.extend**
+
+Any additional style for Tab. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```
+
 **tab.hover.background**
 
 background style of the Tab on hover. Expects `string | object`.

--- a/src/js/components/Tab/doc.js
+++ b/src/js/components/Tab/doc.js
@@ -80,6 +80,11 @@ export const themeDoc = {
     type: 'string | {dark: string, light: string}',
     defaultValue: undefined,
   },
+  'tab.extend': {
+    description: 'Any additional style for Tab.',
+    type: 'string | (props) => {}',
+    defaultValue: undefined,
+  },
   'tab.hover.background': {
     description: 'background style of the Tab on hover.',
     type: 'string | object',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -13367,6 +13367,16 @@ Defaults to
 undefined
 \`\`\`
 
+**tab.extend**
+
+Any additional style for Tab. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
 **tab.hover.background**
 
 background style of the Tab on hover. Expects \`string | object\`.


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds missing documentation for the `tab.extend` component, mentioned on #4310 

#### Where should the reviewer start?
`/Tab/doc.js`
#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #4310 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
