### PR TITLE
Organize typescript stories into component folders

### DIFF
--- a/src/js/all/stories/typescript/AllComponents.tsx
+++ b/src/js/all/stories/typescript/AllComponents.tsx
@@ -367,5 +367,5 @@ const Components = () => {
 };
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/All', module).add('All', () => <Components />);
+  storiesOf('All/TypeScript', module).add('All', () => <Components />);
 }

--- a/src/js/all/stories/typescript/ExtendTheme.tsx
+++ b/src/js/all/stories/typescript/ExtendTheme.tsx
@@ -59,4 +59,4 @@ const ExtendTheme: React.FC = () => {
   );
 };
 
-storiesOf('TypeScript/Theme', module).add('Extend', () => <ExtendTheme />);
+storiesOf('Theme/TypeScript', module).add('Extend', () => <ExtendTheme />);

--- a/src/js/all/stories/typescript/Focus.tsx
+++ b/src/js/all/stories/typescript/Focus.tsx
@@ -41,5 +41,5 @@ const CustomFocusFC = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Theme', module).add('Focus', () => <CustomFocusFC />);
+  storiesOf('Theme/TypeScript', module).add('Focus', () => <CustomFocusFC />);
 }

--- a/src/js/components/Accordion/stories/typescript/Rich.tsx
+++ b/src/js/components/Accordion/stories/typescript/Rich.tsx
@@ -249,7 +249,7 @@ const RichAccordion = () => {
 };
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Accordion', module).add('Rich', () => (
+  storiesOf('Accordion/TypeScript', module).add('Rich', () => (
     <RichAccordion />
   ));
 }

--- a/src/js/components/Avatar/stories/typescript/All.tsx
+++ b/src/js/components/Avatar/stories/typescript/All.tsx
@@ -104,5 +104,5 @@ const Avatars = () => {
 };
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Avatar', module).add('All', () => <Avatars />);
+  storiesOf('Avatar/TypeScript', module).add('All', () => <Avatars />);
 }

--- a/src/js/components/Box/stories/typescript/Background.tsx
+++ b/src/js/components/Box/stories/typescript/Background.tsx
@@ -45,7 +45,7 @@ const BackgroundBox = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Box', module).add('Background', () => (
+  storiesOf('Box/TypeScript', module).add('Background', () => (
     <BackgroundBox />
   ));
 }

--- a/src/js/components/Box/stories/typescript/Simple.tsx
+++ b/src/js/components/Box/stories/typescript/Simple.tsx
@@ -39,5 +39,5 @@ const SimpleBox = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Box', module).add('Simple', () => <SimpleBox />);
+  storiesOf('Box/TypeScript', module).add('Simple', () => <SimpleBox />);
 }

--- a/src/js/components/Button/stories/typescript/Basic.tsx
+++ b/src/js/components/Button/stories/typescript/Basic.tsx
@@ -22,5 +22,5 @@ const BasicButtons = props => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Button', module).add('Basic', () => <BasicButtons />);
+  storiesOf('Button/TypeScript', module).add('Basic', () => <BasicButtons />);
 }

--- a/src/js/components/Button/stories/typescript/Custom.tsx
+++ b/src/js/components/Button/stories/typescript/Custom.tsx
@@ -69,5 +69,5 @@ const CustomTheme = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Button', module).add('Custom', () => <CustomTheme />);
+  storiesOf('Button/TypeScript', module).add('Custom', () => <CustomTheme />);
 }

--- a/src/js/components/Button/stories/typescript/CustomColor.tsx
+++ b/src/js/components/Button/stories/typescript/CustomColor.tsx
@@ -52,5 +52,5 @@ const Colored = props => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Button', module).add('Colored', () => <Colored />);
+  storiesOf('Button/TypeScript', module).add('Colored', () => <Colored />);
 }

--- a/src/js/components/Clock/stories/typescript/Analog.tsx
+++ b/src/js/components/Clock/stories/typescript/Analog.tsx
@@ -14,5 +14,5 @@ const AnalogClock = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Clock', module).add('Analog', () => <AnalogClock />);
+  storiesOf('Clock/TypeScript', module).add('Analog', () => <AnalogClock />);
 }

--- a/src/js/components/Clock/stories/typescript/CustomAnalog.tsx
+++ b/src/js/components/Clock/stories/typescript/CustomAnalog.tsx
@@ -39,7 +39,7 @@ const CustomAnalog = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Clock', module).add('Custom Analog', () => (
+  storiesOf('Clock/TypeScript', module).add('Custom Analog', () => (
     <CustomAnalog />
   ));
 }

--- a/src/js/components/Clock/stories/typescript/Digital.tsx
+++ b/src/js/components/Clock/stories/typescript/Digital.tsx
@@ -14,5 +14,5 @@ const DigitalClock = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Clock', module).add('Digital', () => <DigitalClock />);
+  storiesOf('Clock/TypeScript', module).add('Digital', () => <DigitalClock />);
 }

--- a/src/js/components/Collapsible/stories/typescript/Simple.tsx
+++ b/src/js/components/Collapsible/stories/typescript/Simple.tsx
@@ -29,7 +29,7 @@ const SimpleCollapsible = props => {
   );
 };
 if (!isChromatic()) {
-  storiesOf('TypeScript/Collapsible', module).add('Default', () => (
+  storiesOf('Collapsible/TypeScript', module).add('Default', () => (
     <SimpleCollapsible />
   ));
 }

--- a/src/js/components/DataTable/stories/typescript/Clickable.tsx
+++ b/src/js/components/DataTable/stories/typescript/Clickable.tsx
@@ -150,7 +150,7 @@ const ClickableDataTable = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/DataTable', module).add('Clickable', () => (
+  storiesOf('DataTable/TypeScript', module).add('Clickable', () => (
     <ClickableDataTable />
   ));
 }

--- a/src/js/components/DataTable/stories/typescript/Styled.tsx
+++ b/src/js/components/DataTable/stories/typescript/Styled.tsx
@@ -156,7 +156,7 @@ const StyledDataTable = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/DataTable', module).add('Style', () => (
+  storiesOf('DataTable/TypeScript', module).add('Style', () => (
     <StyledDataTable />
   ));
 }

--- a/src/js/components/DateInput/stories/typescript/European.tsx
+++ b/src/js/components/DateInput/stories/typescript/European.tsx
@@ -24,5 +24,5 @@ const Example = () => {
 };
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/DateInput', module).add('European', () => <Example />);
+  storiesOf('DateInput/TypeScript', module).add('European', () => <Example />);
 }

--- a/src/js/components/Diagram/stories/typescript/Connections.tsx
+++ b/src/js/components/Diagram/stories/typescript/Connections.tsx
@@ -40,6 +40,6 @@ const Connections = () => {
   );
 };
 
-storiesOf('TypeScript/Diagram', module).add('Connections', () => (
+storiesOf('Diagram/TypeScript', module).add('Connections', () => (
   <Connections />
 ));

--- a/src/js/components/Distribution/stories/typescript/Simple.tsx
+++ b/src/js/components/Distribution/stories/typescript/Simple.tsx
@@ -27,7 +27,7 @@ const SimpleDistribution = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Distribution', module).add('Simple', () => (
+  storiesOf('Distribution/TypeScript', module).add('Simple', () => (
     <SimpleDistribution />
   ));
 }

--- a/src/js/components/DropButton/stories/typescript/Calendar.tsx
+++ b/src/js/components/DropButton/stories/typescript/Calendar.tsx
@@ -37,7 +37,7 @@ const CalendarDropButton = () => {
 };
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/DropButton', module).add('Calendar', () => (
+  storiesOf('DropButton/TypeScript', module).add('Calendar', () => (
     <CalendarDropButton />
   ));
 }

--- a/src/js/components/Form/stories/typescript/CustomTheme.tsx
+++ b/src/js/components/Form/stories/typescript/CustomTheme.tsx
@@ -38,7 +38,7 @@ const CustomFormField = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Form', module).add('Custom Theme', () => (
+  storiesOf('Form/TypeScript', module).add('Custom Theme', () => (
     <CustomFormField />
   ));
 }

--- a/src/js/components/Form/stories/typescript/Submit.tsx
+++ b/src/js/components/Form/stories/typescript/Submit.tsx
@@ -91,5 +91,5 @@ const Example = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Form', module).add('All FormFields', () => <Example />);
+  storiesOf('Form/TypeScript', module).add('All FormFields', () => <Example />);
 }

--- a/src/js/components/Grid/stories/typescript/App.tsx
+++ b/src/js/components/Grid/stories/typescript/App.tsx
@@ -61,5 +61,5 @@ const AppGrid = () => {
 };
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Grid', module).add('App', () => <AppGrid />);
+  storiesOf('Grid/TypeScript', module).add('App', () => <AppGrid />);
 }

--- a/src/js/components/Grid/stories/typescript/AreasPropAlternative.tsx
+++ b/src/js/components/Grid/stories/typescript/AreasPropAlternative.tsx
@@ -39,7 +39,7 @@ const GridAreasAlternative = () => {
 };
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Grid', module).add('Areas prop alternative', () => (
+  storiesOf('Grid/TypeScript', module).add('Areas prop alternative', () => (
     <GridAreasAlternative />
   ));
 }

--- a/src/js/components/Grid/stories/typescript/NColumn.tsx
+++ b/src/js/components/Grid/stories/typescript/NColumn.tsx
@@ -25,7 +25,7 @@ const NColumnGrid = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Grid', module).add('N-column layout', () => (
+  storiesOf('Grid/TypeScript', module).add('N-column layout', () => (
     <NColumnGrid />
   ));
 }

--- a/src/js/components/Grid/stories/typescript/Percentages.tsx
+++ b/src/js/components/Grid/stories/typescript/Percentages.tsx
@@ -24,7 +24,7 @@ const Percentages = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Grid', module).add('Percentages', () => (
+  storiesOf('Grid/TypeScript', module).add('Percentages', () => (
     <Percentages />
   ));
 }

--- a/src/js/components/Header/stories/typescript/Simple.tsx
+++ b/src/js/components/Header/stories/typescript/Simple.tsx
@@ -21,5 +21,5 @@ const Simple = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Header', module).add('Simple', () => <Simple />);
+  storiesOf('Header/TypeScript', module).add('Simple', () => <Simple />);
 }

--- a/src/js/components/InfiniteScroll/stories/typescript/Basic.tsx
+++ b/src/js/components/InfiniteScroll/stories/typescript/Basic.tsx
@@ -30,7 +30,7 @@ const Example = props => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/InfiniteScroll', module).add('Basic', () => (
+  storiesOf('InfiniteScroll/TypeScript', module).add('Basic', () => (
     <Example />
   ));
 }

--- a/src/js/components/List/stories/typescript/selected.tsx
+++ b/src/js/components/List/stories/typescript/selected.tsx
@@ -48,7 +48,7 @@ const SelectedItem = () => {
 };
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/List', module).add('selectedItem', () => (
+  storiesOf('List/TypeScript', module).add('selectedItem', () => (
     <SelectedItem />
   ));
 }

--- a/src/js/components/List/stories/typescript/theme.tsx
+++ b/src/js/components/List/stories/typescript/theme.tsx
@@ -33,5 +33,5 @@ const ThemedList = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/List', module).add('theme', () => <ThemedList />);
+  storiesOf('List/TypeScript', module).add('theme', () => <ThemedList />);
 }

--- a/src/js/components/Main/stories/typescript/Simple.tsx
+++ b/src/js/components/Main/stories/typescript/Simple.tsx
@@ -17,5 +17,5 @@ const Simple = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Main', module).add('Simple', () => <Simple />);
+  storiesOf('Main/TypeScript', module).add('Simple', () => <Simple />);
 }

--- a/src/js/components/MaskedInput/stories/typescript/Email.tsx
+++ b/src/js/components/MaskedInput/stories/typescript/Email.tsx
@@ -50,7 +50,7 @@ const EmailMaskedInput = () => {
 };
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/MaskedInput', module).add('Email', () => (
+  storiesOf('MaskedInput/TypeScript', module).add('Email', () => (
     <EmailMaskedInput />
   ));
 }

--- a/src/js/components/Menu/stories/typescript/Custom.tsx
+++ b/src/js/components/Menu/stories/typescript/Custom.tsx
@@ -41,5 +41,5 @@ const CustomMenu = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Menu', module).add('Custom', () => <CustomMenu />);
+  storiesOf('Menu/TypeScript', module).add('Custom', () => <CustomMenu />);
 }

--- a/src/js/components/Menu/stories/typescript/Themed.tsx
+++ b/src/js/components/Menu/stories/typescript/Themed.tsx
@@ -79,5 +79,5 @@ const App = () => {
 };
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Menu', module).add('Themed', () => <App />);
+  storiesOf('Menu/TypeScript', module).add('Themed', () => <App />);
 }

--- a/src/js/components/Meter/stories/typescript/MultipleValues.tsx
+++ b/src/js/components/Meter/stories/typescript/MultipleValues.tsx
@@ -53,7 +53,7 @@ const MultipleValues = () => {
 };
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Meter', module).add('Multiple Values', () => (
+  storiesOf('Meter/TypeScript', module).add('Multiple Values', () => (
     <MultipleValues />
   ));
 }

--- a/src/js/components/RadioButtonGroup/stories/typescript/Simple.tsx
+++ b/src/js/components/RadioButtonGroup/stories/typescript/Simple.tsx
@@ -30,5 +30,5 @@ export const App = () => {
 };
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/RadioButtonGroup', module).add('Simple', () => <App />);
+  storiesOf('RadioButtonGroup/TypeScript', module).add('Simple', () => <App />);
 }

--- a/src/js/components/Select/stories/typescript/CreateOption.tsx
+++ b/src/js/components/Select/stories/typescript/CreateOption.tsx
@@ -90,7 +90,7 @@ const CreateOption = () => {
 };
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Select', module).add('Create Option', () => (
+  storiesOf('Select/TypeScript', module).add('Create Option', () => (
     <CreateOption />
   ));
 }

--- a/src/js/components/Sidebar/stories/typescript/Simple.tsx
+++ b/src/js/components/Sidebar/stories/typescript/Simple.tsx
@@ -59,5 +59,5 @@ export const SidebarIcons = () => (
 );
 
 if (!isChromatic()) {
-  storiesOf('Typescript/Sidebar', module).add('Icons', () => <SidebarIcons />);
+  storiesOf('Sidebar/TypeScript', module).add('Icons', () => <SidebarIcons />);
 }

--- a/src/js/components/Tabs/stories/typescript/Controlled.tsx
+++ b/src/js/components/Tabs/stories/typescript/Controlled.tsx
@@ -34,7 +34,7 @@ const ControlledTabs = () => {
 };
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Tabs', module).add('Controlled', () => (
+  storiesOf('Tabs/TypeScript', module).add('Controlled', () => (
     <ControlledTabs />
   ));
 }

--- a/src/js/components/TextInput/stories/typescript/Custom.tsx
+++ b/src/js/components/TextInput/stories/typescript/Custom.tsx
@@ -175,7 +175,7 @@ const CustomSuggestionsTextInput = () => {
 };
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/TextInput', module).add('Custom', () => (
+  storiesOf('TextInput/TypeScript', module).add('Custom', () => (
     <CustomSuggestionsTextInput />
   ));
 }

--- a/src/js/components/Video/stories/typescript/Simple.tsx
+++ b/src/js/components/Video/stories/typescript/Simple.tsx
@@ -28,7 +28,7 @@ const SimpleVideo = props => (
 );
 
 if (!isChromatic()) {
-  storiesOf('TypeScript/Video', module)
+  storiesOf('Video/TypeScript', module)
     .add('Simple', () => <SimpleVideo />)
     .add('Controls Below', () => <SimpleVideo controls="below" />);
 }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changes storybook organization of typescript stories. Previously all typescript stories were in a typescript folder. Now they are in a sub-folder within their component.

#### Where should the reviewer start?

#### What testing has been done on this PR?
storybook

#### How should this be manually tested?
`yarn storybook`

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #4005 

#### Screenshots (if appropriate)
Before:
![image](https://user-images.githubusercontent.com/54560994/90272798-238abe80-de1b-11ea-8167-9c0a108bd67c.png)

After:
<img width="212" alt="Screen Shot 2020-08-14 at 10 41 32 AM" src="https://user-images.githubusercontent.com/54560994/90272495-be36cd80-de1a-11ea-97c8-0b2201e6265f.png">

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backward compatible
