### PR TITLE
Storybook example Tabs - Icon.js parsing template literal

### DIFF
--- a/src/js/components/Tabs/stories/Icon.js
+++ b/src/js/components/Tabs/stories/Icon.js
@@ -28,11 +28,11 @@ const customTheme = deepMerge(grommet, {
     },
     pad: 'small',
     margin: 'none',
-    extend: () => css`
+    extend: ({ theme }) => css`
       border-top-left-radius: '4px';
-      /* or theme.global.control.border.radius */
+        /* or 'border-top-left-radius: ${theme.global.control.border.radius}' */
       border-top-right-radius: '4px';
-      /* or theme.global.control.border.radius */
+      /* or 'border-top-right-radius: ${theme.global.control.border.radius} */
       font-weight: bold;
     `,
   },

--- a/src/js/components/Tabs/stories/Icon.js
+++ b/src/js/components/Tabs/stories/Icon.js
@@ -28,9 +28,11 @@ const customTheme = deepMerge(grommet, {
     },
     pad: 'small',
     margin: 'none',
-    extend: ({ theme }) => css`
-      border-top-left-radius: ${theme.global.control.border.radius};
-      border-top-right-radius: ${theme.global.control.border.radius};
+    extend: () => css`
+      border-top-left-radius: '4px';
+      /* or theme.global.control.border.radius */
+      border-top-right-radius: '4px';
+      /* or theme.global.control.border.radius */
       font-weight: bold;
     `,
   },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changes the template literal found in Tabs/Icons.js to a static value, and adds a comment.

#### Where should the reviewer start?
Tabs - Icons.js storybook example

#### What testing has been done on this PR?
storybook

#### How should this be manually tested?
same as above
#### Any background context you want to provide?
Some template literals are being parsed and showing up as ___CSS_0___ or __CSS_1___
It looks like its due to react-syntax-highlighter that storybook uses. It might think that this is a css value and needs to be parsed. It also, doesn't look like this issue has a very high priority on either storybook or react-syntax-highlighter. Storybook plans to fix it by migrating to a new syntax highlighter eventually.

This fix just makes it easier for people to copy and paste the example on storybook.
#### What are the relevant issues?
none on grommet
storybook - https://github.com/storybookjs/storybook/issues/10011
react syntax highllighter - https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/223
#### Screenshots (if appropriate)
issue in storybook
<img width="377" alt="Screen Shot 2020-08-07 at 3 21 50 PM" src="https://user-images.githubusercontent.com/21990914/89685327-be3a4900-d8c1-11ea-807d-d59f7aa293eb.png">

original code
```
    extend: ({ theme }) => css`
      border-top-left-radius: ${theme.global.control.border.radius};
      border-top-right-radius: ${theme.global.control.border.radius};
      font-weight: bold;
    `,
```

new code
```
    extend: () => css`
      border-top-left-radius: '4px';
      /* or theme.global.control.border.radius */
      border-top-right-radius: '4px';
      /* or theme.global.control.border.radius */
      font-weight: bold;
    `,
```

new storybook
<img width="428" alt="Screen Shot 2020-08-07 at 3 28 31 PM" src="https://user-images.githubusercontent.com/21990914/89685832-ba5af680-d8c2-11ea-8904-e59629eaa949.png">

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible