### PR TITLE
RangeInput TS: Rely on intrinsic onChange

### DIFF
--- a/src/js/all/stories/typescript/AllComponents.tsx
+++ b/src/js/all/stories/typescript/AllComponents.tsx
@@ -163,7 +163,7 @@ const Components = () => {
       />
       <RangeInput
         value={rangeInputValue}
-        onChange={event => setRangeInputValue(event.target.value)}
+        onChange={event => setRangeInputValue(parseInt(event.target.value, 10))}
       />
       <Stack>
         <Box direction="row" justify="between">

--- a/src/js/components/RangeInput/index.d.ts
+++ b/src/js/components/RangeInput/index.d.ts
@@ -1,5 +1,5 @@
-import * as React from "react";
-import { A11yTitleType } from "../../utils";
+import * as React from 'react';
+import { A11yTitleType } from '../../utils';
 
 export interface RangeInputProps {
   a11yTitle?: A11yTitleType;
@@ -7,11 +7,11 @@ export interface RangeInputProps {
   min?: number | string;
   max?: number | string;
   name?: string;
-  onChange?: ((event: React.ChangeEvent) => void);
   step?: number;
   value?: number | string;
 }
 
-declare const RangeInput: React.FC<RangeInputProps & JSX.IntrinsicElements['input']>;
+declare const RangeInput: React.FC<RangeInputProps &
+  JSX.IntrinsicElements['input']>;
 
 export { RangeInput };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Relies on intrinsic `input` types, which include `onChange` as opposed to duplicating in our props. Takes over https://github.com/grommet/grommet/pull/4304 which was addressing the same thing.

#### Where should the reviewer start?
src/js/components/RangeInput/index.d.ts

#### What testing has been done on this PR?
Tested local, no TS errors.

#### How should this be manually tested?
Open in TS grommet project and ensure no typing flags for `RangeInput` onChange.

#### Any background context you want to provide?
No need to override the `onChange` since we are not modifying the default behavior.

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/pull/4304
Closes https://github.com/grommet/grommet/pull/4275
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, backward compatible.