### PR TITLE
onEsc and onClickOutside for non-modal layers

### DIFF
--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -66,8 +66,16 @@ const LayerContainer = forwardRef(
         if (modal && !element && anchorRef.current) {
           anchorRef.current.focus();
         }
+        if (
+          !modal &&
+          !element &&
+          anchorRef.current &&
+          (onEsc || onClickOutside)
+        ) {
+          anchorRef.current.focus();
+        }
       }
-    }, [modal, position, ref]);
+    }, [modal, position, ref, onEsc, onClickOutside]);
 
     useEffect(() => {
       if (position !== 'hidden') {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds a new condition to allow onEsc and onClickOutside for non-modal layers.
Layers with modal={false} will not allow onEsc and onClickOutside by default, but layers with modal={false} and onEsc and onClickOutside handlers will work

Keystrokes will not be taken
```
<Layer modal={false}>...</Layer>
```

Keystrokes will be taken
```
<Layer modal={false} onEsc={onEsc} onClickOutside={onClickOutside}>...</Layer>
```

Keystrokes will be taken
```
<Layer modal={false} onClickOutside={onClickOutside}>...</Layer>
```

Keystrokes will be taken
```
<Layer modal={false} onEsc={onEsc}>...</Layer>
```

#### Where should the reviewer start?
LayerContainer.js

#### What testing has been done on this PR?
None yet. Will test with storybook.

#### How should this be manually tested?
Same as above

#### Any background context you want to provide?
onEsc functionality of layers with modal set to false was removed with this PR #3632.

#### What are the relevant issues?
#3771 

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Yes