### PR TITLE
Fix/box gap doc

### DIFF
--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -450,9 +450,8 @@ boolean
 
 The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
-        will not wrap gracefully. If a child component renders a fragment,
-        Box will not add a gap between the individual elements in the
-        fragment.
+        will not wrap gracefully. If a child is a Fragment,
+        Box will not add a gap between the choldren of the Fragment.
 
 ```
 none

--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -450,7 +450,9 @@ boolean
 
 The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
-        will not wrap gracefully.
+        will not wrap gracefully. If a child component is or renders a fragment,
+        Box will not add a gap between the individual elements in the
+        fragment
 
 ```
 none

--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -450,9 +450,9 @@ boolean
 
 The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
-        will not wrap gracefully. If a child component is or renders a fragment,
+        will not wrap gracefully. If a child component renders a fragment,
         Box will not add a gap between the individual elements in the
-        fragment
+        fragment.
 
 ```
 none

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -212,9 +212,8 @@ export const doc = Box => {
       PropTypes.string,
     ]).description(`The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
-        will not wrap gracefully. If a child component renders a fragment,
-        Box will not add a gap between the individual elements in the
-        fragment.`),
+        will not wrap gracefully. If a child is a Fragment,
+        Box will not add a gap between the choldren of the Fragment.`),
     height: PropTypes.oneOfType([
       PropTypes.oneOf([
         'xxsmall',

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -212,7 +212,9 @@ export const doc = Box => {
       PropTypes.string,
     ]).description(`The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
-        will not wrap gracefully.`),
+        will not wrap gracefully. If a child component is or renders a fragment,
+        Box will not add a gap between the individual elements in the
+        fragment`),
     height: PropTypes.oneOfType([
       PropTypes.oneOf([
         'xxsmall',

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -212,9 +212,9 @@ export const doc = Box => {
       PropTypes.string,
     ]).description(`The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
-        will not wrap gracefully. If a child component is or renders a fragment,
+        will not wrap gracefully. If a child component renders a fragment,
         Box will not add a gap between the individual elements in the
-        fragment`),
+        fragment.`),
     height: PropTypes.oneOfType([
       PropTypes.oneOf([
         'xxsmall',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1306,9 +1306,9 @@ boolean
 
 The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
-        will not wrap gracefully. If a child component is or renders a fragment,
+        will not wrap gracefully. If a child component renders a fragment,
         Box will not add a gap between the individual elements in the
-        fragment
+        fragment.
 
 \`\`\`
 none

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1307,7 +1307,8 @@ boolean
 The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
         will not wrap gracefully. If a child component is or renders a fragment,
-        Box will not add a gap between the individual elements in the fragment
+        Box will not add a gap between the individual elements in the
+        fragment
 
 \`\`\`
 none

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1306,7 +1306,8 @@ boolean
 
 The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
-        will not wrap gracefully.
+        will not wrap gracefully. If a child component is or renders a fragment,
+        Box will not add a gap between the individual elements in the fragment
 
 \`\`\`
 none

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1306,9 +1306,8 @@ boolean
 
 The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
-        will not wrap gracefully. If a child component renders a fragment,
-        Box will not add a gap between the individual elements in the
-        fragment.
+        will not wrap gracefully. If a child is a Fragment,
+        Box will not add a gap between the choldren of the Fragment.
 
 \`\`\`
 none

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -788,9 +788,8 @@ boolean",
       Object {
         "description": "The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
-        will not wrap gracefully. If a child component renders a fragment,
-        Box will not add a gap between the individual elements in the
-        fragment.",
+        will not wrap gracefully. If a child is a Fragment,
+        Box will not add a gap between the choldren of the Fragment.",
         "format": "none
 xxsmall
 xsmall

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -788,9 +788,9 @@ boolean",
       Object {
         "description": "The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
-        will not wrap gracefully. If a child component is or renders a fragment,
+        will not wrap gracefully. If a child component renders a fragment,
         Box will not add a gap between the individual elements in the
-        fragment",
+        fragment.",
         "format": "none
 xxsmall
 xsmall

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -788,7 +788,9 @@ boolean",
       Object {
         "description": "The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
-        will not wrap gracefully.",
+        will not wrap gracefully. If a child component is or renders a fragment,
+        Box will not add a gap between the individual elements in the
+        fragment",
         "format": "none
 xxsmall
 xsmall


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Updates the Box documentation for the gap property to note that gap won't be added between any elements that are contained in a fragment.

#### Where should the reviewer start?
doc.js

#### What testing has been done on this PR?
jest tests updated

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
#4076 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Done

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
It's backwards compatible
