### PR TITLE
Added 'as' option to the gap property

### DIFF
--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -95,8 +95,8 @@ const Box = forwardRef(
           } else {
             contents.push(
               <StyledBoxGap
-                // eslint-disable-next-line react/no-array-index-key
                 as={gap && gap.as ? gap.as : undefined}
+                // eslint-disable-next-line react/no-array-index-key
                 key={`gap-${index}`}
                 gap={gapSize}
                 directionProp={direction}

--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -83,7 +83,9 @@ const Box = forwardRef(
     }
 
     let contents = children;
-    if (gap && gap !== 'none') {
+    const gapSize = gap && gap.size ? gap.size : gap;
+
+    if (gapSize && gapSize !== 'none') {
       contents = [];
       let firstIndex;
       Children.forEach(children, (child, index) => {
@@ -94,8 +96,9 @@ const Box = forwardRef(
             contents.push(
               <StyledBoxGap
                 // eslint-disable-next-line react/no-array-index-key
+                as={gap && gap.as ? gap.as : undefined}
                 key={`gap-${index}`}
-                gap={gap}
+                gap={gapSize}
                 directionProp={direction}
                 responsive={responsive}
                 border={border}

--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -462,6 +462,18 @@ medium
 large
 xlarge
 string
+{
+  as: string,
+  size: 
+    none
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
 ```
 
 **height**

--- a/src/js/components/Box/__tests__/Box-test.js
+++ b/src/js/components/Box/__tests__/Box-test.js
@@ -265,6 +265,10 @@ describe('Box', () => {
             <Box />
           </Box>
         ))}
+        <Box as="ul" gap={{ as: 'li', size: 'small' }}>
+          <li>first</li>
+          <li>second</li>
+        </Box>
       </Grommet>,
     );
     const tree = component.toJSON();

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -2578,6 +2578,22 @@ exports[`Box gap 1`] = `
   flex-direction: column;
 }
 
+.c3 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    height: 6px;
+  }
+}
+
 <div
   className="c0"
 >
@@ -2623,6 +2639,19 @@ exports[`Box gap 1`] = `
       className="c2"
     />
   </div>
+  <ul
+    className="c2"
+  >
+    <li>
+      first
+    </li>
+    <li
+      className="c3"
+    />
+    <li>
+      second
+    </li>
+  </ul>
 </div>
 `;
 

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -210,6 +210,21 @@ export const doc = Box => {
         'xlarge',
       ]),
       PropTypes.string,
+      PropTypes.shape({
+        as: PropTypes.string,
+        size: PropTypes.oneOfType([
+          PropTypes.oneOf([
+            'none',
+            'xxsmall',
+            'xsmall',
+            'small',
+            'medium',
+            'large',
+            'xlarge',
+          ]),
+          PropTypes.string,
+        ]),
+      }),
     ]).description(`The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
         will not wrap gracefully. If a child is a Fragment,

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -32,7 +32,7 @@ export interface BoxProps {
   flex?: "grow" | "shrink" | boolean | { grow?: number, shrink?: number };
   fill?: FillType;
   focusIndicator?: boolean;
-  gap?: GapType;
+  gap?: GapType | {as?: string, size?: GapType};
   height?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string | {max?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string,min?: "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | string};
   hoverIndicator?: BackgroundType | boolean;
   justify?: "around" | "between" | "center" | "end" | "evenly" | "start" | "stretch";

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1318,6 +1318,18 @@ medium
 large
 xlarge
 string
+{
+  as: string,
+  size: 
+    none
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
 \`\`\`
 
 **height**

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -797,7 +797,19 @@ small
 medium
 large
 xlarge
-string",
+string
+{
+  as: string,
+  size: 
+    none
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}",
         "name": "gap",
       },
       Object {


### PR DESCRIPTION

#### What does this PR do?
This is a backward compatible way to make the tag used for the gap be
something other than a div. This is useful in cases where the box
'as' property is used to make the box something other than a div like
a span or ul, etc.

#### Where should the reviewer start?
Box.js

#### What testing has been done on this PR?
JEST, storybook

#### How should this be manually tested?

#### Any background context you want to provide?
See #3046 and #3130 for background.

#### What are the relevant issues?
#3046

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Done

#### Should this PR be mentioned in the release notes?
Can be

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible