### PR TITLE
Box props added to RadioButtonGroup theme

### DIFF
--- a/src/js/components/RadioButtonGroup/README.md
+++ b/src/js/components/RadioButtonGroup/README.md
@@ -88,3 +88,14 @@ object
 ```
 div
 ```
+## Theme
+  
+**radioButtonGroup.container**
+
+Any valid Box props for the RadioButtonGroup container. Expects `object`.
+
+Defaults to
+
+```
+undefined
+```

--- a/src/js/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/js/components/RadioButtonGroup/RadioButtonGroup.js
@@ -23,6 +23,7 @@ const RadioButtonGroup = forwardRef(
       onChange,
       options: optionsProp,
       value: valueProp,
+      gap = 'small',
       ...rest
     },
     ref,
@@ -102,7 +103,12 @@ const RadioButtonGroup = forwardRef(
         onLeft={focus ? onPrevious : undefined}
         onRight={focus ? onNext : undefined}
       >
-        <Box ref={ref} {...theme.radioButtonGroup.container} {...rest}>
+        <Box
+          ref={ref}
+          gap={gap}
+          {...theme.radioButtonGroup.container}
+          {...rest}
+        >
           {options.map(
             (
               {

--- a/src/js/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/js/components/RadioButtonGroup/RadioButtonGroup.js
@@ -7,9 +7,11 @@ import React, {
   useState,
 } from 'react';
 
-import { Box } from '../Box';
+import { ThemeContext } from 'styled-components';
 import { FormContext } from '../Form/FormContext';
+import { defaultProps } from '../../default-props';
 import { Keyboard } from '../Keyboard';
+import { Box } from '../Box';
 import { RadioButton } from '../RadioButton';
 
 const RadioButtonGroup = forwardRef(
@@ -17,7 +19,6 @@ const RadioButtonGroup = forwardRef(
     {
       children,
       disabled,
-      gap = 'small',
       name,
       onChange,
       options: optionsProp,
@@ -27,6 +28,7 @@ const RadioButtonGroup = forwardRef(
     ref,
   ) => {
     const formContext = useContext(FormContext);
+    const theme = useContext(ThemeContext) || defaultProps.theme;
 
     // normalize options to always use an object
     const options = useMemo(
@@ -92,7 +94,6 @@ const RadioButtonGroup = forwardRef(
     };
 
     const onBlur = () => focus && setFocus(false);
-
     return (
       <Keyboard
         target="document"
@@ -101,7 +102,7 @@ const RadioButtonGroup = forwardRef(
         onLeft={focus ? onPrevious : undefined}
         onRight={focus ? onNext : undefined}
       >
-        <Box ref={ref} gap={gap} {...rest}>
+        <Box ref={ref} {...theme.radioButtonGroup.container} {...rest}>
           {options.map(
             (
               {

--- a/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
+++ b/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
@@ -68,16 +68,6 @@ exports[`RadioButtonGroup adding additional props 1`] = `
   border-radius: 100%;
 }
 
-.c6 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 12px;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -120,12 +110,6 @@ exports[`RadioButtonGroup adding additional props 1`] = `
   }
 }
 
-@media only screen and (max-width:768px) {
-  .c6 {
-    height: 6px;
-  }
-}
-
 <div
   className="c0"
 >
@@ -159,9 +143,6 @@ exports[`RadioButtonGroup adding additional props 1`] = `
         />
       </div>
     </label>
-    <div
-      className="c6"
-    />
     <label
       className="c2"
       htmlFor="TWO"
@@ -262,7 +243,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
   border-radius: 100%;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -286,16 +267,6 @@ exports[`RadioButtonGroup boolean options 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   border-radius: 100%;
-}
-
-.c7 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 12px;
 }
 
 .c2 {
@@ -354,14 +325,8 @@ exports[`RadioButtonGroup boolean options 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
-    border: solid 2px rgba(0,0,0,0.15);
-  }
-}
-
-@media only screen and (max-width:768px) {
   .c7 {
-    height: 6px;
+    border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
@@ -414,9 +379,6 @@ exports[`RadioButtonGroup boolean options 1`] = `
         true
       </span>
     </label>
-    <div
-      className="c7"
-    />
     <label
       className="c2"
       htmlFor="false"
@@ -439,7 +401,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
           value={false}
         />
         <div
-          className="c8 "
+          className="c7 "
         />
       </div>
       <span
@@ -511,16 +473,6 @@ exports[`RadioButtonGroup children 1`] = `
   padding: 12px;
 }
 
-.c6 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 12px;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -563,12 +515,6 @@ exports[`RadioButtonGroup children 1`] = `
   }
 }
 
-@media only screen and (max-width:768px) {
-  .c6 {
-    height: 6px;
-  }
-}
-
 <div
   className="c0"
 >
@@ -601,9 +547,6 @@ exports[`RadioButtonGroup children 1`] = `
         />
       </div>
     </label>
-    <div
-      className="c6"
-    />
     <label
       className="c2"
       htmlFor="two"
@@ -703,7 +646,7 @@ exports[`RadioButtonGroup number options 1`] = `
   border-radius: 100%;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -727,16 +670,6 @@ exports[`RadioButtonGroup number options 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   border-radius: 100%;
-}
-
-.c7 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 12px;
 }
 
 .c2 {
@@ -795,14 +728,8 @@ exports[`RadioButtonGroup number options 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
-    border: solid 2px rgba(0,0,0,0.15);
-  }
-}
-
-@media only screen and (max-width:768px) {
   .c7 {
-    height: 6px;
+    border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
@@ -855,9 +782,6 @@ exports[`RadioButtonGroup number options 1`] = `
         1
       </span>
     </label>
-    <div
-      className="c7"
-    />
     <label
       className="c2"
       htmlFor="2"
@@ -880,7 +804,7 @@ exports[`RadioButtonGroup number options 1`] = `
           value={2}
         />
         <div
-          className="c8 "
+          className="c7 "
         />
       </div>
       <span
@@ -962,16 +886,6 @@ exports[`RadioButtonGroup object options 1`] = `
   border-radius: 100%;
 }
 
-.c6 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 12px;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1020,12 +934,6 @@ exports[`RadioButtonGroup object options 1`] = `
   }
 }
 
-@media only screen and (max-width:768px) {
-  .c6 {
-    height: 6px;
-  }
-}
-
 <div
   className="c0"
 >
@@ -1063,9 +971,6 @@ exports[`RadioButtonGroup object options 1`] = `
         One
       </span>
     </label>
-    <div
-      className="c6"
-    />
     <label
       className="c2"
       htmlFor="twO"
@@ -1169,16 +1074,6 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   border-radius: 100%;
 }
 
-.c6 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 12px;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1207,7 +1102,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   border-color: #000000;
 }
 
-.c7 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1229,8 +1124,8 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   cursor: pointer;
 }
 
-.c7:hover input:not([disabled]) + div,
-.c7:hover input:not([disabled]) + span {
+.c6:hover input:not([disabled]) + div,
+.c6:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
@@ -1242,7 +1137,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   margin: 0;
 }
 
-.c8 {
+.c7 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -1254,12 +1149,6 @@ exports[`RadioButtonGroup object options disabled 1`] = `
 @media only screen and (max-width:768px) {
   .c5 {
     border: solid 2px rgba(0,0,0,0.15);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    height: 6px;
   }
 }
 
@@ -1295,11 +1184,8 @@ exports[`RadioButtonGroup object options disabled 1`] = `
         />
       </div>
     </label>
-    <div
-      className="c6"
-    />
     <label
-      className="c7"
+      className="c6"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -1309,7 +1195,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
       >
         <input
           checked={false}
-          className="c8"
+          className="c7"
           name="test"
           onBlur={[Function]}
           onChange={[Function]}
@@ -1394,7 +1280,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
   border-radius: 100%;
 }
 
-.c7 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1418,16 +1304,6 @@ exports[`RadioButtonGroup object options just value 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   border-radius: 100%;
-}
-
-.c6 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 12px;
 }
 
 .c2 {
@@ -1466,7 +1342,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
   cursor: pointer;
 }
 
-.c8 {
+.c7 {
   box-sizing: border-box;
   width: 24px;
   height: 24px;
@@ -1480,14 +1356,8 @@ exports[`RadioButtonGroup object options just value 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
-    border: solid 2px #7D4CDB;
-  }
-}
-
-@media only screen and (max-width:768px) {
   .c6 {
-    height: 6px;
+    border: solid 2px #7D4CDB;
   }
 }
 
@@ -1521,9 +1391,6 @@ exports[`RadioButtonGroup object options just value 1`] = `
         />
       </div>
     </label>
-    <div
-      className="c6"
-    />
     <label
       className="c2"
       onClick={[Function]}
@@ -1544,10 +1411,10 @@ exports[`RadioButtonGroup object options just value 1`] = `
           value="two"
         />
         <div
-          className="c7 "
+          className="c6 "
         >
           <svg
-            className="c8"
+            className="c7"
             preserveAspectRatio="xMidYMid meet"
             viewBox="0 0 24 24"
           >
@@ -1669,7 +1536,7 @@ exports[`RadioButtonGroup string options 1`] = `
   border-radius: 100%;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1693,16 +1560,6 @@ exports[`RadioButtonGroup string options 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   border-radius: 100%;
-}
-
-.c7 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 12px;
 }
 
 .c2 {
@@ -1761,14 +1618,8 @@ exports[`RadioButtonGroup string options 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
-    border: solid 2px rgba(0,0,0,0.15);
-  }
-}
-
-@media only screen and (max-width:768px) {
   .c7 {
-    height: 6px;
+    border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
@@ -1821,9 +1672,6 @@ exports[`RadioButtonGroup string options 1`] = `
         one
       </span>
     </label>
-    <div
-      className="c7"
-    />
     <label
       className="c2"
       htmlFor="two"
@@ -1846,7 +1694,7 @@ exports[`RadioButtonGroup string options 1`] = `
           value="two"
         />
         <div
-          className="c8 "
+          className="c7 "
         />
       </div>
       <span

--- a/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
+++ b/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
@@ -68,6 +68,16 @@ exports[`RadioButtonGroup adding additional props 1`] = `
   border-radius: 100%;
 }
 
+.c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -110,6 +120,12 @@ exports[`RadioButtonGroup adding additional props 1`] = `
   }
 }
 
+@media only screen and (max-width:768px) {
+  .c6 {
+    height: 6px;
+  }
+}
+
 <div
   className="c0"
 >
@@ -143,6 +159,9 @@ exports[`RadioButtonGroup adding additional props 1`] = `
         />
       </div>
     </label>
+    <div
+      className="c6"
+    />
     <label
       className="c2"
       htmlFor="TWO"
@@ -243,7 +262,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
   border-radius: 100%;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -267,6 +286,16 @@ exports[`RadioButtonGroup boolean options 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   border-radius: 100%;
+}
+
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
 }
 
 .c2 {
@@ -325,8 +354,14 @@ exports[`RadioButtonGroup boolean options 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     border: solid 2px rgba(0,0,0,0.15);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    height: 6px;
   }
 }
 
@@ -379,6 +414,9 @@ exports[`RadioButtonGroup boolean options 1`] = `
         true
       </span>
     </label>
+    <div
+      className="c7"
+    />
     <label
       className="c2"
       htmlFor="false"
@@ -401,7 +439,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
           value={false}
         />
         <div
-          className="c7 "
+          className="c8 "
         />
       </div>
       <span
@@ -473,6 +511,16 @@ exports[`RadioButtonGroup children 1`] = `
   padding: 12px;
 }
 
+.c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -515,6 +563,12 @@ exports[`RadioButtonGroup children 1`] = `
   }
 }
 
+@media only screen and (max-width:768px) {
+  .c6 {
+    height: 6px;
+  }
+}
+
 <div
   className="c0"
 >
@@ -547,6 +601,9 @@ exports[`RadioButtonGroup children 1`] = `
         />
       </div>
     </label>
+    <div
+      className="c6"
+    />
     <label
       className="c2"
       htmlFor="two"
@@ -646,7 +703,7 @@ exports[`RadioButtonGroup number options 1`] = `
   border-radius: 100%;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -670,6 +727,16 @@ exports[`RadioButtonGroup number options 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   border-radius: 100%;
+}
+
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
 }
 
 .c2 {
@@ -728,8 +795,14 @@ exports[`RadioButtonGroup number options 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     border: solid 2px rgba(0,0,0,0.15);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    height: 6px;
   }
 }
 
@@ -782,6 +855,9 @@ exports[`RadioButtonGroup number options 1`] = `
         1
       </span>
     </label>
+    <div
+      className="c7"
+    />
     <label
       className="c2"
       htmlFor="2"
@@ -804,7 +880,7 @@ exports[`RadioButtonGroup number options 1`] = `
           value={2}
         />
         <div
-          className="c7 "
+          className="c8 "
         />
       </div>
       <span
@@ -886,6 +962,16 @@ exports[`RadioButtonGroup object options 1`] = `
   border-radius: 100%;
 }
 
+.c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -934,6 +1020,12 @@ exports[`RadioButtonGroup object options 1`] = `
   }
 }
 
+@media only screen and (max-width:768px) {
+  .c6 {
+    height: 6px;
+  }
+}
+
 <div
   className="c0"
 >
@@ -971,6 +1063,9 @@ exports[`RadioButtonGroup object options 1`] = `
         One
       </span>
     </label>
+    <div
+      className="c6"
+    />
     <label
       className="c2"
       htmlFor="twO"
@@ -1074,6 +1169,16 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   border-radius: 100%;
 }
 
+.c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1102,7 +1207,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   border-color: #000000;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1124,8 +1229,8 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   cursor: pointer;
 }
 
-.c6:hover input:not([disabled]) + div,
-.c6:hover input:not([disabled]) + span {
+.c7:hover input:not([disabled]) + div,
+.c7:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
@@ -1137,7 +1242,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   margin: 0;
 }
 
-.c7 {
+.c8 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -1149,6 +1254,12 @@ exports[`RadioButtonGroup object options disabled 1`] = `
 @media only screen and (max-width:768px) {
   .c5 {
     border: solid 2px rgba(0,0,0,0.15);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    height: 6px;
   }
 }
 
@@ -1184,8 +1295,11 @@ exports[`RadioButtonGroup object options disabled 1`] = `
         />
       </div>
     </label>
-    <label
+    <div
       className="c6"
+    />
+    <label
+      className="c7"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -1195,7 +1309,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
       >
         <input
           checked={false}
-          className="c7"
+          className="c8"
           name="test"
           onBlur={[Function]}
           onChange={[Function]}
@@ -1280,7 +1394,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
   border-radius: 100%;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1304,6 +1418,16 @@ exports[`RadioButtonGroup object options just value 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   border-radius: 100%;
+}
+
+.c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
 }
 
 .c2 {
@@ -1342,7 +1466,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
   cursor: pointer;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   width: 24px;
   height: 24px;
@@ -1356,8 +1480,14 @@ exports[`RadioButtonGroup object options just value 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c7 {
     border: solid 2px #7D4CDB;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    height: 6px;
   }
 }
 
@@ -1391,6 +1521,9 @@ exports[`RadioButtonGroup object options just value 1`] = `
         />
       </div>
     </label>
+    <div
+      className="c6"
+    />
     <label
       className="c2"
       onClick={[Function]}
@@ -1411,10 +1544,10 @@ exports[`RadioButtonGroup object options just value 1`] = `
           value="two"
         />
         <div
-          className="c6 "
+          className="c7 "
         >
           <svg
-            className="c7"
+            className="c8"
             preserveAspectRatio="xMidYMid meet"
             viewBox="0 0 24 24"
           >
@@ -1536,7 +1669,7 @@ exports[`RadioButtonGroup string options 1`] = `
   border-radius: 100%;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1560,6 +1693,16 @@ exports[`RadioButtonGroup string options 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   border-radius: 100%;
+}
+
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
 }
 
 .c2 {
@@ -1618,8 +1761,14 @@ exports[`RadioButtonGroup string options 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     border: solid 2px rgba(0,0,0,0.15);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    height: 6px;
   }
 }
 
@@ -1672,6 +1821,9 @@ exports[`RadioButtonGroup string options 1`] = `
         one
       </span>
     </label>
+    <div
+      className="c7"
+    />
     <label
       className="c2"
       htmlFor="two"
@@ -1694,7 +1846,7 @@ exports[`RadioButtonGroup string options 1`] = `
           value="two"
         />
         <div
-          className="c7 "
+          className="c8 "
         />
       </div>
       <span

--- a/src/js/components/RadioButtonGroup/doc.js
+++ b/src/js/components/RadioButtonGroup/doc.js
@@ -61,3 +61,11 @@ export const doc = RadioButtonGroup => {
 
   return DocumentedRadioButtonGroup;
 };
+
+export const themeDoc = {
+  'radioButtonGroup.container': {
+    description: 'Any valid Box props for the RadioButtonGroup container.',
+    type: 'object',
+    defaultValue: 'undefined',
+  },
+};

--- a/src/js/components/RadioButtonGroup/stories/CustomTheme.js
+++ b/src/js/components/RadioButtonGroup/stories/CustomTheme.js
@@ -9,7 +9,6 @@ const customTheme = deepMerge(grommet, {
   radioButtonGroup: {
     container: {
       gap: 'xlarge',
-      animation: 'fadeIn',
     },
   },
   radioButton: {

--- a/src/js/components/RadioButtonGroup/stories/CustomTheme.js
+++ b/src/js/components/RadioButtonGroup/stories/CustomTheme.js
@@ -6,6 +6,12 @@ import { grommet } from 'grommet/themes';
 import { deepMerge } from 'grommet/utils';
 
 const customTheme = deepMerge(grommet, {
+  radioButtonGroup: {
+    container: {
+      gap: 'xlarge',
+      animation: 'fadeIn',
+    },
+  },
   radioButton: {
     border: {
       color: 'red',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11907,7 +11907,19 @@ object
 
 \`\`\`
 div
-\`\`\`",
+\`\`\`
+## Theme
+  
+**radioButtonGroup.container**
+
+Any valid Box props for the RadioButtonGroup container. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+",
   "RangeInput": "## RangeInput
 A slider control to input a value within a fixed range.
 

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -940,6 +940,9 @@ export interface ThemeType {
       weight?: number | string;
     };
   };
+  radioButtonGroup?: {
+    container?: BoxProps;
+  };
   rangeInput?: {
     track?: {
       height?: string;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -921,6 +921,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // weight: undefined,
       },
     },
+    radioButtonGroup: {
+      // container: {}, // any box props
+    },
     rangeInput: {
       // extend: undefined
       track: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,15 +42,15 @@
     semver "^5.5.0"
 
 "@babel/core@^7.1.0", "@babel/core@^7.3.4", "@babel/core@^7.4.5", "@babel/core@^7.7.5":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.0.tgz#73b9c33f1658506887f767c26dae07798b30df76"
-  integrity sha512-mkLq8nwaXmDtFmRkQ8ED/eA2CnVw4zr7dCztKalZXBvdK5EeNUAesrrwUqjQEzFgomJssayzB0aqlOsP1vGLqg==
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.1.tgz#2c55b604e73a40dc21b0e52650b11c65cf276643"
+  integrity sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/generator" "^7.11.0"
     "@babel/helper-module-transforms" "^7.11.0"
     "@babel/helpers" "^7.10.4"
-    "@babel/parser" "^7.11.0"
+    "@babel/parser" "^7.11.1"
     "@babel/template" "^7.10.4"
     "@babel/traverse" "^7.11.0"
     "@babel/types" "^7.11.0"
@@ -312,10 +312,10 @@
     resolve "^1.13.1"
     v8flags "^3.1.1"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.0", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.0.tgz#a9d7e11aead25d3b422d17b2c6502c8dddef6a5d"
-  integrity sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==
+"@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.0", "@babel/parser@^7.11.1", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.2.tgz#0882ab8a455df3065ea2dcb4c753b2460a24bead"
+  integrity sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw==
 
 "@babel/plugin-proposal-async-generator-functions@^7.10.4":
   version "7.10.5"
@@ -605,9 +605,9 @@
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-block-scoping@^7.10.4":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.5.tgz#b81b8aafefbfe68f0f65f7ef397b9ece68a6037d"
-  integrity sha512-6Ycw3hjpQti0qssQcA6AMSFDHeNJ++R6dIMnpRqUjFeBBTmTDPa8zgF90OVfTvAo11mXZTlVUViY1g8ffrURLg==
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz#5b7efe98852bef8d652c0b28144cd93a9e4b5215"
+  integrity sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
@@ -1015,17 +1015,17 @@
     source-map-support "^0.5.16"
 
 "@babel/runtime-corejs3@^7.10.2":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.11.0.tgz#db54a2251206f0f8579b41918acb14488b8dd2c0"
-  integrity sha512-K0ioacsw8JgzDSPpUiGWokMvLzGvnZPXLrTsJfyHPrFsnp4yoKn+Ap/8NNZgWKZG9o5+qotH8tAa8AXn8gTN5A==
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz#02c3029743150188edeb66541195f54600278419"
+  integrity sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==
   dependencies:
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.0.tgz#f10245877042a815e07f7e693faff0ae9d3a2aac"
-  integrity sha512-qArkXsjJq7H+T86WrIFV0Fnu/tNOkZ4cgXmjkzAu3b/58D5mFIO8JH/y77t7C9q0OdDRdh9s7Ue5GasYssxtXw==
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1970,9 +1970,9 @@
     loader-utils "^1.2.3"
 
 "@testing-library/dom@*":
-  version "7.21.7"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.21.7.tgz#23c57c361db5e961afa3e6f3f15bd57fbda01187"
-  integrity sha512-GVNrLAt0yq7Squz1HrW8IiDVKP5jeWSv9cpgQJsfmXYXLFPpaFoRxn+H/NcUitVXyb0J62PkpVWjMe5b0fvYrQ==
+  version "7.22.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.22.0.tgz#07cc67f4670c2ce564b8d7f0e1826d7caf0645e3"
+  integrity sha512-soXVCM/F2WxMidqGlZsSvTkmLsmi72q5N2IrB7o1aTFpMCfEL+Kl0kzv+2Lk/dLxny/c7CWUDa+yjve5VEsjMg==
   dependencies:
     "@babel/runtime" "^7.10.3"
     "@types/aria-query" "^4.2.0"
@@ -2322,9 +2322,9 @@
   integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
 
 "@types/yargs@^13.0.0":
-  version "13.0.9"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.9.tgz#44028e974343c7afcf3960f1a2b1099c39a7b5e1"
-  integrity sha512-xrvhZ4DZewMDhoH1utLtOAwYQy60eYFoXeje30TzM3VOvQlBwQaEpKFq5m34k1wOw2AKIi2pwtiAjdmhvlBUzg==
+  version "13.0.10"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.10.tgz#e77bf3fc73c781d48c2eb541f87c453e321e5f4b"
+  integrity sha512-MU10TSgzNABgdzKvQVW1nuuT+sgBMWeXNc3XOs5YXV5SDAK+PPja2eUuBNB9iqElu03xyEDqlnGw0jgl4nbqGQ==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -3584,15 +3584,15 @@ browserify-rsa@^4.0.0, browserify-rsa@^4.0.1:
     randombytes "^2.0.1"
 
 browserify-sign@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.2.0.tgz#545d0b1b07e6b2c99211082bf1b12cce7a0b0e11"
-  integrity sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.2.1.tgz#eaf4add46dd54be3bb3b36c0cf15abbeba7956c3"
+  integrity sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==
   dependencies:
     bn.js "^5.1.1"
     browserify-rsa "^4.0.1"
     create-hash "^1.2.0"
     create-hmac "^1.1.7"
-    elliptic "^6.5.2"
+    elliptic "^6.5.3"
     inherits "^2.0.4"
     parse-asn1 "^5.1.5"
     readable-stream "^3.6.0"
@@ -3806,9 +3806,9 @@ can-use-dom@^0.1.0:
   integrity sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=
 
 caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001109:
-  version "1.0.30001109"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001109.tgz#a9f3f26a0c3753b063d7acbb48dfb9c0e46f2b19"
-  integrity sha512-4JIXRodHzdS3HdK8nSgIqXYLExOvG+D2/EenSvcub2Kp3QEADjo2v2oUn5g0n0D+UNwG9BtwKOyGcSq2qvQXvQ==
+  version "1.0.30001111"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001111.tgz#dd0ce822c70eb6c7c068e4a55c22e19ec1501298"
+  integrity sha512-xnDje2wchd/8mlJu8sXvWxOGvMgv+uT3iZ3bkIAynKOzToCssWCmkz/ZIkQBs/2pUB4uwnJKVORWQ31UkbVjOg==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -4394,12 +4394,12 @@ cosmiconfig@^6.0.0:
     yaml "^1.7.2"
 
 create-ecdh@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
-  integrity sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
+  integrity sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==
   dependencies:
     bn.js "^4.1.0"
-    elliptic "^6.0.0"
+    elliptic "^6.5.3"
 
 create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
@@ -5091,9 +5091,9 @@ ejs@^2.7.4:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.488:
-  version "1.3.516"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.516.tgz#03ec071b061e462b786bf7e7ce226fd7ab7cf1f6"
-  integrity sha512-WDM5AAQdOrvLqSX8g3Zd5AujBXfMxf96oeZkff0U2HF5op3tjShE+on2yay3r1UD4M9I3p0iHpAS4+yV8U8A9A==
+  version "1.3.523"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.523.tgz#494080b318ba929614eebd04405b94c359ea9333"
+  integrity sha512-D4/3l5DpciddD92IDRtpLearQSGzly8FwBJv+nITvLH8YJrFabpDFe4yuiOJh2MS4/EsXqyQTXyw1toeYPtshQ==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -5107,7 +5107,7 @@ element-resize-detector@^1.2.1:
   dependencies:
     batch-processor "1.0.0"
 
-elliptic@^6.0.0, elliptic@^6.5.2:
+elliptic@^6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
   integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
@@ -5542,9 +5542,9 @@ estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
 estraverse@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
-  integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
+  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -7161,9 +7161,9 @@ is-directory@^0.3.1:
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
 is-docker@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.0.tgz#25dc043e4fdc3cf969d622735e05a86ba9952e2b"
-  integrity sha512-mB2WygGsSeoXtLKpSYzP6sa0Z9DyU9ZyKlnvuZWxCociaI0qsF8u12sR72DFTX236g1u6oWSWYFuUk09nGQEjg==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
+  integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -7318,9 +7318,9 @@ is-promise@^2.1.0:
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
 
 is-regex@^1.0.4, is-regex@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.0.tgz#ece38e389e490df0dc21caea2bd596f987f767ff"
-  integrity sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
+  integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
   dependencies:
     has-symbols "^1.0.1"
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
closes #4184 
Adds boxprops to RadioButtonGroup in theme

#### Where should the reviewer start?
RadioButtonGroup.js
base.js
base.d.ts
RadioButtonGroup Stories - CustomTheme.js
RadioButtonGroup doc.js

#### What testing has been done on this PR?
Storybook, tested with and without custom theme.
Used none, xxsmall, small, medium, large, xlarge, and px values to test gap within custom theme.
Also, tested other box props, like animation, to see if they applied.

#### How should this be manually tested?
same as above

#### Any background context you want to provide?
RadioButtonGroup did not have the ability to set box props within theme.

#### What are the relevant issues?
#4341 

#### Do the grommet docs need to be updated?
Yes, they are in this pr

#### Is this change backwards compatible or is it a breaking change?
backwards compatible