### PR TITLE
Changed Chart to add per-value color and thickness for bar and point types

### DIFF
--- a/src/js/components/Chart/Chart.js
+++ b/src/js/components/Chart/Chart.js
@@ -225,6 +225,7 @@ const Chart = React.forwardRef(
             color: valueColor,
             label,
             onHover: valueOnHover,
+            opacity: valueOpacity,
             thickness: valueThickness,
             value,
             ...valueRest
@@ -268,6 +269,11 @@ const Chart = React.forwardRef(
                   ? parseMetricToNum(
                       theme.global.edgeSize[valueThickness] || valueThickness,
                     )
+                  : undefined
+              }
+              opacity={
+                valueOpacity
+                  ? theme.global.opacity[valueOpacity] || valueOpacity
                   : undefined
               }
             >
@@ -383,6 +389,7 @@ const Chart = React.forwardRef(
             color: valueColor,
             label,
             onHover: valueOnHover,
+            opacity: valueOpacity,
             thickness: valueThickness,
             value,
             ...valueRest
@@ -442,6 +449,11 @@ const Chart = React.forwardRef(
               key={key}
               stroke="none"
               fill={valueColor ? normalizeColor(valueColor, theme) : undefined}
+              opacity={
+                valueOpacity
+                  ? theme.global.opacity[valueOpacity] || valueOpacity
+                  : undefined
+              }
             >
               <title>{label}</title>
               {renderPoint(value[0], value[1])}
@@ -469,7 +481,9 @@ const Chart = React.forwardRef(
       else if (theme.chart && theme.chart.color) colorName = theme.chart.color;
     }
     const opacity =
-      color && color.opacity ? theme.global.opacity[color.opacity] : undefined;
+      color && color.opacity
+        ? theme.global.opacity[color.opacity] || color.opacity
+        : undefined;
 
     let stroke;
     if (type !== 'point') {

--- a/src/js/components/Chart/Chart.js
+++ b/src/js/components/Chart/Chart.js
@@ -222,8 +222,10 @@ const Chart = React.forwardRef(
         .filter(({ value }) => value[1] !== undefined)
         .map((valueArg, index) => {
           const {
+            color: valueColor,
             label,
             onHover: valueOnHover,
+            thickness: valueThickness,
             value,
             ...valueRest
           } = valueArg;
@@ -255,7 +257,20 @@ const Chart = React.forwardRef(
           }
 
           return (
-            <g key={key} fill="none">
+            <g
+              key={key}
+              fill="none"
+              stroke={
+                valueColor ? normalizeColor(valueColor, theme) : undefined
+              }
+              strokeWidth={
+                valueThickness
+                  ? parseMetricToNum(
+                      theme.global.edgeSize[valueThickness] || valueThickness,
+                    )
+                  : undefined
+              }
+            >
               <title>{label}</title>
               <path
                 d={d}
@@ -365,8 +380,10 @@ const Chart = React.forwardRef(
         .filter(({ value }) => value[1] !== undefined)
         .map((valueArg, index) => {
           const {
+            color: valueColor,
             label,
             onHover: valueOnHover,
+            thickness: valueThickness,
             value,
             ...valueRest
           } = valueArg;
@@ -385,10 +402,16 @@ const Chart = React.forwardRef(
             clickProps = { onClick };
           }
 
+          const width = valueThickness
+            ? parseMetricToNum(
+                theme.global.edgeSize[valueThickness] || valueThickness,
+              )
+            : strokeWidth;
+
           const renderPoint = (valueX, valueY) => {
             const props = { ...hoverProps, ...clickProps, ...valueRest };
             const [cx, cy] = valueToCoordinate(valueX, valueY);
-            const off = strokeWidth / 2;
+            const off = width / 2;
             if (point === 'circle' || (!point && round))
               return <circle cx={cx} cy={cy} r={off} {...props} />;
             let d;
@@ -415,7 +438,11 @@ const Chart = React.forwardRef(
           };
 
           return (
-            <g key={key} stroke="none">
+            <g
+              key={key}
+              stroke="none"
+              fill={valueColor ? normalizeColor(valueColor, theme) : undefined}
+            >
               <title>{label}</title>
               {renderPoint(value[0], value[1])}
               {value[2] !== undefined && renderPoint(value[0], value[2])}

--- a/src/js/components/Chart/Chart.js
+++ b/src/js/components/Chart/Chart.js
@@ -272,9 +272,8 @@ const Chart = React.forwardRef(
                   : undefined
               }
               opacity={
+                (valueOpacity && theme.global.opacity[valueOpacity]) ||
                 valueOpacity
-                  ? theme.global.opacity[valueOpacity] || valueOpacity
-                  : undefined
               }
             >
               <title>{label}</title>
@@ -450,9 +449,8 @@ const Chart = React.forwardRef(
               stroke="none"
               fill={valueColor ? normalizeColor(valueColor, theme) : undefined}
               opacity={
+                (valueOpacity && theme.global.opacity[valueOpacity]) ||
                 valueOpacity
-                  ? theme.global.opacity[valueOpacity] || valueOpacity
-                  : undefined
               }
             >
               <title>{label}</title>

--- a/src/js/components/Chart/README.md
+++ b/src/js/components/Chart/README.md
@@ -390,6 +390,7 @@ large
 xlarge
 none
 string
+number
 ```
 
 **type**
@@ -420,6 +421,9 @@ Required. Array of value objects describing the data.
     label: string,
     onClick: function,
     onHover: function,
+    opacity: 
+      string
+      number,
     thickness: 
       hair
       xsmall
@@ -428,7 +432,8 @@ Required. Array of value objects describing the data.
       large
       xlarge
       none
-      string,
+      string
+      number,
     value: 
       number
       [number]

--- a/src/js/components/Chart/README.md
+++ b/src/js/components/Chart/README.md
@@ -149,7 +149,16 @@ A color identifier to use for the graphic color. If an
 ```
 string
 {
-  color: string,
+  dark: string,
+  light: string
+}
+{
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
   opacity: 
     weak
     medium
@@ -157,7 +166,12 @@ string
     boolean
 }
 [{
-  color: string,
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
   value: number
 }]
 ```
@@ -411,13 +425,20 @@ Required. Array of value objects describing the data.
       indicating the x coordinate and a range of two y coordinates.
       'label' is a text string describing it.
       'onHover' and 'onClick' only work when type='bar'.
+      'color', 'opacity', and 'thickness' allow bar and point charts to have
+      color variation per-value.
 
 ```
 [
   number
   [number]
   {
-    color: string,
+    color: 
+      string
+      {
+        dark: string,
+        light: string
+      },
     label: string,
     onClick: function,
     onHover: function,

--- a/src/js/components/Chart/README.md
+++ b/src/js/components/Chart/README.md
@@ -416,9 +416,19 @@ Required. Array of value objects describing the data.
   number
   [number]
   {
+    color: string,
     label: string,
     onClick: function,
     onHover: function,
+    thickness: 
+      hair
+      xsmall
+      small
+      medium
+      large
+      xlarge
+      none
+      string,
     value: 
       number
       [number]

--- a/src/js/components/Chart/__tests__/Chart-test.js
+++ b/src/js/components/Chart/__tests__/Chart-test.js
@@ -21,6 +21,11 @@ const UNDEFINED_VALUES = [
   { value: [0, 0], label: 'zero' },
 ];
 
+const STYLED_VALUES = [
+  { value: [1, 60], label: 'sixty', color: 'status-ok', thickness: 'small' },
+  { value: [0, 0], label: 'zero', color: 'status-warning', thickness: 'large' },
+];
+
 describe('Chart', () => {
   afterEach(cleanup);
 
@@ -155,6 +160,17 @@ describe('Chart', () => {
         <Chart type="point" point="star" values={VALUES} />
         <Chart type="point" point="triangle" values={VALUES} />
         <Chart type="point" point="triangleDown" values={VALUES} />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('value style', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Chart type="point" point="circle" values={STYLED_VALUES} />
+        <Chart type="bar" values={STYLED_VALUES} />
       </Grommet>,
     );
     const tree = component.toJSON();

--- a/src/js/components/Chart/__tests__/Chart-test.js
+++ b/src/js/components/Chart/__tests__/Chart-test.js
@@ -22,8 +22,20 @@ const UNDEFINED_VALUES = [
 ];
 
 const STYLED_VALUES = [
-  { value: [1, 60], label: 'sixty', color: 'status-ok', thickness: 'small' },
-  { value: [0, 0], label: 'zero', color: 'status-warning', thickness: 'large' },
+  {
+    value: [1, 60],
+    label: 'sixty',
+    color: 'status-ok',
+    opacity: 'strong',
+    thickness: 'small',
+  },
+  {
+    value: [0, 0],
+    label: 'zero',
+    color: '#123456',
+    opacity: 0.27,
+    thickness: 27,
+  },
 ];
 
 describe('Chart', () => {

--- a/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
+++ b/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
@@ -2006,3 +2006,107 @@ exports[`Chart undefined values 1`] = `
   </svg>
 </div>
 `;
+
+exports[`Chart value style 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: block;
+  max-width: 100%;
+  overflow: visible;
+}
+
+<div
+  className="c0"
+>
+  <svg
+    className="c1"
+    height={192}
+    preserveAspectRatio="none"
+    viewBox="-12 -12 408 216"
+    width={384}
+  >
+    <g
+      fill="#6FFFB0"
+      stroke="none"
+      strokeLinecap="butt"
+      strokeLinejoin="miter"
+    >
+      <g
+        fill="#00C781"
+        stroke="none"
+      >
+        <title>
+          sixty
+        </title>
+        <circle
+          cx={384}
+          cy={0}
+          r={6}
+        />
+      </g>
+      <g
+        fill="#FFAA15"
+        stroke="none"
+      >
+        <title>
+          zero
+        </title>
+        <circle
+          cx={0}
+          cy={192}
+          r={24}
+        />
+      </g>
+    </g>
+  </svg>
+  <svg
+    className="c1"
+    height={192}
+    preserveAspectRatio="none"
+    viewBox="-12 -12 408 216"
+    width={384}
+  >
+    <g
+      fill="none"
+      stroke="#6FFFB0"
+      strokeLinecap="butt"
+      strokeLinejoin="miter"
+      strokeWidth={24}
+    >
+      <g
+        fill="none"
+        stroke="#00C781"
+        strokeWidth={12}
+      >
+        <title>
+          sixty
+        </title>
+        <path
+          d="M 384,192 L 384,0"
+        />
+      </g>
+      <g
+        fill="none"
+        stroke="#FFAA15"
+        strokeWidth={48}
+      >
+        <title>
+          zero
+        </title>
+        <path
+          d="M 0,192 L 0,192"
+        />
+      </g>
+    </g>
+  </svg>
+</div>
+`;

--- a/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
+++ b/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
@@ -2042,6 +2042,7 @@ exports[`Chart value style 1`] = `
     >
       <g
         fill="#00C781"
+        opacity={0.8}
         stroke="none"
       >
         <title>
@@ -2054,7 +2055,8 @@ exports[`Chart value style 1`] = `
         />
       </g>
       <g
-        fill="#FFAA15"
+        fill="#123456"
+        opacity={0.27}
         stroke="none"
       >
         <title>
@@ -2063,7 +2065,7 @@ exports[`Chart value style 1`] = `
         <circle
           cx={0}
           cy={192}
-          r={24}
+          r={13.5}
         />
       </g>
     </g>
@@ -2084,6 +2086,7 @@ exports[`Chart value style 1`] = `
     >
       <g
         fill="none"
+        opacity={0.8}
         stroke="#00C781"
         strokeWidth={12}
       >
@@ -2096,8 +2099,9 @@ exports[`Chart value style 1`] = `
       </g>
       <g
         fill="none"
-        stroke="#FFAA15"
-        strokeWidth={48}
+        opacity={0.27}
+        stroke="#123456"
+        strokeWidth={27}
       >
         <title>
           zero

--- a/src/js/components/Chart/doc.js
+++ b/src/js/components/Chart/doc.js
@@ -2,6 +2,19 @@ import { describe, PropTypes } from 'react-desc';
 
 import { genericProps, getAvailableAtBadge, padPropType } from '../../utils';
 
+const thicknessType = PropTypes.oneOfType([
+  PropTypes.oneOf([
+    'hair',
+    'xsmall',
+    'small',
+    'medium',
+    'large',
+    'xlarge',
+    'none',
+  ]),
+  PropTypes.string,
+]);
+
 export const doc = Chart => {
   const DocumentedChart = describe(Chart)
     .availableAt(getAvailableAtBadge('Chart'))
@@ -146,18 +159,7 @@ export const doc = Chart => {
       used elsewhere.`,
       )
       .defaultValue({ width: 'medium', height: 'small' }),
-    thickness: PropTypes.oneOfType([
-      PropTypes.oneOf([
-        'hair',
-        'xsmall',
-        'small',
-        'medium',
-        'large',
-        'xlarge',
-        'none',
-      ]),
-      PropTypes.string,
-    ])
+    thickness: thicknessType
       .description('The width of the stroke.')
       .defaultValue('medium'),
     type: PropTypes.oneOf(['bar', 'line', 'area', 'point'])
@@ -168,9 +170,11 @@ export const doc = Chart => {
         PropTypes.number,
         PropTypes.arrayOf(PropTypes.number),
         PropTypes.shape({
-          label: PropTypes.string, // for accessibility of bars
+          color: PropTypes.string,
+          label: PropTypes.string, // for accessibility of bars and points
           onClick: PropTypes.func,
           onHover: PropTypes.func,
+          thickness: thicknessType,
           value: PropTypes.oneOfType([
             PropTypes.number.isRequired,
             PropTypes.arrayOf(PropTypes.number).isRequired,

--- a/src/js/components/Chart/doc.js
+++ b/src/js/components/Chart/doc.js
@@ -1,6 +1,11 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { genericProps, getAvailableAtBadge, padPropType } from '../../utils';
+import {
+  colorPropType,
+  genericProps,
+  getAvailableAtBadge,
+  padPropType,
+} from '../../utils';
 
 const thicknessType = PropTypes.oneOfType([
   PropTypes.oneOf([
@@ -35,9 +40,9 @@ export const doc = Chart => {
       the provided values.`,
     ),
     color: PropTypes.oneOfType([
-      PropTypes.string,
+      colorPropType,
       PropTypes.shape({
-        color: PropTypes.string,
+        color: colorPropType,
         opacity: PropTypes.oneOfType([
           PropTypes.oneOf(['weak', 'medium', 'strong']),
           PropTypes.bool,
@@ -45,7 +50,7 @@ export const doc = Chart => {
       }),
       PropTypes.arrayOf(
         PropTypes.shape({
-          color: PropTypes.string,
+          color: colorPropType,
           value: PropTypes.number,
         }),
       ),
@@ -171,7 +176,7 @@ export const doc = Chart => {
         PropTypes.number,
         PropTypes.arrayOf(PropTypes.number),
         PropTypes.shape({
-          color: PropTypes.string,
+          color: colorPropType,
           label: PropTypes.string, // for accessibility of bars and points
           onClick: PropTypes.func,
           onHover: PropTypes.func,
@@ -188,7 +193,9 @@ export const doc = Chart => {
       'value' is a tuple indicating the coordinate of the value or a triple
       indicating the x coordinate and a range of two y coordinates.
       'label' is a text string describing it.
-      'onHover' and 'onClick' only work when type='bar'.`,
+      'onHover' and 'onClick' only work when type='bar'.
+      'color', 'opacity', and 'thickness' allow bar and point charts to have
+      color variation per-value.`,
     ).isRequired,
   };
 

--- a/src/js/components/Chart/doc.js
+++ b/src/js/components/Chart/doc.js
@@ -13,6 +13,7 @@ const thicknessType = PropTypes.oneOfType([
     'none',
   ]),
   PropTypes.string,
+  PropTypes.number,
 ]);
 
 export const doc = Chart => {
@@ -174,6 +175,7 @@ export const doc = Chart => {
           label: PropTypes.string, // for accessibility of bars and points
           onClick: PropTypes.func,
           onHover: PropTypes.func,
+          opacity: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
           thickness: thicknessType,
           value: PropTypes.oneOfType([
             PropTypes.number.isRequired,

--- a/src/js/components/Chart/index.d.ts
+++ b/src/js/components/Chart/index.d.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from 'react';
 import {
   A11yTitleType,
   AlignSelfType,
@@ -6,7 +6,17 @@ import {
   GapType,
   GridAreaType,
   MarginType,
-} from "../../utils";
+} from '../../utils';
+
+type ThicknessType =
+  | 'hair'
+  | 'xsmall'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'xlarge'
+  | 'none'
+  | string;
 
 export interface ChartProps {
   a11yTitle?: A11yTitleType;
@@ -14,19 +24,70 @@ export interface ChartProps {
   gridArea?: GridAreaType;
   margin?: MarginType;
   bounds?: number[][];
-  color?: string | {color?: string,opacity?: "weak" | "medium" | "strong" | boolean} | {color: string, value: number | number[]}[];
+  color?:
+    | string
+    | { color?: string; opacity?: 'weak' | 'medium' | 'strong' | boolean }
+    | { color: string; value: number | number[] }[];
   dash?: boolean;
   gap?: GapType;
-  onClick?: ((...args: any[]) => any);
-  onHover?: ((...args: any[]) => any);
+  onClick?: (...args: any[]) => any;
+  onHover?: (...args: any[]) => any;
   overflow?: boolean;
-  pad?: EdgeSizeType | { horizontal?: EdgeSizeType, vertical?: EdgeSizeType };
-  point?: "circle" | "diamond" | "square" | "star" | "triangle" | "triangleDown";
+  pad?: EdgeSizeType | { horizontal?: EdgeSizeType; vertical?: EdgeSizeType };
+  point?:
+    | 'circle'
+    | 'diamond'
+    | 'square'
+    | 'star'
+    | 'triangle'
+    | 'triangleDown';
   round?: boolean;
-  size?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "fill" | "full" | {height?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "fill" | "full" | string,width?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "fill" | "full" | string} | string;
-  thickness?: "hair" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "none" | string;
-  type?: "bar" | "line" | "area" | "point";
-  values: (number | number[] | {label?: string,onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any),value: number | number[]})[];
+  size?:
+    | 'xxsmall'
+    | 'xsmall'
+    | 'small'
+    | 'medium'
+    | 'large'
+    | 'xlarge'
+    | 'fill'
+    | 'full'
+    | {
+        height?:
+          | 'xxsmall'
+          | 'xsmall'
+          | 'small'
+          | 'medium'
+          | 'large'
+          | 'xlarge'
+          | 'fill'
+          | 'full'
+          | string;
+        width?:
+          | 'xxsmall'
+          | 'xsmall'
+          | 'small'
+          | 'medium'
+          | 'large'
+          | 'xlarge'
+          | 'fill'
+          | 'full'
+          | string;
+      }
+    | string;
+  thickness?: ThicknessType;
+  type?: 'bar' | 'line' | 'area' | 'point';
+  values: (
+    | number
+    | number[]
+    | {
+        color?: string;
+        label?: string;
+        onClick?: (...args: any[]) => any;
+        onHover?: (...args: any[]) => any;
+        thickness?: ThicknessType;
+        value: number | number[];
+      }
+  )[];
 }
 
 declare const Chart: React.ComponentClass<ChartProps>;

--- a/src/js/components/Chart/index.d.ts
+++ b/src/js/components/Chart/index.d.ts
@@ -16,7 +16,8 @@ type ThicknessType =
   | 'large'
   | 'xlarge'
   | 'none'
-  | string;
+  | string
+  | number;
 
 export interface ChartProps {
   a11yTitle?: A11yTitleType;
@@ -26,7 +27,10 @@ export interface ChartProps {
   bounds?: number[][];
   color?:
     | string
-    | { color?: string; opacity?: 'weak' | 'medium' | 'strong' | boolean }
+    | {
+        color?: string;
+        opacity?: 'weak' | 'medium' | 'strong' | boolean | number;
+      }
     | { color: string; value: number | number[] }[];
   dash?: boolean;
   gap?: GapType;
@@ -84,6 +88,7 @@ export interface ChartProps {
         label?: string;
         onClick?: (...args: any[]) => any;
         onHover?: (...args: any[]) => any;
+        opacity?: 'weak' | 'medium' | 'strong' | boolean | number;
         thickness?: ThicknessType;
         value: number | number[];
       }

--- a/src/js/components/Chart/index.d.ts
+++ b/src/js/components/Chart/index.d.ts
@@ -2,22 +2,13 @@ import * as React from 'react';
 import {
   A11yTitleType,
   AlignSelfType,
+  ColorType,
   EdgeSizeType,
   GapType,
   GridAreaType,
   MarginType,
+  ThicknessType,
 } from '../../utils';
-
-type ThicknessType =
-  | 'hair'
-  | 'xsmall'
-  | 'small'
-  | 'medium'
-  | 'large'
-  | 'xlarge'
-  | 'none'
-  | string
-  | number;
 
 export interface ChartProps {
   a11yTitle?: A11yTitleType;
@@ -26,12 +17,12 @@ export interface ChartProps {
   margin?: MarginType;
   bounds?: number[][];
   color?:
-    | string
+    | ColorType
     | {
-        color?: string;
+        color?: ColorType;
         opacity?: 'weak' | 'medium' | 'strong' | boolean | number;
       }
-    | { color: string; value: number | number[] }[];
+    | { color: ColorType; value: number | number[] }[];
   dash?: boolean;
   gap?: GapType;
   onClick?: (...args: any[]) => any;
@@ -84,7 +75,7 @@ export interface ChartProps {
     | number
     | number[]
     | {
-        color?: string;
+        color?: ColorType;
         label?: string;
         onClick?: (...args: any[]) => any;
         onHover?: (...args: any[]) => any;

--- a/src/js/components/Chart/stories/ValueStyle.js
+++ b/src/js/components/Chart/stories/ValueStyle.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { Grommet, Box, Chart } from 'grommet';
+import { grommet } from 'grommet/themes';
+
+const values = [
+  { value: [10, 20], thickness: 'small', color: 'status-critical' },
+  { value: [20, 30], thickness: 'medium', color: 'status-ok' },
+  { value: [30, 15], thickness: 'large', color: 'status-warning' },
+];
+
+const Example = () => (
+  <Grommet theme={grommet}>
+    <Box align="center" pad="large" gap="large">
+      <Chart type="point" point="circle" values={values} />
+      <Chart type="bar" values={values} />
+    </Box>
+  </Grommet>
+);
+
+storiesOf('Chart', module).add('Value Style', () => <Example />);

--- a/src/js/components/Chart/stories/ValueStyle.js
+++ b/src/js/components/Chart/stories/ValueStyle.js
@@ -5,8 +5,33 @@ import { Grommet, Box, Chart } from 'grommet';
 import { grommet } from 'grommet/themes';
 
 const values = [
-  { value: [10, 20], thickness: 'small', color: 'status-critical' },
-  { value: [20, 30], thickness: 'medium', color: 'status-ok' },
+  {
+    value: [10, 20],
+    thickness: 12,
+    color: 'status-critical',
+    opacity: 'medium',
+  },
+  {
+    value: [10, 30],
+    thickness: 29,
+    color: 'status-critical',
+    opacity: 'medium',
+  },
+  {
+    value: [11, 37],
+    thickness: 68,
+    color: 'status-critical',
+    opacity: 'medium',
+  },
+  {
+    value: [13, 10],
+    thickness: 'small',
+    color: 'status-critical',
+    opacity: 'medium',
+  },
+  { value: [20, 30], thickness: 'small', color: 'status-ok' },
+  { value: [22, 5], thickness: 'medium', color: 'status-ok' },
+  { value: [27, 42], thickness: 'large', color: 'status-ok' },
   { value: [30, 15], thickness: 'large', color: 'status-warning' },
 ];
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4332,9 +4332,19 @@ Required. Array of value objects describing the data.
   number
   [number]
   {
+    color: string,
     label: string,
     onClick: function,
     onHover: function,
+    thickness: 
+      hair
+      xsmall
+      small
+      medium
+      large
+      xlarge
+      none
+      string,
     value: 
       number
       [number]

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4306,6 +4306,7 @@ large
 xlarge
 none
 string
+number
 \`\`\`
 
 **type**
@@ -4336,6 +4337,9 @@ Required. Array of value objects describing the data.
     label: string,
     onClick: function,
     onHover: function,
+    opacity: 
+      string
+      number,
     thickness: 
       hair
       xsmall
@@ -4344,7 +4348,8 @@ Required. Array of value objects describing the data.
       large
       xlarge
       none
-      string,
+      string
+      number,
     value: 
       number
       [number]

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4065,7 +4065,16 @@ A color identifier to use for the graphic color. If an
 \`\`\`
 string
 {
-  color: string,
+  dark: string,
+  light: string
+}
+{
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
   opacity: 
     weak
     medium
@@ -4073,7 +4082,12 @@ string
     boolean
 }
 [{
-  color: string,
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
   value: number
 }]
 \`\`\`
@@ -4327,13 +4341,20 @@ Required. Array of value objects describing the data.
       indicating the x coordinate and a range of two y coordinates.
       'label' is a text string describing it.
       'onHover' and 'onClick' only work when type='bar'.
+      'color', 'opacity', and 'thickness' allow bar and point charts to have
+      color variation per-value.
 
 \`\`\`
 [
   number
   [number]
   {
-    color: string,
+    color: 
+      string
+      {
+        dark: string,
+        light: string
+      },
     label: string,
     onClick: function,
     onHover: function,

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2005,9 +2005,19 @@ point",
   number
   [number]
   {
+    color: string,
     label: string,
     onClick: function,
     onHover: function,
+    thickness: 
+      hair
+      xsmall
+      small
+      medium
+      large
+      xlarge
+      none
+      string,
     value: 
       number
       [number]

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1983,7 +1983,8 @@ medium
 large
 xlarge
 none
-string",
+string
+number",
         "name": "thickness",
       },
       Object {
@@ -2009,6 +2010,9 @@ point",
     label: string,
     onClick: function,
     onHover: function,
+    opacity: 
+      string
+      number,
     thickness: 
       hair
       xsmall
@@ -2017,7 +2021,8 @@ point",
       large
       xlarge
       none
-      string,
+      string
+      number,
     value: 
       number
       [number]

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1771,7 +1771,16 @@ string",
       where the gradient colors change.",
         "format": "string
 {
-  color: string,
+  dark: string,
+  light: string
+}
+{
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
   opacity: 
     weak
     medium
@@ -1779,7 +1788,12 @@ string",
     boolean
 }
 [{
-  color: string,
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
   value: number
 }]",
         "name": "color",
@@ -2001,12 +2015,19 @@ point",
       'value' is a tuple indicating the coordinate of the value or a triple
       indicating the x coordinate and a range of two y coordinates.
       'label' is a text string describing it.
-      'onHover' and 'onClick' only work when type='bar'.",
+      'onHover' and 'onClick' only work when type='bar'.
+      'color', 'opacity', and 'thickness' allow bar and point charts to have
+      color variation per-value.",
         "format": "[
   number
   [number]
   {
-    color: string,
+    color: 
+      string
+      {
+        dark: string,
+        light: string
+      },
     label: string,
     onClick: function,
     onHover: function,

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -2,66 +2,206 @@
 declare const normalizeColor: (
   color: string | { dark?: string; light?: string },
   theme: object,
-  required?: boolean
+  required?: boolean,
 ) => string;
 
-export {normalizeColor}
+export { normalizeColor };
 
 // object.js
 export type DeepReadonly<T extends object> = {
   readonly [K in keyof T]: T[K] extends object ? DeepReadonly<T[K]> : T[K];
-}
-export type NonUndefined<T> = T extends undefined ? never: T;
+};
+export type NonUndefined<T> = T extends undefined ? never : T;
 export type NonUndefinedProps<T extends object> = {
   [K in keyof T]?: NonUndefined<T[K]>;
-}
+};
 
 export type DeepFreeze = <T extends object>(obj: T) => DeepReadonly<T>;
 
 // overload because generic variadic solution has messy result and all/most mergings are binary
 export interface DeepMerge {
   <T extends object, S extends object>(target: T, source: S): T & S;
-  <T extends object, S extends object[]>(target: T, ...sources: S): T & S[number];
+  <T extends object, S extends object[]>(target: T, ...sources: S): T &
+    S[number];
 }
 
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
-export type PolymorphicType = keyof JSX.IntrinsicElements | React.ComponentType<any>
+export type PolymorphicType =
+  | keyof JSX.IntrinsicElements
+  | React.ComponentType<any>;
 
-declare const isObject: (item:any) => boolean;
+declare const isObject: (item: any) => boolean;
 declare const deepFreeze: DeepFreeze;
 declare const deepMerge: DeepMerge;
-declare const removeUndefined: <T extends object>(obj: T) => NonUndefinedProps<T>;
+declare const removeUndefined: <T extends object>(
+  obj: T,
+) => NonUndefinedProps<T>;
 
-export {isObject, deepFreeze, deepMerge, removeUndefined};
+export { isObject, deepFreeze, deepMerge, removeUndefined };
 
 // Extracting types for common properties among components
-type BoxSideType = "top" | "left" | "bottom" | "right" | "start" | "end" | "horizontal" | "vertical" | "all" | "between";
-type BoxSizeType = "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
-type BoxStyleType = "solid" | "dashed" | "dotted" | "double" | "groove" | "ridge" | "inset" | "outset" | "hidden";
-export type EdgeSizeType = "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge";
-type EdgeType = "none" | EdgeSizeType | {bottom?: EdgeSizeType | string,end?: EdgeSizeType | string,horizontal?: EdgeSizeType | string,left?: EdgeSizeType | string,right?: EdgeSizeType | string,start?: EdgeSizeType | string,top?: EdgeSizeType | string,vertical?: EdgeSizeType | string} | string
+type BoxSideType =
+  | 'top'
+  | 'left'
+  | 'bottom'
+  | 'right'
+  | 'start'
+  | 'end'
+  | 'horizontal'
+  | 'vertical'
+  | 'all'
+  | 'between';
+type BoxSizeType = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | string;
+type BoxStyleType =
+  | 'solid'
+  | 'dashed'
+  | 'dotted'
+  | 'double'
+  | 'groove'
+  | 'ridge'
+  | 'inset'
+  | 'outset'
+  | 'hidden';
+export type EdgeSizeType =
+  | 'xxsmall'
+  | 'xsmall'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'xlarge';
+type EdgeType =
+  | 'none'
+  | EdgeSizeType
+  | {
+      bottom?: EdgeSizeType | string;
+      end?: EdgeSizeType | string;
+      horizontal?: EdgeSizeType | string;
+      left?: EdgeSizeType | string;
+      right?: EdgeSizeType | string;
+      start?: EdgeSizeType | string;
+      top?: EdgeSizeType | string;
+      vertical?: EdgeSizeType | string;
+    }
+  | string;
 
 export type A11yTitleType = string;
-export type AlignContentType = "start" | "center" | "end" | "between" | "around" | "stretch";
-export type AlignSelfType = "start" | "center" | "end" | "stretch";
+export type AlignContentType =
+  | 'start'
+  | 'center'
+  | 'end'
+  | 'between'
+  | 'around'
+  | 'stretch';
+export type AlignSelfType = 'start' | 'center' | 'end' | 'stretch';
 export type AnimateType = boolean;
-export type BackgroundType = string | {color?: ColorType,dark?: boolean | string,image?: string,position?: string,opacity?: "weak" | "medium" | "strong" | number | boolean,repeat?: "no-repeat" | "repeat" | string,size?: "cover" | "contain" | string,light?: string};
-export type BasisType = "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "full" | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "auto" | string;
-export type BorderType = boolean | BoxSideType | {color?: ColorType, side?: BoxSideType, size?: BoxSizeType, style?: BoxStyleType} | ({color?: ColorType, side?: BoxSideType, size?: BoxSizeType, style?: BoxStyleType})[];
-export type ColorType = string | {dark?: string,light?: string} | undefined;
-export type ElevationType = "none" | "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
-export type FillType = "horizontal" | "vertical" | boolean;
-export type GapType = "none" | EdgeSizeType | string;
-export type GraphColorsType = string[] | {dark?: string[],light?: string[]};
+export type BackgroundType =
+  | string
+  | {
+      color?: ColorType;
+      dark?: boolean | string;
+      image?: string;
+      position?: string;
+      opacity?: 'weak' | 'medium' | 'strong' | number | boolean;
+      repeat?: 'no-repeat' | 'repeat' | string;
+      size?: 'cover' | 'contain' | string;
+      light?: string;
+    };
+export type BasisType =
+  | 'xxsmall'
+  | 'xsmall'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'xlarge'
+  | 'xxlarge'
+  | 'full'
+  | '1/2'
+  | '1/3'
+  | '2/3'
+  | '1/4'
+  | '2/4'
+  | '3/4'
+  | 'auto'
+  | string;
+export type BorderType =
+  | boolean
+  | BoxSideType
+  | {
+      color?: ColorType;
+      side?: BoxSideType;
+      size?: BoxSizeType;
+      style?: BoxStyleType;
+    }
+  | {
+      color?: ColorType;
+      side?: BoxSideType;
+      size?: BoxSizeType;
+      style?: BoxStyleType;
+    }[];
+export type ColorType = string | { dark?: string; light?: string } | undefined;
+export type ElevationType =
+  | 'none'
+  | 'xsmall'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'xlarge'
+  | string;
+export type FillType = 'horizontal' | 'vertical' | boolean;
+export type GapType = 'none' | EdgeSizeType | string;
+export type GraphColorsType = string[] | { dark?: string[]; light?: string[] };
 export type GridAreaType = string;
-export type JustifyContentType = "start" | "center" | "end" | "between" | "around" | "stretch";
-export type KeyboardType = ((event: React.KeyboardEvent<HTMLElement>) => void);
+export type JustifyContentType =
+  | 'start'
+  | 'center'
+  | 'end'
+  | 'between'
+  | 'around'
+  | 'stretch';
+export type KeyboardType = (event: React.KeyboardEvent<HTMLElement>) => void;
 export type MarginType = EdgeType;
-export type OpacityType = "weak" | "medium" | "strong" | string | true | false | number;
+export type OpacityType =
+  | 'weak'
+  | 'medium'
+  | 'strong'
+  | string
+  | true
+  | false
+  | number;
 export type PadType = EdgeType;
 export type PlaceHolderType = string | JSX.Element | React.ReactNode;
-export type RoundType = boolean | "xsmall" | "small" | "medium" | "large" | "xlarge" | "full" | string | {corner?: "top" | "left" | "bottom" | "right" | "top-left" | "top-right" | "bottom-left" | "bottom-right",size?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string};
-export type TextAlignType = "start" | "center" | "end";
+export type RoundType =
+  | boolean
+  | 'xsmall'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'xlarge'
+  | 'full'
+  | string
+  | {
+      corner?:
+        | 'top'
+        | 'left'
+        | 'bottom'
+        | 'right'
+        | 'top-left'
+        | 'top-right'
+        | 'bottom-left'
+        | 'bottom-right';
+      size?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | string;
+    };
+export type TextAlignType = 'start' | 'center' | 'end';
+export type ThicknessType =
+  | 'hair'
+  | 'xsmall'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'xlarge'
+  | 'none'
+  | string
+  | number;
 
 declare const breakpointEdgeSize: {
   none?: string;
@@ -76,15 +216,15 @@ declare const breakpointEdgeSize: {
 export type BreakpointEdgeSize = typeof breakpointEdgeSize;
 
 declare const breakpointBorderSize: {
-    xsmall?: string;
-    small?: string;
-    medium?: string;
-    large?: string;
-    xlarge?: string;
-}
+  xsmall?: string;
+  small?: string;
+  medium?: string;
+  large?: string;
+  xlarge?: string;
+};
 export type BreakpointBorderSize = typeof breakpointBorderSize;
 
-declare const breakpointSize: {          
+declare const breakpointSize: {
   xxsmall?: string;
   xsmall?: string;
   small?: string;

--- a/src/js/utils/mixins.js
+++ b/src/js/utils/mixins.js
@@ -1,10 +1,11 @@
 import { css } from 'styled-components';
 
-export const parseMetricToNum = fontAsString => {
-  if (fontAsString.match(/\s/) && process.env.NODE_ENV !== 'production') {
-    console.warn(`Invalid single measurement value: "${fontAsString}"`);
+export const parseMetricToNum = metric => {
+  if (typeof metric === 'number') return metric;
+  if (metric.match(/\s/) && process.env.NODE_ENV !== 'production') {
+    console.warn(`Invalid single measurement value: "${metric}"`);
   }
-  return parseFloat(fontAsString.match(/\d+(\.\d+)?/), 10);
+  return parseFloat(metric.match(/\d+(\.\d+)?/), 10);
 };
 
 export const fontSize = (size, lineHeight) => css`


### PR DESCRIPTION
#### What does this PR do?

Changed Chart to add per-value color and thickness for bar and point types.

#### Where should the reviewer start?

Take a look at the new story to see how they are used.

#### What testing has been done on this PR?

Added unit tests and a storybook story.

#### How should this be manually tested?

storybook

#### Any background context you want to provide?

This was asked for by a group doing data science work as a way to represent four values in one Chart: x, y, thickness, and color.

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
