### PR TITLE
Changed SkipLinks 

### DIFF
--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -6926,14 +6926,14 @@ exports[`Calendar disabled 1`] = `
             className="c5"
             size="medium"
           >
-            July 2020
+            August 2020
           </h3>
         </div>
         <div
           className="c6"
         >
           <button
-            aria-label="June 2020"
+            aria-label="July 2020"
             className="c7"
             disabled={false}
             onBlur={[Function]}
@@ -6958,7 +6958,7 @@ exports[`Calendar disabled 1`] = `
             </svg>
           </button>
           <button
-            aria-label="August 2020"
+            aria-label="September 2020"
             className="c7"
             disabled={false}
             onBlur={[Function]}
@@ -7000,610 +7000,6 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Sun Jun 28 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c14"
-                >
-                  28
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Mon Jun 29 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c14"
-                >
-                  29
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Tue Jun 30 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c14"
-                >
-                  30
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Wed Jul 01 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  1
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Thu Jul 02 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  2
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Fri Jul 03 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  3
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Sat Jul 04 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  4
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            className="c11"
-          >
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Sun Jul 05 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  5
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Mon Jul 06 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  6
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Tue Jul 07 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  7
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Wed Jul 08 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  8
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Thu Jul 09 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  9
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Fri Jul 10 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  10
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Sat Jul 11 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  11
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            className="c11"
-          >
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Sun Jul 12 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  12
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Mon Jul 13 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  13
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Tue Jul 14 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  14
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Wed Jul 15 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  15
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Thu Jul 16 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  16
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Fri Jul 17 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  17
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Sat Jul 18 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  18
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            className="c11"
-          >
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Sun Jul 19 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  19
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Mon Jul 20 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  20
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Tue Jul 21 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  21
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Wed Jul 22 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  22
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Thu Jul 23 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  23
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Fri Jul 24 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  24
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Sat Jul 25 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c15"
-                >
-                  25
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            className="c11"
-          >
-            <div
-              className="c12"
-            >
-              <button
                 aria-label="Sun Jul 26 2020"
                 className="c13"
                 onBlur={[Function]}
@@ -7615,7 +7011,7 @@ exports[`Calendar disabled 1`] = `
                 type="button"
               >
                 <div
-                  className="c15"
+                  className="c14"
                 >
                   26
                 </div>
@@ -7636,7 +7032,7 @@ exports[`Calendar disabled 1`] = `
                 type="button"
               >
                 <div
-                  className="c15"
+                  className="c14"
                 >
                   27
                 </div>
@@ -7657,7 +7053,7 @@ exports[`Calendar disabled 1`] = `
                 type="button"
               >
                 <div
-                  className="c15"
+                  className="c14"
                 >
                   28
                 </div>
@@ -7678,7 +7074,7 @@ exports[`Calendar disabled 1`] = `
                 type="button"
               >
                 <div
-                  className="c15"
+                  className="c14"
                 >
                   29
                 </div>
@@ -7699,7 +7095,7 @@ exports[`Calendar disabled 1`] = `
                 type="button"
               >
                 <div
-                  className="c15"
+                  className="c14"
                 >
                   30
                 </div>
@@ -7720,7 +7116,7 @@ exports[`Calendar disabled 1`] = `
                 type="button"
               >
                 <div
-                  className="c15"
+                  className="c14"
                 >
                   31
                 </div>
@@ -7741,7 +7137,7 @@ exports[`Calendar disabled 1`] = `
                 type="button"
               >
                 <div
-                  className="c14"
+                  className="c15"
                 >
                   1
                 </div>
@@ -7766,7 +7162,7 @@ exports[`Calendar disabled 1`] = `
                 type="button"
               >
                 <div
-                  className="c14"
+                  className="c15"
                 >
                   2
                 </div>
@@ -7787,7 +7183,7 @@ exports[`Calendar disabled 1`] = `
                 type="button"
               >
                 <div
-                  className="c14"
+                  className="c15"
                 >
                   3
                 </div>
@@ -7808,7 +7204,7 @@ exports[`Calendar disabled 1`] = `
                 type="button"
               >
                 <div
-                  className="c14"
+                  className="c15"
                 >
                   4
                 </div>
@@ -7829,7 +7225,7 @@ exports[`Calendar disabled 1`] = `
                 type="button"
               >
                 <div
-                  className="c14"
+                  className="c15"
                 >
                   5
                 </div>
@@ -7850,7 +7246,7 @@ exports[`Calendar disabled 1`] = `
                 type="button"
               >
                 <div
-                  className="c14"
+                  className="c15"
                 >
                   6
                 </div>
@@ -7871,7 +7267,7 @@ exports[`Calendar disabled 1`] = `
                 type="button"
               >
                 <div
-                  className="c14"
+                  className="c15"
                 >
                   7
                 </div>
@@ -7892,9 +7288,613 @@ exports[`Calendar disabled 1`] = `
                 type="button"
               >
                 <div
-                  className="c14"
+                  className="c15"
                 >
                   8
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            className="c11"
+          >
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Sun Aug 09 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  9
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Mon Aug 10 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  10
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Tue Aug 11 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  11
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Wed Aug 12 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  12
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Thu Aug 13 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  13
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Fri Aug 14 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  14
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Sat Aug 15 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  15
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            className="c11"
+          >
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Sun Aug 16 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  16
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Mon Aug 17 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  17
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Tue Aug 18 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  18
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Wed Aug 19 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  19
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Thu Aug 20 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  20
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Fri Aug 21 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  21
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Sat Aug 22 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  22
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            className="c11"
+          >
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Sun Aug 23 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  23
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Mon Aug 24 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  24
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Tue Aug 25 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  25
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Wed Aug 26 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  26
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Thu Aug 27 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  27
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Fri Aug 28 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  28
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Sat Aug 29 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  29
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            className="c11"
+          >
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Sun Aug 30 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  30
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Mon Aug 31 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c15"
+                >
+                  31
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Tue Sep 01 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c14"
+                >
+                  1
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Wed Sep 02 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c14"
+                >
+                  2
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Thu Sep 03 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c14"
+                >
+                  3
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Fri Sep 04 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c14"
+                >
+                  4
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Sat Sep 05 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c14"
+                >
+                  5
                 </div>
               </button>
             </div>

--- a/src/js/components/Layer/Layer.js
+++ b/src/js/components/Layer/Layer.js
@@ -8,14 +8,15 @@ import { animationDuration } from './StyledLayer';
 import { ContainerTargetContext } from '../../contexts/ContainerTargetContext';
 
 const Layer = forwardRef((props, ref) => {
-  const { animate, animation, bodyTarget } = props;
+  const { animate, animation, targetChildPosition } = props;
   const [originalFocusedElement, setOriginalFocusedElement] = useState();
   useEffect(() => setOriginalFocusedElement(document.activeElement), []);
   const [layerContainer, setLayerContainer] = useState();
   const containerTarget = useContext(ContainerTargetContext);
   useEffect(
-    () => setLayerContainer(getNewContainer(containerTarget, bodyTarget)),
-    [containerTarget, bodyTarget],
+    () =>
+      setLayerContainer(getNewContainer(containerTarget, targetChildPosition)),
+    [containerTarget, targetChildPosition],
   );
 
   // just a few things to clean up when the Layer is unmounted

--- a/src/js/components/Layer/Layer.js
+++ b/src/js/components/Layer/Layer.js
@@ -8,14 +8,15 @@ import { animationDuration } from './StyledLayer';
 import { ContainerTargetContext } from '../../contexts/ContainerTargetContext';
 
 const Layer = forwardRef((props, ref) => {
-  const { animate, animation } = props;
+  const { animate, animation, bodyTarget } = props;
   const [originalFocusedElement, setOriginalFocusedElement] = useState();
   useEffect(() => setOriginalFocusedElement(document.activeElement), []);
   const [layerContainer, setLayerContainer] = useState();
   const containerTarget = useContext(ContainerTargetContext);
-  useEffect(() => setLayerContainer(getNewContainer(containerTarget)), [
-    containerTarget,
-  ]);
+  useEffect(
+    () => setLayerContainer(getNewContainer(containerTarget, bodyTarget)),
+    [containerTarget, bodyTarget],
+  );
 
   // just a few things to clean up when the Layer is unmounted
   useEffect(

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -618,7 +618,14 @@ const POSITIONS = {
 };
 
 const desktopContainerStyle = css`
-  position: ${props => (props.modal ? 'absolute' : 'fixed')};
+  ${props => {
+    if (!props.modal && props.position === 'hidden') {
+      return hiddenPositionStyle;
+    }
+    return css`
+      position: ${props.modal ? 'absolute' : 'fixed'};
+    `;
+  }}
   max-height: ${props =>
     `calc(100% - ${getBounds(
       props.targetBounds,
@@ -670,7 +677,8 @@ const responsiveContainerStyle = css`
 `;
 
 const StyledContainer = styled.div`
-  ${props => (!props.modal ? baseStyle : '')} display: flex;
+  ${props => (!props.modal ? baseStyle : '')}
+  display: flex;
   flex-direction: column;
   min-height: ${props => props.theme.global.size.xxsmall};
   ${props =>
@@ -680,7 +688,8 @@ const StyledContainer = styled.div`
   pointer-events: all;
   z-index: ${props => props.theme.layer.container.zIndex};
 
-  ${desktopContainerStyle} ${props => {
+  ${desktopContainerStyle}
+  ${props => {
     if (props.responsive && props.theme.layer.responsiveBreakpoint) {
       const breakpoint =
         props.theme.global.breakpoints[props.theme.layer.responsiveBreakpoint];

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -157,7 +157,7 @@ exports[`Layer animation fadeIn 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -332,7 +332,7 @@ exports[`Layer animation false 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -509,7 +509,7 @@ exports[`Layer animation slide 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -686,7 +686,7 @@ exports[`Layer animation true 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -863,7 +863,7 @@ exports[`Layer custom margin 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -973,7 +973,7 @@ exports[`Layer dark context 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1226,7 +1226,7 @@ exports[`Layer full false 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1404,7 +1404,7 @@ exports[`Layer full horizontal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1580,7 +1580,7 @@ exports[`Layer full true 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1758,7 +1758,7 @@ exports[`Layer full vertical 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1899,7 +1899,7 @@ exports[`Layer hidden 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1929,7 +1929,7 @@ exports[`Layer hidden 3`] = `
     class="StyledLayer__StyledOverlay-rmtehz-1 TgNMj"
   />
   <div
-    class="StyledLayer__StyledContainer-rmtehz-2 hyqqbS"
+    class="StyledLayer__StyledContainer-rmtehz-2 cXCBJx"
     id="hidden-test"
   >
     <a
@@ -1976,7 +1976,7 @@ exports[`Layer hidden 4`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2210,7 +2210,7 @@ exports[`Layer margin large 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2387,7 +2387,7 @@ exports[`Layer margin medium 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2564,7 +2564,7 @@ exports[`Layer margin none 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2741,7 +2741,7 @@ exports[`Layer margin small 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2918,7 +2918,7 @@ exports[`Layer margin xsmall 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3028,7 +3028,7 @@ exports[`Layer non-modal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3284,7 +3284,7 @@ exports[`Layer plain 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3461,7 +3461,7 @@ exports[`Layer position bottom 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3638,7 +3638,7 @@ exports[`Layer position center 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3815,7 +3815,7 @@ exports[`Layer position end 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3992,7 +3992,7 @@ exports[`Layer position left 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4169,7 +4169,7 @@ exports[`Layer position right 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4346,7 +4346,7 @@ exports[`Layer position start 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4523,7 +4523,7 @@ exports[`Layer position top 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4685,7 +4685,7 @@ exports[`Layer target 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4799,7 +4799,7 @@ exports[`Layer target not modal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .fYgBNY {
+  .gLOatX {
     position: relative;
     max-height: none;
     max-width: none;

--- a/src/js/components/Layer/index.d.ts
+++ b/src/js/components/Layer/index.d.ts
@@ -1,20 +1,32 @@
-import * as React from "react";
-import { AnimateType, MarginType, KeyboardType } from "../../utils";
+import * as React from 'react';
+import { AnimateType, MarginType, KeyboardType } from '../../utils';
 
+export type LayerPositionType =
+  | 'bottom'
+  | 'bottom-left'
+  | 'bottom-right'
+  | 'center'
+  | 'hidden'
+  | 'left'
+  | 'right'
+  | 'top'
+  | 'top-left'
+  | 'top-right';
 export interface LayerProps {
   animate?: AnimateType;
-  animation?: "none" | "slide" | "fadeIn" | boolean;
-  full?: boolean | "vertical" | "horizontal";
+  animation?: 'none' | 'slide' | 'fadeIn' | boolean;
+  full?: boolean | 'vertical' | 'horizontal';
   margin?: MarginType;
   modal?: boolean;
-  onClickOutside?: ((...args: any[]) => any);
+  onClickOutside?: (...args: any[]) => any;
   onEsc?: KeyboardType;
   plain?: boolean;
-  position?: "bottom" | "bottom-left" | "bottom-right" | "center" | "hidden" | "left" | "right" | "top" | "top-left" | "top-right";
+  position?: LayerPositionType;
   responsive?: boolean;
   target?: object;
 }
 
-declare const Layer: React.ComponentClass<LayerProps & JSX.IntrinsicElements['div']>;
+declare const Layer: React.ComponentClass<LayerProps &
+  JSX.IntrinsicElements['div']>;
 
 export { Layer };

--- a/src/js/components/SkipLink/SkipLink.js
+++ b/src/js/components/SkipLink/SkipLink.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { Anchor } from '../Anchor';
 import { Box } from '../Box';
 
-export const SkipLink = ({ id, label, ...rest }) => (
+export const SkipLink = forwardRef(({ id, label, ...rest }, ref) => (
   <Box margin="small">
-    <Anchor href={`#${id}`} label={label} {...rest} />
+    <Anchor href={`#${id}`} ref={ref} label={label} {...rest} />
   </Box>
-);
+));

--- a/src/js/components/SkipLink/SkipLink.js
+++ b/src/js/components/SkipLink/SkipLink.js
@@ -1,10 +1,7 @@
 import React, { forwardRef } from 'react';
 
 import { Anchor } from '../Anchor';
-import { Box } from '../Box';
 
 export const SkipLink = forwardRef(({ id, label, ...rest }, ref) => (
-  <Box margin="small">
-    <Anchor href={`#${id}`} ref={ref} label={label} {...rest} />
-  </Box>
+  <Anchor href={`#${id}`} ref={ref} label={label} {...rest} />
 ));

--- a/src/js/components/SkipLinks/README.md
+++ b/src/js/components/SkipLinks/README.md
@@ -94,7 +94,7 @@ Defaults to
 { margin: 'small', size: 'medium' }
 ```
 
-**skipLinks.text.margin**
+**skipLinks.label.margin**
 
 The margin size around the text message. Expects `string`.
 
@@ -104,7 +104,7 @@ Defaults to
 medium
 ```
 
-**skipLinks.text.size**
+**skipLinks.label.size**
 
 The font size of the text label. Expects `string`.
 

--- a/src/js/components/SkipLinks/README.md
+++ b/src/js/components/SkipLinks/README.md
@@ -23,7 +23,7 @@ node
 
 Custom messages for SkipLinks. Used for accessibility by screen 
 readers. Defaults to `{
-  "skipTo": "Skip To"
+  "skipTo": "Skip To:"
 }`.
 
 ```

--- a/src/js/components/SkipLinks/README.md
+++ b/src/js/components/SkipLinks/README.md
@@ -32,3 +32,94 @@ readers. Defaults to `{
 }
 ```
   
+## Theme
+  
+**skipLinks.position**
+
+Position of the layer content once opened. Expects `string`.
+
+Defaults to
+
+```
+top
+```
+
+**skipLinks.container**
+
+Any valid Box prop for the SkipLinks container. Expects `object`.
+
+Defaults to
+
+```
+{ elevation: 'large', pad: 'medium', round: 'small' }
+```
+
+**skipLinks.container.elevation**
+
+The container shadow. Expects `string`.
+
+Defaults to
+
+```
+large
+```
+
+**skipLinks.container.pad**
+
+The pad used for the layer container. Expects `string | object`.
+
+Defaults to
+
+```
+medium
+```
+
+**skipLinks.container.round**
+
+The rounding of the later container. Expects `boolean | string | object`.
+
+Defaults to
+
+```
+small
+```
+
+**skipLinks.text**
+
+Any valid Text prop for the text message. Expects `object`.
+
+Defaults to
+
+```
+{ margin: 'small', size: 'medium' }
+```
+
+**skipLinks.text.margin**
+
+The margin size around the text message. Expects `string`.
+
+Defaults to
+
+```
+medium
+```
+
+**skipLinks.text.size**
+
+The font size of the text label. Expects `string`.
+
+Defaults to
+
+```
+medium
+```
+
+**text.medium.size**
+
+The font size of the text label. Expects `string`.
+
+Defaults to
+
+```
+18px
+```

--- a/src/js/components/SkipLinks/README.md
+++ b/src/js/components/SkipLinks/README.md
@@ -84,7 +84,7 @@ Defaults to
 small
 ```
 
-**skipLinks.text**
+**skipLinks.label**
 
 Any valid Text prop for the text message. Expects `object`.
 

--- a/src/js/components/SkipLinks/README.md
+++ b/src/js/components/SkipLinks/README.md
@@ -101,7 +101,7 @@ The margin size around the text message. Expects `string`.
 Defaults to
 
 ```
-medium
+{ bottom: medium }
 ```
 
 **skipLinks.label.size**

--- a/src/js/components/SkipLinks/SkipLinks.js
+++ b/src/js/components/SkipLinks/SkipLinks.js
@@ -10,10 +10,24 @@ const SkipLinks = ({ children, id, messages }) => {
   const theme = useContext(ThemeContext) || defaultProps.theme;
   const [showLayer, setShowLayer] = useState(false);
 
+  const firstAnchorRef = useRef(null);
   const layerRef = useRef(null);
 
   const onFocus = () => {
     setShowLayer(true);
+    // timeout needed so it gives enough time for activeElement to be updated
+    setTimeout(() => {
+      // The layer container is receiving the focus by default since the layer
+      // isn't on the DOM yet and its children are not accessible.
+      // Once the layer is focused and the children of the layer are
+      // accessible on the DOM, the first anchor of the skiplink list will
+      // steal the focus to itself.
+      const layerNode = layerRef.current;
+      // change the focus to the first SkipLink anchor
+      if (layerNode === document.activeElement) {
+        firstAnchorRef.current.focus();
+      }
+    }, 0);
   };
 
   const removeLayer = () => {
@@ -54,6 +68,7 @@ const SkipLinks = ({ children, id, messages }) => {
             {children.map((element, index) =>
               cloneElement(element, {
                 key: `skip-link-${index}`,
+                ref: index === 0 ? firstAnchorRef : undefined,
                 onClick: removeLayer,
               }),
             )}

--- a/src/js/components/SkipLinks/SkipLinks.js
+++ b/src/js/components/SkipLinks/SkipLinks.js
@@ -1,10 +1,13 @@
-import React, { cloneElement, useRef, useState } from 'react';
+import React, { cloneElement, useContext, useRef, useState } from 'react';
+import { ThemeContext } from 'styled-components';
 
 import { Box } from '../Box';
-import { Heading } from '../Heading';
+import { Text } from '../Text';
 import { Layer } from '../Layer';
+import { defaultProps } from '../../default-props';
 
 const SkipLinks = ({ children, id, messages }) => {
+  const theme = useContext(ThemeContext) || defaultProps.theme;
   const [showLayer, setShowLayer] = useState(false);
 
   const layerRef = useRef(null);
@@ -20,12 +23,11 @@ const SkipLinks = ({ children, id, messages }) => {
   const onBlur = () => {
     // timeout needed so it gives enough time for activeElement to be updated
     setTimeout(() => {
-      const layerNode = layerRef.current;
+      // close the layer in case the activeElement isn't an anchor
       if (
-        layerNode &&
-        layerNode.layerContainer &&
-        layerNode.layerContainer.contains &&
-        !layerNode.layerContainer.contains(document.activeElement)
+        document &&
+        document.activeElement &&
+        document.activeElement.tagName !== 'A'
       ) {
         removeLayer();
       }
@@ -35,29 +37,38 @@ const SkipLinks = ({ children, id, messages }) => {
   return (
     <Layer
       id={id}
-      position={showLayer ? 'top' : 'hidden'}
+      position={showLayer ? theme.skipLinks.position : 'hidden'}
       ref={layerRef}
       onFocus={onFocus}
       onBlur={onBlur}
+      tabIndex={0}
+      modal={false}
+      bodyTarget="first" // prepend the Layer on the body container
+      // modal={false} will take the full screen a small breakpoint
+      responsive={false}
     >
-      <Box pad={{ horizontal: 'medium' }}>
-        <Heading level={2}>{messages.skipTo}:</Heading>
-        <Box direction="row" align="center" pad={{ bottom: 'medium' }}>
-          {children.map((element, index) =>
-            cloneElement(element, {
-              key: `skip-link-${index}`,
-              onClick: removeLayer,
-            }),
+      {showLayer && (
+        <Box {...theme.skipLinks.container}>
+          {messages.skipTo && (
+            <Text {...theme.skipLinks.text}>{messages.skipTo}</Text>
           )}
+          <Box align="center">
+            {children.map((element, index) =>
+              cloneElement(element, {
+                key: `skip-link-${index}`,
+                onClick: removeLayer,
+              }),
+            )}
+          </Box>
         </Box>
-      </Box>
+      )}
     </Layer>
   );
 };
 
 SkipLinks.defaultProps = {
   messages: {
-    skipTo: 'Skip To',
+    skipTo: 'Skip To:',
   },
 };
 

--- a/src/js/components/SkipLinks/SkipLinks.js
+++ b/src/js/components/SkipLinks/SkipLinks.js
@@ -52,29 +52,26 @@ const SkipLinks = ({ children, id, messages }) => {
       ref={layerRef}
       onFocus={onFocus}
       onBlur={onBlur}
-      tabIndex={0}
       modal={false}
       targetChildPosition="first" // prepend the Layer on the body container
       // Non-modal Layer's will take the full screen at small breakpoints
       // by default, which isn't what we want, hence setting responsive false
       responsive={false}
     >
-      {showLayer && (
-        <Box {...theme.skipLinks.container}>
-          {messages.skipTo && (
-            <Text {...theme.skipLinks.label}>{messages.skipTo}</Text>
+      <Box {...theme.skipLinks.container}>
+        {messages.skipTo && (
+          <Text {...theme.skipLinks.label}>{messages.skipTo}</Text>
+        )}
+        <Box align="center">
+          {children.map((element, index) =>
+            cloneElement(element, {
+              key: `skip-link-${index}`,
+              ref: index === 0 ? firstAnchorRef : undefined,
+              onClick: removeLayer,
+            }),
           )}
-          <Box align="center">
-            {children.map((element, index) =>
-              cloneElement(element, {
-                key: `skip-link-${index}`,
-                ref: index === 0 ? firstAnchorRef : undefined,
-                onClick: removeLayer,
-              }),
-            )}
-          </Box>
         </Box>
-      )}
+      </Box>
     </Layer>
   );
 };

--- a/src/js/components/SkipLinks/SkipLinks.js
+++ b/src/js/components/SkipLinks/SkipLinks.js
@@ -44,14 +44,14 @@ const SkipLinks = ({ children, id, messages }) => {
       tabIndex={0}
       modal={false}
       targetChildPosition="first" // prepend the Layer on the body container
-      // Non-modal Layer's will take the full screen at small breakpoints 
-      // by default, which isn't what we want
+      // Non-modal Layer's will take the full screen at small breakpoints
+      // by default, which isn't what we want, hence setting responsive false
       responsive={false}
     >
       {showLayer && (
         <Box {...theme.skipLinks.container}>
           {messages.skipTo && (
-            <Text {...theme.skipLinks.text}>{messages.skipTo}</Text>
+            <Text {...theme.skipLinks.label}>{messages.skipTo}</Text>
           )}
           <Box align="center">
             {children.map((element, index) =>

--- a/src/js/components/SkipLinks/SkipLinks.js
+++ b/src/js/components/SkipLinks/SkipLinks.js
@@ -39,7 +39,9 @@ const SkipLinks = ({ children, id, messages }) => {
       onFocus={onFocus}
       onBlur={onBlur}
       modal={false}
-      targetChildPosition="first" // prepend the Layer on the body container
+      // Prepend the Layer so any SkipLink will be the first element that
+      // pressing the Tab key reaches, targetChildPosition triggers prepend.
+      targetChildPosition="first"
       // Non-modal Layer's will take the full screen at small breakpoints
       // by default, which isn't what we want, hence setting responsive false
       responsive={false}
@@ -48,7 +50,7 @@ const SkipLinks = ({ children, id, messages }) => {
         {messages.skipTo && (
           <Text {...theme.skipLinks.label}>{messages.skipTo}</Text>
         )}
-        <Box align="center">
+        <Box align="center" gap="medium">
           {children.map((element, index) =>
             cloneElement(element, {
               key: `skip-link-${index}`,

--- a/src/js/components/SkipLinks/SkipLinks.js
+++ b/src/js/components/SkipLinks/SkipLinks.js
@@ -43,8 +43,9 @@ const SkipLinks = ({ children, id, messages }) => {
       onBlur={onBlur}
       tabIndex={0}
       modal={false}
-      bodyTarget="first" // prepend the Layer on the body container
-      // modal={false} will take the full screen a small breakpoint
+      targetChildPosition="first" // prepend the Layer on the body container
+      // Non-modal Layer's will take the full screen at small breakpoints 
+      // by default, which isn't what we want
       responsive={false}
     >
       {showLayer && (

--- a/src/js/components/SkipLinks/SkipLinks.js
+++ b/src/js/components/SkipLinks/SkipLinks.js
@@ -10,24 +10,10 @@ const SkipLinks = ({ children, id, messages }) => {
   const theme = useContext(ThemeContext) || defaultProps.theme;
   const [showLayer, setShowLayer] = useState(false);
 
-  const firstAnchorRef = useRef(null);
   const layerRef = useRef(null);
 
   const onFocus = () => {
     setShowLayer(true);
-    // timeout needed so it gives enough time for activeElement to be updated
-    setTimeout(() => {
-      // The layer container is receiving the focus by default since the layer
-      // isn't on the DOM yet and its children are not accessible.
-      // Once the layer is focused and the children of the layer are
-      // accessible on the DOM, the first anchor of the skiplink list will
-      // steal the focus to itself.
-      const layerNode = layerRef.current;
-      // change the focus to the first SkipLink anchor
-      if (layerNode === document.activeElement) {
-        firstAnchorRef.current.focus();
-      }
-    }, 0);
   };
 
   const removeLayer = () => {
@@ -66,7 +52,6 @@ const SkipLinks = ({ children, id, messages }) => {
           {children.map((element, index) =>
             cloneElement(element, {
               key: `skip-link-${index}`,
-              ref: index === 0 ? firstAnchorRef : undefined,
               onClick: removeLayer,
             }),
           )}

--- a/src/js/components/SkipLinks/SkipLinks.js
+++ b/src/js/components/SkipLinks/SkipLinks.js
@@ -23,12 +23,9 @@ const SkipLinks = ({ children, id, messages }) => {
   const onBlur = () => {
     // timeout needed so it gives enough time for activeElement to be updated
     setTimeout(() => {
-      // close the layer in case the activeElement isn't an anchor
-      if (
-        document &&
-        document.activeElement &&
-        document.activeElement.tagName !== 'A'
-      ) {
+      const layerNode = layerRef.current;
+      if (layerNode && !layerNode.contains(document.activeElement)) {
+        // close the layer when the activeElement isn't contained in the layer
         removeLayer();
       }
     }, 0);

--- a/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
+++ b/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
@@ -34,6 +34,18 @@ exports[`SkipLink basic 1`] = `
   position: absolute;
 }
 
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
 <div
   class="c0"
 >

--- a/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
+++ b/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
@@ -34,30 +34,6 @@ exports[`SkipLink basic 1`] = `
   position: absolute;
 }
 
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
 <div
   class="c0"
 >
@@ -129,14 +105,11 @@ exports[`SkipLink basic 3`] = `
     <a
       aria-hidden="true"
       class="StyledAnchor-sc-1rp7lwl-0 cfNrRd SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
-      data-g-tabindex="-1"
       id="main"
       tabindex="-1"
     />
     Main Content
     <input
-      data-g-tabindex="none"
-      tabindex="-1"
       type="text"
       value="main content"
     />
@@ -145,13 +118,10 @@ exports[`SkipLink basic 3`] = `
     <a
       aria-hidden="true"
       class="StyledAnchor-sc-1rp7lwl-0 cfNrRd SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
-      data-g-tabindex="-1"
       id="footer"
       tabindex="-1"
     />
     <input
-      data-g-tabindex="none"
-      tabindex="-1"
       type="text"
       value="footer"
     />

--- a/src/js/components/SkipLinks/doc.js
+++ b/src/js/components/SkipLinks/doc.js
@@ -55,12 +55,12 @@ export const themeDoc = {
     type: 'object',
     defaultValue: "{ margin: 'small', size: 'medium' }",
   },
-  'skipLinks.text.margin': {
+  'skipLinks.label.margin': {
     description: 'The margin size around the text message.',
     type: 'string',
     defaultValue: 'medium',
   },
-  'skipLinks.text.size': {
+  'skipLinks.label.size': {
     description: 'The font size of the text label.',
     type: 'string',
     defaultValue: 'medium',

--- a/src/js/components/SkipLinks/doc.js
+++ b/src/js/components/SkipLinks/doc.js
@@ -58,7 +58,7 @@ export const themeDoc = {
   'skipLinks.label.margin': {
     description: 'The margin size around the text message.',
     type: 'string',
-    defaultValue: 'medium',
+    defaultValue: '{ bottom: medium }',
   },
   'skipLinks.label.size': {
     description: 'The font size of the text label.',

--- a/src/js/components/SkipLinks/doc.js
+++ b/src/js/components/SkipLinks/doc.js
@@ -50,7 +50,7 @@ export const themeDoc = {
     type: 'boolean | string | object',
     defaultValue: 'small',
   },
-  'skipLinks.text': {
+  'skipLinks.label': {
     description: 'Any valid Text prop for the text message.',
     type: 'object',
     defaultValue: "{ margin: 'small', size: 'medium' }",

--- a/src/js/components/SkipLinks/doc.js
+++ b/src/js/components/SkipLinks/doc.js
@@ -23,3 +23,51 @@ readers.`,
 
   return DocumentedSkipLinks;
 };
+
+export const themeDoc = {
+  'skipLinks.position': {
+    description: 'Position of the layer content once opened.',
+    type: 'string',
+    defaultValue: 'top',
+  },
+  'skipLinks.container': {
+    description: 'Any valid Box prop for the SkipLinks container.',
+    type: 'object',
+    defaultValue: "{ elevation: 'large', pad: 'medium', round: 'small' }",
+  },
+  'skipLinks.container.elevation': {
+    description: 'The container shadow.',
+    type: 'string',
+    defaultValue: 'large',
+  },
+  'skipLinks.container.pad': {
+    description: 'The pad used for the layer container.',
+    type: 'string | object',
+    defaultValue: 'medium',
+  },
+  'skipLinks.container.round': {
+    description: 'The rounding of the later container.',
+    type: 'boolean | string | object',
+    defaultValue: 'small',
+  },
+  'skipLinks.text': {
+    description: 'Any valid Text prop for the text message.',
+    type: 'object',
+    defaultValue: "{ margin: 'small', size: 'medium' }",
+  },
+  'skipLinks.text.margin': {
+    description: 'The margin size around the text message.',
+    type: 'string',
+    defaultValue: 'medium',
+  },
+  'skipLinks.text.size': {
+    description: 'The font size of the text label.',
+    type: 'string',
+    defaultValue: 'medium',
+  },
+  'text.medium.size': {
+    description: 'The font size of the text label.',
+    type: 'string',
+    defaultValue: '18px',
+  },
+};

--- a/src/js/components/SkipLinks/stories/Simple.js
+++ b/src/js/components/SkipLinks/stories/Simple.js
@@ -1,0 +1,127 @@
+/* eslint-disable jsx-a11y/tabindex-no-positive */
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import {
+  grommet,
+  Avatar,
+  Box,
+  Anchor,
+  Grommet,
+  Header,
+  Nav,
+  Paragraph,
+  SkipLinkTarget,
+  SkipLink,
+  SkipLinks,
+  Heading,
+} from 'grommet';
+
+const avatarSrc =
+  '//s.gravatar.com/avatar/b7fb138d53ba0f573212ccce38a7c43b?s=80';
+
+const contentFiller = `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit
+esse cillum dolore eu fugiat nulla pariatur. Excepteur
+sint occaecat cupidatat non proident, sunt in culpa qui
+officia deserunt mollit anim id est laborum.
+`;
+
+const introContent = `
+The main content is not usually the first thing on a web page. Keyboard and 
+screen reader users generally must navigate a long list of navigation 
+links, sub-lists of links, corporate icons, site searches, and other 
+elements before ever arriving at the main content. This is particularly 
+difficult for users with some forms of motor disabilities.
+Without some sort of system for bypassing the long list of links, some users 
+are at a huge disadvantage. Consider users with no arm movement, who use 
+computers by tapping their heads on a switch or that use a stick in their 
+mouth to press keyboard keys. Requiring users to perform any action perhaps 
+100s of times before reaching the main content is simply unacceptable.
+Of course, sighted people who use their mouse do not have any trouble with 
+pages such as this. They can almost immediately scan over the page and 
+identify where the main content is. In effect, sighted users have a built-in 
+"skip navigation" mechanism: their eyes. They can also bypass the many links 
+before the main content and click directly on the link they want with the mouse.
+The "skip navigation" idea was invented to give screen reader and keyboard 
+users the same capability of going directly to the main content that 
+sighted mouse users take for granted.
+`;
+
+const howDoesItWorkContent = `
+To get the most of Grommet's SkipLinks example, use a narrow window width and
+open this page in a full screen (you can either use the 
+storybook "full-screen" icon or click on any of the Header's anchors 
+on the top right of the page (Home, Profile or Setting links) to achieve it) 
+and then enter Tab on your keyboard.
+The first tabbed element of the page will be the SkipLinks layer, 
+the layer will provide you the option to skip the navigation 
+of the page to the Main Content or the Footer. 
+For example, let's take a user that isn't using a mouse, and is interested in 
+skipping to the Main Content or the Footer without tabbing through all 
+the Header links, the user can choose one of the suggested options of the layer 
+either 'Main Content' or 'Footer', and that will 
+set the focus of the page to the 
+targeted (SkipLinkTarget) position and hence speeding the navigation 
+throughout the page.`;
+
+const Info = ({ label }) => (
+  <Paragraph>
+    After choosing the {label} option on the SkipLinks layer, the following
+    interactive element will be the next focusable item.
+  </Paragraph>
+);
+
+export const Example = () => (
+  <Grommet theme={grommet}>
+    <SkipLinks>
+      <SkipLink id="main" label="Main Content" />
+      <SkipLink id="footer" label="Footer" />
+    </SkipLinks>
+    <Box gap="large" margin={{ bottom: 'xlarge' }}>
+      <Box background="light-4" pad="small" fill="horizontal">
+        <Header pad={{ horizontal: 'large' }}>
+          <Avatar src={avatarSrc} />
+          <Nav direction="row">
+            <Anchor label="Home" href="#" />
+            <Anchor label="Profile" href="#" />
+            <Anchor label="Setting" href="#" />
+          </Nav>
+        </Header>
+      </Box>
+      <Box pad={{ horizontal: 'large' }}>
+        <Box gap="medium" align="start">
+          <Heading level={1}>SkipLinks Example</Heading>
+          <Heading level={2}>Accessibility Overview</Heading>
+          {introContent}
+          <Anchor
+            href="https://webaim.org/techniques/skipnav/"
+            label="Content taken from WebAIM"
+          />
+          <Heading level={2}>How does it work</Heading>
+          {howDoesItWorkContent}
+        </Box>
+        <Box gap="medium" align="start" margin={{ vertical: 'medium' }}>
+          <SkipLinkTarget id="main" />
+          <Heading level={2}>Main Content</Heading>
+          <Info label="Main Content" />
+          <Anchor href="#" label="Interactive Element" />
+          {contentFiller}
+        </Box>
+        <Box gap="medium" align="start">
+          <SkipLinkTarget id="footer" />
+          <Heading level={2}>Footer</Heading>
+          <Info label="Footer" />
+          <Anchor href="#" label="Interactive Element" />
+          {contentFiller}
+        </Box>
+      </Box>
+    </Box>
+  </Grommet>
+);
+
+storiesOf('SkipLinks', module).add('Simple', () => <Example />);

--- a/src/js/components/SkipLinks/stories/Themed.js
+++ b/src/js/components/SkipLinks/stories/Themed.js
@@ -1,0 +1,147 @@
+/* eslint-disable jsx-a11y/tabindex-no-positive */
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import {
+  Avatar,
+  Box,
+  Anchor,
+  Footer,
+  Grommet,
+  Header,
+  Nav,
+  Paragraph,
+  SkipLinkTarget,
+  SkipLink,
+  SkipLinks,
+  Heading,
+} from 'grommet';
+
+const avatarSrc =
+  '//s.gravatar.com/avatar/b7fb138d53ba0f573212ccce38a7c43b?s=80';
+
+const contentFiller = `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit
+esse cillum dolore eu fugiat nulla pariatur. Excepteur
+sint occaecat cupidatat non proident, sunt in culpa qui
+officia deserunt mollit anim id est laborum.
+`;
+
+const introContent = `
+The main content is not usually the first thing on a web page. Keyboard and 
+screen reader users generally must navigate a long list of navigation 
+links, sub-lists of links, corporate icons, site searches, and other 
+elements before ever arriving at the main content. This is particularly 
+difficult for users with some forms of motor disabilities.
+Without some sort of system for bypassing the long list of links, some users 
+are at a huge disadvantage. Consider users with no arm movement, who use 
+computers by tapping their heads on a switch or that use a stick in their 
+mouth to press keyboard keys. Requiring users to perform any action perhaps 
+100s of times before reaching the main content is simply unacceptable.
+Of course, sighted people who use their mouse do not have any trouble with 
+pages such as this. They can almost immediately scan over the page and 
+identify where the main content is. In effect, sighted users have a built-in 
+"skip navigation" mechanism: their eyes. They can also bypass the many links 
+before the main content and click directly on the link they want with the mouse.
+The "skip navigation" idea was invented to give screen reader and keyboard 
+users the same capability of going directly to the main content that 
+sighted mouse users take for granted.
+`;
+
+const howDoesItWorkContent = `
+To get the most of Grommet's SkipLinks example, use a narrow window width and
+open this page in a full screen (you can either use the 
+storybook "full-screen" icon or click on any of the Header's anchors 
+on the top right of the page (Home, Profile or Setting links) to achieve it) 
+and then enter Tab on your keyboard.
+The first tabbed element of the page will be the SkipLinks layer, 
+the layer will provide you the option to skip the navigation 
+of the page to the Main Content or the Footer. 
+For example, let's take a user that isn't using a mouse, and is interested in 
+skipping to the Main Content or the Footer without tabbing through all 
+the Header links, the user can choose one of the suggested options of the layer 
+either 'Main Content' or 'Footer', and that will 
+set the focus of the page to the 
+targeted (SkipLinkTarget) position and hence speeding the navigation 
+throughout the page.`;
+
+const Info = ({ label }) => (
+  <Paragraph>
+    After choosing the {label} option on the SkipLinks layer, the following
+    interactive element will be the next focusable item:
+  </Paragraph>
+);
+
+const theme = {
+  global: {
+    font: {
+      family: `-apple-system,
+       BlinkMacSystemFont, 
+       "Segoe UI", 
+       Roboto`,
+    },
+  },
+  skipLinks: {
+    position: 'top-left',
+    container: {
+      background: 'dark-1',
+      elevation: 'large',
+      pad: 'small',
+      round: 'none',
+    },
+  },
+};
+
+export const Example = () => (
+  <Grommet theme={theme}>
+    <SkipLinks messages={{ skipTo: undefined }}>
+      <SkipLink id="main" label="Main Content" />
+      <SkipLink id="footer" label="Footer" />
+    </SkipLinks>
+    <Box gap="large">
+      <Box background="light-4" pad="small" fill="horizontal">
+        <Header pad={{ horizontal: 'large' }}>
+          <Avatar src={avatarSrc} />
+          <Nav direction="row">
+            <Anchor label="Home" href="#" />
+            <Anchor label="Profile" href="#" />
+            <Anchor label="Setting" href="#" />
+          </Nav>
+        </Header>
+      </Box>
+      <Box pad={{ horizontal: 'large' }}>
+        <Box gap="medium" align="start">
+          <Heading level={1}>Themed SkipLinks Example</Heading>
+          <Heading level={2}>Accessibility Overview</Heading>
+          {introContent}
+          <Anchor
+            href="https://webaim.org/techniques/skipnav/"
+            label="Content taken from WebAIM"
+          />
+          <Heading level={2}>How does it work</Heading>
+          {howDoesItWorkContent}
+        </Box>
+        <Box gap="medium" align="start">
+          <SkipLinkTarget id="main" />
+          <Heading level={2}>Main Content</Heading>
+          <Info label="Main Content" />
+          <Anchor href="#" label="Interactive Element" />
+          {contentFiller}
+        </Box>
+        <Footer direction="column" align="start">
+          <SkipLinkTarget id="footer" />
+          <Heading level={2}>Footer</Heading>
+          <Info label="Footer" />
+          <Anchor href="#" label="Interactive Element" />
+          {contentFiller}
+        </Footer>
+      </Box>
+    </Box>
+  </Grommet>
+);
+
+storiesOf('SkipLinks', module).add('Themed', () => <Example />);

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -13219,7 +13219,7 @@ Defaults to
 small
 \`\`\`
 
-**skipLinks.text**
+**skipLinks.label**
 
 Any valid Text prop for the text message. Expects \`object\`.
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -13241,7 +13241,7 @@ Defaults to
 { margin: 'small', size: 'medium' }
 \`\`\`
 
-**skipLinks.text.margin**
+**skipLinks.label.margin**
 
 The margin size around the text message. Expects \`string\`.
 
@@ -13251,7 +13251,7 @@ Defaults to
 medium
 \`\`\`
 
-**skipLinks.text.size**
+**skipLinks.label.size**
 
 The font size of the text label. Expects \`string\`.
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -13148,7 +13148,7 @@ node
 
 Custom messages for SkipLinks. Used for accessibility by screen 
 readers. Defaults to \`{
-  \\"skipTo\\": \\"Skip To\\"
+  \\"skipTo\\": \\"Skip To:\\"
 }\`.
 
 \`\`\`

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -13166,7 +13166,99 @@ readers. Defaults to \`{
   skipTo: string
 }
 \`\`\`
-  ",
+  
+## Theme
+  
+**skipLinks.position**
+
+Position of the layer content once opened. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+top
+\`\`\`
+
+**skipLinks.container**
+
+Any valid Box prop for the SkipLinks container. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{ elevation: 'large', pad: 'medium', round: 'small' }
+\`\`\`
+
+**skipLinks.container.elevation**
+
+The container shadow. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+large
+\`\`\`
+
+**skipLinks.container.pad**
+
+The pad used for the layer container. Expects \`string | object\`.
+
+Defaults to
+
+\`\`\`
+medium
+\`\`\`
+
+**skipLinks.container.round**
+
+The rounding of the later container. Expects \`boolean | string | object\`.
+
+Defaults to
+
+\`\`\`
+small
+\`\`\`
+
+**skipLinks.text**
+
+Any valid Text prop for the text message. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{ margin: 'small', size: 'medium' }
+\`\`\`
+
+**skipLinks.text.margin**
+
+The margin size around the text message. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+medium
+\`\`\`
+
+**skipLinks.text.size**
+
+The font size of the text label. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+medium
+\`\`\`
+
+**text.medium.size**
+
+The font size of the text label. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+18px
+\`\`\`
+",
   "Stack": "## Stack
 A container that stacks contents on top of each other. One child is
       designated as the \`guidingChild\` which determines the size. All

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -13248,7 +13248,7 @@ The margin size around the text message. Expects \`string\`.
 Defaults to
 
 \`\`\`
-medium
+{ bottom: medium }
 \`\`\`
 
 **skipLinks.label.size**

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -6376,7 +6376,10 @@ function
 <Select />",
   },
   "Sidebar": [Function],
-  "SkipLink": [Function],
+  "SkipLink": Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "render": [Function],
+  },
   "SkipLinkTarget": [Function],
   "SkipLinks": [Function],
   "Stack": [Function],

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -998,7 +998,7 @@ export interface ThemeType {
   skipLinks?: {
     position?: LayerPositionType;
     container?: BoxProps;
-    text?: TextProps;
+    label?: TextProps;
   };
   tab?: {
     active?: {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -3,6 +3,7 @@ import {
   FlattenSimpleInterpolation,
   ThemedStyledProps,
 } from 'styled-components';
+import { ReactComponentElement } from 'react';
 
 import {
   BackgroundType,
@@ -25,7 +26,7 @@ import { BoxProps } from '../components/Box';
 import { Anchor } from '../components/Anchor';
 import { Box } from '../components/Box';
 import { Text, TextProps } from '../components/Text';
-import { ReactComponentElement } from 'react';
+import { LayerPositionType } from '../components/Layer';
 
 export declare const base: DeepReadonly<ThemeType>;
 export declare const generate: (
@@ -995,7 +996,7 @@ export interface ThemeType {
     step?: number;
   };
   skipLinks?: {
-    position?: string;
+    position?: LayerPositionType;
     container?: BoxProps;
     text?: TextProps;
   };

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -994,6 +994,11 @@ export interface ThemeType {
     searchInput?: ReactComponentElement<any>;
     step?: number;
   };
+  skipLinks?: {
+    position?: string;
+    container?: BoxProps;
+    text?: TextProps;
+  };
   tab?: {
     active?: {
       background?: BackgroundType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -986,7 +986,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         round: 'small',
         pad: 'medium',
       },
-      text: {
+      label: {
         margin: 'small',
         size: 'medium',
       },

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -979,6 +979,18 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // searchInput: undefined,
       step: 20,
     },
+    skipLinks: {
+      position: 'top',
+      container: {
+        elevation: 'large',
+        round: 'small',
+        pad: 'medium',
+      },
+      text: {
+        margin: 'small',
+        size: 'medium',
+      },
+    },
     tab: {
       active: {
         color: 'text',

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -990,7 +990,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         pad: 'medium',
       },
       label: {
-        margin: 'small',
+        margin: { bottom: 'medium' },
         size: 'medium',
       },
     },

--- a/src/js/utils/DOM.js
+++ b/src/js/utils/DOM.js
@@ -86,16 +86,16 @@ export const getBodyChildElements = () => {
 };
 
 export const getNewContainer = (
-  rootNode = document.body,
+  target = document.body,
   targetChildPosition,
 ) => {
   // setup DOM
   const container = document.createElement('div');
   if (targetChildPosition === 'first') {
     // for SkipLinks
-    rootNode.prepend(container);
+    target.prepend(container);
   } else {
-    rootNode.appendChild(container);
+    target.appendChild(container);
   }
   return container;
 };

--- a/src/js/utils/DOM.js
+++ b/src/js/utils/DOM.js
@@ -85,10 +85,15 @@ export const getBodyChildElements = () => {
   return children;
 };
 
-export const getNewContainer = (rootNode = document.body) => {
+export const getNewContainer = (rootNode = document.body, bodyTarget) => {
   // setup DOM
   const container = document.createElement('div');
-  rootNode.appendChild(container);
+  if (bodyTarget === 'first') {
+    // for SkipLinks
+    rootNode.prepend(container);
+  } else {
+    rootNode.appendChild(container);
+  }
   return container;
 };
 
@@ -131,7 +136,7 @@ export const makeNodeUnfocusable = node => {
     node.setAttribute('aria-hidden', true);
     // prevent children to receive focus
     const elements = node.getElementsByTagName('*');
-    // first, save off the tabindex of any element with one
+    // first, save off the tabIndex of any element with one
     Array.prototype.filter
       .call(elements || [], element => element.getAttribute(TABINDEX) !== null)
       .forEach(element => {
@@ -139,7 +144,7 @@ export const makeNodeUnfocusable = node => {
         element.setAttribute(TABINDEX, -1);
       });
     // then, if any element is inherently focusable and not handled above,
-    // give it a tabindex of -1 so it can't receive focus
+    // give it a tabIndex of -1 so it can't receive focus
     Array.prototype.filter
       .call(elements || [], element => {
         const currentTag = element.tagName.toLowerCase();

--- a/src/js/utils/DOM.js
+++ b/src/js/utils/DOM.js
@@ -85,10 +85,13 @@ export const getBodyChildElements = () => {
   return children;
 };
 
-export const getNewContainer = (rootNode = document.body, bodyTarget) => {
+export const getNewContainer = (
+  rootNode = document.body,
+  targetChildPosition,
+) => {
   // setup DOM
   const container = document.createElement('div');
-  if (bodyTarget === 'first') {
+  if (targetChildPosition === 'first') {
     // for SkipLinks
     rootNode.prepend(container);
   } else {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
1. Allows the SkipLinks layer to open by entering Tab on the keyboard once the page loaded.
1. Allows skipping the SkipLinks layer content and tabbing to the header.
1. Allows editing the SkipLinks message and styling the container, layer, and the text message.
1. Allows cyclic navigation of the page that includes the layer using the keyboard.
1. Enabling access to the rest of the interactive elements while the layer is shown.
1. Changing the DOM behavior to prepend the Layer to the DOM so tabIndex order will behave correctly by default.
1. Provides clear examples of how to use the component on Storybook.
1. Tested with typescript.
1. Change initial focus behavior to the first focused link instead of the container.

#### Where should the reviewer start?
SkipLinks.js
#### What testing has been done on this PR?
Manual testing - many.
Typescript local testing - all passed.
#### How should this be manually tested?
Go to the storybook examples of SkipLinks, enter Tab on the keyboard, and follow directions.
#### Any background context you want to provide?
I would like to add one more enhancement on a separate PR, that the first focusable element will be the first SkipLink element and not the container as its behaving now (and always behaved that way). I can file it on a separate PR if agreed.
Edit: this functionality is already done on this PR.
#### What are the relevant issues?
closes #4360 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Done
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible as this PR is a bug fix.