### PR TITLE
Fix vertical height for svg in plain button

### DIFF
--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -215,7 +215,6 @@ const fillStyle = fillContainer => {
 
 // The > svg rule is to ensure Buttons with just an icon don't add additional
 // vertical height internally.
-
 const plainStyle = () => css`
   outline: none;
   border: none;

--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -213,12 +213,19 @@ const fillStyle = fillContainer => {
   return undefined;
 };
 
+// The > svg rule is to ensure Buttons with just an icon don't add additional
+// vertical height internally.
+
 const plainStyle = () => css`
   outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
   color: inherit;
+
+  > svg {
+    vertical-align: bottom;
+  }
 `;
 
 const StyledButtonKind = styled.button`

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -545,6 +545,10 @@ exports[`Button kind hover 1`] = `
   color: inherit;
 }
 
+.c1 > svg {
+  vertical-align: bottom;
+}
+
 .c1:hover {
   background-color: rgba(221,221,221,0.4);
   color: #444444;

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -2291,6 +2291,10 @@ exports[`Tabs should apply custom theme disabled style when theme.button.default
   color: inherit;
 }
 
+.c3 > svg {
+  vertical-align: bottom;
+}
+
 .c7 {
   display: inline-block;
   box-sizing: border-box;
@@ -2309,6 +2313,10 @@ exports[`Tabs should apply custom theme disabled style when theme.button.default
   color: inherit;
   opacity: 0.3;
   cursor: default;
+}
+
+.c7 > svg {
+  vertical-align: bottom;
 }
 
 .c6 {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds the alignment of svgs when used within a plain button
#### Where should the reviewer start?
button/styledbuttonkind.js
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
https://design-system.hpe.design/components/layer#notifications

Using the code 

```
  <Box
      align="center"
      direction="row"
      gap="xsmall"
      justify="between"
      round="medium"
      elevation="medium"
      pad={{ vertical: "xxsmall", horizontal: "small" }}
      background="status-ok"
    >
      <Box align="center" direction="row" gap="small">
        <StatusGood color="text-strong" />
        <Text color={{ light: "text", dark: "text-strong" }}>
          This is a notifcation with position="top"
        </Text>
      </Box>
      <Button plain icon={<FormClose color="text-strong" />} />
    </Box>

```

with the hpe theme 
#### Any background context you want to provide?
https://github.com/hpe-design/design-system/issues/865
#### What are the relevant issues?
issue #865 in design system
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible