### PR TITLE
rework chart gradient id

### DIFF
--- a/src/js/components/Chart/Chart.js
+++ b/src/js/components/Chart/Chart.js
@@ -472,8 +472,9 @@ const Chart = React.forwardRef(
     let defs;
     let gradientRect;
     if (useGradient && size[1]) {
-      const gradientId = `${id}-gradient`;
-      const maskId = `${id}-mask`;
+      const uniqueGradientId = color.map(element => element.color).join('-');
+      const gradientId = `${uniqueGradientId}-${id}-gradient`;
+      const maskId = `${uniqueGradientId}-${id}-mask`;
       defs = (
         <defs>
           <linearGradient id={gradientId} x1={0} y1={0} x2={0} y2={1}>

--- a/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
+++ b/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
@@ -475,7 +475,7 @@ exports[`Chart color 1`] = `
   >
     <defs>
       <linearGradient
-        id="undefined-gradient"
+        id="border-brand-undefined-gradient"
         x1={0}
         x2={0}
         y1={0}
@@ -491,7 +491,7 @@ exports[`Chart color 1`] = `
         />
       </linearGradient>
       <mask
-        id="undefined-mask"
+        id="border-brand-undefined-mask"
       >
         <g
           fill="none"
@@ -524,9 +524,9 @@ exports[`Chart color 1`] = `
       </mask>
     </defs>
     <rect
-      fill="url(#undefined-gradient)"
+      fill="url(#border-brand-undefined-gradient)"
       height={216}
-      mask="url(#undefined-mask)"
+      mask="url(#border-brand-undefined-mask)"
       width={408}
       x={-12}
       y={-12}


### PR DESCRIPTION
#### What does this PR do?

Proposes a new approach to chart gradients ID, as a fallback to missing `id` prop.

#### Where should the reviewer start?

src/js/components/Chart/Chart.js:475

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#3992 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
