### PR TITLE
InfiniteScroll Test `show` item should be visible

### DIFF
--- a/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
+++ b/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
@@ -4,10 +4,15 @@ import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
 import { InfiniteScroll } from '..';
+import { Box } from '../..';
 
 describe('InfiniteScroll', () => {
   const items = [];
   while (items.length < 4) items.push(items.length);
+  const simpleItems = value =>
+    Array(value)
+      .fill()
+      .map((_, i) => `item ${i + 1}`);
 
   test('basic', () => {
     const { container } = render(
@@ -74,5 +79,23 @@ describe('InfiniteScroll', () => {
       </Grommet>,
     );
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test(`Show item should be visible in window`, () => {
+    const { container } = render(
+      <Grommet>
+        <InfiniteScroll
+          items={simpleItems(300)}
+          // show={105}
+        >
+          {item => <Box key={item}>{item}</Box>}
+        </InfiniteScroll>
+      </Grommet>,
+    );
+    // item(104) = 'item 105' because indexing starts at 0
+    const renderedItems = container.firstChild.children.item(10).outerHTML;
+    expect(renderedItems).toContain('item 11');
+    // const renderedItems = container.firstChild.children.item(104).outerHTML;
+    // expect(renderedItems).toContain('item 105');
   });
 });

--- a/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
+++ b/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
@@ -86,15 +86,18 @@ describe('InfiniteScroll', () => {
       <Grommet>
         <InfiniteScroll
           items={simpleItems(300)}
+          /* Uncomment the next 2 lines once fix for show is in place */
           // show={105}
         >
           {item => <Box key={item}>{item}</Box>}
         </InfiniteScroll>
       </Grommet>,
     );
-    // item(104) = 'item 105' because indexing starts at 0
+    // item(104) = 'item 105' because indexing starts at 0.
+    /* Delete the next 2 lines once fix for show is in place */
     const renderedItems = container.firstChild.children.item(10).outerHTML;
     expect(renderedItems).toContain('item 11');
+    /* Uncomment the next 2 lines once fix for show is in place */
     // const renderedItems = container.firstChild.children.item(104).outerHTML;
     // expect(renderedItems).toContain('item 105');
   });


### PR DESCRIPTION
#### What does this PR do?
Adds a test to infinite scroll that checks if the `show` item is being rendered when show > step

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
Currently this test is passing, but once the show prop is fixed lines 96 and 97 need to be deleted and lines 89, 98, and 99 uncommented for the test to work correctly.

#### Any background context you want to provide?

#### What are the relevant issues?
#4334 #4369 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards Compatible
