### PR TITLE
Removed chromatic snapshots for stories in DateInput and Layer

### DIFF
--- a/src/js/components/DateInput/stories/Range.js
+++ b/src/js/components/DateInput/stories/Range.js
@@ -36,4 +36,6 @@ const Example = () => {
   );
 };
 
-storiesOf('DateInput', module).add('Range', () => <Example />);
+storiesOf('DateInput', module).add('Range', () => <Example />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/DateInput/stories/Simple.js
+++ b/src/js/components/DateInput/stories/Simple.js
@@ -23,4 +23,6 @@ const Example = () => {
   );
 };
 
-storiesOf('DateInput', module).add('Simple', () => <Example />);
+storiesOf('DateInput', module).add('Simple', () => <Example />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Layer/stories/Center.js
+++ b/src/js/components/Layer/stories/Center.js
@@ -86,4 +86,6 @@ const CenterLayer = () => {
   );
 };
 
-storiesOf('Layer', module).add('Center', () => <CenterLayer />);
+storiesOf('Layer', module).add('Center', () => <CenterLayer />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Layer/stories/Corner.js
+++ b/src/js/components/Layer/stories/Corner.js
@@ -38,4 +38,6 @@ const CornerLayer = () => {
   );
 };
 
-storiesOf('Layer', module).add('Corner', () => <CornerLayer />);
+storiesOf('Layer', module).add('Corner', () => <CornerLayer />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Layer/stories/Form.js
+++ b/src/js/components/Layer/stories/Form.js
@@ -91,4 +91,6 @@ const FormLayer = () => {
   );
 };
 
-storiesOf('Layer', module).add('Form', () => <FormLayer />);
+storiesOf('Layer', module).add('Form', () => <FormLayer />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Layer/stories/Full.js
+++ b/src/js/components/Layer/stories/Full.js
@@ -32,4 +32,6 @@ const FullLayer = () => {
   );
 };
 
-storiesOf('Layer', module).add('Full', () => <FullLayer />);
+storiesOf('Layer', module).add('Full', () => <FullLayer />, {
+  chromatic: { disable: true },
+});


### PR DESCRIPTION
#### What does this PR do?
Removed chromatic testing from the following stories because the screenshots weren't capturing anything useful
DateInput: Range and Simple stories
Layer: Center, Corner, Form, and Full stories

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
Number of chromatic snapshots should be reduced by 6 (326 => 320).

#### Any background context you want to provide?

#### What are the relevant issues?
Issue #4385

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
