### PR TITLE
Removed chromatic import that causes warning

### DIFF
--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -1,5 +1,4 @@
 import { configure } from '@storybook/react';
-import 'chromatic';
 
 const req = require.context(
   '../src/js',


### PR DESCRIPTION
#### What does this PR do?
Removes import that causes warning on `yarn storybook`

#### Where should the reviewer start?

#### What testing has been done on this PR?
storybook

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
#4385 

#### Screenshots (if appropriate)
![](https://user-images.githubusercontent.com/6320236/89604045-ae6e2680-d827-11ea-8f4d-75709bc21612.png)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
