### PR TITLE
Infinite Scroll test number of items generated

### DIFF
--- a/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
+++ b/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
@@ -83,8 +83,11 @@ describe('Number of Items Rendered', () => {
     Array(value)
       .fill()
       .map((_, i) => `item ${i + 1}`);
-  function filterRefs(childItem) {
-    return childItem.outerHTML.includes('item');
+
+  function createPageItems(allChildren) {
+    const unfiltered = Array.from(allChildren);
+    // Removing any children which are serving as refs
+    return unfiltered.filter(childItem => childItem.outerHTML.includes('item'));
   }
 
   test(`Should render items equal to the length of 
@@ -102,9 +105,7 @@ describe('Number of Items Rendered', () => {
       </Grommet>,
     );
 
-    const allChildren = Array.from(container.firstChild.children);
-    // Removing any children which are serving as refs
-    const pageItems = allChildren.filter(filterRefs);
+    const pageItems = createPageItems(container.firstChild.children);
     const expectedItems = step;
     expect(pageItems.length).toEqual(expectedItems);
   });
@@ -120,9 +121,7 @@ describe('Number of Items Rendered', () => {
       </Grommet>,
     );
 
-    const allChildren = Array.from(container.firstChild.children);
-    // Removing any children which are serving as refs
-    const pageItems = allChildren.filter(filterRefs);
+    const pageItems = createPageItems(container.firstChild.children);
     const expectedItems = step;
     expect(pageItems.length).toEqual(expectedItems);
   });
@@ -138,9 +137,7 @@ describe('Number of Items Rendered', () => {
       </Grommet>,
     );
 
-    const allChildren = Array.from(container.firstChild.children);
-    // Removing any children which are serving as refs
-    const pageItems = allChildren.filter(filterRefs);
+    const pageItems = createPageItems(container.firstChild.children);
     const expectedItems = numItems;
     expect(pageItems.length).toEqual(expectedItems);
   });

--- a/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
+++ b/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
@@ -98,8 +98,8 @@ describe('InfiniteScroll', () => {
 
     const allChildren = Array.from(container.firstChild.children);
     // Removing any children which are serving as refs
-    const pageItems = allChildren.filter(
-      childItem => !!childItem.outerHTML.includes('item'),
+    const pageItems = allChildren.filter(childItem =>
+      childItem.outerHTML.includes('item'),
     );
     const expectedItems = step;
     expect(pageItems.length).toEqual(expectedItems);
@@ -118,8 +118,8 @@ describe('InfiniteScroll', () => {
 
     const allChildren = Array.from(container.firstChild.children);
     // Removing any children which are serving as refs
-    const pageItems = allChildren.filter(
-      childItem => !!childItem.outerHTML.includes('item'),
+    const pageItems = allChildren.filter(childItem =>
+      childItem.outerHTML.includes('item'),
     );
     const expectedItems = step;
     expect(pageItems.length).toEqual(expectedItems);
@@ -138,8 +138,8 @@ describe('InfiniteScroll', () => {
 
     const allChildren = Array.from(container.firstChild.children);
     // Removing any children which are serving as refs
-    const pageItems = allChildren.filter(
-      childItem => !!childItem.outerHTML.includes('item'),
+    const pageItems = allChildren.filter(childItem =>
+      childItem.outerHTML.includes('item'),
     );
     const expectedItems = numItems;
     expect(pageItems.length).toEqual(expectedItems);

--- a/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
+++ b/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
@@ -4,6 +4,7 @@ import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
 import { InfiniteScroll } from '..';
+import { Box } from '../..';
 
 describe('InfiniteScroll', () => {
   const items = [];
@@ -74,5 +75,38 @@ describe('InfiniteScroll', () => {
       </Grommet>,
     );
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('length when step < array', () => {
+    const allItems = Array(1000)
+      .fill()
+      .map((_, i) => `item ${i + 1}`);
+    const step = 50;
+    const { container } = render(
+      <Grommet>
+        <InfiniteScroll
+          items={allItems}
+          // show={117}
+          step={step}
+        >
+          {item => <Box key={item}>{item}</Box>}
+        </InfiniteScroll>
+      </Grommet>,
+    );
+    expect(container.firstChild.children.length).toEqual(step + 1);
+  });
+
+  test('length when step > array', () => {
+    const allItems = Array(1000)
+      .fill()
+      .map((_, i) => `item ${i + 1}`);
+    const { container } = render(
+      <Grommet>
+        <InfiniteScroll items={allItems} step={allItems.length + 1}>
+          {item => <Box key={item}>{item}</Box>}
+        </InfiniteScroll>
+      </Grommet>,
+    );
+    expect(container.firstChild.children.length).toEqual(allItems.length);
   });
 });

--- a/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
+++ b/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
@@ -9,10 +9,6 @@ import { Box } from '../..';
 describe('InfiniteScroll', () => {
   const items = [];
   while (items.length < 4) items.push(items.length);
-  const simpleItems = value =>
-    Array(value)
-      .fill()
-      .map((_, i) => `item ${i + 1}`);
 
   test('basic', () => {
     const { container } = render(
@@ -80,6 +76,16 @@ describe('InfiniteScroll', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
   });
+});
+
+describe('Number of Items Rendered', () => {
+  const simpleItems = value =>
+    Array(value)
+      .fill()
+      .map((_, i) => `item ${i + 1}`);
+  function filterRefs(childItem) {
+    return childItem.outerHTML.includes('item');
+  }
 
   test(`Should render items equal to the length of 
   step + 1 when step < items.length`, () => {
@@ -98,9 +104,7 @@ describe('InfiniteScroll', () => {
 
     const allChildren = Array.from(container.firstChild.children);
     // Removing any children which are serving as refs
-    const pageItems = allChildren.filter(childItem =>
-      childItem.outerHTML.includes('item'),
-    );
+    const pageItems = allChildren.filter(filterRefs);
     const expectedItems = step;
     expect(pageItems.length).toEqual(expectedItems);
   });
@@ -118,9 +122,7 @@ describe('InfiniteScroll', () => {
 
     const allChildren = Array.from(container.firstChild.children);
     // Removing any children which are serving as refs
-    const pageItems = allChildren.filter(childItem =>
-      childItem.outerHTML.includes('item'),
-    );
+    const pageItems = allChildren.filter(filterRefs);
     const expectedItems = step;
     expect(pageItems.length).toEqual(expectedItems);
   });
@@ -138,9 +140,7 @@ describe('InfiniteScroll', () => {
 
     const allChildren = Array.from(container.firstChild.children);
     // Removing any children which are serving as refs
-    const pageItems = allChildren.filter(childItem =>
-      childItem.outerHTML.includes('item'),
-    );
+    const pageItems = allChildren.filter(filterRefs);
     const expectedItems = numItems;
     expect(pageItems.length).toEqual(expectedItems);
   });

--- a/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
+++ b/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
@@ -123,9 +123,10 @@ describe('InfiniteScroll', () => {
 
   test(`Should render items equal to the length of 
   step when step > array`, () => {
+    const numItems = 1000;
     const { container } = render(
       <Grommet>
-        <InfiniteScroll items={simpleItems(1000)} show={117} step={1050}>
+        <InfiniteScroll items={simpleItems(numItems)} show={117} step={1050}>
           {item => <Box key={item}>{item}</Box>}
         </InfiniteScroll>
       </Grommet>,
@@ -135,7 +136,7 @@ describe('InfiniteScroll', () => {
     // don't approach the end of the page. This is why the total
     // number of items is the length of simpleItems, 1000.
     const renderedItems = container.firstChild.children.length;
-    const expectedItems = 1000;
+    const expectedItems = numItems;
     expect(renderedItems).toEqual(expectedItems);
   });
 });

--- a/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
+++ b/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
@@ -9,6 +9,10 @@ import { Box } from '../..';
 describe('InfiniteScroll', () => {
   const items = [];
   while (items.length < 4) items.push(items.length);
+  const simpleItems = value =>
+    Array(value)
+      .fill()
+      .map((_, i) => `item ${i + 1}`);
 
   test('basic', () => {
     const { container } = render(
@@ -77,15 +81,13 @@ describe('InfiniteScroll', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('length when step < array', () => {
-    const allItems = Array(1000)
-      .fill()
-      .map((_, i) => `item ${i + 1}`);
+  test(`Should render items equal to the length of 
+  step + 1 when step < items.length`, () => {
     const step = 50;
     const { container } = render(
       <Grommet>
         <InfiniteScroll
-          items={allItems}
+          items={simpleItems(1000)}
           // show={117}
           step={step}
         >
@@ -93,35 +95,47 @@ describe('InfiniteScroll', () => {
         </InfiniteScroll>
       </Grommet>,
     );
-    expect(container.firstChild.children.length).toEqual(step + 1);
+    // When step < the length of the number of items, an additional
+    // item is rendered as a marker for when scrolling nears the end
+    // of the rendered items. This is why expectedItems is step + 1.
+    const renderedItems = container.firstChild.children.length;
+    const expectedItems = step + 1;
+    expect(renderedItems).toEqual(expectedItems);
   });
 
-  test('length when step = array', () => {
-    const allItems = Array(200)
-      .fill()
-      .map((_, i) => `item ${i + 1}`);
+  test(`Should render items equal to the length of 
+  step + 1 when step = array`, () => {
     const step = 200;
     const { container } = render(
       <Grommet>
-        <InfiniteScroll items={allItems} show={117} step={step}>
+        <InfiniteScroll items={simpleItems(200)} show={117} step={step}>
           {item => <Box key={item}>{item}</Box>}
         </InfiniteScroll>
       </Grommet>,
     );
-    expect(container.firstChild.children.length).toEqual(step + 1);
+    // When step = the length of the number of items, an additional
+    // item is rendered as a marker for when scrolling nears the end
+    // of the rendered items. This is why expectedItems is step + 1.
+    const renderedItems = container.firstChild.children.length;
+    const expectedItems = step + 1;
+    expect(renderedItems).toEqual(expectedItems);
   });
 
-  test('length when step > array', () => {
-    const allItems = Array(1000)
-      .fill()
-      .map((_, i) => `item ${i + 1}`);
+  test(`Should render items equal to the length of 
+  step when step > array`, () => {
     const { container } = render(
       <Grommet>
-        <InfiniteScroll items={allItems} show={117} step={allItems.length + 50}>
+        <InfiniteScroll items={simpleItems(1000)} show={117} step={1050}>
           {item => <Box key={item}>{item}</Box>}
         </InfiniteScroll>
       </Grommet>,
     );
-    expect(container.firstChild.children.length).toEqual(allItems.length);
+    // When step > the length of the number of items,
+    // an additional item is NOT rendered because the items
+    // don't approach the end of the page. This is why the total
+    // number of items is the length of simpleItems, 1000.
+    const renderedItems = container.firstChild.children.length;
+    const expectedItems = 1000;
+    expect(renderedItems).toEqual(expectedItems);
   });
 });

--- a/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
+++ b/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
@@ -95,12 +95,14 @@ describe('InfiniteScroll', () => {
         </InfiniteScroll>
       </Grommet>,
     );
-    // When step < the length of the number of items, an additional
-    // item is rendered as a marker for when scrolling nears the end
-    // of the rendered items. This is why expectedItems is step + 1.
-    const renderedItems = container.firstChild.children.length;
-    const expectedItems = step + 1;
-    expect(renderedItems).toEqual(expectedItems);
+
+    const allChildren = Array.from(container.firstChild.children);
+    // Removing any children which are serving as refs
+    const pageItems = allChildren.filter(
+      childItem => !!childItem.outerHTML.includes('item'),
+    );
+    const expectedItems = step;
+    expect(pageItems.length).toEqual(expectedItems);
   });
 
   test(`Should render items equal to the length of 
@@ -113,12 +115,14 @@ describe('InfiniteScroll', () => {
         </InfiniteScroll>
       </Grommet>,
     );
-    // When step = the length of the number of items, an additional
-    // item is rendered as a marker for when scrolling nears the end
-    // of the rendered items. This is why expectedItems is step + 1.
-    const renderedItems = container.firstChild.children.length;
-    const expectedItems = step + 1;
-    expect(renderedItems).toEqual(expectedItems);
+
+    const allChildren = Array.from(container.firstChild.children);
+    // Removing any children which are serving as refs
+    const pageItems = allChildren.filter(
+      childItem => !!childItem.outerHTML.includes('item'),
+    );
+    const expectedItems = step;
+    expect(pageItems.length).toEqual(expectedItems);
   });
 
   test(`Should render items equal to the length of 
@@ -131,12 +135,13 @@ describe('InfiniteScroll', () => {
         </InfiniteScroll>
       </Grommet>,
     );
-    // When step > the length of the number of items,
-    // an additional item is NOT rendered because the items
-    // don't approach the end of the page. This is why the total
-    // number of items is the length of simpleItems, 1000.
-    const renderedItems = container.firstChild.children.length;
+
+    const allChildren = Array.from(container.firstChild.children);
+    // Removing any children which are serving as refs
+    const pageItems = allChildren.filter(
+      childItem => !!childItem.outerHTML.includes('item'),
+    );
     const expectedItems = numItems;
-    expect(renderedItems).toEqual(expectedItems);
+    expect(pageItems.length).toEqual(expectedItems);
   });
 });

--- a/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
+++ b/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
@@ -96,13 +96,28 @@ describe('InfiniteScroll', () => {
     expect(container.firstChild.children.length).toEqual(step + 1);
   });
 
+  test('length when step = array', () => {
+    const allItems = Array(200)
+      .fill()
+      .map((_, i) => `item ${i + 1}`);
+    const step = 200;
+    const { container } = render(
+      <Grommet>
+        <InfiniteScroll items={allItems} show={117} step={step}>
+          {item => <Box key={item}>{item}</Box>}
+        </InfiniteScroll>
+      </Grommet>,
+    );
+    expect(container.firstChild.children.length).toEqual(step + 1);
+  });
+
   test('length when step > array', () => {
     const allItems = Array(1000)
       .fill()
       .map((_, i) => `item ${i + 1}`);
     const { container } = render(
       <Grommet>
-        <InfiniteScroll items={allItems} step={allItems.length + 1}>
+        <InfiniteScroll items={allItems} show={117} step={allItems.length + 50}>
           {item => <Box key={item}>{item}</Box>}
         </InfiniteScroll>
       </Grommet>,


### PR DESCRIPTION
#### What does this PR do?
Adds testing to infinite scroll `step` prop. Tests small, medium, and large step sizes. Ensures that the number of elements being rendered is correct.

NOTE: this also tests that only unique items are being rendered, (no duplicates). On the `length when step < array` test if you uncomment `show={117}` the test will generate a warning and fail because of a bug causing there to be duplicate items when `show` is set and it is a higher value than `step`.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
`yarn test` before and after uncommenting line 89

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
<img width="567" alt="Screen Shot 2020-08-07 at 4 49 44 PM" src="https://user-images.githubusercontent.com/54560994/89695232-75d65780-d8d0-11ea-895e-42547e856e96.png">

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
