### PR TITLE
change value is set in dateInput

### DIFF
--- a/src/js/components/DateInput/DateInput.js
+++ b/src/js/components/DateInput/DateInput.js
@@ -133,15 +133,13 @@ const DateInput = forwardRef(
               const nextTextValue = event.target.value;
               setTextValue(nextTextValue);
               const nextValue = textToValue(nextTextValue, schema);
-              if (nextValue) {
-                // valid value
-                setValue(nextValue);
-                if (onChange) {
-                  event.persist(); // extract from React synthetic event pool
-                  const adjustedEvent = event;
-                  adjustedEvent.value = nextValue;
-                  onChange(adjustedEvent);
-                }
+              // update value even when undefined
+              setValue(nextValue);
+              if (onChange) {
+                event.persist(); // extract from React synthetic event pool
+                const adjustedEvent = event;
+                adjustedEvent.value = nextValue;
+                onChange(adjustedEvent);
               }
             }}
             onFocus={event => {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
### Discussion
#### What does this PR do?
This PR takes out a statement that only sets value if it is valid 
#### Where should the reviewer start?
DateInput.js
#### What testing has been done on this PR?
storybook 

I wanted to be able to access the value in `onChange`
the value was only being passed if it was valid
so If the field was empty I was not able to set an error 

```

  const onChange = event => {
    const nextValue = event.value;
    setValue(nextValue);
    if (!nextValue) {
      console.log('no value error message ');
    } else {
      console.log('value no error message');
    }
  };


```
#### How should this be manually tested?
above code 
I want to be able to access the event.value even if it is undefined 
#### Any background context you want to provide?
design-system 
showing an example of validation 
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible