### PR TITLE
Storybook example Tabs - CustomTheme.js parsing template literal

### DIFF
--- a/src/js/components/Tabs/stories/CustomTheme.js
+++ b/src/js/components/Tabs/stories/CustomTheme.js
@@ -39,8 +39,10 @@ const customTheme = deepMerge(grommet, {
       horizontal: 'small',
     },
     extend: ({ theme }) => css`
-      border-radius: ${theme.global.control.border.radius};
-      box-shadow: ${theme.global.elevation.light.small};
+      border-radius: 4px;
+      /* or 'border-radius: ${theme.global.control.border.radius}' */
+      box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.5);
+      /* or 'box-shadow: ${theme.global.elevation.light.small}' */
     `,
   },
   tabs: {
@@ -49,15 +51,19 @@ const customTheme = deepMerge(grommet, {
     header: {
       background: 'dark-2',
       extend: ({ theme }) => css`
-        padding: ${theme.global.edgeSize.small};
-        box-shadow: ${theme.global.elevation.light.medium};
-      `,
+      padding: 10px;
+      /* or 'padding: ${theme.global.edgeSize.small}' */
+      box-shadow: 0px 3px 8px rgba(0, 0, 0, 0.50);
+      /* or 'box-shadow: ${theme.global.elevation.light.medium}' */
+    `,
     },
     panel: {
       extend: ({ theme }) => css`
-        padding: ${theme.global.edgeSize.large};
-        box-shadow: ${theme.global.elevation.light.medium};
-      `,
+      padding: 48px;
+      /* or 'padding: ${theme.global.edgeSize.large}' */
+      box-shadow:  0px 3px 8px rgba(0, 0, 0, 0.50);
+       /* or 'box-shadow: ${theme.global.elevation.light.medium}' */
+    `,
     },
   },
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changes the template literal found in Tabs/Icons.js to a static value, and adds a comment.

#### Where should the reviewer start?
Tabs - CustomTheme.js storybook example

#### What testing has been done on this PR?
storybook

#### How should this be manually tested?
same as above

#### Any background context you want to provide?
Some template literals are being parsed and showing up as ___CSS_0___ or __CSS_1___
It looks like its due to react-syntax-highlighter that storybook uses. It might think that this is a css value and needs to be parsed. It also, doesn't look like this issue has a very high priority on either storybook or react-syntax-highlighter. Storybook plans to fix it by migrating to a new syntax highlighter eventually.

This fix just makes it easier for people to copy and paste the example on storybook.

#### What are the relevant issues?
none on grommet
storybook - https://github.com/storybookjs/storybook/issues/10011
react syntax highllighter - https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/223

#### Screenshots (if appropriate)
issue in storybook
<img width="347" alt="Screen Shot 2020-08-13 at 12 52 39 PM" src="https://user-images.githubusercontent.com/21990914/90169250-f5967300-dd63-11ea-8961-2c44e867596b.png">


new storybook
<img width="469" alt="Screen Shot 2020-08-13 at 12 50 48 PM" src="https://user-images.githubusercontent.com/21990914/90169136-cb44b580-dd63-11ea-8ccd-15c071eccafe.png">

#### Do the grommet docs need to be updated?
no

#### Should this PR be mentioned in the release notes?
no

#### Is this change backwards compatible or is it a breaking change?
backwards compatible