### PR TITLE
Allow Text and Heading to accept ref

### DIFF
--- a/src/js/components/Heading/Heading.js
+++ b/src/js/components/Heading/Heading.js
@@ -21,6 +21,7 @@ const Heading = forwardRef((props, ref) => {
   );
 });
 
+Heading.displayName = 'Heading';
 Heading.defaultProps = {
   level: 1,
   responsive: true,

--- a/src/js/components/Heading/Heading.js
+++ b/src/js/components/Heading/Heading.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { StyledHeading } from './StyledHeading';
 
-const Heading = props => {
+const Heading = forwardRef((props, ref) => {
   const {
     color, // munged to avoid styled-components putting it in the DOM
     level,
@@ -16,9 +16,10 @@ const Heading = props => {
       colorProp={color}
       level={+level}
       {...rest}
+      ref={ref}
     />
   );
-};
+});
 
 Heading.defaultProps = {
   level: 1,

--- a/src/js/components/Heading/__tests__/Heading-test.js
+++ b/src/js/components/Heading/__tests__/Heading-test.js
@@ -15,6 +15,19 @@ test('Heading renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('Heading accepts ref', () => {
+  const ref = React.createRef();
+  const component = renderer.create(
+    <Grommet>
+      <Heading ref={ref} />
+    </Grommet>,
+    { createNodeMock: el => el },
+  );
+  expect(ref.current).not.toBeNull();
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('Heading level renders', () => {
   const component = renderer.create(
     <Grommet>

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -1,5 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Heading accepts ref 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  font-size: 50px;
+  line-height: 56px;
+  max-width: 1200px;
+  font-weight: 600;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    font-size: 34px;
+    line-height: 40px;
+    max-width: 816px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <h1
+    className="c1"
+  />
+</div>
+`;
+
 exports[`Heading color renders 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/Text/Text.js
+++ b/src/js/components/Text/Text.js
@@ -12,6 +12,7 @@ const Text = forwardRef(({ color, tag, as, a11yTitle, ...rest }, ref) => (
   />
 ));
 
+Text.displayName = 'Text';
 Text.defaultProps = {
   level: 1,
 };

--- a/src/js/components/Text/Text.js
+++ b/src/js/components/Text/Text.js
@@ -1,15 +1,16 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { StyledText } from './StyledText';
 
-const Text = ({ color, tag, as, a11yTitle, ...rest }) => (
+const Text = forwardRef(({ color, tag, as, a11yTitle, ...rest }, ref) => (
   <StyledText
     as={!as && tag ? tag : as}
     colorProp={color}
     aria-label={a11yTitle}
     {...rest}
+    ref={ref}
   />
-);
+));
 
 Text.defaultProps = {
   level: 1,

--- a/src/js/components/Text/__tests__/Text-test.js
+++ b/src/js/components/Text/__tests__/Text-test.js
@@ -31,6 +31,19 @@ test('renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('accepts ref', () => {
+  const ref = React.createRef();
+  const component = renderer.create(
+    <Grommet>
+      <Text ref={ref}>text</Text>
+    </Grommet>,
+    { createNodeMock: el => el },
+  );
+  expect(ref.current).not.toBeNull();
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('renders size', () => {
   const component = renderer.create(
     <Grommet>

--- a/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
+++ b/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`accepts ref 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+<div
+  className="c0"
+>
+  <span
+    className="c1"
+  >
+    text
+  </span>
+</div>
+`;
+
 exports[`renders 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -4081,7 +4081,196 @@ function",
   },
   "Grommet": [Function],
   "Header": [Function],
-  "Heading": [Function],
+  "Heading": Object {
+    "availableAt": Array [
+      Object {
+        "badge": "https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png",
+        "label": "Storybook",
+        "url": "https://storybook.grommet.io/?selectedKind=Heading&full=0&addons=0&stories=1&panelRight=0",
+      },
+      Object {
+        "badge": "https://codesandbox.io/static/img/play-codesandbox.svg",
+        "label": "CodeSandbox",
+        "url": "https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=/heading&module=%2Fsrc%2FHeading.js",
+      },
+    ],
+    "description": "Heading text structured in levels.",
+    "intrinsicElement": Array [
+      "h1",
+      "h2",
+      "h3",
+      "h4",
+    ],
+    "name": "Heading",
+    "properties": Array [
+      Object {
+        "description": "Custom label to be used by screen readers. When provided, an aria-label will
+   be added to the element.",
+        "format": "string",
+        "name": "a11yTitle",
+      },
+      Object {
+        "description": "How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.",
+        "format": "start
+center
+end
+stretch",
+        "name": "alignSelf",
+      },
+      Object {
+        "description": "The name of the area to place
+    this inside a parent Grid.",
+        "format": "string",
+        "name": "gridArea",
+      },
+      Object {
+        "description": "The amount of margin around the component. An object can
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.",
+        "format": "none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  end: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  start: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string",
+        "name": "margin",
+      },
+      Object {
+        "description": "Color when hovering over places while selecting.",
+        "format": "string
+{
+  dark: string,
+  light: string
+}",
+        "name": "color",
+      },
+      Object {
+        "defaultValue": 1,
+        "description": "The heading level. It corresponds to the number after the 'H' for
+the DOM tag. Set the level for semantic accuracy and accessibility.
+The sizing can be further adjusted using the size property.",
+        "format": "1
+2
+3
+4
+5
+6
+1
+2
+3
+4
+5
+6",
+        "name": "level",
+      },
+      Object {
+        "defaultValue": true,
+        "description": "Whether the font size should be scaled for
+      mobile environments.",
+        "format": "boolean",
+        "name": "responsive",
+      },
+      Object {
+        "defaultValue": "medium",
+        "description": "The font size is primarily driven by the chosen tag. But, it can
+be adjusted via this size property. The tag should be set for semantic
+correctness and accessibility. This size property allows for stylistic
+adjustments.",
+        "format": "small
+medium
+large
+xlarge
+string",
+        "name": "size",
+      },
+      Object {
+        "defaultValue": "start",
+        "description": "How to align the text inside the heading.",
+        "format": "start
+center
+end",
+        "name": "textAlign",
+      },
+      Object {
+        "defaultValue": false,
+        "description": "Restrict the text to a single line and truncate with ellipsis if it
+is too long to all fit.",
+        "format": "boolean",
+        "name": "truncate",
+      },
+    ],
+    "usage": "import { Heading } from 'grommet';
+<Heading />",
+  },
   "Image": Object {
     "availableAt": Array [
       Object {
@@ -6446,7 +6635,198 @@ currently active tab changes.",
   <Tab title='Tab 2'>...</Tab>
 </Tabs>",
   },
-  "Text": [Function],
+  "Text": Object {
+    "availableAt": Array [
+      Object {
+        "badge": "https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png",
+        "label": "Storybook",
+        "url": "https://storybook.grommet.io/?selectedKind=Text&full=0&addons=0&stories=1&panelRight=0",
+      },
+      Object {
+        "badge": "https://codesandbox.io/static/img/play-codesandbox.svg",
+        "label": "CodeSandbox",
+        "url": "https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=/text&module=%2Fsrc%2FText.js",
+      },
+    ],
+    "description": "Arbitrary text.",
+    "intrinsicElement": "span",
+    "name": "Text",
+    "properties": Array [
+      Object {
+        "description": "Custom label to be used by screen readers. When provided, an aria-label will
+   be added to the element.",
+        "format": "string",
+        "name": "a11yTitle",
+      },
+      Object {
+        "description": "How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.",
+        "format": "start
+center
+end
+stretch",
+        "name": "alignSelf",
+      },
+      Object {
+        "description": "The name of the area to place
+    this inside a parent Grid.",
+        "format": "string",
+        "name": "gridArea",
+      },
+      Object {
+        "description": "The amount of margin around the component. An object can
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.",
+        "format": "none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  end: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  start: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string",
+        "name": "margin",
+      },
+      Object {
+        "description": "Color when hovering over places while selecting.",
+        "format": "string
+{
+  dark: string,
+  light: string
+}",
+        "name": "color",
+      },
+      Object {
+        "defaultValue": "medium",
+        "description": "The font size and line height are primarily driven by the chosen tag. 
+But, it can be adjusted via this size property. The tag should be set for 
+semantic correctness and accessibility. This size property allows for stylistic
+adjustments.",
+        "format": "xsmall
+small
+medium
+large
+xlarge
+xxlarge
+string",
+        "name": "size",
+      },
+      Object {
+        "description": "The DOM tag to use for the element. NOTE: This is deprecated in favor
+         of indicating the DOM tag via the 'as' property.",
+        "format": "string
+function",
+        "name": "tag",
+      },
+      Object {
+        "defaultValue": "span",
+        "description": "The DOM tag or react component to use for the element.",
+        "format": "string
+function
+element",
+        "name": "as",
+      },
+      Object {
+        "defaultValue": "start",
+        "description": "How to align the text inside the component.",
+        "format": "start
+center
+end",
+        "name": "textAlign",
+      },
+      Object {
+        "defaultValue": false,
+        "description": "Restrict the text to a single line and truncate with ellipsis if it
+is too long to all fit.",
+        "format": "boolean",
+        "name": "truncate",
+      },
+      Object {
+        "description": "Font weight",
+        "format": "normal
+bold
+number",
+        "name": "weight",
+      },
+      Object {
+        "defaultValue": "normal",
+        "description": "Whether words should break when reaching the end of a line.",
+        "format": "normal
+break-all
+keep-all
+break-word",
+        "name": "wordBreak",
+      },
+    ],
+    "usage": "import { Text } from 'grommet';
+<Text />",
+  },
   "TextArea": Object {
     "availableAt": Array [
       Object {


### PR DESCRIPTION
#### What does this PR do?
Allow `Text` and `Heading` components to accept the React `ref` prop

#### Where should the reviewer start?
Look at the tests in the first commit, then look at the fix in the second commit.

#### What testing has been done on this PR?
Unit tests, run storybook

#### How should this be manually tested?
Not sure

#### Any background context you want to provide?
I have a use case where all my components must be able to accept `ref` (specifically for use in Slate.js). Most grommet components already call `forwardRef`, but it's missing on `Text` and `Heading` (it might be missing on more, but I didn't check).

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/3133

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Not sure

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
