### PR TITLE
Add clarification to text margin docs

### DIFF
--- a/src/js/components/Text/README.md
+++ b/src/js/components/Text/README.md
@@ -43,9 +43,10 @@ string
 
 **margin**
 
-The amount of margin around the component. An object can
-    be specified to distinguish horizontal margin, vertical margin, and
-    margin on a particular side.
+The amount of margin around the component. For margin to be 
+      applied, Text needs to be wrapped in a containing Box. An object can be 
+      specified to distinguish horizontal margin, vertical margin, and margin 
+      on a particular side.
 
 ```
 none

--- a/src/js/components/Text/README.md
+++ b/src/js/components/Text/README.md
@@ -43,10 +43,12 @@ string
 
 **margin**
 
-The amount of margin around the component. For margin to be 
-      applied, Text needs to be wrapped in a containing Box. An object can be 
-      specified to distinguish horizontal margin, vertical margin, and margin 
-      on a particular side.
+The amount of margin around the component. An object can be 
+    specified to distinguish horizontal margin, vertical margin, and margin on 
+    a particular side. For vertical margin to be applied, Text needs to be 
+    contained within a layout component (such as Box or a generic div) or 
+    behave as a div (by applying as="div" or a display style of 
+    inline-block).
 
 ```
 none

--- a/src/js/components/Text/doc.js
+++ b/src/js/components/Text/doc.js
@@ -60,10 +60,12 @@ export const doc = Text => {
         ]),
       }),
       PropTypes.string,
-    ]).description(`The amount of margin around the component. For margin to be 
-      applied, Text needs to be wrapped in a containing Box. An object can be 
-      specified to distinguish horizontal margin, vertical margin, and margin 
-      on a particular side.`),
+    ]).description(`The amount of margin around the component. An object can be 
+    specified to distinguish horizontal margin, vertical margin, and margin on 
+    a particular side. For vertical margin to be applied, Text needs to be 
+    contained within a layout component (such as Box or a generic div) or 
+    behave as a div (by applying as="div" or a display style of 
+    inline-block).`),
     size: PropTypes.oneOfType([
       PropTypes.oneOf([
         'xsmall',

--- a/src/js/components/Text/doc.js
+++ b/src/js/components/Text/doc.js
@@ -4,6 +4,7 @@ import {
   colorPropType,
   genericProps,
   getAvailableAtBadge,
+  MARGIN_SIZES,
   themeDocUtils,
 } from '../../utils';
 
@@ -22,6 +23,47 @@ export const doc = Text => {
     color: colorPropType.description(
       'A color identifier to use for the text color.',
     ),
+    margin: PropTypes.oneOfType([
+      PropTypes.oneOf(['none', ...MARGIN_SIZES]),
+      PropTypes.shape({
+        bottom: PropTypes.oneOfType([
+          PropTypes.oneOf(MARGIN_SIZES),
+          PropTypes.string,
+        ]),
+        end: PropTypes.oneOfType([
+          PropTypes.oneOf(MARGIN_SIZES),
+          PropTypes.string,
+        ]),
+        horizontal: PropTypes.oneOfType([
+          PropTypes.oneOf(MARGIN_SIZES),
+          PropTypes.string,
+        ]),
+        left: PropTypes.oneOfType([
+          PropTypes.oneOf(MARGIN_SIZES),
+          PropTypes.string,
+        ]),
+        right: PropTypes.oneOfType([
+          PropTypes.oneOf(MARGIN_SIZES),
+          PropTypes.string,
+        ]),
+        start: PropTypes.oneOfType([
+          PropTypes.oneOf(MARGIN_SIZES),
+          PropTypes.string,
+        ]),
+        top: PropTypes.oneOfType([
+          PropTypes.oneOf(MARGIN_SIZES),
+          PropTypes.string,
+        ]),
+        vertical: PropTypes.oneOfType([
+          PropTypes.oneOf(MARGIN_SIZES),
+          PropTypes.string,
+        ]),
+      }),
+      PropTypes.string,
+    ]).description(`The amount of margin around the component. For margin to be 
+      applied, Text needs to be wrapped in a containing Box. An object can be 
+      specified to distinguish horizontal margin, vertical margin, and margin 
+      on a particular side.`),
     size: PropTypes.oneOfType([
       PropTypes.oneOf([
         'xsmall',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -14454,9 +14454,10 @@ string
 
 **margin**
 
-The amount of margin around the component. An object can
-    be specified to distinguish horizontal margin, vertical margin, and
-    margin on a particular side.
+The amount of margin around the component. For margin to be 
+      applied, Text needs to be wrapped in a containing Box. An object can be 
+      specified to distinguish horizontal margin, vertical margin, and margin 
+      on a particular side.
 
 \`\`\`
 none

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -14454,10 +14454,12 @@ string
 
 **margin**
 
-The amount of margin around the component. For margin to be 
-      applied, Text needs to be wrapped in a containing Box. An object can be 
-      specified to distinguish horizontal margin, vertical margin, and margin 
-      on a particular side.
+The amount of margin around the component. An object can be 
+    specified to distinguish horizontal margin, vertical margin, and margin on 
+    a particular side. For vertical margin to be applied, Text needs to be 
+    contained within a layout component (such as Box or a generic div) or 
+    behave as a div (by applying as=\\"div\\" or a display style of 
+    inline-block).
 
 \`\`\`
 none

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -6699,10 +6699,12 @@ stretch",
         "name": "gridArea",
       },
       Object {
-        "description": "The amount of margin around the component. For margin to be 
-      applied, Text needs to be wrapped in a containing Box. An object can be 
-      specified to distinguish horizontal margin, vertical margin, and margin 
-      on a particular side.",
+        "description": "The amount of margin around the component. An object can be 
+    specified to distinguish horizontal margin, vertical margin, and margin on 
+    a particular side. For vertical margin to be applied, Text needs to be 
+    contained within a layout component (such as Box or a generic div) or 
+    behave as a div (by applying as=\\"div\\" or a display style of 
+    inline-block).",
         "format": "none
 xxsmall
 xsmall

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -6699,9 +6699,10 @@ stretch",
         "name": "gridArea",
       },
       Object {
-        "description": "The amount of margin around the component. An object can
-    be specified to distinguish horizontal margin, vertical margin, and
-    margin on a particular side.",
+        "description": "The amount of margin around the component. For margin to be 
+      applied, Text needs to be wrapped in a containing Box. An object can be 
+      specified to distinguish horizontal margin, vertical margin, and margin 
+      on a particular side.",
         "format": "none
 xxsmall
 xsmall

--- a/src/js/utils/prop-types.js
+++ b/src/js/utils/prop-types.js
@@ -37,7 +37,7 @@ export const backgroundDoc = PropTypes.oneOfType([
 identifier to use for the background color. For example: 'neutral-1'. Or, a 
 'url()' for an image. Dark is not needed if color is provided.`);
 
-const MARGIN_SIZES = [
+export const MARGIN_SIZES = [
   'xxsmall',
   'xsmall',
   'small',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Clarifies docs for Text margin by explaining that Text needs to be wrapped in a Box for margin to take effect. Uses the `genericStyles` as a base for wording, then adds clarification sentence.

#### Where should the reviewer start?

src/js/components/Text/doc.js

#### What testing has been done on this PR?

Updated snapshots.

#### How should this be manually tested?

#### Any background context you want to provide?
Reasoning can be found here: https://github.com/grommet/grommet/issues/4093#issuecomment-631759230

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/4093

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Updated in this PR.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.