### PR TITLE
[Typescript] Fix WorldMap color Type error

### DIFF
--- a/src/js/components/WorldMap/index.d.ts
+++ b/src/js/components/WorldMap/index.d.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from 'react';
 import {
   A11yTitleType,
   AlignSelfType,
@@ -6,21 +6,39 @@ import {
   FillType,
   GridAreaType,
   MarginType,
-} from "../../utils";
+} from '../../utils';
 
 export interface WorldMapProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
   color?: ColorType;
-  continents?: {color?: string | {dark?: string,light?: string},name: "Africa" | "Asia" | "Australia" | "Europe" | "North America" | "South America",onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any)}[];
+  continents?: {
+    color?: string | { dark?: string; light?: string };
+    name:
+      | 'Africa'
+      | 'Asia'
+      | 'Australia'
+      | 'Europe'
+      | 'North America'
+      | 'South America';
+    onClick?: (...args: any[]) => any;
+    onHover?: (...args: any[]) => any;
+  }[];
   fill?: FillType;
   gridArea?: GridAreaType;
-  hoverColor?: string | {dark?: string,light?: string};
+  hoverColor?: string | { dark?: string; light?: string };
   margin?: MarginType;
-  onSelectPlace?: ((place: number[]) => void);
-  places?: {color?: string | {dark?: string,light?: string},name?: string,location: number[],onClick?: ((...args: any[]) => any),onHover?: ((...args: any[]) => any)}[];
+  onSelectPlace?: (place: number[]) => void;
+  places?: {
+    color?: string | { dark?: string; light?: string };
+    name?: string;
+    location: number[];
+    onClick?: (...args: any[]) => any;
+    onHover?: (...args: any[]) => any;
+  }[];
 }
 
-declare const WorldMap: React.ComponentClass<WorldMapProps & JSX.IntrinsicElements['svg']>;
+declare const WorldMap: React.ComponentClass<WorldMapProps &
+  Omit<JSX.IntrinsicElements['svg'], 'color'>>;
 
 export { WorldMap };


### PR DESCRIPTION
#### What does this PR do?
Fixes a Typescript error when setting `WorldMap`'s `color` property to a `{ dark: string, light: string }` object.
##### Context:
It looks like the intersection of `WorldMapProps` and `JSX.IntrinsicElements['svg']` results in `color` getting type `ColorType & string`. So, when you use a ColorType object, the following error occurs:
```
Type '{ dark: string; light: string; }' is not assignable to type 'string | ({ dark?: string; light?: string; } & string)'.
Type '{ dark: string; light: string; }' is not assignable to type '{ dark?: string; light?: string; } & string'.
Type '{ dark: string; light: string; }' is not assignable to type 'string'.
```
I fixed it by omitting `color` from the intersection. This way `color` stays `ColorType` only.
I'd be happy to make changes if there is another preferred way of fixing it.

##### Workaround
Set the color with a custom Grommet theme.

#### Where should the reviewer start?
Change in line 42. The other changes were introduced by prettier.

#### What testing has been done on this PR?
Used it locally in a project.

#### How should this be manually tested?
Define `WorldMap` like this in a Typescript project:
 `<WorldMap color={{ dark: "brand", light: "brand" }} />`

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
🤷‍♂️ 

#### Is this change backwards compatible or is it a breaking change?
backwards compatible 