### PR TITLE
Removed Chromatic snapshots from some Menu and Collapsible stories

### DIFF
--- a/src/js/components/Collapsible/stories/Horizontal.js
+++ b/src/js/components/Collapsible/stories/Horizontal.js
@@ -51,6 +51,8 @@ const HorizontalCollapsible = () => {
   );
 };
 
-storiesOf('Collapsible', module).add('Horizontal', () => (
-  <HorizontalCollapsible />
-));
+storiesOf('Collapsible', module).add(
+  'Horizontal',
+  () => <HorizontalCollapsible />,
+  { chromatic: { disable: true } },
+);

--- a/src/js/components/Collapsible/stories/Nested.js
+++ b/src/js/components/Collapsible/stories/Nested.js
@@ -105,4 +105,6 @@ const NestedCollapsible = () => {
   );
 };
 
-storiesOf('Collapsible', module).add('Nested', () => <NestedCollapsible />);
+storiesOf('Collapsible', module).add('Nested', () => <NestedCollapsible />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Collapsible/stories/Simple.js
+++ b/src/js/components/Collapsible/stories/Simple.js
@@ -28,4 +28,6 @@ const SimpleCollapsible = props => {
   );
 };
 
-storiesOf('Collapsible', module).add('Default', () => <SimpleCollapsible />);
+storiesOf('Collapsible', module).add('Default', () => <SimpleCollapsible />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Menu/stories/ControlBottom.js
+++ b/src/js/components/Menu/stories/ControlBottom.js
@@ -20,4 +20,8 @@ const ControlBottom = () => (
   </Grommet>
 );
 
-storiesOf('Menu', module).add('Bottom Control Button', () => <ControlBottom />);
+storiesOf('Menu', module).add(
+  'Bottom Control Button',
+  () => <ControlBottom />,
+  { chromatic: { disable: true } },
+);

--- a/src/js/components/Menu/stories/Custom.js
+++ b/src/js/components/Menu/stories/Custom.js
@@ -38,4 +38,6 @@ const CustomMenu = () => (
   </Grommet>
 );
 
-storiesOf('Menu', module).add('Custom', () => <CustomMenu />);
+storiesOf('Menu', module).add('Custom', () => <CustomMenu />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Menu/stories/Reverse.js
+++ b/src/js/components/Menu/stories/Reverse.js
@@ -21,4 +21,6 @@ const Reverse = () => (
   </Grommet>
 );
 
-storiesOf('Menu', module).add('Reverse', () => <Reverse />);
+storiesOf('Menu', module).add('Reverse', () => <Reverse />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Menu/stories/Simple.js
+++ b/src/js/components/Menu/stories/Simple.js
@@ -23,4 +23,6 @@ const SimpleMenu = () => (
   </Grommet>
 );
 
-storiesOf('Menu', module).add('Simple', () => <SimpleMenu />);
+storiesOf('Menu', module).add('Simple', () => <SimpleMenu />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Menu/stories/Themed.js
+++ b/src/js/components/Menu/stories/Themed.js
@@ -34,4 +34,6 @@ const Themed = () => (
   </Grommet>
 );
 
-storiesOf('Menu', module).add('Themed', () => <Themed />);
+storiesOf('Menu', module).add('Themed', () => <Themed />, {
+  chromatic: { disable: true },
+});


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Removes all the Collapsible stories and all Menu stories (except for for Item with Icon) from chromatic testing because the chromatic snapshots aren't capturing anything valuable.

#### Where should the reviewer start?
Look at the Menu and Collapsible snapshots

#### What testing has been done on this PR?

#### How should this be manually tested?
Number of chromatic snapshots should be reduced by 8 (318 -> 310)

#### Any background context you want to provide?

#### What are the relevant issues?
#4385

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
