### PR TITLE
Removed Chromatic testing from DropButton stories

### DIFF
--- a/src/js/components/DropButton/stories/Calendar.js
+++ b/src/js/components/DropButton/stories/Calendar.js
@@ -35,10 +35,6 @@ const CalendarDropButton = () => {
   );
 };
 
-storiesOf('DropButton', module).add('Calendar', () => <CalendarDropButton />);
-
-CalendarDropButton.story = {
-  parameters: {
-    chromatic: { disable: true },
-  },
-};
+storiesOf('DropButton', module).add('Calendar', () => <CalendarDropButton />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/DropButton/stories/Calendar.js
+++ b/src/js/components/DropButton/stories/Calendar.js
@@ -36,3 +36,9 @@ const CalendarDropButton = () => {
 };
 
 storiesOf('DropButton', module).add('Calendar', () => <CalendarDropButton />);
+
+CalendarDropButton.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+};

--- a/src/js/components/DropButton/stories/Menu.js
+++ b/src/js/components/DropButton/stories/Menu.js
@@ -44,10 +44,6 @@ const MenuDropButton = () => {
   );
 };
 
-storiesOf('DropButton', module).add('Menu', () => <MenuDropButton />);
-
-MenuDropButton.story = {
-  parameters: {
-    chromatic: { disable: true },
-  },
-};
+storiesOf('DropButton', module).add('Menu', () => <MenuDropButton />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/DropButton/stories/Menu.js
+++ b/src/js/components/DropButton/stories/Menu.js
@@ -45,3 +45,9 @@ const MenuDropButton = () => {
 };
 
 storiesOf('DropButton', module).add('Menu', () => <MenuDropButton />);
+
+MenuDropButton.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+};

--- a/src/js/components/DropButton/stories/Simple.js
+++ b/src/js/components/DropButton/stories/Simple.js
@@ -47,10 +47,6 @@ const SimpleDropButton = () => {
   );
 };
 
-storiesOf('DropButton', module).add('Simple', () => <SimpleDropButton />);
-
-SimpleDropButton.story = {
-  parameters: {
-    chromatic: { disable: true },
-  },
-};
+storiesOf('DropButton', module).add('Simple', () => <SimpleDropButton />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/DropButton/stories/Simple.js
+++ b/src/js/components/DropButton/stories/Simple.js
@@ -48,3 +48,9 @@ const SimpleDropButton = () => {
 };
 
 storiesOf('DropButton', module).add('Simple', () => <SimpleDropButton />);
+
+SimpleDropButton.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+};


### PR DESCRIPTION
#### What does this PR do?
Removes Chromatic testing from DropButton stories because the chromatic screenshots aren't capturing anything valuable for DropButton.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
Number of chromatic snapshots should be reduced by three (326 => 323).

#### Any background context you want to provide?

#### What are the relevant issues?
Issue #4385 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
