### PR TITLE
Removed new Date() from stories and replaced with static date

### DIFF
--- a/src/js/components/Calendar/stories/Dual.js
+++ b/src/js/components/Calendar/stories/Dual.js
@@ -6,16 +6,11 @@ import { grommet } from 'grommet/themes';
 
 import { Blank, Previous, Next } from 'grommet-icons';
 
-const now = new Date();
-const next = new Date(now);
-next.setMonth(now.getMonth() + 1, 1);
-
 const DualCalendar = () => {
   const [date, setDate] = useState();
   const [dates, setDates] = useState();
-  const [reference1, setReference1] = useState(now);
-  const [reference2, setReference2] = useState(next);
-
+  const [reference1, setReference1] = useState('2020-08-07T15:13:47.290Z');
+  const [reference2, setReference2] = useState('2020-09-01T15:15:34.916Z');
   const onSelect = arg => {
     if (Array.isArray(arg)) {
       setDate(undefined);
@@ -36,10 +31,12 @@ const DualCalendar = () => {
           date={date}
           dates={dates}
           onSelect={onSelect}
-          reference={reference1.toISOString()}
+          reference={reference1}
           onReference={reference => {
             const refDate = new Date(reference);
             const nextDate = new Date(refDate);
+            console.log(refDate);
+            console.log(nextDate);
             nextDate.setMonth(refDate.getMonth() + 1, 1);
             setReference1(refDate);
             setReference2(nextDate);
@@ -73,7 +70,7 @@ const DualCalendar = () => {
           dates={dates}
           range
           onSelect={onSelect}
-          reference={reference2.toISOString()}
+          reference={reference2}
           onReference={reference => {
             const refDate = new Date(reference);
             const priorDate = new Date(refDate);

--- a/src/js/components/DateInput/stories/Range.js
+++ b/src/js/components/DateInput/stories/Range.js
@@ -4,10 +4,6 @@ import { storiesOf } from '@storybook/react';
 import { Grommet, Box, DateInput } from 'grommet';
 import { grommet } from 'grommet/themes';
 
-const now = new Date();
-const lastWeek = new Date(now);
-lastWeek.setDate(lastWeek.getDate() - 7);
-
 const dateFormat = new Intl.DateTimeFormat(undefined, {
   month: 'short',
   day: 'numeric',
@@ -15,8 +11,8 @@ const dateFormat = new Intl.DateTimeFormat(undefined, {
 
 const Example = () => {
   const [value, setValue] = React.useState([
-    lastWeek.toISOString(),
-    now.toISOString(),
+    '2020-07-31T15:27:42.920Z',
+    '2020-08-07T15:27:42.920Z',
   ]);
   const onChange = event => {
     const nextValue = event.value;

--- a/src/js/components/DateInput/stories/RangeFormat.js
+++ b/src/js/components/DateInput/stories/RangeFormat.js
@@ -4,10 +4,6 @@ import { storiesOf } from '@storybook/react';
 import { Grommet, Box, DateInput } from 'grommet';
 import { grommet } from 'grommet/themes';
 
-const now = new Date();
-const lastWeek = new Date(now);
-lastWeek.setDate(lastWeek.getDate() - 7);
-
 const dateFormat = new Intl.DateTimeFormat(undefined, {
   month: 'short',
   day: 'numeric',
@@ -15,8 +11,8 @@ const dateFormat = new Intl.DateTimeFormat(undefined, {
 
 const Example = () => {
   const [value, setValue] = React.useState([
-    lastWeek.toISOString(),
-    now.toISOString(),
+    '2020-07-31T15:24:26.256Z',
+    '2020-08-07T15:24:26.256Z',
   ]);
   const onChange = event => {
     const nextValue = event.value;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Replaces new Date() found in some stories with a static date

#### Where should the reviewer start?
Calendar Stories - Dual.js
DateInput Stories - Range.js, RangeFormat.js

#### What testing has been done on this PR?
Double checked if examples functioned the same as they did before the change

#### How should this be manually tested?
Same as above, in storybook

#### Any background context you want to provide?
new Date() was causing unnecessary updates to snapshots

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible