### PR TITLE
CheckBox added `a11yTitle` and updated documentation

### DIFF
--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -29,6 +29,7 @@ const stopLabelClick = event => {
 const CheckBox = forwardRef(
   (
     {
+      a11yTitle,
       checked: checkedProp,
       disabled,
       focus: focusProp,
@@ -190,6 +191,7 @@ const CheckBox = forwardRef(
 
     return (
       <StyledCheckBoxContainer
+        aria-label={a11yTitle}
         reverse={reverse}
         {...removeUndefined({ htmlFor: id, disabled })}
         checked={checked}

--- a/src/js/components/CheckBox/README.md
+++ b/src/js/components/CheckBox/README.md
@@ -11,6 +11,15 @@ import { CheckBox } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom label to be used by screen readers.
+      When provided, an aria-label will be added to the element.
+
+```
+string
+```
+
 **checked**
 
 Same as React <input checked={} />
@@ -38,7 +47,8 @@ string
 
 **label**
 
-Label text to place next to the control.
+Label text to place next to the control. 
+      Can be used instead of a11yTitle to meet accessibility requirements
 
 ```
 node

--- a/src/js/components/CheckBox/__tests__/CheckBox-test.js
+++ b/src/js/components/CheckBox/__tests__/CheckBox-test.js
@@ -15,6 +15,17 @@ describe('CheckBox', () => {
   test('should not have accessibility violations', async () => {
     const { container } = render(
       <Grommet>
+        <CheckBox a11yTitle="test" />
+      </Grommet>,
+    );
+    const results = await axe(container);
+    expect(container.firstChild).toMatchSnapshot();
+    expect(results).toHaveNoViolations();
+  });
+
+  test('label should not have accessibility violations', async () => {
+    const { container } = render(
+      <Grommet>
         <CheckBox label="test" />
       </Grommet>,
     );

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -995,6 +995,149 @@ exports[`CheckBox label renders 1`] = `
 </div>
 `;
 
+exports[`CheckBox label should not have accessibility violations 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-right: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px rgba(0,0,0,0.15);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: pointer;
+}
+
+.c1:hover input:not([disabled]) + div,
+.c1:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c4 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.c4:checked + span > span {
+  left: calc( 48px - 24px );
+  background: #7D4CDB;
+}
+
+.c3 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    border: solid 2px rgba(0,0,0,0.15);
+  }
+}
+
+<div
+  class="c0"
+>
+  <label
+    class="c1"
+  >
+    <div
+      class="c2 c3"
+    >
+      <input
+        class="c4"
+        type="checkbox"
+      />
+      <div
+        class="c5 "
+      />
+    </div>
+    <span>
+      test
+    </span>
+  </label>
+</div>
+`;
+
 exports[`CheckBox renders 1`] = `
 .c0 {
   font-size: 18px;
@@ -1331,7 +1474,6 @@ exports[`CheckBox should not have accessibility violations 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  margin-right: 12px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1421,12 +1563,6 @@ exports[`CheckBox should not have accessibility violations 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
-    margin-right: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
   .c5 {
     border: solid 2px rgba(0,0,0,0.15);
   }
@@ -1436,6 +1572,7 @@ exports[`CheckBox should not have accessibility violations 1`] = `
   class="c0"
 >
   <label
+    aria-label="test"
     class="c1"
   >
     <div
@@ -1449,9 +1586,6 @@ exports[`CheckBox should not have accessibility violations 1`] = `
         class="c5 "
       />
     </div>
-    <span>
-      test
-    </span>
   </label>
 </div>
 `;

--- a/src/js/components/CheckBox/doc.js
+++ b/src/js/components/CheckBox/doc.js
@@ -13,6 +13,10 @@ export const doc = CheckBox => {
     .intrinsicElement('input');
 
   DocumentedCheckBox.propTypes = {
+    a11yTitle: PropTypes.string.description(
+      `Custom label to be used by screen readers.
+      When provided, an aria-label will be added to the element.`,
+    ),
     checked: PropTypes.bool
       .description('Same as React <input checked={} />')
       .defaultValue(false),
@@ -26,7 +30,8 @@ export const doc = CheckBox => {
       'The DOM id attribute value to use for the underlying <input/> element.',
     ),
     label: PropTypes.node.description(
-      'Label text to place next to the control.',
+      `Label text to place next to the control. 
+      Can be used instead of a11yTitle to meet accessibility requirements`,
     ),
     name: PropTypes.string.description(
       `The DOM name attribute value to use for the underlying <input/> 

--- a/src/js/components/CheckBox/index.d.ts
+++ b/src/js/components/CheckBox/index.d.ts
@@ -1,6 +1,8 @@
-import * as React from "react";
+import * as React from 'react';
+import { A11yTitleType } from '../../utils';
 
 export interface CheckBoxProps {
+  a11yTitle?: A11yTitleType;
   checked?: boolean;
   disabled?: boolean;
   id?: string;
@@ -11,6 +13,7 @@ export interface CheckBoxProps {
   indeterminate?: boolean;
 }
 
-declare const CheckBox: React.FC<CheckBoxProps & JSX.IntrinsicElements['input']>;
+declare const CheckBox: React.FC<CheckBoxProps &
+  JSX.IntrinsicElements['input']>;
 
 export { CheckBox };

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4444,6 +4444,15 @@ import { CheckBox } from 'grommet';
 
 ## Properties
 
+**a11yTitle**
+
+Custom label to be used by screen readers.
+      When provided, an aria-label will be added to the element.
+
+\`\`\`
+string
+\`\`\`
+
 **checked**
 
 Same as React <input checked={} />
@@ -4471,7 +4480,8 @@ string
 
 **label**
 
-Label text to place next to the control.
+Label text to place next to the control. 
+      Can be used instead of a11yTitle to meet accessibility requirements
 
 \`\`\`
 node

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2038,6 +2038,12 @@ point",
     "name": "CheckBox",
     "properties": Array [
       Object {
+        "description": "Custom label to be used by screen readers.
+      When provided, an aria-label will be added to the element.",
+        "format": "string",
+        "name": "a11yTitle",
+      },
+      Object {
         "defaultValue": false,
         "description": "Same as React <input checked={} />",
         "format": "boolean",
@@ -2056,7 +2062,8 @@ point",
         "name": "id",
       },
       Object {
-        "description": "Label text to place next to the control.",
+        "description": "Label text to place next to the control. 
+      Can be used instead of a11yTitle to meet accessibility requirements",
         "format": "node",
         "name": "label",
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds `a11yTitle` to CheckBox. Updates documentation to show `a11yTitle` and show that setting the `label` prop also fulfills accessibility requirements

#### Where should the reviewer start?
CheckBox.js

#### What testing has been done on this PR?
Added a second accessability test to test accessibility for `a11yTitle` and `label`

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
#4244 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Done

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
