### PR TITLE
Changed the gap to be a span if the box is a span

### DIFF
--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
@@ -169,7 +169,7 @@ exports[`Anchor icon label renders 1`] = `
       <svg
         color="#7D4CDB"
       />
-      <div
+      <span
         className="c3"
       />
       Test
@@ -412,7 +412,7 @@ exports[`Anchor reverse icon label renders 1`] = `
       }
     >
       Test
-      <div
+      <span
         className="c3"
       />
       <svg

--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -84,6 +84,7 @@ const Box = forwardRef(
 
     let contents = children;
     if (gap && gap !== 'none') {
+      const boxAs = !as && tag ? tag : as;
       contents = [];
       let firstIndex;
       Children.forEach(children, (child, index) => {
@@ -95,6 +96,7 @@ const Box = forwardRef(
               <StyledBoxGap
                 // eslint-disable-next-line react/no-array-index-key
                 key={`gap-${index}`}
+                as={boxAs === 'span' ? boxAs : 'div'}
                 gap={gap}
                 directionProp={direction}
                 responsive={responsive}

--- a/src/js/components/Box/__tests__/Box-test.js
+++ b/src/js/components/Box/__tests__/Box-test.js
@@ -265,6 +265,10 @@ describe('Box', () => {
             <Box />
           </Box>
         ))}
+        <Box as="span" gap="small">
+          <span>first</span>
+          <span>second</span>
+        </Box>
       </Grommet>,
     );
     const tree = component.toJSON();

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -2578,6 +2578,22 @@ exports[`Box gap 1`] = `
   flex-direction: column;
 }
 
+.c3 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    height: 6px;
+  }
+}
+
 <div
   className="c0"
 >
@@ -2623,6 +2639,19 @@ exports[`Box gap 1`] = `
       className="c2"
     />
   </div>
+  <span
+    className="c2"
+  >
+    <span>
+      first
+    </span>
+    <span
+      className="c3"
+    />
+    <span>
+      second
+    </span>
+  </span>
 </div>
 `;
 

--- a/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
+++ b/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
@@ -298,7 +298,7 @@ exports[`Grommet custom theme 1`] = `
             strokeWidth="2"
           />
         </svg>
-        <div
+        <span
           className="c5"
         />
         Add
@@ -329,7 +329,7 @@ exports[`Grommet custom theme 1`] = `
             strokeWidth="2"
           />
         </svg>
-        <div
+        <span
           className="c5"
         />
         Add
@@ -364,7 +364,7 @@ exports[`Grommet custom theme 1`] = `
             strokeWidth="2"
           />
         </svg>
-        <div
+        <span
           className="c5"
         />
         Add
@@ -395,7 +395,7 @@ exports[`Grommet custom theme 1`] = `
             strokeWidth="2"
           />
         </svg>
-        <div
+        <span
           className="c5"
         />
         Add


### PR DESCRIPTION
## What does this PR do?
Implements the solution recommended by Eric. It makes the gap element be a span rather than a div if the box is a span. Browsers produce warnings in the console if a div is a child of a span.

One example of this is the implementation of Anchor with an icon and label. This change fixes this situation.

This PR replaces #4436 and #3130 with a different implementation

## Where should the reviewer start?
Box.js

## What testing has been done on this PR?
JEST, storybook

## How should this be manually tested?
Any background context you want to provide?
See #3046 and #3130 for background.

## What are the relevant issues?
#3046

## Screenshots (if appropriate)
## Do the grommet docs need to be updated?
Done

## Should this PR be mentioned in the release notes?
No need.

## Is this change backwards compatible or is it a breaking change?
Backwards compatible