### PR TITLE
refactor formField.border.error to formField.error.border to match pattern

### DIFF
--- a/src/js/components/Form/stories/FieldStatesCustom.js
+++ b/src/js/components/Form/stories/FieldStatesCustom.js
@@ -7,9 +7,6 @@ import { deepMerge } from '../../../utils';
 const customTheme = deepMerge(grommet, {
   formField: {
     border: {
-      error: {
-        color: 'border',
-      },
       color: 'border',
       side: 'all',
     },
@@ -27,6 +24,9 @@ const customTheme = deepMerge(grommet, {
     error: {
       background: {
         color: { light: '#FF404033', dark: '#FF40404D' },
+      },
+      border: {
+        color: 'border',
       },
       size: 'xsmall',
       color: 'text-weak',

--- a/src/js/components/FormField/README.md
+++ b/src/js/components/FormField/README.md
@@ -239,16 +239,6 @@ Defaults to
 border
 ```
 
-**formField.border.error.color**
-
-The border color of the error. Expects `string | {'dark': string, 'light': string}`.
-
-Defaults to
-
-```
-{ dark: 'white', light: 'status-critical' },
-```
-
 **formField.border.position**
 
 The border position. Expects `string`.
@@ -347,6 +337,16 @@ Defaults to
 
 ```
 undefined
+```
+
+**formField.error.border.color**
+
+The border color of the error. Expects `string | {'dark': string, 'light': string}`.
+
+Defaults to
+
+```
+{ dark: 'white', light: 'status-critical' },
 ```
 
 **formField.error.color**

--- a/src/js/components/FormField/doc.js
+++ b/src/js/components/FormField/doc.js
@@ -92,11 +92,6 @@ export const themeDoc = {
     type: "string | { 'dark': string, 'light': string }",
     defaultValue: 'border',
   },
-  'formField.border.error.color': {
-    description: 'The border color of the error.',
-    type: "string | {'dark': string, 'light': string}",
-    defaultValue: "{ dark: 'white', light: 'status-critical' },",
-  },
   'formField.border.position': {
     description: 'The border position.',
     type: 'string',
@@ -148,6 +143,11 @@ export const themeDoc = {
       'The opacity of the FormField background when there is an error.',
     type: 'string | boolean | number',
     defaultValue: undefined,
+  },
+  'formField.error.border.color': {
+    description: 'The border color of the error.',
+    type: "string | {'dark': string, 'light': string}",
+    defaultValue: "{ dark: 'white', light: 'status-critical' },",
   },
   'formField.error.color': {
     description: 'The color of the FormField error.',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -7687,16 +7687,6 @@ Defaults to
 border
 \`\`\`
 
-**formField.border.error.color**
-
-The border color of the error. Expects \`string | {'dark': string, 'light': string}\`.
-
-Defaults to
-
-\`\`\`
-{ dark: 'white', light: 'status-critical' },
-\`\`\`
-
 **formField.border.position**
 
 The border position. Expects \`string\`.
@@ -7795,6 +7785,16 @@ Defaults to
 
 \`\`\`
 undefined
+\`\`\`
+
+**formField.error.border.color**
+
+The border color of the error. Expects \`string | {'dark': string, 'light': string}\`.
+
+Defaults to
+
+\`\`\`
+{ dark: 'white', light: 'status-critical' },
 \`\`\`
 
 **formField.error.color**


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
changes formField.border.error to formField.error.border so it matches the pattern of the other errors,

#### What does this PR do?

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
on storyboard  `/story/form--field-states-custom`
#### Any background context you want to provide?

#### What are the relevant issues?
#4004 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?