### PR TITLE
Update button docs to clarify effects of adding children

### DIFF
--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -134,7 +134,8 @@ Function that can be called to render the visual representation.
       Button can take in Children as a function, node, or object. 
       For example hover can be passed as an object that would 
       then return a react element.
-      `children={({ hover }) => <Box...>{...}</Box>}`
+      `children={({ hover }) => <Box...>{...}</Box>}`. When Button has
+      children, it is styled as a `plain` button.
       
 
 ```

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -34,7 +34,8 @@ export const doc = Button => {
       Button can take in Children as a function, node, or object. 
       For example hover can be passed as an object that would 
       then return a react element.
-      \`children={({ hover }) => <Box...>{...}</Box>}\`
+      \`children={({ hover }) => <Box...>{...}</Box>}\`. When Button has
+      children, it is styled as a \`plain\` button.
       `,
     ),
     active: PropTypes.bool

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1983,7 +1983,8 @@ Function that can be called to render the visual representation.
       Button can take in Children as a function, node, or object. 
       For example hover can be passed as an object that would 
       then return a react element.
-      \`children={({ hover }) => <Box...>{...}</Box>}\`
+      \`children={({ hover }) => <Box...>{...}</Box>}\`. When Button has
+      children, it is styled as a \`plain\` button.
       
 
 \`\`\`

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1207,7 +1207,8 @@ string",
       Button can take in Children as a function, node, or object. 
       For example hover can be passed as an object that would 
       then return a react element.
-      \`children={({ hover }) => <Box...>{...}</Box>}\`
+      \`children={({ hover }) => <Box...>{...}</Box>}\`. When Button has
+      children, it is styled as a \`plain\` button.
       ",
         "format": "function
 object


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Clarifies that if children are provided to button, it will be styled as a `plain` Button`.

#### Where should the reviewer start?
src/js/components/Button/doc.js

#### What testing has been done on this PR?
Provide children to button.

#### How should this be manually tested?
Provide children to button.

#### Any background context you want to provide?
https://github.com/grommet/grommet/blob/master/src/js/components/Button/Button.js#L320

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/4272#issuecomment-676784288

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, updated here.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.