### PR TITLE
Replace babel-plugin-styled-components with babel-plugin-macros

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,10 @@
 {
-  "presets": ["./tools/grommet-babel-preset-es2015", "@babel/preset-react"],
+  "presets": [
+    "./tools/grommet-babel-preset-es2015",
+    "@babel/preset-react"
+  ],
   "plugins": [
-    ["styled-components", { "useDisplayName": false }],
+    "macros",
     "@babel/plugin-proposal-class-properties"
   ],
   "env": {

--- a/babel-plugin-macros.config.js
+++ b/babel-plugin-macros.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  styledComponents: {
+    pure: true,
+    fileName: true,
+    displayName: true,
+  },
+};

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.8.0",
     "babel-loader": "^8.0.0-beta.6",
-    "babel-plugin-styled-components": "^1.6.4",
+    "babel-plugin-macros": "^2.8.0",
     "babel-plugin-transform-imports": "^2.0.0",
     "bundlesize": "^0.18.0",
     "chromatic": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grommet",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "main": "index.js",
   "module": "es6/index.js",
   "jsnext:main": "es6/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grommet",
-  "version": "2.15.1",
+  "version": "2.15.0",
   "main": "index.js",
   "module": "es6/index.js",
   "jsnext:main": "es6/index.js",

--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -1251,36 +1251,36 @@ exports[`Accordion change active index 1`] = `
 
 exports[`Accordion change active index 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormDown"
@@ -1298,33 +1298,33 @@ exports[`Accordion change active index 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       />
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormUp"
@@ -1343,7 +1343,7 @@ exports[`Accordion change active index 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         Panel body 2
       </div>
@@ -1693,36 +1693,36 @@ exports[`Accordion change to second Panel 1`] = `
 
 exports[`Accordion change to second Panel 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormDown"
@@ -1740,40 +1740,40 @@ exports[`Accordion change to second Panel 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
+          class="StyledBox-sc-13pk1d4-0 gzDuuM Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             .c0 {
   display: inline-block;
@@ -1842,11 +1842,11 @@ exports[`Accordion change to second Panel 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         <div
           aria-hidden="false"
-          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 gPSerh"
+          class="StyledBox-sc-13pk1d4-0 gzDuuM Collapsible__AnimatedBox-sc-15kniua-0 gPSerh"
           open=""
         >
           Panel body 2
@@ -2176,36 +2176,36 @@ exports[`Accordion change to second Panel without onActive 1`] = `
 
 exports[`Accordion change to second Panel without onActive 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormDown"
@@ -2223,33 +2223,33 @@ exports[`Accordion change to second Panel without onActive 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       />
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             .c0 {
   display: inline-block;
@@ -2318,7 +2318,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         Panel body 2
       </div>
@@ -3715,36 +3715,36 @@ exports[`Accordion multiple panels 1`] = `
 
 exports[`Accordion multiple panels 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormDown"
@@ -3762,33 +3762,33 @@ exports[`Accordion multiple panels 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       />
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             .c0 {
   display: inline-block;
@@ -3857,7 +3857,7 @@ exports[`Accordion multiple panels 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         Panel body 2
       </div>
@@ -3868,36 +3868,36 @@ exports[`Accordion multiple panels 2`] = `
 
 exports[`Accordion multiple panels 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             .c0 {
   display: inline-block;
@@ -3966,35 +3966,35 @@ exports[`Accordion multiple panels 3`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         Panel body 1
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormUp"
@@ -4013,7 +4013,7 @@ exports[`Accordion multiple panels 3`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         Panel body 2
       </div>
@@ -4024,36 +4024,36 @@ exports[`Accordion multiple panels 3`] = `
 
 exports[`Accordion multiple panels 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormUp"
@@ -4072,35 +4072,35 @@ exports[`Accordion multiple panels 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         Panel body 1
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             .c0 {
   display: inline-block;
@@ -4168,7 +4168,7 @@ exports[`Accordion multiple panels 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       />
     </div>
   </div>
@@ -4177,36 +4177,36 @@ exports[`Accordion multiple panels 4`] = `
 
 exports[`Accordion multiple panels 5`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             .c0 {
   display: inline-block;
@@ -4274,33 +4274,33 @@ exports[`Accordion multiple panels 5`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       />
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormDown"
@@ -4318,7 +4318,7 @@ exports[`Accordion multiple panels 5`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       />
     </div>
   </div>
@@ -4701,36 +4701,36 @@ exports[`Accordion set on hover 1`] = `
 
 exports[`Accordion set on hover 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 iXwLsH"
+              class="StyledHeading-sc-1rdh4aw-0 ftJvDc"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormDown"
@@ -4748,40 +4748,40 @@ exports[`Accordion set on hover 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
+          class="StyledBox-sc-13pk1d4-0 gzDuuM Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormDown"
@@ -4799,11 +4799,11 @@ exports[`Accordion set on hover 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
+          class="StyledBox-sc-13pk1d4-0 gzDuuM Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
         >
           Panel body 2
         </div>
@@ -4815,36 +4815,36 @@ exports[`Accordion set on hover 2`] = `
 
 exports[`Accordion set on hover 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 iXwLsH"
+              class="StyledHeading-sc-1rdh4aw-0 ftJvDc"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormDown"
@@ -4862,40 +4862,40 @@ exports[`Accordion set on hover 3`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
+          class="StyledBox-sc-13pk1d4-0 gzDuuM Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 iXwLsH"
+              class="StyledHeading-sc-1rdh4aw-0 ftJvDc"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormDown"
@@ -4913,11 +4913,11 @@ exports[`Accordion set on hover 3`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
+          class="StyledBox-sc-13pk1d4-0 gzDuuM Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
         >
           Panel body 2
         </div>
@@ -4929,36 +4929,36 @@ exports[`Accordion set on hover 3`] = `
 
 exports[`Accordion set on hover 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormDown"
@@ -4976,40 +4976,40 @@ exports[`Accordion set on hover 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
+          class="StyledBox-sc-13pk1d4-0 gzDuuM Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 iXwLsH"
+              class="StyledHeading-sc-1rdh4aw-0 ftJvDc"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormDown"
@@ -5027,11 +5027,11 @@ exports[`Accordion set on hover 4`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
+          class="StyledBox-sc-13pk1d4-0 gzDuuM Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
         >
           Panel body 2
         </div>
@@ -5043,36 +5043,36 @@ exports[`Accordion set on hover 4`] = `
 
 exports[`Accordion set on hover 5`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormDown"
@@ -5090,40 +5090,40 @@ exports[`Accordion set on hover 5`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
+          class="StyledBox-sc-13pk1d4-0 gzDuuM Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
         >
           Panel body 1
         </div>
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormDown"
@@ -5141,11 +5141,11 @@ exports[`Accordion set on hover 5`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         <div
           aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
+          class="StyledBox-sc-13pk1d4-0 gzDuuM Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
         >
           Panel body 2
         </div>
@@ -6011,36 +6011,36 @@ exports[`Accordion wrapped panel 1`] = `
 
 exports[`Accordion wrapped panel 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 1
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             .c0 {
   display: inline-block;
@@ -6109,36 +6109,36 @@ exports[`Accordion wrapped panel 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       >
         Panel body 
         1
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 gzfjUM"
+      class="StyledBox-sc-13pk1d4-0 hOInWF"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ckSWz"
+            class="StyledBox-sc-13pk1d4-0 iWUiyy"
           >
             <h4
-              class="StyledHeading-sc-1rdh4aw-0 cJdkwo"
+              class="StyledHeading-sc-1rdh4aw-0 iAtQJn"
             >
               Panel 2
             </h4>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <svg
               aria-label="FormDown"
@@ -6156,7 +6156,7 @@ exports[`Accordion wrapped panel 2`] = `
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL"
       />
     </div>
   </div>

--- a/src/js/components/Anchor/StyledAnchor.js
+++ b/src/js/components/Anchor/StyledAnchor.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import { focusStyle, genericStyles, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/Avatar/StyledAvatar.js
+++ b/src/js/components/Avatar/StyledAvatar.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import { defaultProps } from '../../default-props';
 

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -1,4 +1,5 @@
-import styled, { css, keyframes } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css, keyframes } from 'styled-components';
 
 import { defaultProps } from '../../default-props';
 

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import {
   activeStyle,
@@ -206,7 +207,7 @@ const StyledButton = styled.button`
     props.theme.button &&
     props.theme.button.disabled &&
     disabledButtonStyle(props)}
-  
+
   &:focus {
     ${props => (!props.plain || props.focusIndicator) && focusStyle()}
   }

--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import {
   activeStyle,
@@ -260,7 +261,7 @@ const StyledButtonKind = styled.button`
   &:focus {
     ${props => (!props.plain || props.focusIndicator) && focusStyle()}
   }
-  
+
   ${props =>
     !props.plain &&
     props.theme.button.transition &&

--- a/src/js/components/Calendar/StyledCalendar.js
+++ b/src/js/components/Calendar/StyledCalendar.js
@@ -1,4 +1,5 @@
-import styled, { css, keyframes } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css, keyframes } from 'styled-components';
 import {
   backgroundStyle,
   focusStyle,

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -1559,32 +1559,32 @@ exports[`Calendar change months 1`] = `
 
 exports[`Calendar change months 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledCalendar-sc-1y4xhmp-0 eMLsHu"
+    class="StyledCalendar-sc-1y4xhmp-0 dCeKZu"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+      class="StyledBox-sc-13pk1d4-0 gzDuuM"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 VvbUh"
+        class="StyledBox-sc-13pk1d4-0 gWfleo"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 ecbFEh"
+          class="StyledBox-sc-13pk1d4-0 qOIBY"
         >
           <h3
-            class="StyledHeading-sc-1rdh4aw-0 eEcLoL"
+            class="StyledHeading-sc-1rdh4aw-0 bGGmgW"
           >
             January 2020
           </h3>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 bBymtc"
+          class="StyledBox-sc-13pk1d4-0 cCCDBZ"
         >
           <button
             aria-label="December 2019"
-            class="StyledButton-sc-323bzc-0 fKcmhi"
+            class="StyledButton-sc-323bzc-0 gHTUFP"
             type="button"
           >
             <svg
@@ -1603,7 +1603,7 @@ exports[`Calendar change months 2`] = `
           </button>
           <button
             aria-label="February 2020"
-            class="StyledButton-sc-323bzc-0 fKcmhi"
+            class="StyledButton-sc-323bzc-0 gHTUFP"
             type="button"
           >
             <svg
@@ -1636,7 +1636,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sun Dec 01 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1652,7 +1652,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Mon Dec 02 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1668,7 +1668,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Tue Dec 03 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1684,7 +1684,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Wed Dec 04 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1700,7 +1700,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Thu Dec 05 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1716,7 +1716,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Fri Dec 06 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1732,7 +1732,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sat Dec 07 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1752,7 +1752,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sun Dec 08 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1768,7 +1768,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Mon Dec 09 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1784,7 +1784,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Tue Dec 10 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1800,7 +1800,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Wed Dec 11 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1816,7 +1816,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Thu Dec 12 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1832,7 +1832,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Fri Dec 13 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1848,7 +1848,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sat Dec 14 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1868,7 +1868,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sun Dec 15 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1884,7 +1884,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Mon Dec 16 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1900,7 +1900,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Tue Dec 17 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1916,7 +1916,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Wed Dec 18 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1932,7 +1932,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Thu Dec 19 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1948,7 +1948,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Fri Dec 20 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1964,7 +1964,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sat Dec 21 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -1984,7 +1984,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sun Dec 22 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2000,7 +2000,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Mon Dec 23 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2016,7 +2016,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Tue Dec 24 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2032,7 +2032,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Wed Dec 25 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2048,7 +2048,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Thu Dec 26 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2064,7 +2064,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Fri Dec 27 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2080,7 +2080,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sat Dec 28 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2100,7 +2100,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sun Dec 29 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2116,7 +2116,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Mon Dec 30 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2132,7 +2132,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Tue Dec 31 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2148,7 +2148,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Wed Jan 01 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2164,7 +2164,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Thu Jan 02 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2180,7 +2180,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Fri Jan 03 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2196,7 +2196,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sat Jan 04 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2216,7 +2216,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sun Jan 05 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2232,7 +2232,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Mon Jan 06 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2248,7 +2248,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Tue Jan 07 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2264,7 +2264,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Wed Jan 08 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2280,7 +2280,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Thu Jan 09 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2296,7 +2296,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Fri Jan 10 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2312,7 +2312,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sat Jan 11 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2332,7 +2332,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sun Jan 12 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2348,7 +2348,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Mon Jan 13 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2364,7 +2364,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Tue Jan 14 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2380,12 +2380,12 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Wed Jan 15 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gBUPeV"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 fchDJz"
                 >
                   15
                 </div>
@@ -2396,7 +2396,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Thu Jan 16 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2412,7 +2412,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Fri Jan 17 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2428,7 +2428,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sat Jan 18 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2448,7 +2448,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sun Jan 19 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2464,7 +2464,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Mon Jan 20 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2480,7 +2480,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Tue Jan 21 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2496,7 +2496,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Wed Jan 22 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2512,7 +2512,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Thu Jan 23 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2528,7 +2528,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Fri Jan 24 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2544,7 +2544,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sat Jan 25 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2564,7 +2564,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sun Jan 26 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2580,7 +2580,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Mon Jan 27 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2596,7 +2596,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Tue Jan 28 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2612,7 +2612,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Wed Jan 29 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2628,7 +2628,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Thu Jan 30 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2644,7 +2644,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Fri Jan 31 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2660,7 +2660,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sat Feb 01 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2680,7 +2680,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sun Feb 02 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2696,7 +2696,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Mon Feb 03 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2712,7 +2712,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Tue Feb 04 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2728,7 +2728,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Wed Feb 05 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2744,7 +2744,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Thu Feb 06 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2760,7 +2760,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Fri Feb 07 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -2776,7 +2776,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sat Feb 08 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15182,32 +15182,32 @@ exports[`Calendar select date 1`] = `
 
 exports[`Calendar select date 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledCalendar-sc-1y4xhmp-0 eMLsHu"
+    class="StyledCalendar-sc-1y4xhmp-0 dCeKZu"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+      class="StyledBox-sc-13pk1d4-0 gzDuuM"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 VvbUh"
+        class="StyledBox-sc-13pk1d4-0 gWfleo"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 ecbFEh"
+          class="StyledBox-sc-13pk1d4-0 qOIBY"
         >
           <h3
-            class="StyledHeading-sc-1rdh4aw-0 eEcLoL"
+            class="StyledHeading-sc-1rdh4aw-0 bGGmgW"
           >
             January 2020
           </h3>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 bBymtc"
+          class="StyledBox-sc-13pk1d4-0 cCCDBZ"
         >
           <button
             aria-label="December 2019"
-            class="StyledButton-sc-323bzc-0 fKcmhi"
+            class="StyledButton-sc-323bzc-0 gHTUFP"
             type="button"
           >
             <svg
@@ -15226,7 +15226,7 @@ exports[`Calendar select date 2`] = `
           </button>
           <button
             aria-label="February 2020"
-            class="StyledButton-sc-323bzc-0 fKcmhi"
+            class="StyledButton-sc-323bzc-0 gHTUFP"
             type="button"
           >
             <svg
@@ -15245,7 +15245,7 @@ exports[`Calendar select date 2`] = `
         </div>
       </div>
       <div
-        class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 bzlxGD"
+        class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 jSvBPP"
         tabindex="0"
       >
         <div
@@ -15259,7 +15259,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Dec 29 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15275,7 +15275,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Dec 30 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15291,7 +15291,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Dec 31 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15307,7 +15307,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 01 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15323,7 +15323,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 02 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15339,7 +15339,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 03 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15355,7 +15355,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Jan 04 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15375,7 +15375,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Jan 05 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15391,7 +15391,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 06 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15407,7 +15407,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 07 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15423,7 +15423,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 08 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15439,7 +15439,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 09 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15455,7 +15455,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 10 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15471,7 +15471,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Jan 11 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15491,7 +15491,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Jan 12 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15507,7 +15507,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 13 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15523,7 +15523,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 14 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15539,7 +15539,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 15 2020"
-                class="StyledButton-sc-323bzc-0 kUquzo"
+                class="StyledButton-sc-323bzc-0 hXtzf"
                 tabindex="-1"
                 type="button"
               >
@@ -15555,7 +15555,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 16 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15571,12 +15571,12 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 17 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gBUPeV"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 fchDJz"
                 >
                   17
                 </div>
@@ -15587,7 +15587,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Jan 18 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15607,7 +15607,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Jan 19 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15623,7 +15623,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 20 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15639,7 +15639,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 21 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15655,7 +15655,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 22 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15671,7 +15671,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 23 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15687,7 +15687,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 24 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15703,7 +15703,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Jan 25 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15723,7 +15723,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Jan 26 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15739,7 +15739,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 27 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15755,7 +15755,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 28 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15771,7 +15771,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 29 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15787,7 +15787,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 30 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15803,7 +15803,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 31 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15819,7 +15819,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Feb 01 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15839,7 +15839,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Feb 02 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15855,7 +15855,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Feb 03 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15871,7 +15871,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Feb 04 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15887,7 +15887,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Feb 05 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15903,7 +15903,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Feb 06 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15919,7 +15919,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Feb 07 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -15935,7 +15935,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Feb 08 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17046,32 +17046,32 @@ exports[`Calendar select dates 1`] = `
 
 exports[`Calendar select dates 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledCalendar-sc-1y4xhmp-0 eMLsHu"
+    class="StyledCalendar-sc-1y4xhmp-0 dCeKZu"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+      class="StyledBox-sc-13pk1d4-0 gzDuuM"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 VvbUh"
+        class="StyledBox-sc-13pk1d4-0 gWfleo"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 ecbFEh"
+          class="StyledBox-sc-13pk1d4-0 qOIBY"
         >
           <h3
-            class="StyledHeading-sc-1rdh4aw-0 eEcLoL"
+            class="StyledHeading-sc-1rdh4aw-0 bGGmgW"
           >
             January 2020
           </h3>
         </div>
         <div
-          class="StyledBox-sc-13pk1d4-0 bBymtc"
+          class="StyledBox-sc-13pk1d4-0 cCCDBZ"
         >
           <button
             aria-label="December 2019"
-            class="StyledButton-sc-323bzc-0 fKcmhi"
+            class="StyledButton-sc-323bzc-0 gHTUFP"
             type="button"
           >
             <svg
@@ -17090,7 +17090,7 @@ exports[`Calendar select dates 2`] = `
           </button>
           <button
             aria-label="February 2020"
-            class="StyledButton-sc-323bzc-0 fKcmhi"
+            class="StyledButton-sc-323bzc-0 gHTUFP"
             type="button"
           >
             <svg
@@ -17109,7 +17109,7 @@ exports[`Calendar select dates 2`] = `
         </div>
       </div>
       <div
-        class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 bzlxGD"
+        class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 jSvBPP"
         tabindex="0"
       >
         <div
@@ -17123,7 +17123,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Dec 29 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17139,7 +17139,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Dec 30 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17155,7 +17155,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Dec 31 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17171,7 +17171,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 01 2020"
-                class="StyledButton-sc-323bzc-0 kUquzo"
+                class="StyledButton-sc-323bzc-0 hXtzf"
                 tabindex="-1"
                 type="button"
               >
@@ -17187,7 +17187,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 02 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17203,7 +17203,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 03 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17219,7 +17219,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Jan 04 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17239,7 +17239,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Jan 05 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17255,7 +17255,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 06 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17271,7 +17271,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 07 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17287,7 +17287,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 08 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17303,7 +17303,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 09 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17319,7 +17319,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 10 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17335,7 +17335,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Jan 11 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17355,7 +17355,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Jan 12 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17371,7 +17371,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 13 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17387,7 +17387,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 14 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17403,7 +17403,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 15 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17419,7 +17419,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 16 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17435,7 +17435,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 17 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17451,7 +17451,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Jan 18 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17471,7 +17471,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Jan 19 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17487,7 +17487,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 20 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17503,7 +17503,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 21 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17519,7 +17519,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 22 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17535,7 +17535,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 23 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17551,7 +17551,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 24 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17567,7 +17567,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Jan 25 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17587,7 +17587,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Jan 26 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17603,7 +17603,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 27 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17619,7 +17619,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 28 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17635,7 +17635,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 29 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17651,7 +17651,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 30 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17667,7 +17667,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 31 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17683,7 +17683,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Feb 01 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17703,7 +17703,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Feb 02 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17719,7 +17719,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Feb 03 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17735,7 +17735,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Feb 04 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17751,7 +17751,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Feb 05 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17767,7 +17767,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Feb 06 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17783,7 +17783,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Feb 07 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >
@@ -17799,7 +17799,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Feb 08 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="StyledButton-sc-323bzc-0 dRLPCJ"
                 tabindex="-1"
                 type="button"
               >

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -1413,23 +1413,23 @@ exports[`Carousel navigate 1`] = `
 
 exports[`Carousel navigate 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledStack-ajspsk-0 liEjfH"
+    class="StyledStack-ajspsk-0 MouK"
     data-testid="test-carousel"
   >
     <div
       class="StyledStack__StyledStackLayer-ajspsk-1 gzpmgV"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 kpwHpK"
+        class="StyledBox-sc-13pk1d4-0 iqiriX"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fijLVp"
+          class="StyledBox-sc-13pk1d4-0 jRCHDw"
         >
           <img
-            class="StyledImage-ey4zx9-0 gtXVuX"
+            class="StyledImage-ey4zx9-0 AAkWw"
             src="//v2.grommet.io/assets/IMG_4245.jpg"
           />
         </div>
@@ -1439,13 +1439,13 @@ exports[`Carousel navigate 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 eFfYoG"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 kpwHpK"
+        class="StyledBox-sc-13pk1d4-0 iqiriX"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fyNJTz"
+          class="StyledBox-sc-13pk1d4-0 icTVmm"
         >
           <img
-            class="StyledImage-ey4zx9-0 gtXVuX"
+            class="StyledImage-ey4zx9-0 AAkWw"
             src="//v2.grommet.io/assets/IMG_4210.jpg"
           />
         </div>
@@ -1455,11 +1455,11 @@ exports[`Carousel navigate 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 gzpmgV"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 iLSfXS"
+        class="StyledBox-sc-13pk1d4-0 dfvURv"
         tabindex="0"
       >
         <button
-          class="StyledButton-sc-323bzc-0 ggXSon"
+          class="StyledButton-sc-323bzc-0 kpSdbQ"
           type="button"
         >
           <svg
@@ -1477,13 +1477,13 @@ exports[`Carousel navigate 2`] = `
           </svg>
         </button>
         <div
-          class="StyledBox-sc-13pk1d4-0 idXMGj"
+          class="StyledBox-sc-13pk1d4-0 jysPFm"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 jmTzhV"
+            class="StyledBox-sc-13pk1d4-0 iNaCiQ"
           >
             <button
-              class="StyledButton-sc-323bzc-0 fKcmhi"
+              class="StyledButton-sc-323bzc-0 gHTUFP"
               type="button"
             >
               <svg
@@ -1500,7 +1500,7 @@ exports[`Carousel navigate 2`] = `
               </svg>
             </button>
             <button
-              class="StyledButton-sc-323bzc-0 fKcmhi"
+              class="StyledButton-sc-323bzc-0 gHTUFP"
               type="button"
             >
               <svg
@@ -1519,7 +1519,7 @@ exports[`Carousel navigate 2`] = `
           </div>
         </div>
         <button
-          class="StyledButton-sc-323bzc-0 elqUnZ"
+          class="StyledButton-sc-323bzc-0 gvkzWm"
           disabled=""
           type="button"
         >
@@ -1544,23 +1544,23 @@ exports[`Carousel navigate 2`] = `
 
 exports[`Carousel navigate 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledStack-ajspsk-0 liEjfH"
+    class="StyledStack-ajspsk-0 MouK"
     data-testid="test-carousel"
   >
     <div
       class="StyledStack__StyledStackLayer-ajspsk-1 eFfYoG"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 kpwHpK"
+        class="StyledBox-sc-13pk1d4-0 iqiriX"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 dGhOz"
+          class="StyledBox-sc-13pk1d4-0 iXbCdS"
         >
           <img
-            class="StyledImage-ey4zx9-0 gtXVuX"
+            class="StyledImage-ey4zx9-0 AAkWw"
             src="//v2.grommet.io/assets/IMG_4245.jpg"
           />
         </div>
@@ -1570,13 +1570,13 @@ exports[`Carousel navigate 3`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 gzpmgV"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 kpwHpK"
+        class="StyledBox-sc-13pk1d4-0 iqiriX"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fijLVp"
+          class="StyledBox-sc-13pk1d4-0 jRCHDw"
         >
           <img
-            class="StyledImage-ey4zx9-0 gtXVuX"
+            class="StyledImage-ey4zx9-0 AAkWw"
             src="//v2.grommet.io/assets/IMG_4210.jpg"
           />
         </div>
@@ -1586,11 +1586,11 @@ exports[`Carousel navigate 3`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 gzpmgV"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 iLSfXS"
+        class="StyledBox-sc-13pk1d4-0 dfvURv"
         tabindex="0"
       >
         <button
-          class="StyledButton-sc-323bzc-0 elqUnZ"
+          class="StyledButton-sc-323bzc-0 gvkzWm"
           disabled=""
           type="button"
         >
@@ -1609,13 +1609,13 @@ exports[`Carousel navigate 3`] = `
           </svg>
         </button>
         <div
-          class="StyledBox-sc-13pk1d4-0 idXMGj"
+          class="StyledBox-sc-13pk1d4-0 jysPFm"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 jmTzhV"
+            class="StyledBox-sc-13pk1d4-0 iNaCiQ"
           >
             <button
-              class="StyledButton-sc-323bzc-0 fKcmhi"
+              class="StyledButton-sc-323bzc-0 gHTUFP"
               type="button"
             >
               <svg
@@ -1632,7 +1632,7 @@ exports[`Carousel navigate 3`] = `
               </svg>
             </button>
             <button
-              class="StyledButton-sc-323bzc-0 fKcmhi"
+              class="StyledButton-sc-323bzc-0 gHTUFP"
               type="button"
             >
               <svg
@@ -1651,7 +1651,7 @@ exports[`Carousel navigate 3`] = `
           </div>
         </div>
         <button
-          class="StyledButton-sc-323bzc-0 ggXSon"
+          class="StyledButton-sc-323bzc-0 kpSdbQ"
           type="button"
         >
           <svg
@@ -2129,22 +2129,22 @@ exports[`Carousel play 1`] = `
 
 exports[`Carousel play 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledStack-ajspsk-0 liEjfH"
+    class="StyledStack-ajspsk-0 MouK"
   >
     <div
       class="StyledStack__StyledStackLayer-ajspsk-1 gzpmgV"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 kpwHpK"
+        class="StyledBox-sc-13pk1d4-0 iqiriX"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fijLVp"
+          class="StyledBox-sc-13pk1d4-0 jRCHDw"
         >
           <img
-            class="StyledImage-ey4zx9-0 gtXVuX"
+            class="StyledImage-ey4zx9-0 AAkWw"
             src="//v2.grommet.io/assets/IMG_4245.jpg"
           />
         </div>
@@ -2154,13 +2154,13 @@ exports[`Carousel play 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 eFfYoG"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 kpwHpK"
+        class="StyledBox-sc-13pk1d4-0 iqiriX"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fyNJTz"
+          class="StyledBox-sc-13pk1d4-0 icTVmm"
         >
           <img
-            class="StyledImage-ey4zx9-0 gtXVuX"
+            class="StyledImage-ey4zx9-0 AAkWw"
             src="//v2.grommet.io/assets/IMG_4210.jpg"
           />
         </div>
@@ -2170,11 +2170,11 @@ exports[`Carousel play 2`] = `
       class="StyledStack__StyledStackLayer-ajspsk-1 gzpmgV"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 iLSfXS"
+        class="StyledBox-sc-13pk1d4-0 dfvURv"
         tabindex="0"
       >
         <button
-          class="StyledButton-sc-323bzc-0 ggXSon"
+          class="StyledButton-sc-323bzc-0 kpSdbQ"
           type="button"
         >
           <svg
@@ -2192,13 +2192,13 @@ exports[`Carousel play 2`] = `
           </svg>
         </button>
         <div
-          class="StyledBox-sc-13pk1d4-0 idXMGj"
+          class="StyledBox-sc-13pk1d4-0 jysPFm"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 jmTzhV"
+            class="StyledBox-sc-13pk1d4-0 iNaCiQ"
           >
             <button
-              class="StyledButton-sc-323bzc-0 fKcmhi"
+              class="StyledButton-sc-323bzc-0 gHTUFP"
               type="button"
             >
               <svg
@@ -2215,7 +2215,7 @@ exports[`Carousel play 2`] = `
               </svg>
             </button>
             <button
-              class="StyledButton-sc-323bzc-0 fKcmhi"
+              class="StyledButton-sc-323bzc-0 gHTUFP"
               type="button"
             >
               <svg
@@ -2234,7 +2234,7 @@ exports[`Carousel play 2`] = `
           </div>
         </div>
         <button
-          class="StyledButton-sc-323bzc-0 elqUnZ"
+          class="StyledButton-sc-323bzc-0 gvkzWm"
           disabled=""
           type="button"
         >

--- a/src/js/components/Chart/StyledChart.js
+++ b/src/js/components/Chart/StyledChart.js
@@ -1,4 +1,5 @@
-import styled, { css, keyframes } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css, keyframes } from 'styled-components';
 
 import { genericStyles } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import { focusStyle, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -326,13 +326,13 @@ exports[`CheckBox controlled 1`] = `
 
 exports[`CheckBox controlled 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <label
     class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+      class="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
     >
       <input
         checked=""
@@ -340,7 +340,7 @@ exports[`CheckBox controlled 2`] = `
         type="checkbox"
       />
       <div
-        class="StyledBox-sc-13pk1d4-0 KsQmP StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+        class="StyledBox-sc-13pk1d4-0 eLzbQa StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
       >
         <svg
           class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 gHRhNW"

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`CheckBoxGroup disabled renders 1`] = `
 <div
-  className="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  className="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    className="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    className="StyledBox-sc-13pk1d4-0 gzDuuM"
   >
     <label
       checked={false}
@@ -15,7 +15,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     >
       <div
         checked={false}
-        className="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        className="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
         disabled={true}
       >
         <input
@@ -29,7 +29,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
         />
         <div
           checked={false}
-          className="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          className="StyledBox-sc-13pk1d4-0 fFOoeO StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
           disabled={true}
         />
       </div>
@@ -38,7 +38,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
       </span>
     </label>
     <div
-      className="StyledBox__StyledBoxGap-sc-13pk1d4-1 liuKJs"
+      className="StyledBox__StyledBoxGap-sc-13pk1d4-1 SQIFI"
     />
     <label
       checked={false}
@@ -48,7 +48,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     >
       <div
         checked={false}
-        className="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        className="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
         disabled={true}
       >
         <input
@@ -62,7 +62,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
         />
         <div
           checked={false}
-          className="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          className="StyledBox-sc-13pk1d4-0 fFOoeO StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
           disabled={true}
         />
       </div>
@@ -72,7 +72,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     </label>
   </div>
   <div
-    className="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    className="StyledBox-sc-13pk1d4-0 gzDuuM"
   >
     <label
       checked={false}
@@ -82,7 +82,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     >
       <div
         checked={false}
-        className="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        className="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
         disabled={true}
       >
         <input
@@ -96,7 +96,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
         />
         <div
           checked={false}
-          className="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          className="StyledBox-sc-13pk1d4-0 fFOoeO StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
           disabled={true}
         />
       </div>
@@ -106,7 +106,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     </label>
   </div>
   <div
-    className="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    className="StyledBox-sc-13pk1d4-0 gzDuuM"
   >
     <label
       checked={false}
@@ -116,7 +116,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     >
       <div
         checked={false}
-        className="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        className="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
         disabled={true}
       >
         <input
@@ -130,7 +130,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
         />
         <div
           checked={false}
-          className="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          className="StyledBox-sc-13pk1d4-0 fFOoeO StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
           disabled={true}
         />
       </div>
@@ -144,10 +144,10 @@ exports[`CheckBoxGroup disabled renders 1`] = `
 
 exports[`CheckBoxGroup initial value renders 1`] = `
 <div
-  className="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  className="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    className="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    className="StyledBox-sc-13pk1d4-0 gzDuuM"
   >
     <label
       checked={false}
@@ -156,7 +156,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
     >
       <div
         checked={false}
-        className="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        className="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           checked={false}
@@ -168,7 +168,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
         />
         <div
           checked={false}
-          className="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          className="StyledBox-sc-13pk1d4-0 fFOoeO StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         />
       </div>
       <span>
@@ -176,7 +176,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
       </span>
     </label>
     <div
-      className="StyledBox__StyledBoxGap-sc-13pk1d4-1 liuKJs"
+      className="StyledBox__StyledBoxGap-sc-13pk1d4-1 SQIFI"
     />
     <label
       checked={true}
@@ -185,7 +185,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
     >
       <div
         checked={true}
-        className="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        className="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           checked={true}
@@ -197,7 +197,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
         />
         <div
           checked={true}
-          className="StyledBox-sc-13pk1d4-0 KsQmP StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          className="StyledBox-sc-13pk1d4-0 eLzbQa StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         >
           <svg
             checked={true}
@@ -217,7 +217,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
       </span>
     </label>
     <div
-      className="StyledBox__StyledBoxGap-sc-13pk1d4-1 liuKJs"
+      className="StyledBox__StyledBoxGap-sc-13pk1d4-1 SQIFI"
     />
     <label
       checked={true}
@@ -226,7 +226,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
     >
       <div
         checked={true}
-        className="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        className="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           checked={true}
@@ -238,7 +238,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
         />
         <div
           checked={true}
-          className="StyledBox-sc-13pk1d4-0 KsQmP StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          className="StyledBox-sc-13pk1d4-0 eLzbQa StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         >
           <svg
             checked={true}
@@ -263,23 +263,23 @@ exports[`CheckBoxGroup initial value renders 1`] = `
 
 exports[`CheckBoxGroup labelKey 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
   >
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        class="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
           type="checkbox"
         />
         <div
-          class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          class="StyledBox-sc-13pk1d4-0 fFOoeO StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         />
       </div>
       <span>
@@ -287,20 +287,20 @@ exports[`CheckBoxGroup labelKey 1`] = `
       </span>
     </label>
     <div
-      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 liuKJs"
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 SQIFI"
     />
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        class="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
           type="checkbox"
         />
         <div
-          class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          class="StyledBox-sc-13pk1d4-0 fFOoeO StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         />
       </div>
       <span>
@@ -313,23 +313,23 @@ exports[`CheckBoxGroup labelKey 1`] = `
 
 exports[`CheckBoxGroup onChange 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
   >
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        class="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
           type="checkbox"
         />
         <div
-          class="StyledBox-sc-13pk1d4-0 KsQmP StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          class="StyledBox-sc-13pk1d4-0 eLzbQa StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         >
           <svg
             class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 gHRhNW"
@@ -348,20 +348,20 @@ exports[`CheckBoxGroup onChange 1`] = `
       </span>
     </label>
     <div
-      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 liuKJs"
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 SQIFI"
     />
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        class="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
           type="checkbox"
         />
         <div
-          class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          class="StyledBox-sc-13pk1d4-0 fFOoeO StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         />
       </div>
       <span>
@@ -374,24 +374,24 @@ exports[`CheckBoxGroup onChange 1`] = `
 
 exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 iDvhFF"
+    class="StyledBox-sc-13pk1d4-0 dkNGss"
     tabindex="0"
   >
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        class="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
           type="checkbox"
         />
         <div
-          class="StyledBox-sc-13pk1d4-0 KsQmP StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          class="StyledBox-sc-13pk1d4-0 eLzbQa StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         >
           <svg
             class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 gHRhNW"
@@ -410,20 +410,20 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
       </span>
     </label>
     <div
-      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 liuKJs"
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 SQIFI"
     />
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        class="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
           type="checkbox"
         />
         <div
-          class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          class="StyledBox-sc-13pk1d4-0 fFOoeO StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         />
       </div>
       <span>
@@ -436,24 +436,24 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
 
 exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 iDvhFF"
+    class="StyledBox-sc-13pk1d4-0 dkNGss"
     tabindex="0"
   >
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        class="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
           type="checkbox"
         />
         <div
-          class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          class="StyledBox-sc-13pk1d4-0 fFOoeO StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         />
       </div>
       <span>
@@ -461,20 +461,20 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
       </span>
     </label>
     <div
-      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 liuKJs"
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 SQIFI"
     />
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        class="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
           type="checkbox"
         />
         <div
-          class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          class="StyledBox-sc-13pk1d4-0 fFOoeO StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         />
       </div>
       <span>
@@ -487,10 +487,10 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
 
 exports[`CheckBoxGroup options renders 1`] = `
 <div
-  className="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  className="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    className="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    className="StyledBox-sc-13pk1d4-0 gzDuuM"
   >
     <label
       checked={false}
@@ -499,7 +499,7 @@ exports[`CheckBoxGroup options renders 1`] = `
     >
       <div
         checked={false}
-        className="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        className="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           checked={false}
@@ -511,7 +511,7 @@ exports[`CheckBoxGroup options renders 1`] = `
         />
         <div
           checked={false}
-          className="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          className="StyledBox-sc-13pk1d4-0 fFOoeO StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         />
       </div>
       <span>
@@ -519,7 +519,7 @@ exports[`CheckBoxGroup options renders 1`] = `
       </span>
     </label>
     <div
-      className="StyledBox__StyledBoxGap-sc-13pk1d4-1 liuKJs"
+      className="StyledBox__StyledBoxGap-sc-13pk1d4-1 SQIFI"
     />
     <label
       checked={false}
@@ -528,7 +528,7 @@ exports[`CheckBoxGroup options renders 1`] = `
     >
       <div
         checked={false}
-        className="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        className="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           checked={false}
@@ -540,7 +540,7 @@ exports[`CheckBoxGroup options renders 1`] = `
         />
         <div
           checked={false}
-          className="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          className="StyledBox-sc-13pk1d4-0 fFOoeO StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         />
       </div>
       <span>
@@ -553,10 +553,10 @@ exports[`CheckBoxGroup options renders 1`] = `
 
 exports[`CheckBoxGroup value renders 1`] = `
 <div
-  className="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  className="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    className="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    className="StyledBox-sc-13pk1d4-0 gzDuuM"
   >
     <label
       checked={true}
@@ -565,7 +565,7 @@ exports[`CheckBoxGroup value renders 1`] = `
     >
       <div
         checked={true}
-        className="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        className="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           checked={true}
@@ -577,7 +577,7 @@ exports[`CheckBoxGroup value renders 1`] = `
         />
         <div
           checked={true}
-          className="StyledBox-sc-13pk1d4-0 KsQmP StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          className="StyledBox-sc-13pk1d4-0 eLzbQa StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         >
           <svg
             checked={true}
@@ -597,7 +597,7 @@ exports[`CheckBoxGroup value renders 1`] = `
       </span>
     </label>
     <div
-      className="StyledBox__StyledBoxGap-sc-13pk1d4-1 liuKJs"
+      className="StyledBox__StyledBoxGap-sc-13pk1d4-1 SQIFI"
     />
     <label
       checked={false}
@@ -606,7 +606,7 @@ exports[`CheckBoxGroup value renders 1`] = `
     >
       <div
         checked={false}
-        className="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        className="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           checked={false}
@@ -618,7 +618,7 @@ exports[`CheckBoxGroup value renders 1`] = `
         />
         <div
           checked={false}
-          className="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          className="StyledBox-sc-13pk1d4-0 fFOoeO StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         />
       </div>
       <span>
@@ -631,23 +631,23 @@ exports[`CheckBoxGroup value renders 1`] = `
 
 exports[`CheckBoxGroup valueKey 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
   >
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        class="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
           type="checkbox"
         />
         <div
-          class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          class="StyledBox-sc-13pk1d4-0 fFOoeO StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         />
       </div>
       <span>
@@ -655,20 +655,20 @@ exports[`CheckBoxGroup valueKey 1`] = `
       </span>
     </label>
     <div
-      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 liuKJs"
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 SQIFI"
     />
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 PHOTu"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 fuEVwc StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+        class="StyledBox-sc-13pk1d4-0 ctUjMz StyledCheckBox-sc-1dbk5ju-6 CBoMo"
       >
         <input
           class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 ljjPfS"
           type="checkbox"
         />
         <div
-          class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+          class="StyledBox-sc-13pk1d4-0 fFOoeO StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
         />
       </div>
       <span>

--- a/src/js/components/Clock/StyledClock.js
+++ b/src/js/components/Clock/StyledClock.js
@@ -1,4 +1,5 @@
-import styled, { css, keyframes } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css, keyframes } from 'styled-components';
 
 import { normalizeColor, genericStyles } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
+++ b/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
@@ -378,10 +378,10 @@ exports[`Clock run 1`] = `
 
 exports[`Clock run 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <svg
-    class="StyledClock__StyledAnalog-y4xw8s-3 gauWBG"
+    class="StyledClock__StyledAnalog-y4xw8s-3 jeuHUZ"
     height="96"
     preserveAspectRatio="xMidYMid meet"
     version="1.1"
@@ -420,7 +420,7 @@ exports[`Clock run 2`] = `
     />
   </svg>
   <svg
-    class="StyledClock__StyledAnalog-y4xw8s-3 gauWBG"
+    class="StyledClock__StyledAnalog-y4xw8s-3 jeuHUZ"
     height="96"
     preserveAspectRatio="xMidYMid meet"
     version="1.1"
@@ -459,7 +459,7 @@ exports[`Clock run 2`] = `
     />
   </svg>
   <div
-    class="StyledBox-sc-13pk1d4-0 bIdaiR"
+    class="StyledBox-sc-13pk1d4-0 gIDpUc"
   >
     <div
       class="StyledClock__StyledDigitalDigit-y4xw8s-4 gvEvWO"
@@ -534,7 +534,7 @@ exports[`Clock run 2`] = `
     </div>
   </div>
   <div
-    class="StyledBox-sc-13pk1d4-0 bIdaiR"
+    class="StyledBox-sc-13pk1d4-0 gIDpUc"
   >
     <div
       class="StyledClock__StyledDigitalDigit-y4xw8s-4 gvEvWO"

--- a/src/js/components/Collapsible/Collapsible.js
+++ b/src/js/components/Collapsible/Collapsible.js
@@ -6,7 +6,8 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import styled, { ThemeContext } from 'styled-components';
+import styled from 'styled-components/macro';
+import { ThemeContext } from 'styled-components';
 
 import { defaultProps } from '../../default-props';
 import { useForwardedRef } from '../../utils';

--- a/src/js/components/Collapsible/__tests__/__snapshots__/Collapsible-test.js.snap
+++ b/src/js/components/Collapsible/__tests__/__snapshots__/Collapsible-test.js.snap
@@ -57,15 +57,15 @@ exports[`Collapsible onClick open default 1`] = `
 
 exports[`Collapsible onClick open default 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
     aria-hidden="true"
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM Collapsible__AnimatedBox-sc-15kniua-0 bEdCNR"
     style="max-height: 0px;"
   >
     <span
-      class="StyledText-sc-1sadyjn-0 hUokoe"
+      class="StyledText-sc-1sadyjn-0 eBGtOg"
     >
       Example
     </span>

--- a/src/js/components/DataChart/Detail.js
+++ b/src/js/components/DataChart/Detail.js
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef, useState } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { Box } from '../Box';
 import { Drop } from '../Drop';
 import { Grid } from '../Grid';

--- a/src/js/components/DataTable/Resizer.js
+++ b/src/js/components/DataTable/Resizer.js
@@ -5,7 +5,8 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import styled, { ThemeContext } from 'styled-components';
+import styled from 'styled-components/macro';
+import { ThemeContext } from 'styled-components';
 
 import { defaultProps } from '../../default-props';
 import { Box } from '../Box';

--- a/src/js/components/DataTable/Sorter.js
+++ b/src/js/components/DataTable/Sorter.js
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
-import styled, { ThemeContext } from 'styled-components';
+import styled from 'styled-components/macro';
+import { ThemeContext } from 'styled-components';
 
 import { defaultProps } from '../../default-props';
 

--- a/src/js/components/DataTable/StyledDataTable.js
+++ b/src/js/components/DataTable/StyledDataTable.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import {
   backgroundStyle,

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2124,10 +2124,10 @@ exports[`DataTable click 1`] = `
 
 exports[`DataTable click 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 koBqev"
+    class="StyledTable-sc-1m3u5g-6 hMukKG StyledDataTable-xrlyjm-0 htayBQ"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 kdPLsZ StyledDataTable__StyledDataTableHeader-xrlyjm-3 hOGMbn"
@@ -2136,11 +2136,11 @@ exports[`DataTable click 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cDyHlQ StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 hUokoe"
+            class="StyledText-sc-1sadyjn-0 eBGtOg"
           >
             A
           </span>
@@ -2148,21 +2148,21 @@ exports[`DataTable click 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 bMdIOJ StyledDataTable__StyledDataTableBody-xrlyjm-2 kERYjL"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 bMdIOJ StyledDataTable__StyledDataTableBody-xrlyjm-2 eMYFgU"
       tabindex="0"
     >
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 imGRIL"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gmtNWw"
+              class="StyledText-sc-1sadyjn-0 bXPEse"
             >
               alpha
             </span>
@@ -2173,14 +2173,14 @@ exports[`DataTable click 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 imGRIL"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gmtNWw"
+              class="StyledText-sc-1sadyjn-0 bXPEse"
             >
               beta
             </span>
@@ -3353,10 +3353,10 @@ exports[`DataTable groupBy 1`] = `
 
 exports[`DataTable groupBy 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 koBqev"
+    class="StyledTable-sc-1m3u5g-6 hMukKG StyledDataTable-xrlyjm-0 htayBQ"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 kdPLsZ StyledDataTable__StyledDataTableHeader-xrlyjm-3 hOGMbn"
@@ -3365,15 +3365,15 @@ exports[`DataTable groupBy 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fxyVpq"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gjWhXc"
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 iTBMXj"
+            class="StyledButton-sc-323bzc-0 NHFvI"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 bCSAfw"
+              class="StyledBox-sc-13pk1d4-0 hvDxHT"
             >
               <svg
                 aria-label="FormDown"
@@ -3391,21 +3391,21 @@ exports[`DataTable groupBy 2`] = `
           </button>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cDyHlQ StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 hUokoe"
+            class="StyledText-sc-1sadyjn-0 eBGtOg"
           >
             A
           </span>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cDyHlQ StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 hUokoe"
+            class="StyledText-sc-1sadyjn-0 eBGtOg"
           >
             B
           </span>
@@ -3413,21 +3413,21 @@ exports[`DataTable groupBy 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 bMdIOJ StyledDataTable__StyledDataTableBody-xrlyjm-2 kERYjL"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 bMdIOJ StyledDataTable__StyledDataTableBody-xrlyjm-2 eMYFgU"
     >
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cfmJQA"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hWfACO"
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 iTBMXj"
+            class="StyledButton-sc-323bzc-0 NHFvI"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 bCSAfw"
+              class="StyledBox-sc-13pk1d4-0 hvDxHT"
             >
               <svg
                 aria-label="FormDown"
@@ -3445,24 +3445,24 @@ exports[`DataTable groupBy 2`] = `
           </button>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 hUokoe"
+              class="StyledText-sc-1sadyjn-0 eBGtOg"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           />
         </td>
       </tr>
@@ -3470,15 +3470,15 @@ exports[`DataTable groupBy 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cfmJQA"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hWfACO"
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 iTBMXj"
+            class="StyledButton-sc-323bzc-0 NHFvI"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 bCSAfw"
+              class="StyledBox-sc-13pk1d4-0 hvDxHT"
             >
               <svg
                 aria-label="FormDown"
@@ -3496,24 +3496,24 @@ exports[`DataTable groupBy 2`] = `
           </button>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 hUokoe"
+              class="StyledText-sc-1sadyjn-0 eBGtOg"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           />
         </td>
       </tr>
@@ -4382,10 +4382,10 @@ exports[`DataTable groupBy property 1`] = `
 
 exports[`DataTable groupBy property 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 koBqev"
+    class="StyledTable-sc-1m3u5g-6 hMukKG StyledDataTable-xrlyjm-0 htayBQ"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 kdPLsZ StyledDataTable__StyledDataTableHeader-xrlyjm-3 hOGMbn"
@@ -4394,15 +4394,15 @@ exports[`DataTable groupBy property 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fxyVpq"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gjWhXc"
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 iTBMXj"
+            class="StyledButton-sc-323bzc-0 NHFvI"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 bCSAfw"
+              class="StyledBox-sc-13pk1d4-0 hvDxHT"
             >
               <svg
                 aria-label="FormDown"
@@ -4420,21 +4420,21 @@ exports[`DataTable groupBy property 2`] = `
           </button>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cDyHlQ StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 hUokoe"
+            class="StyledText-sc-1sadyjn-0 eBGtOg"
           >
             A
           </span>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cDyHlQ StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 hUokoe"
+            class="StyledText-sc-1sadyjn-0 eBGtOg"
           >
             B
           </span>
@@ -4442,21 +4442,21 @@ exports[`DataTable groupBy property 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 bMdIOJ StyledDataTable__StyledDataTableBody-xrlyjm-2 kERYjL"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 bMdIOJ StyledDataTable__StyledDataTableBody-xrlyjm-2 eMYFgU"
     >
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cfmJQA"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hWfACO"
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 iTBMXj"
+            class="StyledButton-sc-323bzc-0 NHFvI"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 bCSAfw"
+              class="StyledBox-sc-13pk1d4-0 hvDxHT"
             >
               <svg
                 aria-label="FormDown"
@@ -4474,24 +4474,24 @@ exports[`DataTable groupBy property 2`] = `
           </button>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 hUokoe"
+              class="StyledText-sc-1sadyjn-0 eBGtOg"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           />
         </td>
       </tr>
@@ -4499,15 +4499,15 @@ exports[`DataTable groupBy property 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cfmJQA"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hWfACO"
         >
           <button
             aria-label="expand"
-            class="StyledButton-sc-323bzc-0 iTBMXj"
+            class="StyledButton-sc-323bzc-0 NHFvI"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 bCSAfw"
+              class="StyledBox-sc-13pk1d4-0 hvDxHT"
             >
               <svg
                 aria-label="FormDown"
@@ -4525,24 +4525,24 @@ exports[`DataTable groupBy property 2`] = `
           </button>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 hUokoe"
+              class="StyledText-sc-1sadyjn-0 eBGtOg"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           />
         </td>
       </tr>
@@ -4846,10 +4846,10 @@ exports[`DataTable onSort 1`] = `
 
 exports[`DataTable onSort 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 koBqev"
+    class="StyledTable-sc-1m3u5g-6 hMukKG StyledDataTable-xrlyjm-0 htayBQ"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 kdPLsZ StyledDataTable__StyledDataTableHeader-xrlyjm-3 hOGMbn"
@@ -4858,18 +4858,18 @@ exports[`DataTable onSort 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cDyHlQ StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 gCGTKO"
+            class="StyledButton-sc-323bzc-0 dXGAND"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 rpWqh"
+              class="StyledBox-sc-13pk1d4-0 fzHvHI"
             >
               <span
-                class="StyledText-sc-1sadyjn-0 hUokoe"
+                class="StyledText-sc-1sadyjn-0 eBGtOg"
               >
                 A
               </span>
@@ -4945,18 +4945,18 @@ exports[`DataTable onSort 2`] = `
           </button>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cDyHlQ StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 gCGTKO"
+            class="StyledButton-sc-323bzc-0 dXGAND"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 rpWqh"
+              class="StyledBox-sc-13pk1d4-0 fzHvHI"
             >
               <span
-                class="StyledText-sc-1sadyjn-0 hUokoe"
+                class="StyledText-sc-1sadyjn-0 eBGtOg"
               >
                 B
               </span>
@@ -4966,33 +4966,33 @@ exports[`DataTable onSort 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 bMdIOJ StyledDataTable__StyledDataTableBody-xrlyjm-2 kERYjL"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 bMdIOJ StyledDataTable__StyledDataTableBody-xrlyjm-2 eMYFgU"
     >
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gmtNWw"
+              class="StyledText-sc-1sadyjn-0 bXPEse"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 hUokoe"
+              class="StyledText-sc-1sadyjn-0 eBGtOg"
             >
               1
             </span>
@@ -5003,27 +5003,27 @@ exports[`DataTable onSort 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gmtNWw"
+              class="StyledText-sc-1sadyjn-0 bXPEse"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 hUokoe"
+              class="StyledText-sc-1sadyjn-0 eBGtOg"
             >
               2
             </span>
@@ -5034,27 +5034,27 @@ exports[`DataTable onSort 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gmtNWw"
+              class="StyledText-sc-1sadyjn-0 bXPEse"
             >
               zero
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 hUokoe"
+              class="StyledText-sc-1sadyjn-0 eBGtOg"
             >
               0
             </span>
@@ -7733,10 +7733,10 @@ exports[`DataTable search 1`] = `
 
 exports[`DataTable search 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 koBqev"
+    class="StyledTable-sc-1m3u5g-6 hMukKG StyledDataTable-xrlyjm-0 htayBQ"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 kdPLsZ StyledDataTable__StyledDataTableHeader-xrlyjm-3 hOGMbn"
@@ -7745,14 +7745,14 @@ exports[`DataTable search 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cDyHlQ StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 empHH"
+            class="StyledBox-sc-13pk1d4-0 iFayjW"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 hUokoe"
+              class="StyledText-sc-1sadyjn-0 eBGtOg"
             >
               A
             </span>
@@ -7873,20 +7873,20 @@ exports[`DataTable search 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 bMdIOJ StyledDataTable__StyledDataTableBody-xrlyjm-2 kERYjL"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 bMdIOJ StyledDataTable__StyledDataTableBody-xrlyjm-2 eMYFgU"
     >
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gmtNWw"
+              class="StyledText-sc-1sadyjn-0 bXPEse"
             >
               []
             </span>
@@ -8193,10 +8193,10 @@ exports[`DataTable sortable 1`] = `
 
 exports[`DataTable sortable 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 koBqev"
+    class="StyledTable-sc-1m3u5g-6 hMukKG StyledDataTable-xrlyjm-0 htayBQ"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 kdPLsZ StyledDataTable__StyledDataTableHeader-xrlyjm-3 hOGMbn"
@@ -8205,18 +8205,18 @@ exports[`DataTable sortable 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cDyHlQ StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 gCGTKO"
+            class="StyledButton-sc-323bzc-0 dXGAND"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 rpWqh"
+              class="StyledBox-sc-13pk1d4-0 fzHvHI"
             >
               <span
-                class="StyledText-sc-1sadyjn-0 hUokoe"
+                class="StyledText-sc-1sadyjn-0 eBGtOg"
               >
                 A
               </span>
@@ -8292,18 +8292,18 @@ exports[`DataTable sortable 2`] = `
           </button>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cDyHlQ StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 gCGTKO"
+            class="StyledButton-sc-323bzc-0 dXGAND"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 rpWqh"
+              class="StyledBox-sc-13pk1d4-0 fzHvHI"
             >
               <span
-                class="StyledText-sc-1sadyjn-0 hUokoe"
+                class="StyledText-sc-1sadyjn-0 eBGtOg"
               >
                 B
               </span>
@@ -8313,33 +8313,33 @@ exports[`DataTable sortable 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 bMdIOJ StyledDataTable__StyledDataTableBody-xrlyjm-2 kERYjL"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 bMdIOJ StyledDataTable__StyledDataTableBody-xrlyjm-2 eMYFgU"
     >
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gmtNWw"
+              class="StyledText-sc-1sadyjn-0 bXPEse"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 hUokoe"
+              class="StyledText-sc-1sadyjn-0 eBGtOg"
             >
               1
             </span>
@@ -8350,27 +8350,27 @@ exports[`DataTable sortable 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gmtNWw"
+              class="StyledText-sc-1sadyjn-0 bXPEse"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 hUokoe"
+              class="StyledText-sc-1sadyjn-0 eBGtOg"
             >
               2
             </span>
@@ -8381,27 +8381,27 @@ exports[`DataTable sortable 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gmtNWw"
+              class="StyledText-sc-1sadyjn-0 bXPEse"
             >
               zero
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hDLYW StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+            class="StyledBox-sc-13pk1d4-0 gzDuuM"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 hUokoe"
+              class="StyledText-sc-1sadyjn-0 eBGtOg"
             >
               0
             </span>

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
@@ -7650,7 +7650,7 @@ exports[`DateInput select format 1`] = `
 
 exports[`DateInput select format 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
     class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 eZPDpF"
@@ -7673,7 +7673,7 @@ exports[`DateInput select format 2`] = `
     </div>
     <input
       autocomplete="off"
-      class="StyledMaskedInput-sc-99vkfa-0 eoroCF"
+      class="StyledMaskedInput-sc-99vkfa-0 cHXMes"
       id="item"
       name="item"
       placeholder="mm/dd/yyyy"
@@ -10012,10 +10012,10 @@ exports[`DateInput select format inline 1`] = `
 
 exports[`DateInput select format inline 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
   >
     <div
       class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 eZPDpF"
@@ -10038,7 +10038,7 @@ exports[`DateInput select format inline 2`] = `
       </div>
       <input
         autocomplete="off"
-        class="StyledMaskedInput-sc-99vkfa-0 dyBLro"
+        class="StyledMaskedInput-sc-99vkfa-0 dcygFZ"
         id="item"
         name="item"
         placeholder="mm/dd/yyyy"
@@ -10046,29 +10046,29 @@ exports[`DateInput select format inline 2`] = `
       />
     </div>
     <div
-      class="StyledCalendar-sc-1y4xhmp-0 eMLsHu"
+      class="StyledCalendar-sc-1y4xhmp-0 dCeKZu"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+        class="StyledBox-sc-13pk1d4-0 gzDuuM"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ecbFEh"
+            class="StyledBox-sc-13pk1d4-0 qOIBY"
           >
             <h3
-              class="StyledHeading-sc-1rdh4aw-0 eEcLoL"
+              class="StyledHeading-sc-1rdh4aw-0 bGGmgW"
             >
               July 2020
             </h3>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 bBymtc"
+            class="StyledBox-sc-13pk1d4-0 cCCDBZ"
           >
             <button
               aria-label="June 2020"
-              class="StyledButton-sc-323bzc-0 fKcmhi"
+              class="StyledButton-sc-323bzc-0 gHTUFP"
               type="button"
             >
               <svg
@@ -10087,7 +10087,7 @@ exports[`DateInput select format inline 2`] = `
             </button>
             <button
               aria-label="August 2020"
-              class="StyledButton-sc-323bzc-0 fKcmhi"
+              class="StyledButton-sc-323bzc-0 gHTUFP"
               type="button"
             >
               <svg
@@ -10106,7 +10106,7 @@ exports[`DateInput select format inline 2`] = `
           </div>
         </div>
         <div
-          class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 bzlxGD"
+          class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 jSvBPP"
           tabindex="0"
         >
           <div
@@ -10120,7 +10120,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jun 28 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10136,7 +10136,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jun 29 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10152,7 +10152,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jun 30 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10168,7 +10168,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 01 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10184,7 +10184,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 02 2020"
-                  class="StyledButton-sc-323bzc-0 kUquzo"
+                  class="StyledButton-sc-323bzc-0 hXtzf"
                   tabindex="-1"
                   type="button"
                 >
@@ -10200,7 +10200,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 03 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10216,7 +10216,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 04 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10236,7 +10236,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 05 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10252,7 +10252,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 06 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10268,7 +10268,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 07 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10284,7 +10284,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 08 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10300,7 +10300,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 09 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10316,7 +10316,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 10 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10332,7 +10332,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 11 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10352,7 +10352,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 12 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10368,7 +10368,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 13 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10384,7 +10384,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 14 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10400,7 +10400,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 15 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10416,7 +10416,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 16 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10432,7 +10432,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 17 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10448,7 +10448,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 18 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10468,7 +10468,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 19 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10484,12 +10484,12 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 20 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
                   <div
-                    class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gBUPeV"
+                    class="StyledCalendar__StyledDay-sc-1y4xhmp-5 fchDJz"
                   >
                     20
                   </div>
@@ -10500,7 +10500,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 21 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10516,7 +10516,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 22 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10532,7 +10532,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 23 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10548,7 +10548,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 24 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10564,7 +10564,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 25 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10584,7 +10584,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 26 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10600,7 +10600,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 27 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10616,7 +10616,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 28 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10632,7 +10632,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 29 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10648,7 +10648,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 30 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10664,7 +10664,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 31 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10680,7 +10680,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sat Aug 01 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10700,7 +10700,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sun Aug 02 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10716,7 +10716,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Mon Aug 03 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10732,7 +10732,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Tue Aug 04 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10748,7 +10748,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Wed Aug 05 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10764,7 +10764,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Thu Aug 06 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10780,7 +10780,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Fri Aug 07 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -10796,7 +10796,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sat Aug 08 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12024,10 +12024,10 @@ exports[`DateInput select format inline range 1`] = `
 
 exports[`DateInput select format inline range 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
   >
     <div
       class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 eZPDpF"
@@ -12050,7 +12050,7 @@ exports[`DateInput select format inline range 2`] = `
       </div>
       <input
         autocomplete="off"
-        class="StyledMaskedInput-sc-99vkfa-0 dyBLro"
+        class="StyledMaskedInput-sc-99vkfa-0 dcygFZ"
         id="item"
         name="item"
         placeholder="mm/dd/yyyy-mm/dd/yyyy"
@@ -12058,29 +12058,29 @@ exports[`DateInput select format inline range 2`] = `
       />
     </div>
     <div
-      class="StyledCalendar-sc-1y4xhmp-0 eMLsHu"
+      class="StyledCalendar-sc-1y4xhmp-0 dCeKZu"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+        class="StyledBox-sc-13pk1d4-0 gzDuuM"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ecbFEh"
+            class="StyledBox-sc-13pk1d4-0 qOIBY"
           >
             <h3
-              class="StyledHeading-sc-1rdh4aw-0 eEcLoL"
+              class="StyledHeading-sc-1rdh4aw-0 bGGmgW"
             >
               July 2020
             </h3>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 bBymtc"
+            class="StyledBox-sc-13pk1d4-0 cCCDBZ"
           >
             <button
               aria-label="June 2020"
-              class="StyledButton-sc-323bzc-0 fKcmhi"
+              class="StyledButton-sc-323bzc-0 gHTUFP"
               type="button"
             >
               <svg
@@ -12099,7 +12099,7 @@ exports[`DateInput select format inline range 2`] = `
             </button>
             <button
               aria-label="August 2020"
-              class="StyledButton-sc-323bzc-0 fKcmhi"
+              class="StyledButton-sc-323bzc-0 gHTUFP"
               type="button"
             >
               <svg
@@ -12118,7 +12118,7 @@ exports[`DateInput select format inline range 2`] = `
           </div>
         </div>
         <div
-          class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 bzlxGD"
+          class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 jSvBPP"
           tabindex="0"
         >
           <div
@@ -12132,7 +12132,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Jun 28 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12148,7 +12148,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Jun 29 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12164,7 +12164,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Jun 30 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12180,7 +12180,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Jul 01 2020"
-                  class="StyledButton-sc-323bzc-0 kUquzo"
+                  class="StyledButton-sc-323bzc-0 hXtzf"
                   tabindex="-1"
                   type="button"
                 >
@@ -12196,12 +12196,12 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Jul 02 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
                   <div
-                    class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gBUPeV"
+                    class="StyledCalendar__StyledDay-sc-1y4xhmp-5 fchDJz"
                   >
                     2
                   </div>
@@ -12212,12 +12212,12 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Jul 03 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
                   <div
-                    class="StyledCalendar__StyledDay-sc-1y4xhmp-5 iqiYtq"
+                    class="StyledCalendar__StyledDay-sc-1y4xhmp-5 czxmyg"
                   >
                     3
                   </div>
@@ -12228,12 +12228,12 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Jul 04 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
                   <div
-                    class="StyledCalendar__StyledDay-sc-1y4xhmp-5 iqiYtq"
+                    class="StyledCalendar__StyledDay-sc-1y4xhmp-5 czxmyg"
                   >
                     4
                   </div>
@@ -12248,12 +12248,12 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Jul 05 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
                   <div
-                    class="StyledCalendar__StyledDay-sc-1y4xhmp-5 iqiYtq"
+                    class="StyledCalendar__StyledDay-sc-1y4xhmp-5 czxmyg"
                   >
                     5
                   </div>
@@ -12264,12 +12264,12 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Jul 06 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
                   <div
-                    class="StyledCalendar__StyledDay-sc-1y4xhmp-5 iqiYtq"
+                    class="StyledCalendar__StyledDay-sc-1y4xhmp-5 czxmyg"
                   >
                     6
                   </div>
@@ -12280,12 +12280,12 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Jul 07 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
                   <div
-                    class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gBUPeV"
+                    class="StyledCalendar__StyledDay-sc-1y4xhmp-5 fchDJz"
                   >
                     7
                   </div>
@@ -12296,7 +12296,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Jul 08 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12312,7 +12312,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Jul 09 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12328,7 +12328,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Jul 10 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12344,7 +12344,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Jul 11 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12364,7 +12364,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Jul 12 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12380,7 +12380,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Jul 13 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12396,7 +12396,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Jul 14 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12412,7 +12412,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Jul 15 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12428,7 +12428,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Jul 16 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12444,7 +12444,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Jul 17 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12460,7 +12460,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Jul 18 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12480,7 +12480,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Jul 19 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12496,7 +12496,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Jul 20 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12512,7 +12512,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Jul 21 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12528,7 +12528,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Jul 22 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12544,7 +12544,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Jul 23 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12560,7 +12560,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Jul 24 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12576,7 +12576,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Jul 25 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12596,7 +12596,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Jul 26 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12612,7 +12612,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Jul 27 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12628,7 +12628,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Jul 28 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12644,7 +12644,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Jul 29 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12660,7 +12660,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Jul 30 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12676,7 +12676,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Jul 31 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12692,7 +12692,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Aug 01 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12712,7 +12712,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Aug 02 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12728,7 +12728,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Aug 03 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12744,7 +12744,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Aug 04 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12760,7 +12760,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Aug 05 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12776,7 +12776,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Aug 06 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12792,7 +12792,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Aug 07 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -12808,7 +12808,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Aug 08 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15109,10 +15109,10 @@ exports[`DateInput type format inline 1`] = `
 
 exports[`DateInput type format inline 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM"
   >
     <div
       class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 eZPDpF"
@@ -15135,7 +15135,7 @@ exports[`DateInput type format inline 2`] = `
       </div>
       <input
         autocomplete="off"
-        class="StyledMaskedInput-sc-99vkfa-0 dyBLro"
+        class="StyledMaskedInput-sc-99vkfa-0 dcygFZ"
         id="item"
         name="item"
         placeholder="mm/dd/yyyy"
@@ -15143,29 +15143,29 @@ exports[`DateInput type format inline 2`] = `
       />
     </div>
     <div
-      class="StyledCalendar-sc-1y4xhmp-0 eMLsHu"
+      class="StyledCalendar-sc-1y4xhmp-0 dCeKZu"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+        class="StyledBox-sc-13pk1d4-0 gzDuuM"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 VvbUh"
+          class="StyledBox-sc-13pk1d4-0 gWfleo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ecbFEh"
+            class="StyledBox-sc-13pk1d4-0 qOIBY"
           >
             <h3
-              class="StyledHeading-sc-1rdh4aw-0 eEcLoL"
+              class="StyledHeading-sc-1rdh4aw-0 bGGmgW"
             >
               July 2020
             </h3>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 bBymtc"
+            class="StyledBox-sc-13pk1d4-0 cCCDBZ"
           >
             <button
               aria-label="June 2020"
-              class="StyledButton-sc-323bzc-0 fKcmhi"
+              class="StyledButton-sc-323bzc-0 gHTUFP"
               type="button"
             >
               <svg
@@ -15184,7 +15184,7 @@ exports[`DateInput type format inline 2`] = `
             </button>
             <button
               aria-label="August 2020"
-              class="StyledButton-sc-323bzc-0 fKcmhi"
+              class="StyledButton-sc-323bzc-0 gHTUFP"
               type="button"
             >
               <svg
@@ -15217,7 +15217,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jun 28 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15233,7 +15233,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jun 29 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15249,7 +15249,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jun 30 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15265,7 +15265,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 01 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15281,12 +15281,12 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 02 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
                   <div
-                    class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gBUPeV"
+                    class="StyledCalendar__StyledDay-sc-1y4xhmp-5 fchDJz"
                   >
                     2
                   </div>
@@ -15297,7 +15297,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 03 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15313,7 +15313,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 04 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15333,7 +15333,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 05 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15349,7 +15349,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 06 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15365,7 +15365,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 07 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15381,7 +15381,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 08 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15397,7 +15397,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 09 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15413,7 +15413,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 10 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15429,7 +15429,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 11 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15449,7 +15449,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 12 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15465,7 +15465,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 13 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15481,7 +15481,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 14 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15497,7 +15497,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 15 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15513,7 +15513,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 16 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15529,7 +15529,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 17 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15545,7 +15545,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 18 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15565,7 +15565,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 19 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15581,7 +15581,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 20 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15597,7 +15597,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 21 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15613,7 +15613,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 22 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15629,7 +15629,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 23 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15645,7 +15645,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 24 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15661,7 +15661,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 25 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15681,7 +15681,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 26 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15697,7 +15697,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 27 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15713,7 +15713,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 28 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15729,7 +15729,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 29 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15745,7 +15745,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 30 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15761,7 +15761,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 31 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15777,7 +15777,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sat Aug 01 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15797,7 +15797,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sun Aug 02 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15813,7 +15813,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Mon Aug 03 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15829,7 +15829,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Tue Aug 04 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15845,7 +15845,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Wed Aug 05 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15861,7 +15861,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Thu Aug 06 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15877,7 +15877,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Fri Aug 07 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >
@@ -15893,7 +15893,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sat Aug 08 2020"
-                  class="StyledButton-sc-323bzc-0 jFJBys"
+                  class="StyledButton-sc-323bzc-0 dRLPCJ"
                   tabindex="-1"
                   type="button"
                 >

--- a/src/js/components/Diagram/StyledDiagram.js
+++ b/src/js/components/Diagram/StyledDiagram.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import { defaultProps } from '../../default-props';
 

--- a/src/js/components/Drop/StyledDrop.js
+++ b/src/js/components/Drop/StyledDrop.js
@@ -1,4 +1,5 @@
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components/macro';
+import { keyframes } from 'styled-components';
 
 import { baseStyle } from '../../utils';
 import { backgroundStyle } from '../../utils/background';

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -66,7 +66,7 @@ exports[`Drop align left left 1`] = `
 `;
 
 exports[`Drop align left left 2`] = `
-".glPSfV {
+".kpkStw {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -82,7 +82,7 @@ exports[`Drop align left left 2`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -161,7 +161,7 @@ exports[`Drop align left right top bottom 1`] = `
 `;
 
 exports[`Drop align left right top bottom 2`] = `
-".glPSfV {
+".kpkStw {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -176,7 +176,7 @@ exports[`Drop align left right top bottom 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.kQAKuZ {
+.jkSCsB {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -200,7 +200,7 @@ exports[`Drop align left right top bottom 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -279,7 +279,7 @@ exports[`Drop align right left top top 1`] = `
 `;
 
 exports[`Drop align right left top top 2`] = `
-".glPSfV {
+".kpkStw {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -295,7 +295,7 @@ exports[`Drop align right left top top 2`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -374,7 +374,7 @@ exports[`Drop align right right 1`] = `
 `;
 
 exports[`Drop align right right 2`] = `
-".glPSfV {
+".kpkStw {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -390,7 +390,7 @@ exports[`Drop align right right 2`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -469,7 +469,7 @@ exports[`Drop align right right bottom top 1`] = `
 `;
 
 exports[`Drop align right right bottom top 2`] = `
-".glPSfV {
+".kpkStw {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -485,7 +485,7 @@ exports[`Drop align right right bottom top 2`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -564,7 +564,7 @@ exports[`Drop align right right bottom top 3`] = `
 `;
 
 exports[`Drop align right right bottom top 4`] = `
-".glPSfV {
+".kpkStw {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -580,7 +580,7 @@ exports[`Drop align right right bottom top 4`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -659,7 +659,7 @@ exports[`Drop basic 1`] = `
 `;
 
 exports[`Drop basic 2`] = `
-".glPSfV {
+".kpkStw {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -674,7 +674,7 @@ exports[`Drop basic 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.kQAKuZ {
+.jkSCsB {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -698,7 +698,7 @@ exports[`Drop basic 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -777,7 +777,7 @@ exports[`Drop close 1`] = `
 `;
 
 exports[`Drop close 2`] = `
-".glPSfV {
+".kpkStw {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -792,7 +792,7 @@ exports[`Drop close 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.kQAKuZ {
+.jkSCsB {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -816,7 +816,7 @@ exports[`Drop close 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -895,7 +895,7 @@ exports[`Drop default elevation renders 1`] = `
 `;
 
 exports[`Drop default elevation renders 2`] = `
-".glPSfV {
+".kpkStw {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -910,7 +910,7 @@ exports[`Drop default elevation renders 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.kQAKuZ {
+.jkSCsB {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -934,7 +934,7 @@ exports[`Drop default elevation renders 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1013,7 +1013,7 @@ exports[`Drop invalid align 1`] = `
 `;
 
 exports[`Drop invalid align 2`] = `
-".glPSfV {
+".kpkStw {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1028,7 +1028,7 @@ exports[`Drop invalid align 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.kQAKuZ {
+.jkSCsB {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1052,7 +1052,7 @@ exports[`Drop invalid align 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1131,7 +1131,7 @@ exports[`Drop invoke onClickOutside 1`] = `
 `;
 
 exports[`Drop invoke onClickOutside 2`] = `
-".glPSfV {
+".kpkStw {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1146,7 +1146,7 @@ exports[`Drop invoke onClickOutside 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.kQAKuZ {
+.jkSCsB {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1170,7 +1170,7 @@ exports[`Drop invoke onClickOutside 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1249,7 +1249,7 @@ exports[`Drop no stretch 1`] = `
 `;
 
 exports[`Drop no stretch 2`] = `
-".glPSfV {
+".kpkStw {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1264,7 +1264,7 @@ exports[`Drop no stretch 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.kQAKuZ {
+.jkSCsB {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1288,7 +1288,7 @@ exports[`Drop no stretch 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1365,7 +1365,7 @@ exports[`Drop plain renders 1`] = `
 
 exports[`Drop plain renders 2`] = `
 "@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1444,7 +1444,7 @@ exports[`Drop props elevation renders 1`] = `
 `;
 
 exports[`Drop props elevation renders 2`] = `
-".kQAKuZ {
+".jkSCsB {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1468,7 +1468,7 @@ exports[`Drop props elevation renders 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1547,7 +1547,7 @@ exports[`Drop resize 1`] = `
 `;
 
 exports[`Drop resize 2`] = `
-".glPSfV {
+".kpkStw {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1562,7 +1562,7 @@ exports[`Drop resize 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.kQAKuZ {
+.jkSCsB {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1586,7 +1586,7 @@ exports[`Drop resize 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1666,7 +1666,7 @@ exports[`Drop restrict focus 1`] = `
 
 exports[`Drop restrict focus 2`] = `
 <div
-  class="StyledBox-sc-13pk1d4-0 glPSfV StyledDrop-sc-16s5rx8-0 kQAKuZ"
+  class="StyledBox-sc-13pk1d4-0 kpkStw StyledDrop-sc-16s5rx8-0 jkSCsB"
   data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -1677,7 +1677,7 @@ exports[`Drop restrict focus 2`] = `
 `;
 
 exports[`Drop restrict focus 3`] = `
-".glPSfV {
+".kpkStw {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1692,7 +1692,7 @@ exports[`Drop restrict focus 3`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.kQAKuZ {
+.jkSCsB {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1716,7 +1716,7 @@ exports[`Drop restrict focus 3`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1833,7 +1833,7 @@ exports[`Drop theme elevation renders 1`] = `
 `;
 
 exports[`Drop theme elevation renders 2`] = `
-".kQAKuZ {
+".jkSCsB {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1857,7 +1857,7 @@ exports[`Drop theme elevation renders 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .kQAKuZ {
+  .jkSCsB {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -189,21 +189,21 @@ exports[`Form controlled controlled 1`] = `
 
 exports[`Form controlled controlled 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             name="test"
             placeholder="test input"
             value="v"
@@ -212,7 +212,7 @@ exports[`Form controlled controlled 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit
@@ -223,21 +223,21 @@ exports[`Form controlled controlled 2`] = `
 
 exports[`Form controlled controlled 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             name="test"
             placeholder="test input"
             value="v"
@@ -246,7 +246,7 @@ exports[`Form controlled controlled 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit
@@ -459,27 +459,27 @@ exports[`Form controlled controlled FormField deprecated 1`] = `
 
 exports[`Form controlled controlled FormField deprecated 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <label
-        class="StyledText-sc-1sadyjn-0 enbIRN"
+        class="StyledText-sc-1sadyjn-0 cLZMRT"
         for="test"
       >
         test
       </label>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             id="test"
             name="test"
             value="v"
@@ -488,7 +488,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit
@@ -499,27 +499,27 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
 
 exports[`Form controlled controlled FormField deprecated 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <label
-        class="StyledText-sc-1sadyjn-0 enbIRN"
+        class="StyledText-sc-1sadyjn-0 cLZMRT"
         for="test"
       >
         test
       </label>
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             id="test"
             name="test"
             value="v"
@@ -528,7 +528,7 @@ exports[`Form controlled controlled FormField deprecated 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit
@@ -726,21 +726,21 @@ exports[`Form controlled controlled input 1`] = `
 
 exports[`Form controlled controlled input 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             name="test"
             placeholder="test input"
             value="v"
@@ -749,7 +749,7 @@ exports[`Form controlled controlled input 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit
@@ -760,21 +760,21 @@ exports[`Form controlled controlled input 2`] = `
 
 exports[`Form controlled controlled input 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             name="test"
             placeholder="test input"
             value="v"
@@ -783,7 +783,7 @@ exports[`Form controlled controlled input 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit
@@ -981,21 +981,21 @@ exports[`Form controlled controlled input lazy 1`] = `
 
 exports[`Form controlled controlled input lazy 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             name="test"
             placeholder="test input"
             value="v"
@@ -1004,7 +1004,7 @@ exports[`Form controlled controlled input lazy 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit
@@ -1015,21 +1015,21 @@ exports[`Form controlled controlled input lazy 2`] = `
 
 exports[`Form controlled controlled input lazy 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             name="test"
             placeholder="test input"
             value="v"
@@ -1038,7 +1038,7 @@ exports[`Form controlled controlled input lazy 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit
@@ -1236,21 +1236,21 @@ exports[`Form controlled controlled lazy 1`] = `
 
 exports[`Form controlled controlled lazy 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             name="test"
             placeholder="test input"
             value="v"
@@ -1259,7 +1259,7 @@ exports[`Form controlled controlled lazy 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit
@@ -1270,21 +1270,21 @@ exports[`Form controlled controlled lazy 2`] = `
 
 exports[`Form controlled controlled lazy 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             name="test"
             placeholder="test input"
             value="v"
@@ -1293,7 +1293,7 @@ exports[`Form controlled controlled lazy 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit
@@ -1491,21 +1491,21 @@ exports[`Form controlled controlled onValidate 1`] = `
 
 exports[`Form controlled controlled onValidate 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 eDbMJS FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 kOCSQH FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             name="test"
             placeholder="test input"
             value=""
@@ -1541,7 +1541,7 @@ exports[`Form controlled controlled onValidate 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit
@@ -1739,21 +1739,21 @@ exports[`Form controlled controlled onValidate custom error 1`] = `
 
 exports[`Form controlled controlled onValidate custom error 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 eDbMJS FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 kOCSQH FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             name="test"
             placeholder="test input"
             value=""
@@ -1789,7 +1789,7 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit
@@ -1987,21 +1987,21 @@ exports[`Form controlled controlled onValidate custom info 1`] = `
 
 exports[`Form controlled controlled onValidate custom info 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             name="test"
             placeholder="test input"
             value=""
@@ -2033,7 +2033,7 @@ exports[`Form controlled controlled onValidate custom info 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -1518,21 +1518,21 @@ exports[`Form uncontrolled uncontrolled 1`] = `
 
 exports[`Form uncontrolled uncontrolled 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             name="test"
             placeholder="test input"
             value=""
@@ -1541,7 +1541,7 @@ exports[`Form uncontrolled uncontrolled 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit
@@ -1552,21 +1552,21 @@ exports[`Form uncontrolled uncontrolled 2`] = `
 
 exports[`Form uncontrolled uncontrolled 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             name="test"
             placeholder="test input"
             value=""
@@ -1575,7 +1575,7 @@ exports[`Form uncontrolled uncontrolled 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit
@@ -1773,21 +1773,21 @@ exports[`Form uncontrolled uncontrolled onValidate 1`] = `
 
 exports[`Form uncontrolled uncontrolled onValidate 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 eDbMJS FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 kOCSQH FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             name="test"
             placeholder="test input"
             value=""
@@ -1823,7 +1823,7 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit
@@ -2021,21 +2021,21 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 1`] = `
 
 exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 eDbMJS FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 kOCSQH FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             name="test"
             placeholder="test input"
             value=""
@@ -2071,7 +2071,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit
@@ -2269,21 +2269,21 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 1`] = `
 
 exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 dtCrhk FormField__FormFieldBox-m9hood-0 eenrNp"
+      class="StyledBox-sc-13pk1d4-0 iMiqhb FormField__FormFieldBox-m9hood-0 eenrNp"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 cptOIG FormField__FormFieldContentBox-m9hood-1 ckZStK"
+        class="StyledBox-sc-13pk1d4-0 cgKvzL FormField__FormFieldContentBox-m9hood-1 ckZStK"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM"
             name="test"
             placeholder="test input"
             value=""
@@ -2315,7 +2315,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 gLndZo"
+      class="StyledButton-sc-323bzc-0 eRWfGb"
       type="submit"
     >
       Submit

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -5,7 +5,8 @@ import React, {
   useContext,
   useState,
 } from 'react';
-import styled, { ThemeContext } from 'styled-components';
+import styled from 'styled-components/macro';
+import { ThemeContext } from 'styled-components';
 import { defaultProps } from '../../default-props';
 
 import { focusStyle, parseMetricToNum } from '../../utils';

--- a/src/js/components/Grid/StyledGrid.js
+++ b/src/js/components/Grid/StyledGrid.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import { edgeStyle, genericStyles } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/Grommet/StyledGrommet.js
+++ b/src/js/components/Grommet/StyledGrommet.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import { baseStyle } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/Heading/StyledHeading.js
+++ b/src/js/components/Heading/StyledHeading.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import { breakpointStyle, genericStyles, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';
@@ -10,8 +11,7 @@ const sizeStyle = props => {
   const levelStyle = headingTheme.level[props.level];
   if (levelStyle) {
     const data = levelStyle[size];
-    const styles =  
-    [
+    const styles = [
       css`
         font-size: ${data ? data.size : size};
         line-height: ${data ? data.height : 'normal'};
@@ -25,7 +25,7 @@ const sizeStyle = props => {
       if (breakpoint) {
         const responsiveData =
           headingTheme.level[Math.min(props.level + 1, 4)][size];
-        if(responsiveData) {
+        if (responsiveData) {
           styles.push(
             breakpointStyle(
               breakpoint,

--- a/src/js/components/Image/StyledImage.js
+++ b/src/js/components/Image/StyledImage.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import { fillStyle, genericStyles } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -5,7 +5,8 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import styled, { ThemeContext } from 'styled-components';
+import styled from 'styled-components/macro';
+import { ThemeContext } from 'styled-components';
 import { defaultProps } from '../../default-props';
 
 import { FocusedContainer } from '../FocusedContainer';

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -1,4 +1,5 @@
-import styled, { css, keyframes } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css, keyframes } from 'styled-components';
 
 import {
   baseStyle,

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -124,7 +124,7 @@ exports[`Layer animation fadeIn 1`] = `
 `;
 
 exports[`Layer animation fadeIn 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -144,7 +144,7 @@ exports[`Layer animation fadeIn 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -152,12 +152,12 @@ exports[`Layer animation fadeIn 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -299,7 +299,7 @@ exports[`Layer animation false 1`] = `
 `;
 
 exports[`Layer animation false 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -319,7 +319,7 @@ exports[`Layer animation false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -327,12 +327,12 @@ exports[`Layer animation false 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -476,7 +476,7 @@ exports[`Layer animation slide 1`] = `
 `;
 
 exports[`Layer animation slide 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -496,7 +496,7 @@ exports[`Layer animation slide 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -504,12 +504,12 @@ exports[`Layer animation slide 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -653,7 +653,7 @@ exports[`Layer animation true 1`] = `
 `;
 
 exports[`Layer animation true 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -673,7 +673,7 @@ exports[`Layer animation true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -681,12 +681,12 @@ exports[`Layer animation true 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -830,7 +830,7 @@ exports[`Layer custom margin 1`] = `
 `;
 
 exports[`Layer custom margin 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -850,7 +850,7 @@ exports[`Layer custom margin 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -858,12 +858,12 @@ exports[`Layer custom margin 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -960,7 +960,7 @@ exports[`Layer dark context 1`] = `
 
 exports[`Layer dark context 2`] = `
 "@media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -968,12 +968,12 @@ exports[`Layer dark context 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1193,7 +1193,7 @@ exports[`Layer full false 1`] = `
 `;
 
 exports[`Layer full false 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1213,7 +1213,7 @@ exports[`Layer full false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -1221,12 +1221,12 @@ exports[`Layer full false 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1371,7 +1371,7 @@ exports[`Layer full horizontal 1`] = `
 `;
 
 exports[`Layer full horizontal 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1391,7 +1391,7 @@ exports[`Layer full horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -1399,12 +1399,12 @@ exports[`Layer full horizontal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1547,7 +1547,7 @@ exports[`Layer full true 1`] = `
 `;
 
 exports[`Layer full true 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1567,7 +1567,7 @@ exports[`Layer full true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -1575,12 +1575,12 @@ exports[`Layer full true 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1725,7 +1725,7 @@ exports[`Layer full vertical 1`] = `
 `;
 
 exports[`Layer full vertical 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1745,7 +1745,7 @@ exports[`Layer full vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -1753,12 +1753,12 @@ exports[`Layer full vertical 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1886,7 +1886,7 @@ exports[`Layer hidden 1`] = `
 
 exports[`Layer hidden 2`] = `
 "@media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -1894,12 +1894,12 @@ exports[`Layer hidden 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1921,15 +1921,15 @@ exports[`Layer hidden 2`] = `
 
 exports[`Layer hidden 3`] = `
 <div
-  class="StyledLayer-rmtehz-0 XIVyE"
+  class="StyledLayer-rmtehz-0 cmloDG"
   id="hidden-test"
   tabindex="-1"
 >
   <div
-    class="StyledLayer__StyledOverlay-rmtehz-1 TgNMj"
+    class="StyledLayer__StyledOverlay-rmtehz-1 itzAMd"
   />
   <div
-    class="StyledLayer__StyledContainer-rmtehz-2 cXCBJx"
+    class="StyledLayer__StyledContainer-rmtehz-2 fVIBQr"
     id="hidden-test"
   >
     <a
@@ -1943,7 +1943,7 @@ exports[`Layer hidden 3`] = `
 `;
 
 exports[`Layer hidden 4`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1963,7 +1963,7 @@ exports[`Layer hidden 4`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -1971,12 +1971,12 @@ exports[`Layer hidden 4`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2177,7 +2177,7 @@ exports[`Layer margin large 1`] = `
 `;
 
 exports[`Layer margin large 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2197,7 +2197,7 @@ exports[`Layer margin large 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -2205,12 +2205,12 @@ exports[`Layer margin large 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2354,7 +2354,7 @@ exports[`Layer margin medium 1`] = `
 `;
 
 exports[`Layer margin medium 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2374,7 +2374,7 @@ exports[`Layer margin medium 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -2382,12 +2382,12 @@ exports[`Layer margin medium 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2531,7 +2531,7 @@ exports[`Layer margin none 1`] = `
 `;
 
 exports[`Layer margin none 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2551,7 +2551,7 @@ exports[`Layer margin none 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -2559,12 +2559,12 @@ exports[`Layer margin none 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2708,7 +2708,7 @@ exports[`Layer margin small 1`] = `
 `;
 
 exports[`Layer margin small 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2728,7 +2728,7 @@ exports[`Layer margin small 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -2736,12 +2736,12 @@ exports[`Layer margin small 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2885,7 +2885,7 @@ exports[`Layer margin xsmall 1`] = `
 `;
 
 exports[`Layer margin xsmall 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2905,7 +2905,7 @@ exports[`Layer margin xsmall 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -2913,12 +2913,12 @@ exports[`Layer margin xsmall 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3015,7 +3015,7 @@ exports[`Layer non-modal 1`] = `
 
 exports[`Layer non-modal 2`] = `
 "@media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -3023,12 +3023,12 @@ exports[`Layer non-modal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3251,7 +3251,7 @@ exports[`Layer plain 1`] = `
 `;
 
 exports[`Layer plain 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3271,7 +3271,7 @@ exports[`Layer plain 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -3279,12 +3279,12 @@ exports[`Layer plain 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3428,7 +3428,7 @@ exports[`Layer position bottom 1`] = `
 `;
 
 exports[`Layer position bottom 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3448,7 +3448,7 @@ exports[`Layer position bottom 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -3456,12 +3456,12 @@ exports[`Layer position bottom 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3605,7 +3605,7 @@ exports[`Layer position center 1`] = `
 `;
 
 exports[`Layer position center 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3625,7 +3625,7 @@ exports[`Layer position center 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -3633,12 +3633,12 @@ exports[`Layer position center 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3782,7 +3782,7 @@ exports[`Layer position end 1`] = `
 `;
 
 exports[`Layer position end 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3802,7 +3802,7 @@ exports[`Layer position end 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -3810,12 +3810,12 @@ exports[`Layer position end 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3959,7 +3959,7 @@ exports[`Layer position left 1`] = `
 `;
 
 exports[`Layer position left 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3979,7 +3979,7 @@ exports[`Layer position left 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -3987,12 +3987,12 @@ exports[`Layer position left 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4136,7 +4136,7 @@ exports[`Layer position right 1`] = `
 `;
 
 exports[`Layer position right 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4156,7 +4156,7 @@ exports[`Layer position right 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -4164,12 +4164,12 @@ exports[`Layer position right 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4313,7 +4313,7 @@ exports[`Layer position start 1`] = `
 `;
 
 exports[`Layer position start 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4333,7 +4333,7 @@ exports[`Layer position start 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -4341,12 +4341,12 @@ exports[`Layer position start 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4490,7 +4490,7 @@ exports[`Layer position top 1`] = `
 `;
 
 exports[`Layer position top 2`] = `
-".XIVyE {
+".cmloDG {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4510,7 +4510,7 @@ exports[`Layer position top 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -4518,12 +4518,12 @@ exports[`Layer position top 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4672,7 +4672,7 @@ exports[`Layer target 1`] = `
 
 exports[`Layer target 2`] = `
 "@media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -4680,12 +4680,12 @@ exports[`Layer target 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4786,7 +4786,7 @@ exports[`Layer target not modal 1`] = `
 
 exports[`Layer target not modal 2`] = `
 "@media only screen and (max-width: 768px) {
-  .XIVyE {
+  .cmloDG {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -4794,12 +4794,12 @@ exports[`Layer target not modal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .TgNMj {
+  .itzAMd {
     position: relative;
   }
 }
 @media only screen and (max-width: 768px) {
-  .gLOatX {
+  .dDeKKx {
     position: relative;
     max-height: none;
     max-width: none;

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -1,5 +1,6 @@
 import React, { useContext, useState } from 'react';
-import styled, { ThemeContext } from 'styled-components';
+import styled from 'styled-components/macro';
+import { ThemeContext } from 'styled-components';
 
 import { Box } from '../Box';
 import { InfiniteScroll } from '../InfiniteScroll';

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -1598,20 +1598,20 @@ exports[`List events Enter key 1`] = `
 
 exports[`List events Enter key 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <ul
-    class="List__StyledList-sc-130gdqg-0 ejwoGX"
+    class="List__StyledList-sc-130gdqg-0 kjYZw"
     tabindex="0"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 hRnMDt List__StyledItem-sc-130gdqg-1 fBniOQ"
+      class="StyledBox-sc-13pk1d4-0 gzxQla List__StyledItem-sc-130gdqg-1 fBniOQ"
       tabindex="-1"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 hEstNb List__StyledItem-sc-130gdqg-1 fBniOQ"
+      class="StyledBox-sc-13pk1d4-0 gABSTY List__StyledItem-sc-130gdqg-1 fBniOQ"
       tabindex="-1"
     >
       beta
@@ -1772,20 +1772,20 @@ exports[`List events focus and blur 1`] = `
 
 exports[`List events focus and blur 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <ul
-    class="List__StyledList-sc-130gdqg-0 ejwoGX"
+    class="List__StyledList-sc-130gdqg-0 kjYZw"
     tabindex="0"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 hRnMDt List__StyledItem-sc-130gdqg-1 fBniOQ"
+      class="StyledBox-sc-13pk1d4-0 gzxQla List__StyledItem-sc-130gdqg-1 fBniOQ"
       tabindex="-1"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 fbIRTP List__StyledItem-sc-130gdqg-1 fBniOQ"
+      class="StyledBox-sc-13pk1d4-0 kbeHxG List__StyledItem-sc-130gdqg-1 fBniOQ"
       tabindex="-1"
     >
       beta
@@ -1946,20 +1946,20 @@ exports[`List events mouse events 1`] = `
 
 exports[`List events mouse events 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <ul
-    class="List__StyledList-sc-130gdqg-0 ejwoGX"
+    class="List__StyledList-sc-130gdqg-0 kjYZw"
     tabindex="0"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 hRnMDt List__StyledItem-sc-130gdqg-1 fBniOQ"
+      class="StyledBox-sc-13pk1d4-0 gzxQla List__StyledItem-sc-130gdqg-1 fBniOQ"
       tabindex="-1"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 fbIRTP List__StyledItem-sc-130gdqg-1 fBniOQ"
+      class="StyledBox-sc-13pk1d4-0 kbeHxG List__StyledItem-sc-130gdqg-1 fBniOQ"
       tabindex="-1"
     >
       beta
@@ -2469,20 +2469,20 @@ exports[`List onClickItem 1`] = `
 
 exports[`List onClickItem 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <ul
-    class="List__StyledList-sc-130gdqg-0 ejwoGX"
+    class="List__StyledList-sc-130gdqg-0 kjYZw"
     tabindex="0"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 hRnMDt List__StyledItem-sc-130gdqg-1 fBniOQ"
+      class="StyledBox-sc-13pk1d4-0 gzxQla List__StyledItem-sc-130gdqg-1 fBniOQ"
       tabindex="-1"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 fbIRTP List__StyledItem-sc-130gdqg-1 fBniOQ"
+      class="StyledBox-sc-13pk1d4-0 kbeHxG List__StyledItem-sc-130gdqg-1 fBniOQ"
       tabindex="-1"
     >
       beta

--- a/src/js/components/Markdown/markdown.stories.js
+++ b/src/js/components/Markdown/markdown.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import { Box, Grommet, Markdown } from 'grommet';
 import { grommet } from 'grommet/themes';

--- a/src/js/components/MaskedInput/StyledMaskedInput.js
+++ b/src/js/components/MaskedInput/StyledMaskedInput.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import {
   disabledStyle,

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -645,7 +645,7 @@ exports[`MaskedInput event target props are available option via mouse 4`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 cDlpsY"
+    class="StyledMaskedInput-sc-99vkfa-0 cXWmON"
     data-testid="test-input"
     id="item"
     name="item"
@@ -1316,7 +1316,7 @@ exports[`MaskedInput next and previous without options 2`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 dqSfNA"
+    class="StyledMaskedInput-sc-99vkfa-0 bVuJBp"
     data-testid="test-input"
     id="item"
     name="item"
@@ -1668,7 +1668,7 @@ exports[`MaskedInput option via mouse 4`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 cDlpsY"
+    class="StyledMaskedInput-sc-99vkfa-0 cXWmON"
     data-testid="test-input"
     id="item"
     name="item"

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -5,7 +5,8 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import styled, { ThemeContext } from 'styled-components';
+import styled from 'styled-components/macro';
+import { ThemeContext } from 'styled-components';
 
 import PropTypes from 'react-desc/lib/PropTypes';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -608,7 +608,7 @@ exports[`Menu close by clicking outside 2`] = `
 
 exports[`Menu close by clicking outside 3`] = `
 "@media only screen and (max-width: 768px) {
-  .hkbjbd {
+  .gUIQOS {
     padding: 6px;
   }
 }"
@@ -2609,19 +2609,19 @@ exports[`Menu open and close on click 1`] = `
 
 exports[`Menu open and close on click 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <button
     aria-label="Open Menu"
-    class="StyledButton-sc-323bzc-0 jFJBys"
+    class="StyledButton-sc-323bzc-0 dRLPCJ"
     id="test-menu"
     type="button"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hkbjbd"
+      class="StyledBox-sc-13pk1d4-0 gUIQOS"
     >
       <span
-        class="StyledText-sc-1sadyjn-0 hUokoe"
+        class="StyledText-sc-1sadyjn-0 eBGtOg"
       >
         Test
       </span>
@@ -2978,7 +2978,7 @@ exports[`Menu open and close on click 3`] = `
 
 exports[`Menu open and close on click 4`] = `
 "@media only screen and (max-width: 768px) {
-  .hkbjbd {
+  .gUIQOS {
     padding: 6px;
   }
 }"
@@ -4122,7 +4122,7 @@ exports[`Menu with dropAlign renders 2`] = `
 
 exports[`Menu with dropAlign renders 3`] = `
 "@media only screen and (max-width: 768px) {
-  .hkbjbd {
+  .gUIQOS {
     padding: 6px;
   }
 }"

--- a/src/js/components/Meter/StyledMeter.js
+++ b/src/js/components/Meter/StyledMeter.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import { genericStyles } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/Paragraph/StyledParagraph.js
+++ b/src/js/components/Paragraph/StyledParagraph.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import { genericStyles, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/RadioButton/StyledRadioButton.js
+++ b/src/js/components/RadioButton/StyledRadioButton.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import { focusStyle, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/RangeInput/StyledRangeInput.js
+++ b/src/js/components/RangeInput/StyledRangeInput.js
@@ -1,5 +1,6 @@
 import { rgba } from 'polished';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import { focusStyle, normalizeColor, parseMetricToNum } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/RangeSelector/EdgeControl.js
+++ b/src/js/components/RangeSelector/EdgeControl.js
@@ -1,5 +1,6 @@
 import React, { forwardRef, useContext, useState } from 'react';
-import styled, { ThemeContext } from 'styled-components';
+import styled from 'styled-components/macro';
+import { ThemeContext } from 'styled-components';
 
 import { defaultProps } from '../../default-props';
 

--- a/src/js/components/RangeSelector/RangeSelector.js
+++ b/src/js/components/RangeSelector/RangeSelector.js
@@ -6,7 +6,8 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import styled, { ThemeContext } from 'styled-components';
+import styled from 'styled-components/macro';
+import { ThemeContext } from 'styled-components';
 
 import { Box } from '../Box';
 import { EdgeControl } from './EdgeControl';

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -8,7 +8,8 @@ import React, {
   useRef,
   useEffect,
 } from 'react';
-import styled, { ThemeContext } from 'styled-components';
+import styled from 'styled-components/macro';
+import { ThemeContext } from 'styled-components';
 
 import { controlBorderStyle, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -6,7 +6,8 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import styled, { ThemeContext } from 'styled-components';
+import styled from 'styled-components/macro';
+import { ThemeContext } from 'styled-components';
 
 import { selectedStyle, setFocusWithoutScroll } from '../../utils';
 

--- a/src/js/components/Select/StyledSelect.js
+++ b/src/js/components/Select/StyledSelect.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import { sizeStyle } from '../../utils';
 

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -1509,22 +1509,22 @@ exports[`Select complex options and children 1`] = `
 exports[`Select complex options and children 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 jFJBys Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
+  class="StyledButton-sc-323bzc-0 dRLPCJ Select__StyledSelectDropButton-sc-17idtfo-1 hkjMbD"
   id="test-select"
   type="button"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 VvbUh"
+    class="StyledBox-sc-13pk1d4-0 gWfleo"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bVYLzf"
+      class="StyledBox-sc-13pk1d4-0 bogiBm"
     >
       <div
         class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 fVbmbP Select__SelectTextInput-sc-17idtfo-0 hWmVID"
+          class="StyledTextInput-sc-1x30a0s-0 KPBDM Select__SelectTextInput-sc-17idtfo-0 hWmVID"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -1535,7 +1535,7 @@ exports[`Select complex options and children 2`] = `
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 iCDnTm"
+      class="StyledBox-sc-13pk1d4-0 idsnXD"
       style="min-width: auto;"
     >
       <svg
@@ -1759,7 +1759,7 @@ exports[`Select complex options and children 3`] = `
 
 exports[`Select complex options and children 4`] = `
 "@media only screen and (max-width: 768px) {
-  .iCDnTm {
+  .idsnXD {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -2018,23 +2018,23 @@ exports[`Select disabled 1`] = `
 exports[`Select disabled 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 bDZaCa Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
+  class="StyledButton-sc-323bzc-0 iAEwjN Select__StyledSelectDropButton-sc-17idtfo-1 hkjMbD"
   disabled=""
   id="test-select"
   type="button"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 VvbUh"
+    class="StyledBox-sc-13pk1d4-0 gWfleo"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bVYLzf"
+      class="StyledBox-sc-13pk1d4-0 bogiBm"
     >
       <div
         class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 fVbmbP Select__SelectTextInput-sc-17idtfo-0 hWmVID"
+          class="StyledTextInput-sc-1x30a0s-0 KPBDM Select__SelectTextInput-sc-17idtfo-0 hWmVID"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -2045,7 +2045,7 @@ exports[`Select disabled 2`] = `
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 iCDnTm"
+      class="StyledBox-sc-13pk1d4-0 idsnXD"
       style="min-width: auto;"
     >
       <svg
@@ -2613,7 +2613,7 @@ exports[`Select disabled key 2`] = `
 
 exports[`Select disabled key 3`] = `
 "@media only screen and (max-width: 768px) {
-  .iCDnTm {
+  .idsnXD {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -2908,7 +2908,7 @@ exports[`Select disabled option value 1`] = `
 
 exports[`Select disabled option value 2`] = `
 "@media only screen and (max-width: 768px) {
-  .iCDnTm {
+  .idsnXD {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -4539,7 +4539,7 @@ exports[`Select onChange with valueKey string 2`] = `
 
 exports[`Select onChange with valueKey string 3`] = `
 "@media only screen and (max-width: 768px) {
-  .iCDnTm {
+  .idsnXD {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -5053,7 +5053,7 @@ exports[`Select onChange without valueKey 2`] = `
 
 exports[`Select onChange without valueKey 3`] = `
 "@media only screen and (max-width: 768px) {
-  .iCDnTm {
+  .idsnXD {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -5834,22 +5834,22 @@ exports[`Select prop: onOpen 1`] = `
 exports[`Select prop: onOpen 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 jFJBys Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
+  class="StyledButton-sc-323bzc-0 dRLPCJ Select__StyledSelectDropButton-sc-17idtfo-1 hkjMbD"
   id="test-select"
   type="button"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 VvbUh"
+    class="StyledBox-sc-13pk1d4-0 gWfleo"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bVYLzf"
+      class="StyledBox-sc-13pk1d4-0 bogiBm"
     >
       <div
         class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 fVbmbP Select__SelectTextInput-sc-17idtfo-0 hWmVID"
+          class="StyledTextInput-sc-1x30a0s-0 KPBDM Select__SelectTextInput-sc-17idtfo-0 hWmVID"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -5860,7 +5860,7 @@ exports[`Select prop: onOpen 2`] = `
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 iCDnTm"
+      class="StyledBox-sc-13pk1d4-0 idsnXD"
       style="min-width: auto;"
     >
       <svg
@@ -6127,7 +6127,7 @@ exports[`Select prop: onOpen 3`] = `
 
 exports[`Select prop: onOpen 4`] = `
 "@media only screen and (max-width: 768px) {
-  .iCDnTm {
+  .idsnXD {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -6141,39 +6141,39 @@ exports[`Select prop: onOpen 5`] = `
   tabindex="-1"
 >
   <button
-    class="StyledButton-sc-323bzc-0 ynEro SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
+    class="StyledButton-sc-323bzc-0 gAioVD SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
     role="menuitem"
     tabindex="-1"
     type="button"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 lcXThF SelectContainer__OptionBox-sc-1wi0ul8-1 cjPAAw"
+      class="StyledBox-sc-13pk1d4-0 jSfGpK SelectContainer__OptionBox-sc-1wi0ul8-1 cjPAAw"
     >
       <span
-        class="StyledText-sc-1sadyjn-0 bilRua"
+        class="StyledText-sc-1sadyjn-0 jzejvm"
       >
         one
       </span>
     </div>
   </button>
   <button
-    class="StyledButton-sc-323bzc-0 ynEro SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
+    class="StyledButton-sc-323bzc-0 gAioVD SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
     role="menuitem"
     tabindex="-1"
     type="button"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 lcXThF SelectContainer__OptionBox-sc-1wi0ul8-1 cjPAAw"
+      class="StyledBox-sc-13pk1d4-0 jSfGpK SelectContainer__OptionBox-sc-1wi0ul8-1 cjPAAw"
     >
       <span
-        class="StyledText-sc-1sadyjn-0 bilRua"
+        class="StyledText-sc-1sadyjn-0 jzejvm"
       >
         two
       </span>
     </div>
   </button>
   <div
-    class="StyledBox-sc-13pk1d4-0 bokQlS"
+    class="StyledBox-sc-13pk1d4-0 hWPwaP"
   />
 </div>
 `;
@@ -6696,25 +6696,25 @@ exports[`Select renders custom up and down icons 1`] = `
 
 exports[`Select renders custom up and down icons 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <button
     aria-label="Open Drop"
-    class="StyledButton-sc-323bzc-0 jFJBys Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
+    class="StyledButton-sc-323bzc-0 dRLPCJ Select__StyledSelectDropButton-sc-17idtfo-1 hkjMbD"
     type="button"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 VvbUh"
+      class="StyledBox-sc-13pk1d4-0 gWfleo"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bVYLzf"
+        class="StyledBox-sc-13pk1d4-0 bogiBm"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP Select__SelectTextInput-sc-17idtfo-0 hWmVID"
+            class="StyledTextInput-sc-1x30a0s-0 KPBDM Select__SelectTextInput-sc-17idtfo-0 hWmVID"
             placeholder="Select..."
             readonly=""
             tabindex="-1"
@@ -6724,7 +6724,7 @@ exports[`Select renders custom up and down icons 2`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 iCDnTm"
+        class="StyledBox-sc-13pk1d4-0 idsnXD"
         style="min-width: auto;"
       >
         .c0 {
@@ -8619,7 +8619,7 @@ exports[`Select search 2`] = `
 
 exports[`Select search 3`] = `
 "@media only screen and (max-width: 768px) {
-  .iCDnTm {
+  .idsnXD {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -8629,7 +8629,7 @@ exports[`Select search 3`] = `
 exports[`Select search 4`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 fFeaOm"
+  class="StyledTextInput-sc-1x30a0s-0 cpRBxV"
   type="search"
   value=""
 />
@@ -8638,7 +8638,7 @@ exports[`Select search 4`] = `
 exports[`Select search 5`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 fFeaOm"
+  class="StyledTextInput-sc-1x30a0s-0 cpRBxV"
   type="search"
   value="o"
 />

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -1016,7 +1016,7 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
 
 exports[`Select Controlled multiple onChange toggle with valueKey reduce 3`] = `
 "@media only screen and (max-width: 768px) {
-  .iCDnTm {
+  .idsnXD {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -1530,7 +1530,7 @@ exports[`Select Controlled multiple onChange with valueKey reduce 2`] = `
 
 exports[`Select Controlled multiple onChange with valueKey reduce 3`] = `
 "@media only screen and (max-width: 768px) {
-  .iCDnTm {
+  .idsnXD {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -2044,7 +2044,7 @@ exports[`Select Controlled multiple onChange with valueKey string 2`] = `
 
 exports[`Select Controlled multiple onChange with valueKey string 3`] = `
 "@media only screen and (max-width: 768px) {
-  .iCDnTm {
+  .idsnXD {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -2558,7 +2558,7 @@ exports[`Select Controlled multiple onChange without valueKey 2`] = `
 
 exports[`Select Controlled multiple onChange without valueKey 3`] = `
 "@media only screen and (max-width: 768px) {
-  .iCDnTm {
+  .idsnXD {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -2567,14 +2567,14 @@ exports[`Select Controlled multiple onChange without valueKey 3`] = `
 
 exports[`Select Controlled multiple onChange without valueKey 4`] = `
 <div
-  class="StyledBox-sc-13pk1d4-0 glPSfV StyledDrop-sc-16s5rx8-0 kQAKuZ"
+  class="StyledBox-sc-13pk1d4-0 kpkStw StyledDrop-sc-16s5rx8-0 jkSCsB"
   data-g-portal-id="0"
   id="test-select__drop"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ StyledSelect__StyledContainer-znp66n-0 evOFkc"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM StyledSelect__StyledContainer-znp66n-0 evOFkc"
     id="test-select__select-drop"
   >
     <div
@@ -2583,39 +2583,39 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
       tabindex="-1"
     >
       <button
-        class="StyledButton-sc-323bzc-0 ynEro SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
+        class="StyledButton-sc-323bzc-0 gAioVD SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
         role="menuitem"
         tabindex="-1"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 lcXThF SelectContainer__OptionBox-sc-1wi0ul8-1 cjPAAw"
+          class="StyledBox-sc-13pk1d4-0 jSfGpK SelectContainer__OptionBox-sc-1wi0ul8-1 cjPAAw"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 bilRua"
+            class="StyledText-sc-1sadyjn-0 jzejvm"
           >
             Value1
           </span>
         </div>
       </button>
       <button
-        class="StyledButton-sc-323bzc-0 ynEro SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
+        class="StyledButton-sc-323bzc-0 gAioVD SelectContainer__SelectOption-sc-1wi0ul8-2 kkPGyb"
         role="menuitem"
         tabindex="-1"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 lcXThF SelectContainer__OptionBox-sc-1wi0ul8-1 cjPAAw"
+          class="StyledBox-sc-13pk1d4-0 jSfGpK SelectContainer__OptionBox-sc-1wi0ul8-1 cjPAAw"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 bilRua"
+            class="StyledText-sc-1sadyjn-0 jzejvm"
           >
             Value2
           </span>
         </div>
       </button>
       <div
-        class="StyledBox-sc-13pk1d4-0 bokQlS"
+        class="StyledBox-sc-13pk1d4-0 hWPwaP"
       />
     </div>
   </div>
@@ -2624,7 +2624,7 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
 
 exports[`Select Controlled multiple onChange without valueKey 5`] = `
 "@media only screen and (max-width: 768px) {
-  .iCDnTm {
+  .idsnXD {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -2880,22 +2880,22 @@ exports[`Select Controlled multiple values 1`] = `
 exports[`Select Controlled multiple values 2`] = `
 <button
   aria-label="Open Drop"
-  class="StyledButton-sc-323bzc-0 jFJBys Select__StyledSelectDropButton-sc-17idtfo-1 ksCGpf"
+  class="StyledButton-sc-323bzc-0 dRLPCJ Select__StyledSelectDropButton-sc-17idtfo-1 hkjMbD"
   id="test-select"
   type="button"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 VvbUh"
+    class="StyledBox-sc-13pk1d4-0 gWfleo"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bVYLzf"
+      class="StyledBox-sc-13pk1d4-0 bogiBm"
     >
       <div
         class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 fVbmbP Select__SelectTextInput-sc-17idtfo-0 hWmVID"
+          class="StyledTextInput-sc-1x30a0s-0 KPBDM Select__SelectTextInput-sc-17idtfo-0 hWmVID"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -2906,7 +2906,7 @@ exports[`Select Controlled multiple values 2`] = `
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 iCDnTm"
+      class="StyledBox-sc-13pk1d4-0 idsnXD"
       style="min-width: auto;"
     >
       <svg
@@ -3178,7 +3178,7 @@ exports[`Select Controlled multiple values 3`] = `
 
 exports[`Select Controlled multiple values 4`] = `
 "@media only screen and (max-width: 768px) {
-  .iCDnTm {
+  .idsnXD {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -3692,7 +3692,7 @@ exports[`Select Controlled multiple with empty results 2`] = `
 
 exports[`Select Controlled multiple with empty results 3`] = `
 "@media only screen and (max-width: 768px) {
-  .iCDnTm {
+  .idsnXD {
     margin-left: 6px;
     margin-right: 6px;
   }

--- a/src/js/components/SkipLinkTarget/SkipLinkTarget.js
+++ b/src/js/components/SkipLinkTarget/SkipLinkTarget.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import { Anchor } from '../Anchor';
 

--- a/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
+++ b/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
@@ -79,12 +79,12 @@ exports[`SkipLink basic 1`] = `
 
 exports[`SkipLink basic 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div>
     <a
       aria-hidden="true"
-      class="StyledAnchor-sc-1rp7lwl-0 cfNrRd SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
+      class="StyledAnchor-sc-1rp7lwl-0 hycMvQ SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
       id="main"
       tabindex="-1"
     />
@@ -97,7 +97,7 @@ exports[`SkipLink basic 2`] = `
   <footer>
     <a
       aria-hidden="true"
-      class="StyledAnchor-sc-1rp7lwl-0 cfNrRd SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
+      class="StyledAnchor-sc-1rp7lwl-0 hycMvQ SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
       id="footer"
       tabindex="-1"
     />
@@ -111,12 +111,12 @@ exports[`SkipLink basic 2`] = `
 
 exports[`SkipLink basic 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div>
     <a
       aria-hidden="true"
-      class="StyledAnchor-sc-1rp7lwl-0 cfNrRd SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
+      class="StyledAnchor-sc-1rp7lwl-0 hycMvQ SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
       id="main"
       tabindex="-1"
     />
@@ -129,7 +129,7 @@ exports[`SkipLink basic 3`] = `
   <footer>
     <a
       aria-hidden="true"
-      class="StyledAnchor-sc-1rp7lwl-0 cfNrRd SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
+      class="StyledAnchor-sc-1rp7lwl-0 hycMvQ SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 iYKTUc"
       id="footer"
       tabindex="-1"
     />

--- a/src/js/components/Stack/StyledStack.js
+++ b/src/js/components/Stack/StyledStack.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import { genericStyles } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/Tab/StyledTab.js
+++ b/src/js/components/Tab/StyledTab.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import { genericStyles, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/Table/StyledTable.js
+++ b/src/js/components/Table/StyledTable.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import {
   backgroundStyle,

--- a/src/js/components/Tabs/StyledTabs.js
+++ b/src/js/components/Tabs/StyledTabs.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import { genericStyles } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -1076,27 +1076,27 @@ exports[`Tabs change to second tab 1`] = `
 
 exports[`Tabs change to second tab 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ StyledTabs-a4fwxl-2 gjpnHh"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM StyledTabs-a4fwxl-2 MjFAY"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 ewBYLf StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
+      class="StyledBox-sc-13pk1d4-0 dYPeyi StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
     >
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 iwzLzf StyledTab-sc-1nnwnsb-0 eWIFpw"
+          class="StyledBox-sc-13pk1d4-0 gfFuAA StyledTab-sc-1nnwnsb-0 cIqgkP"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 iBFVwz"
+            class="StyledText-sc-1sadyjn-0 ikKUvh"
           >
             Tab 1
           </span>
@@ -1105,15 +1105,15 @@ exports[`Tabs change to second tab 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fQtdUH StyledTab-sc-1nnwnsb-0 eWIFpw"
+          class="StyledBox-sc-13pk1d4-0 eGwVpM StyledTab-sc-1nnwnsb-0 cIqgkP"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 kJdDnV"
+            class="StyledText-sc-1sadyjn-0 fMTwEr"
           >
             Tab 2
           </span>
@@ -1835,27 +1835,27 @@ exports[`Tabs set on hover 1`] = `
 
 exports[`Tabs set on hover 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ StyledTabs-a4fwxl-2 gjpnHh"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM StyledTabs-a4fwxl-2 MjFAY"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 ewBYLf StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
+      class="StyledBox-sc-13pk1d4-0 dYPeyi StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fQtdUH StyledTab-sc-1nnwnsb-0 eWIFpw"
+          class="StyledBox-sc-13pk1d4-0 eGwVpM StyledTab-sc-1nnwnsb-0 cIqgkP"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 kJdDnV"
+            class="StyledText-sc-1sadyjn-0 fMTwEr"
           >
             Tab 1
           </span>
@@ -1864,15 +1864,15 @@ exports[`Tabs set on hover 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 iwzLzf StyledTab-sc-1nnwnsb-0 eWIFpw"
+          class="StyledBox-sc-13pk1d4-0 gfFuAA StyledTab-sc-1nnwnsb-0 cIqgkP"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 iBFVwz"
+            class="StyledText-sc-1sadyjn-0 ikKUvh"
           >
             Tab 2
           </span>
@@ -1892,27 +1892,27 @@ exports[`Tabs set on hover 2`] = `
 
 exports[`Tabs set on hover 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ StyledTabs-a4fwxl-2 gjpnHh"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM StyledTabs-a4fwxl-2 MjFAY"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 ewBYLf StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
+      class="StyledBox-sc-13pk1d4-0 dYPeyi StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fQtdUH StyledTab-sc-1nnwnsb-0 eWIFpw"
+          class="StyledBox-sc-13pk1d4-0 eGwVpM StyledTab-sc-1nnwnsb-0 cIqgkP"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 kJdDnV"
+            class="StyledText-sc-1sadyjn-0 fMTwEr"
           >
             Tab 1
           </span>
@@ -1921,15 +1921,15 @@ exports[`Tabs set on hover 3`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fQtdUH StyledTab-sc-1nnwnsb-0 eWIFpw"
+          class="StyledBox-sc-13pk1d4-0 eGwVpM StyledTab-sc-1nnwnsb-0 cIqgkP"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 jvLdFN"
+            class="StyledText-sc-1sadyjn-0 halWmz"
           >
             Tab 2
           </span>
@@ -1949,27 +1949,27 @@ exports[`Tabs set on hover 3`] = `
 
 exports[`Tabs set on hover 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ StyledTabs-a4fwxl-2 gjpnHh"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM StyledTabs-a4fwxl-2 MjFAY"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 ewBYLf StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
+      class="StyledBox-sc-13pk1d4-0 dYPeyi StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fQtdUH StyledTab-sc-1nnwnsb-0 eWIFpw"
+          class="StyledBox-sc-13pk1d4-0 eGwVpM StyledTab-sc-1nnwnsb-0 cIqgkP"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 kJdDnV"
+            class="StyledText-sc-1sadyjn-0 fMTwEr"
           >
             Tab 1
           </span>
@@ -1978,15 +1978,15 @@ exports[`Tabs set on hover 4`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fQtdUH StyledTab-sc-1nnwnsb-0 eWIFpw"
+          class="StyledBox-sc-13pk1d4-0 eGwVpM StyledTab-sc-1nnwnsb-0 cIqgkP"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 jvLdFN"
+            class="StyledText-sc-1sadyjn-0 halWmz"
           >
             Tab 2
           </span>
@@ -2006,27 +2006,27 @@ exports[`Tabs set on hover 4`] = `
 
 exports[`Tabs set on hover 5`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 bFwQzJ StyledTabs-a4fwxl-2 gjpnHh"
+    class="StyledBox-sc-13pk1d4-0 gzDuuM StyledTabs-a4fwxl-2 MjFAY"
     role="tablist"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 ewBYLf StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
+      class="StyledBox-sc-13pk1d4-0 dYPeyi StyledTabs__StyledTabsHeader-a4fwxl-0 fXJmvC"
     >
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 fQtdUH StyledTab-sc-1nnwnsb-0 eWIFpw"
+          class="StyledBox-sc-13pk1d4-0 eGwVpM StyledTab-sc-1nnwnsb-0 cIqgkP"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 kJdDnV"
+            class="StyledText-sc-1sadyjn-0 fMTwEr"
           >
             Tab 1
           </span>
@@ -2035,15 +2035,15 @@ exports[`Tabs set on hover 5`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 jFJBys"
+        class="StyledButton-sc-323bzc-0 dRLPCJ"
         role="tab"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 iwzLzf StyledTab-sc-1nnwnsb-0 eWIFpw"
+          class="StyledBox-sc-13pk1d4-0 gfFuAA StyledTab-sc-1nnwnsb-0 cIqgkP"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 iBFVwz"
+            class="StyledText-sc-1sadyjn-0 ikKUvh"
           >
             Tab 2
           </span>

--- a/src/js/components/Text/StyledText.js
+++ b/src/js/components/Text/StyledText.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import { genericStyles, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/TextArea/StyledTextArea.js
+++ b/src/js/components/TextArea/StyledTextArea.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import { disabledStyle, inputStyle } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/TextInput/StyledTextInput.js
+++ b/src/js/components/TextInput/StyledTextInput.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import {
   disabledStyle,

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -7,7 +7,8 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import styled, { ThemeContext } from 'styled-components';
+import styled from 'styled-components/macro';
+import { ThemeContext } from 'styled-components';
 
 import { defaultProps } from '../../default-props';
 

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -404,14 +404,14 @@ exports[`TextInput calls onSuggestionsClose 3`] = `""`;
 
 exports[`TextInput calls onSuggestionsClose 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 jfUATO"
+      class="StyledTextInput-sc-1x30a0s-0 NdZGr"
       data-testid="test-input"
       id="item"
       name="item"
@@ -909,14 +909,14 @@ exports[`TextInput close suggestion drop 3`] = `""`;
 
 exports[`TextInput close suggestion drop 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 jfUATO"
+      class="StyledTextInput-sc-1x30a0s-0 NdZGr"
       data-testid="test-input"
       id="item"
       name="item"
@@ -1348,14 +1348,14 @@ exports[`TextInput handles next and previous without suggestion 1`] = `
 
 exports[`TextInput handles next and previous without suggestion 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 hsswYj"
+      class="StyledTextInput-sc-1x30a0s-0 cELTAe"
       data-testid="test-input"
       id="item"
       name="item"
@@ -2472,14 +2472,14 @@ exports[`TextInput select suggestion 3`] = `""`;
 
 exports[`TextInput select suggestion 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 ksQrmr"
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 deAfJe"
+      class="StyledTextInput-sc-1x30a0s-0 dFyNxH"
       data-testid="test-input"
       id="item"
       name="item"

--- a/src/js/components/Video/StyledVideo.js
+++ b/src/js/components/Video/StyledVideo.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components/macro';
+import { css } from 'styled-components';
 
 import { genericStyles, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -1349,10 +1349,10 @@ exports[`Video Play and Pause event handlers 1`] = `
 
 exports[`Video Play and Pause event handlers 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+  class="StyledGrommet-sc-19lkkz7-0 kEDHfZ"
 >
   <div
-    class="StyledVideo__StyledVideoContainer-w4v8h9-1 hHffIs"
+    class="StyledVideo__StyledVideoContainer-w4v8h9-1 bjLVkT"
   >
     <video
       class="StyledVideo-w4v8h9-0 dgNywu"
@@ -1367,10 +1367,10 @@ exports[`Video Play and Pause event handlers 2`] = `
       class="StyledVideo__StyledVideoControls-w4v8h9-2 hEQzIv"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 kVoZgG"
+        class="StyledBox-sc-13pk1d4-0 gwZIsB"
       >
         <button
-          class="StyledButton-sc-323bzc-0 WEFIC"
+          class="StyledButton-sc-323bzc-0 cIcNvl"
           type="button"
         >
           .c0 {
@@ -1429,20 +1429,20 @@ exports[`Video Play and Pause event handlers 2`] = `
           </svg>
         </button>
         <div
-          class="StyledBox-sc-13pk1d4-0 cGtqlv"
+          class="StyledBox-sc-13pk1d4-0 lhDLgi"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 jwQkzn"
+            class="StyledBox-sc-13pk1d4-0 jHgdMy"
           >
             <div
-              class="StyledStack-ajspsk-0 liEjfH"
+              class="StyledStack-ajspsk-0 MouK"
             >
               <div
                 class="StyledStack__StyledStackLayer-ajspsk-1 eFfYoG"
               >
                 <svg
                   aria-label="video progress"
-                  class="StyledMeter-nsxarx-0 bPssvJ"
+                  class="StyledMeter-nsxarx-0 dDlnEC"
                   height="12"
                   preserveAspectRatio="none"
                   viewBox="0 0 288 12"
@@ -1470,10 +1470,10 @@ exports[`Video Play and Pause event handlers 2`] = `
             </div>
           </div>
           <div
-            class="StyledBox-sc-13pk1d4-0 iEnXND"
+            class="StyledBox-sc-13pk1d4-0 lhNYay"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bilRua"
+              class="StyledText-sc-1sadyjn-0 jzejvm"
             >
               NaN:NaN
             </span>
@@ -1481,14 +1481,14 @@ exports[`Video Play and Pause event handlers 2`] = `
         </div>
         <button
           aria-label="open menu"
-          class="StyledButton-sc-323bzc-0 jFJBys"
+          class="StyledButton-sc-323bzc-0 dRLPCJ"
           type="button"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hkbjbd"
+            class="StyledBox-sc-13pk1d4-0 gUIQOS"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 hUokoe"
+              class="StyledText-sc-1sadyjn-0 eBGtOg"
             />
             <svg
               aria-label="Actions"

--- a/src/js/components/WorldMap/StyledWorldMap.js
+++ b/src/js/components/WorldMap/StyledWorldMap.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import { genericStyles } from '../../utils';
 import { defaultProps } from '../../default-props';

--- a/storybook/.babelrc
+++ b/storybook/.babelrc
@@ -11,7 +11,7 @@
     ["@babel/plugin-proposal-pipeline-operator", { "proposal": "minimal" }],
     ["@babel/plugin-proposal-nullish-coalescing-operator", { "loose": false }],
     "@babel/plugin-proposal-do-expressions",
-    ["styled-components", { "useDisplayName": false }],
+    "macros",
     ["transform-imports", {
       "grommet-icons/contexts": {
         "transform": "grommet-icons/es6/contexts/${member}",

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,15 +42,15 @@
     semver "^5.5.0"
 
 "@babel/core@^7.1.0", "@babel/core@^7.3.4", "@babel/core@^7.4.5", "@babel/core@^7.7.5":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.1.tgz#2c55b604e73a40dc21b0e52650b11c65cf276643"
-  integrity sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==
+  version "7.11.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.4.tgz#4301dfdfafa01eeb97f1896c5501a3f0655d4229"
+  integrity sha512-5deljj5HlqRXN+5oJTY7Zs37iH3z3b++KjiKtIsJy1NrjOOVSEaJHEetLBhyu0aQOSNNZ/0IuEAan9GzRuDXHg==
   dependencies:
     "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.11.0"
+    "@babel/generator" "^7.11.4"
     "@babel/helper-module-transforms" "^7.11.0"
     "@babel/helpers" "^7.10.4"
-    "@babel/parser" "^7.11.1"
+    "@babel/parser" "^7.11.4"
     "@babel/template" "^7.10.4"
     "@babel/traverse" "^7.11.0"
     "@babel/types" "^7.11.0"
@@ -63,10 +63,10 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.11.0", "@babel/generator@^7.4.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.11.0.tgz#4b90c78d8c12825024568cbe83ee6c9af193585c"
-  integrity sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==
+"@babel/generator@^7.11.0", "@babel/generator@^7.11.4", "@babel/generator@^7.4.0":
+  version "7.11.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.11.4.tgz#1ec7eec00defba5d6f83e50e3ee72ae2fee482be"
+  integrity sha512-Rn26vueFx0eOoz7iifCN2UHT6rGtnkSGWSoDRIy8jZN3B91PzeSULbswfLoOWuTuAcNwpG/mxy+uCTDnZ9Mp1g==
   dependencies:
     "@babel/types" "^7.11.0"
     jsesc "^2.5.1"
@@ -146,11 +146,10 @@
     lodash "^4.17.19"
 
 "@babel/helper-explode-assignable-expression@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.4.tgz#40a1cd917bff1288f699a94a75b37a1a2dbd8c7c"
-  integrity sha512-4K71RyRQNPRrR85sr5QY4X3VwG4wtVoXZB9+L3r1Gp38DhELyHCtovqydRi7c1Ovb17eRGiQ/FD5s8JdU0Uy5A==
+  version "7.11.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.11.4.tgz#2d8e3470252cc17aba917ede7803d4a7a276a41b"
+  integrity sha512-ux9hm3zR4WV1Y3xXxXkdG/0gxF9nvI0YVmKVhvK9AfMoaQkemL3sJpXw+Xbz65azo8qJiEz2XVDUpK3KYhH3ZQ==
   dependencies:
-    "@babel/traverse" "^7.10.4"
     "@babel/types" "^7.10.4"
 
 "@babel/helper-function-name@^7.10.4":
@@ -223,14 +222,13 @@
     lodash "^4.17.19"
 
 "@babel/helper-remap-async-to-generator@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.4.tgz#fce8bea4e9690bbe923056ded21e54b4e8b68ed5"
-  integrity sha512-86Lsr6NNw3qTNl+TBcF1oRZMaVzJtbWTyTko+CQL/tvNvcGYEFKbLXDPxtW0HKk3McNOk4KzY55itGWCAGK5tg==
+  version "7.11.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.11.4.tgz#4474ea9f7438f18575e30b0cac784045b402a12d"
+  integrity sha512-tR5vJ/vBa9wFy3m5LLv2faapJLnDFxNWff2SAYkSE4rLUdbp7CdObYFgI7wK4T/Mj4UzpjPwzR8Pzmr5m7MHGA==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.10.4"
     "@babel/helper-wrap-function" "^7.10.4"
     "@babel/template" "^7.10.4"
-    "@babel/traverse" "^7.10.4"
     "@babel/types" "^7.10.4"
 
 "@babel/helper-replace-supers@^7.10.4":
@@ -312,10 +310,10 @@
     resolve "^1.13.1"
     v8flags "^3.1.1"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.0", "@babel/parser@^7.11.1", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0":
-  version "7.11.3"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.3.tgz#9e1eae46738bcd08e23e867bab43e7b95299a8f9"
-  integrity sha512-REo8xv7+sDxkKvoxEywIdsNFiZLybwdI7hcT5uEPyQrSMB4YQ973BfC9OOrD/81MaIjh6UxdulIQXkjmiH3PcA==
+"@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.0", "@babel/parser@^7.11.4", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0":
+  version "7.11.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.4.tgz#6fa1a118b8b0d80d0267b719213dc947e88cc0ca"
+  integrity sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==
 
 "@babel/plugin-proposal-async-generator-functions@^7.10.4":
   version "7.10.5"
@@ -980,9 +978,9 @@
     "@babel/plugin-transform-flow-strip-types" "^7.10.4"
 
 "@babel/preset-modules@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.3.tgz#13242b53b5ef8c883c3cf7dddd55b36ce80fbc72"
-  integrity sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.4.tgz#362f2b68c662842970fdb5e254ffc8fc1c2e415e"
+  integrity sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-proposal-unicode-property-regex" "^7.4.4"
@@ -1096,9 +1094,9 @@
     "@emotion/weak-memoize" "0.2.5"
 
 "@emotion/core@^10.0.20", "@emotion/core@^10.0.7":
-  version "10.0.34"
-  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.34.tgz#a643889dc32bdde829482539c9438a026631187c"
-  integrity sha512-Kcs8WHZG1NgaVFQsSpgN07G0xpfPAKUclwKvUqKrYrJovezl9uTz++1M4JfXHrgFVEiJ5QO46hMo1ZDDfvY/tw==
+  version "10.0.35"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.35.tgz#513fcf2e22cd4dfe9d3894ed138c9d7a859af9b3"
+  integrity sha512-sH++vJCdk025fBlRZSAhkRlSUoqSqgCzYf5fMOmqqi3bM6how+sQpg3hkgJonj8GxXM4WbD7dRO+4tegDB9fUw==
   dependencies:
     "@babel/runtime" "^7.5.5"
     "@emotion/cache" "^10.0.27"
@@ -1513,15 +1511,15 @@
     type-detect "4.0.8"
 
 "@storybook/addon-storysource@^5.3.19":
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-storysource/-/addon-storysource-5.3.19.tgz#ae693e88db5d220cb256a9ef4a2366c300e8d88c"
-  integrity sha512-W7mIAHuxYT+b1huaHCHLkBAh2MbeWmF8CxeBCFiOgZaYYQUTDEh018HJF8u2AqiWSouRhcfzhTnGxOo0hNRBgw==
+  version "5.3.21"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-storysource/-/addon-storysource-5.3.21.tgz#1c958f0b91128cc1d0410c0660422adfe3b876fb"
+  integrity sha512-xndADOr74/Jf6Dy5bzV/cxmmXZBk4nted5O2fPGGnNIyvG24TPnJcQvPQfiHcC1Br/wW3HMgBcyQp3cT+UhXcg==
   dependencies:
-    "@storybook/addons" "5.3.19"
-    "@storybook/components" "5.3.19"
-    "@storybook/router" "5.3.19"
-    "@storybook/source-loader" "5.3.19"
-    "@storybook/theming" "5.3.19"
+    "@storybook/addons" "5.3.21"
+    "@storybook/components" "5.3.21"
+    "@storybook/router" "5.3.21"
+    "@storybook/source-loader" "5.3.21"
+    "@storybook/theming" "5.3.21"
     core-js "^3.0.1"
     estraverse "^4.2.0"
     loader-utils "^1.2.3"
@@ -1531,31 +1529,31 @@
     regenerator-runtime "^0.13.3"
     util-deprecate "^1.0.2"
 
-"@storybook/addons@5.3.19", "@storybook/addons@^5.3.19":
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-5.3.19.tgz#3a7010697afd6df9a41b8c8a7351d9a06ff490a4"
-  integrity sha512-Ky/k22p6i6FVNvs1VhuFyGvYJdcp+FgXqFgnPyY/OXJW/vPDapdElpTpHJZLFI9I2FQBDcygBPU5RXkumQ+KUQ==
+"@storybook/addons@5.3.21", "@storybook/addons@^5.3.19":
+  version "5.3.21"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-5.3.21.tgz#ee312c738c33e8c34dc11777ef93522c3c36e56a"
+  integrity sha512-Ji/21WADTLVbTbiKcZ64BcL0Es+h1Afxx3kNmGJqPSTUYroCwIFCT9mUzCqU6G+YyWaISAmTii5UJkTwMkChwA==
   dependencies:
-    "@storybook/api" "5.3.19"
-    "@storybook/channels" "5.3.19"
-    "@storybook/client-logger" "5.3.19"
-    "@storybook/core-events" "5.3.19"
+    "@storybook/api" "5.3.21"
+    "@storybook/channels" "5.3.21"
+    "@storybook/client-logger" "5.3.21"
+    "@storybook/core-events" "5.3.21"
     core-js "^3.0.1"
     global "^4.3.2"
     util-deprecate "^1.0.2"
 
-"@storybook/api@5.3.19":
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-5.3.19.tgz#77f15e9e2eee59fe1ddeaba1ef39bc34713a6297"
-  integrity sha512-U/VzDvhNCPmw2igvJYNNM+uwJCL+3teiL6JmuoL4/cmcqhI6IqqG9dZmMP1egoCd19wXEP7rnAfB/VcYVg41dQ==
+"@storybook/api@5.3.21":
+  version "5.3.21"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-5.3.21.tgz#8f1772de53b65e1a65d2f0257463d621a8617c58"
+  integrity sha512-K1o4an/Rx8daKRDooks6qzN6ZGyqizeacZZbair3F8CsSfTgrr2zCcf9pgKojLQa9koEmMHlcdb2KnS+GwPEgA==
   dependencies:
     "@reach/router" "^1.2.1"
-    "@storybook/channels" "5.3.19"
-    "@storybook/client-logger" "5.3.19"
-    "@storybook/core-events" "5.3.19"
+    "@storybook/channels" "5.3.21"
+    "@storybook/client-logger" "5.3.21"
+    "@storybook/core-events" "5.3.21"
     "@storybook/csf" "0.0.1"
-    "@storybook/router" "5.3.19"
-    "@storybook/theming" "5.3.19"
+    "@storybook/router" "5.3.21"
+    "@storybook/theming" "5.3.21"
     "@types/reach__router" "^1.2.3"
     core-js "^3.0.1"
     fast-deep-equal "^2.0.1"
@@ -1570,34 +1568,34 @@
     telejson "^3.2.0"
     util-deprecate "^1.0.2"
 
-"@storybook/channel-postmessage@5.3.19":
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-5.3.19.tgz#ef9fe974c2a529d89ce342ff7acf5cc22805bae9"
-  integrity sha512-Iq0f4NPHR0UVVFCWt0cI7Myadk4/SATXYJPT6sv95KhnLjKEeYw571WBlThfp8a9FM80887xG+eIRe93c8dleA==
+"@storybook/channel-postmessage@5.3.21":
+  version "5.3.21"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-5.3.21.tgz#9c08bf1c108ff973dbca18e582680d25178db1d4"
+  integrity sha512-CfoP7aEbZtJ35R9zeujMRdIwprETUi+Ve+y84DhXYQ2uJ0rR3vO4zHLZnxMMyJ5VnYOfuO042uch07+EKBz40Q==
   dependencies:
-    "@storybook/channels" "5.3.19"
-    "@storybook/client-logger" "5.3.19"
+    "@storybook/channels" "5.3.21"
+    "@storybook/client-logger" "5.3.21"
     core-js "^3.0.1"
     global "^4.3.2"
     telejson "^3.2.0"
 
-"@storybook/channels@5.3.19":
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-5.3.19.tgz#65ad7cd19d70aa5eabbb2e5e39ceef5e510bcb7f"
-  integrity sha512-38seaeyshRGotTEZJppyYMg/Vx2zRKgFv1L6uGqkJT0LYoNSYtJhsiNFCJ2/KUJu2chAJ/j8h80bpVBVLQ/+WA==
+"@storybook/channels@5.3.21":
+  version "5.3.21"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-5.3.21.tgz#53ba622b171d68b3b102983a62aa05149a49497b"
+  integrity sha512-OXoFs9XtBVg/cCk6lYMrxkzaNlJRf54ABdorp7YAAj7S9tRL1JxOZHxmjNQwEoiRvssmem2rAWtEAxfuEANsAA==
   dependencies:
     core-js "^3.0.1"
 
-"@storybook/client-api@5.3.19":
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-5.3.19.tgz#7a5630bb8fffb92742b1773881e9004ee7fdf8e0"
-  integrity sha512-Dh8ZLrLH91j9Fa28Gmp0KFUvvgK348aNMrDNAUdj4m4witz/BWQ2pxz6qq9/xFVErk/GanVC05kazGElqgYCRQ==
+"@storybook/client-api@5.3.21":
+  version "5.3.21"
+  resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-5.3.21.tgz#5b218a28f24219c32ab4b92a6af2a3e452fb8089"
+  integrity sha512-vS4DfA2Avvl7JNQymO4e3RUNoTWIGVfZJ70Irnd6PTAZNojbCXTYuigDavrmyf83F3g5rQpwmSAPjuoi/X/FRA==
   dependencies:
-    "@storybook/addons" "5.3.19"
-    "@storybook/channel-postmessage" "5.3.19"
-    "@storybook/channels" "5.3.19"
-    "@storybook/client-logger" "5.3.19"
-    "@storybook/core-events" "5.3.19"
+    "@storybook/addons" "5.3.21"
+    "@storybook/channel-postmessage" "5.3.21"
+    "@storybook/channels" "5.3.21"
+    "@storybook/client-logger" "5.3.21"
+    "@storybook/core-events" "5.3.21"
     "@storybook/csf" "0.0.1"
     "@types/webpack-env" "^1.15.0"
     core-js "^3.0.1"
@@ -1611,20 +1609,20 @@
     ts-dedent "^1.1.0"
     util-deprecate "^1.0.2"
 
-"@storybook/client-logger@5.3.19":
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-5.3.19.tgz#fbbd186e82102eaca1d6a5cca640271cae862921"
-  integrity sha512-nHftT9Ow71YgAd2/tsu79kwKk30mPuE0sGRRUHZVyCRciGFQweKNOS/6xi2Aq+WwBNNjPKNlbgxwRt1yKe1Vkg==
+"@storybook/client-logger@5.3.21":
+  version "5.3.21"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-5.3.21.tgz#912c83b0d358e70acad1ad4abe199de4c38b109f"
+  integrity sha512-OzQkwpZ5SK9cXD9Mv6lxPGPot+hSZvnkEW12kpt1AHfJz4ET26YTDOI3oetPsjfRJo6qYLeQX8+wF7rklfXbzA==
   dependencies:
     core-js "^3.0.1"
 
-"@storybook/components@5.3.19":
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-5.3.19.tgz#aac1f9eea1247cc85bd93b10fca803876fb84a6b"
-  integrity sha512-3g23/+ktlocaHLJKISu9Neu3XKa6aYP2ctDYkRtGchSB0Q55hQsUVGO+BEVuT7Pk2D59mVCxboBjxcRoPUY4pw==
+"@storybook/components@5.3.21":
+  version "5.3.21"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-5.3.21.tgz#17ee371a2455c6e807c3d3135a9266e63ad7651a"
+  integrity sha512-42QQk6qZl6wrtajP8yNCfmNS2t8Iod5QY+4V/l6iNnnT9O+j6cWOlnO+ZyvjNv0Xm0zIOt+VyVjdkKh8FUjQmA==
   dependencies:
-    "@storybook/client-logger" "5.3.19"
-    "@storybook/theming" "5.3.19"
+    "@storybook/client-logger" "5.3.21"
+    "@storybook/theming" "5.3.21"
     "@types/react-syntax-highlighter" "11.0.4"
     "@types/react-textarea-autosize" "^4.3.3"
     core-js "^3.0.1"
@@ -1645,33 +1643,33 @@
     simplebar-react "^1.0.0-alpha.6"
     ts-dedent "^1.1.0"
 
-"@storybook/core-events@5.3.19":
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-5.3.19.tgz#18020cd52e0d8ef0973a8e9622a10d5f99796f79"
-  integrity sha512-lh78ySqMS7pDdMJAQAe35d1I/I4yPTqp09Cq0YIYOxx9BQZhah4DZTV1QIZt22H5p2lPb5MWLkWSxBaexZnz8A==
+"@storybook/core-events@5.3.21":
+  version "5.3.21"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-5.3.21.tgz#41d81c3f107302a032545fc86ff344230c04b9e9"
+  integrity sha512-/Zsm1sKAh6pzQv8jQUmuhM7nuM01ZljIRKy8p2HjPNlMjDB5yaRkBfyeAUXUg+qXNI6aHVWa4jGdPEdwwY4oLA==
   dependencies:
     core-js "^3.0.1"
 
-"@storybook/core@5.3.19":
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/@storybook/core/-/core-5.3.19.tgz#1e61f35c5148343a0c580f5d5efb77f3b4243a30"
-  integrity sha512-4EYzglqb1iD6x9gxtAYpRGwGP6qJGiU2UW4GiYrErEmeu6y6tkyaqW5AwGlIo9+6jAfwD0HjaK8afvjKTtmmMQ==
+"@storybook/core@5.3.21":
+  version "5.3.21"
+  resolved "https://registry.yarnpkg.com/@storybook/core/-/core-5.3.21.tgz#da963166ea24601f318266a3aa6bbc06fc8fb175"
+  integrity sha512-plD47WIsn/JoyRJDOpmH7N7mEMo/jiA8ZlOitLW55zYvzUn8UrVpRFpMYo91OJxiCT6JFoaEh3XtNdhbgUwnPA==
   dependencies:
     "@babel/plugin-proposal-class-properties" "^7.7.0"
     "@babel/plugin-proposal-object-rest-spread" "^7.6.2"
     "@babel/plugin-syntax-dynamic-import" "^7.2.0"
     "@babel/plugin-transform-react-constant-elements" "^7.2.0"
     "@babel/preset-env" "^7.4.5"
-    "@storybook/addons" "5.3.19"
-    "@storybook/channel-postmessage" "5.3.19"
-    "@storybook/client-api" "5.3.19"
-    "@storybook/client-logger" "5.3.19"
-    "@storybook/core-events" "5.3.19"
+    "@storybook/addons" "5.3.21"
+    "@storybook/channel-postmessage" "5.3.21"
+    "@storybook/client-api" "5.3.21"
+    "@storybook/client-logger" "5.3.21"
+    "@storybook/core-events" "5.3.21"
     "@storybook/csf" "0.0.1"
-    "@storybook/node-logger" "5.3.19"
-    "@storybook/router" "5.3.19"
-    "@storybook/theming" "5.3.19"
-    "@storybook/ui" "5.3.19"
+    "@storybook/node-logger" "5.3.21"
+    "@storybook/router" "5.3.21"
+    "@storybook/theming" "5.3.21"
+    "@storybook/ui" "5.3.21"
     airbnb-js-shims "^2.2.1"
     ansi-to-html "^0.6.11"
     autoprefixer "^9.7.2"
@@ -1738,10 +1736,10 @@
   dependencies:
     lodash "^4.17.15"
 
-"@storybook/node-logger@5.3.19":
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-5.3.19.tgz#c414e4d3781aeb06298715220012f552a36dff29"
-  integrity sha512-hKshig/u5Nj9fWy0OsyU04yqCxr0A9pydOHIassr4fpLAaePIN2YvqCqE2V+TxQHjZUnowSSIhbXrGt0DI5q2A==
+"@storybook/node-logger@5.3.21":
+  version "5.3.21"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-5.3.21.tgz#f11d45042bd57dc69e9037d8f374d9fd0aad8071"
+  integrity sha512-8xibncy873JXePCK5MC0qem1MKtWI1Lc4hv6rwURSwYpZtkO7yElay3XAFGUSfz8qFJkoDBmMTxBR3fp4Dln7g==
   dependencies:
     "@types/npmlog" "^4.1.2"
     chalk "^3.0.0"
@@ -1751,16 +1749,16 @@
     regenerator-runtime "^0.13.3"
 
 "@storybook/react@^5.3.19":
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-5.3.19.tgz#ad7e7a5538399e2794cdb5a1b844a2b77c10bd09"
-  integrity sha512-OBRUqol3YLQi/qE55x2pWkv4YpaAmmfj6/Km+7agx+og+oNQl0nnlXy7r27X/4j3ERczzURa5pJHtSjwiNaJNw==
+  version "5.3.21"
+  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-5.3.21.tgz#f7f364d3d3adc70746a12cf8b6614952f41d4bd0"
+  integrity sha512-A50F8dDZxyLGa/dE3q0Zxt7T5r9UbomoSclqw7oJTO9GI76QOu7GfsoWrEL2gTEDAmqXreLVQqGuTLQhBz0rlA==
   dependencies:
     "@babel/plugin-transform-react-constant-elements" "^7.6.3"
     "@babel/preset-flow" "^7.0.0"
     "@babel/preset-react" "^7.0.0"
-    "@storybook/addons" "5.3.19"
-    "@storybook/core" "5.3.19"
-    "@storybook/node-logger" "5.3.19"
+    "@storybook/addons" "5.3.21"
+    "@storybook/core" "5.3.21"
+    "@storybook/node-logger" "5.3.21"
     "@svgr/webpack" "^4.0.3"
     "@types/webpack-env" "^1.15.0"
     babel-plugin-add-react-displayname "^0.0.5"
@@ -1777,10 +1775,10 @@
     ts-dedent "^1.1.0"
     webpack "^4.33.0"
 
-"@storybook/router@5.3.19":
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-5.3.19.tgz#0f783b85658f99e4007f74347ad7ef17dbf7fc3a"
-  integrity sha512-yNClpuP7BXQlBTRf6Ggle3/R349/k6kvI5Aim4jf6X/2cFVg2pzBXDAF41imNm9PcvdxwabQLm6I48p7OvKr/w==
+"@storybook/router@5.3.21":
+  version "5.3.21"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-5.3.21.tgz#32b08e5daa90a6ffa024bb670b874525a712a901"
+  integrity sha512-c29m5UikK5Q1lyd6FltOGFhIcpd6PIb855YS3OUNe3F6ZA1tfJ+aNKrCBc65d1c+fvCGG76dYYYv0RvwEmKXXg==
   dependencies:
     "@reach/router" "^1.2.1"
     "@storybook/csf" "0.0.1"
@@ -1792,13 +1790,13 @@
     qs "^6.6.0"
     util-deprecate "^1.0.2"
 
-"@storybook/source-loader@5.3.19", "@storybook/source-loader@^5.3.19":
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/@storybook/source-loader/-/source-loader-5.3.19.tgz#ff0a00731c24c61721d8b9d84152f8542913a3b7"
-  integrity sha512-srSZRPgEOUse8nRVnlazweB2QGp63mPqM0uofg8zYARyaYSOzkC155ymdeiHsmiBTS3X3I0FQE4+KnwiH7iLtw==
+"@storybook/source-loader@5.3.21", "@storybook/source-loader@^5.3.19":
+  version "5.3.21"
+  resolved "https://registry.yarnpkg.com/@storybook/source-loader/-/source-loader-5.3.21.tgz#d5f8758fc6b2d9f0ca45e2ffbffa513d5151fd9e"
+  integrity sha512-kzaxvmWhRdkgp7a/XhsHxOB1D3XOkA8kmFahMAJD506hts8he+G2QSaj3BosOFCxa2OYAxbcIBs3JFyaXQGJ0A==
   dependencies:
-    "@storybook/addons" "5.3.19"
-    "@storybook/client-logger" "5.3.19"
+    "@storybook/addons" "5.3.21"
+    "@storybook/client-logger" "5.3.21"
     "@storybook/csf" "0.0.1"
     core-js "^3.0.1"
     estraverse "^4.2.0"
@@ -1808,14 +1806,14 @@
     prop-types "^15.7.2"
     regenerator-runtime "^0.13.3"
 
-"@storybook/theming@5.3.19":
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-5.3.19.tgz#177d9819bd64f7a1a6ea2f1920ffa5baf9a5f467"
-  integrity sha512-ecG+Rq3hc1GOzKHamYnD4wZ0PEP9nNg0mXbC3RhbxfHj+pMMCWWmx9B2Uu75SL1PTT8WcfkFO0hU/0IO84Pzlg==
+"@storybook/theming@5.3.21":
+  version "5.3.21"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-5.3.21.tgz#ae2dc101aa57c3be4df1724ae729e11bad118e0b"
+  integrity sha512-FZbxjizqdO9lV5LUixPio/7+6UdPiswCzTJn8Hcot9uwwgfnrViRdN7xyjmSYRqv9nHP3OlYbtdeCAgZ4aPq8g==
   dependencies:
     "@emotion/core" "^10.0.20"
     "@emotion/styled" "^10.0.17"
-    "@storybook/client-logger" "5.3.19"
+    "@storybook/client-logger" "5.3.21"
     core-js "^3.0.1"
     deep-object-diff "^1.1.0"
     emotion-theming "^10.0.19"
@@ -1826,20 +1824,20 @@
     resolve-from "^5.0.0"
     ts-dedent "^1.1.0"
 
-"@storybook/ui@5.3.19":
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-5.3.19.tgz#ac03b67320044a3892ee784111d4436b61874332"
-  integrity sha512-r0VxdWab49nm5tzwvveVDnsHIZHMR76veYOu/NHKDUZ5hnQl1LMG1YyMCFFa7KiwD/OrZxRWr6/Ma7ep9kR4Gw==
+"@storybook/ui@5.3.21":
+  version "5.3.21"
+  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-5.3.21.tgz#b42568e03353b47aaab1b6449311f38858585f81"
+  integrity sha512-OUf8JYY9LN+XfzLSZE6KtboITGDL6C8Z0W9QOXM5LJwFLv4PkANK/f9qsB5vVHFm7vhoO96butFzs6SjTKhxkw==
   dependencies:
     "@emotion/core" "^10.0.20"
-    "@storybook/addons" "5.3.19"
-    "@storybook/api" "5.3.19"
-    "@storybook/channels" "5.3.19"
-    "@storybook/client-logger" "5.3.19"
-    "@storybook/components" "5.3.19"
-    "@storybook/core-events" "5.3.19"
-    "@storybook/router" "5.3.19"
-    "@storybook/theming" "5.3.19"
+    "@storybook/addons" "5.3.21"
+    "@storybook/api" "5.3.21"
+    "@storybook/channels" "5.3.21"
+    "@storybook/client-logger" "5.3.21"
+    "@storybook/components" "5.3.21"
+    "@storybook/core-events" "5.3.21"
+    "@storybook/router" "5.3.21"
+    "@storybook/theming" "5.3.21"
     copy-to-clipboard "^3.0.8"
     core-js "^3.0.1"
     core-js-pure "^3.0.1"
@@ -1970,15 +1968,15 @@
     loader-utils "^1.2.3"
 
 "@testing-library/dom@*":
-  version "7.22.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.22.2.tgz#6deaa828500993cc94bdd62875c251b5b5b70d69"
-  integrity sha512-taxURh+4Lwr//uC1Eghat95aMnTlI4G4ETosnZK0wliwHWdutLDVKIvHXAOYdXGdzrBAy1wNhSGmNBbZ72ml4g==
+  version "7.23.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.23.0.tgz#c54c0fa53705ad867bcefb52fc0c96487fbc10f6"
+  integrity sha512-H5m090auYH+obdZmsaYLrSWC5OauWD2CvNbz88KBxQJoXgkJzbU0DpAG8BS7Evj5WqCC3nAAKrLS6vw0ljUYLg==
   dependencies:
     "@babel/runtime" "^7.10.3"
     "@types/aria-query" "^4.2.0"
     aria-query "^4.2.2"
-    dom-accessibility-api "^0.5.0"
-    pretty-format "^25.5.0"
+    dom-accessibility-api "^0.5.1"
+    pretty-format "^26.4.2"
 
 "@testing-library/dom@^6.1.0", "@testing-library/dom@^6.15.0":
   version "6.16.0"
@@ -2151,9 +2149,9 @@
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
 "@types/node@*":
-  version "14.0.27"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
-  integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
+  version "14.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.2.tgz#264b44c5a28dfa80198fc2f7b6d3c8a054b9491f"
+  integrity sha512-onlIwbaeqvZyniGPfdw/TEhKIh79pz66L1q06WUQqJLnAb6wbjvOtepLYTGHTqzdXgBYIE3ZdmqHDGsRsbBz7A==
 
 "@types/node@^13.5.0":
   version "13.13.15"
@@ -2206,9 +2204,9 @@
     "@types/react" "*"
 
 "@types/react-native@*":
-  version "0.63.8"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.8.tgz#73ec087122c64c309eeaf150b565b8d755f0fb1f"
-  integrity sha512-QRwGFRTyGafRVTUS+0GYyJrlpmS3boyBaFI0ULSc+mh/lQNxrzbdQvoL2k5X7+t9hxyqA4dTQAlP6l0ir/fNJQ==
+  version "0.63.11"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.11.tgz#0965552aa4cfe8a7c0c64f1afb1c101d2fa7510a"
+  integrity sha512-OjYwDiMZGENGd5P+su0OZY0t0ctTnmmToS/mJOAErktpZWqfDj99Q2hy3M09tQj+h2KnpsT+WUPozUKoossSxw==
   dependencies:
     "@types/react" "*"
 
@@ -2227,9 +2225,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.9.11":
-  version "16.9.46"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.46.tgz#f0326cd7adceda74148baa9bff6e918632f5069e"
-  integrity sha512-dbHzO3aAq1lB3jRQuNpuZ/mnu+CdD3H0WVaaBQA8LTT3S33xhVBUj232T8M3tAhSWJs/D/UqORYUlJNl/8VQZg==
+  version "16.9.48"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.48.tgz#d3387329f070d1b1bc0ff4a54a54ceefd5a8485c"
+  integrity sha512-4ykBVswgYitPGMXFRxJCHkxJDU2rjfU3/zw67f8+dB7sNdVJXsrwqoYxz/stkAucymnEEbRPFmX7Ce5Mc/kJCw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -2544,9 +2542,9 @@ address@1.1.2, address@^1.0.1:
   integrity sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
 
 aggregate-error@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
-  integrity sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
+  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
   dependencies:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
@@ -2585,9 +2583,9 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
 ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.3:
-  version "6.12.3"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
-  integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
+  version "6.12.4"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
+  integrity sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -2863,9 +2861,11 @@ ast-types@0.11.3:
   integrity sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA==
 
 ast-types@^0.13.2:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.3.tgz#50da3f28d17bdbc7969a3a2d83a0e4a72ae755a7"
-  integrity sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.4.tgz#ee0d77b343263965ecc3fb62da16e7222b2b6782"
+  integrity sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==
+  dependencies:
+    tslib "^2.0.1"
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -3125,7 +3125,7 @@ babel-plugin-jest-hoist@^25.5.0:
     "@babel/types" "^7.3.3"
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.7.0:
+babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.7.0, babel-plugin-macros@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
   integrity sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
@@ -3229,7 +3229,7 @@ babel-plugin-require-context-hook@^1.0.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-require-context-hook/-/babel-plugin-require-context-hook-1.0.0.tgz#3f0e7cce87c338f53639b948632fd4e73834632d"
   integrity sha512-EMZD1563QUqLhzrqcThk759RhuNVX/ZJdrtGK6drwzgvnR+ARjWyXIHPbu+tUNaMGtPz/gQeAM2M6VUw2UiUeA==
 
-"babel-plugin-styled-components@>= 1", babel-plugin-styled-components@^1.6.4:
+"babel-plugin-styled-components@>= 1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.11.1.tgz#5296a9e557d736c3186be079fff27c6665d63d76"
   integrity sha512-YwrInHyKUk1PU3avIRdiLyCpM++18Rs1NgyMXEAQC33rIXs/vro0A+stf4sT0Gf22Got+xRWB8Cm0tw+qkRzBA==
@@ -3431,9 +3431,9 @@ bindings@^1.5.0:
     file-uri-to-path "1.0.0"
 
 bl@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.2.tgz#52b71e9088515d0606d9dd9cc7aa48dc1f98e73a"
-  integrity sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
+  integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
   dependencies:
     buffer "^5.5.0"
     inherits "^2.0.4"
@@ -3457,9 +3457,9 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
   integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
 
 bn.js@^5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.2.tgz#c9686902d3c9a27729f43ab10f9d79c2004da7b0"
-  integrity sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
+  integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==
 
 body-parser@1.19.0:
   version "1.19.0"
@@ -3814,9 +3814,9 @@ can-use-dom@^0.1.0:
   integrity sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=
 
 caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001111:
-  version "1.0.30001113"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001113.tgz#22016ab55b5a8b04fa00ca342d9ee1b98df48065"
-  integrity sha512-qMvjHiKH21zzM/VDZr6oosO6Ri3U0V2tC015jRXjOecwQCJtsU5zklTNTk31jQbIOP8gha0h1ccM/g0ECP+4BA==
+  version "1.0.30001120"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001120.tgz#cd21d35e537214e19f7b9f4f161f7b0f2710d46c"
+  integrity sha512-JBP68okZs1X8D7MQTY602jxMYBmXEKOFkzTBaNSkubooMPFOAv2TXWaKle7qgHpjLDhUzA/TMT0qsNleVyXGUQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -4320,9 +4320,9 @@ copy-to-clipboard@^3.0.8:
     toggle-selection "^1.0.6"
 
 copy-webpack-plugin@^5.0.4:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz#5481a03dea1123d88a988c6ff8b78247214f0b88"
-  integrity sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-5.1.2.tgz#8a889e1dcafa6c91c6cd4be1ad158f1d3823bae2"
+  integrity sha512-Uh7crJAco3AjBvgAy9Z75CjK8IG+gxaErro71THQ+vv/bl4HaQcpkexAY8KVW/T6D2W2IRr+couF/knIRkZMIQ==
   dependencies:
     cacache "^12.0.3"
     find-cache-dir "^2.1.0"
@@ -4334,7 +4334,7 @@ copy-webpack-plugin@^5.0.4:
     normalize-path "^3.0.0"
     p-limit "^2.2.1"
     schema-utils "^1.0.0"
-    serialize-javascript "^2.1.2"
+    serialize-javascript "^4.0.0"
     webpack-log "^2.0.0"
 
 copyfiles@^2.3.0:
@@ -4627,9 +4627,9 @@ csstype@^2.5.7:
   integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
 
 csstype@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.2.tgz#ee5ff8f208c8cd613b389f7b222c9801ca62b3f7"
-  integrity sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.3.tgz#2b410bbeba38ba9633353aff34b05d9755d065f8"
+  integrity sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -4958,10 +4958,10 @@ dom-accessibility-api@^0.3.0:
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz#511e5993dd673b97c87ea47dba0e3892f7e0c983"
   integrity sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==
 
-dom-accessibility-api@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.0.tgz#fddffd04e178796e241436c3f21be2f89c91afac"
-  integrity sha512-eCVf9n4Ni5UQAFc2+fqfMPHdtiX7DA0rLakXgNBZfXNJzEbNo3MQIYd+zdYpFBqAaGYVrkd8leNSLGPrG4ODmA==
+dom-accessibility-api@^0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.2.tgz#ef3cdb5d3f0d599d8f9c8b18df2fb63c9793739d"
+  integrity sha512-k7hRNKAiPJXD2aBqfahSo4/01cTsKWXf+LqJgglnkN2Nz8TsxXKQBXHhKe0Ye9fEfHEZY49uSA5Sr3AqP/sWKA==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -5099,9 +5099,9 @@ ejs@^2.7.4:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.523:
-  version "1.3.533"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.533.tgz#d7e5ca4d57e9bc99af87efbe13e7be5dde729b0f"
-  integrity sha512-YqAL+NXOzjBnpY+dcOKDlZybJDCOzgsq4koW3fvyty/ldTmsb4QazZpOWmVvZ2m0t5jbBf7L0lIGU3BUipwG+A==
+  version "1.3.555"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.555.tgz#a096716ff77cf8da9a608eb628fd6927869503d2"
+  integrity sha512-/55x3nF2feXFZ5tdGUOr00TxnUjUgdxhrn+eCJ1FAcoAt+cKQTjQkUC5XF4frMWE1R5sjHk+JueuBalimfe5Pg==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -5227,6 +5227,24 @@ es-abstract@^1.17.0, es-abstract@^1.17.0-next.0, es-abstract@^1.17.0-next.1, es-
     is-callable "^1.2.0"
     is-regex "^1.1.0"
     object-inspect "^1.7.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.0"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
+
+es-abstract@^1.18.0-next.0:
+  version "1.18.0-next.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.0.tgz#b302834927e624d8e5837ed48224291f2c66e6fc"
+  integrity sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.0"
+    is-negative-zero "^2.0.0"
+    is-regex "^1.1.1"
+    object-inspect "^1.8.0"
     object-keys "^1.1.1"
     object.assign "^4.1.0"
     string.prototype.trimend "^1.0.1"
@@ -5565,9 +5583,9 @@ etag@~1.8.1:
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
 eventemitter3@^4.0.0:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.4.tgz#b5463ace635a083d018bdc7c917b4c5f10a85384"
-  integrity sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
 events@^3.0.0:
   version "3.2.0"
@@ -6743,9 +6761,9 @@ html-minifier-terser@^5.0.1:
     terser "^4.6.3"
 
 html-webpack-plugin@^4.0.0-beta.2:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.3.0.tgz#53bf8f6d696c4637d5b656d3d9863d89ce8174fd"
-  integrity sha512-C0fzKN8yQoVLTelcJxZfJCE+aAvQiY2VUf3UuKrR4a9k5UMWYOtpDLsaXwATbcVCnI05hUS7L9ULQHWLZhyi3w==
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.4.0.tgz#ed6ab2b5e4e476ffa3c5ce52505aa31a42075029"
+  integrity sha512-FHeg2JN9ar1kaR0SLgbF07w46o/n1nGszyByYlPxqEymSpl82vA8EX0leE67kZr3GJnOBh8BbBzmCLO6O1YTIQ==
   dependencies:
     "@types/html-minifier-terser" "^5.0.0"
     "@types/tapable" "^1.0.5"
@@ -7260,6 +7278,11 @@ is-map@^2.0.1:
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.1.tgz#520dafc4307bb8ebc33b813de5ce7c9400d644a1"
   integrity sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==
 
+is-negative-zero@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.0.tgz#9553b121b0fac28869da9ed459e20c7543788461"
+  integrity sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -7325,7 +7348,7 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
 
-is-regex@^1.0.4, is-regex@^1.1.0:
+is-regex@^1.0.4, is-regex@^1.1.0, is-regex@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
   integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
@@ -7596,15 +7619,15 @@ jest-diff@^25.5.0:
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
 
-jest-diff@^26.4.0:
-  version "26.4.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.4.0.tgz#d073a0a11952b5bd9f1ff39bb9ad24304a0c55f7"
-  integrity sha512-wwC38HlOW+iTq6j5tkj/ZamHn6/nrdcEOc/fKaVILNtN2NLWGdkfRaHWwfNYr5ehaLvuoG2LfCZIcWByVj0gjg==
+jest-diff@^26.4.2:
+  version "26.4.2"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.4.2.tgz#a1b7b303bcc534aabdb3bd4a7caf594ac059f5aa"
+  integrity sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==
   dependencies:
     chalk "^4.0.0"
     diff-sequences "^26.3.0"
     jest-get-type "^26.3.0"
-    pretty-format "^26.4.0"
+    pretty-format "^26.4.2"
 
 jest-docblock@^25.3.0:
   version "25.3.0"
@@ -7754,14 +7777,14 @@ jest-matcher-utils@^25.5.0:
     pretty-format "^25.5.0"
 
 jest-matcher-utils@^26.0.1:
-  version "26.4.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-26.4.0.tgz#2bce9a939e008b894faf1bd4b5bb58facd00c252"
-  integrity sha512-u+xdCdq+F262DH+PutJKXLGr2H5P3DImdJCir51PGSfi3TtbLQ5tbzKaN8BkXbiTIU6ayuAYBWTlU1nyckVdzA==
+  version "26.4.2"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz#fa81f3693f7cb67e5fc1537317525ef3b85f4b06"
+  integrity sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==
   dependencies:
     chalk "^4.0.0"
-    jest-diff "^26.4.0"
+    jest-diff "^26.4.2"
     jest-get-type "^26.3.0"
-    pretty-format "^26.4.0"
+    pretty-format "^26.4.2"
 
 jest-message-util@^24.9.0:
   version "24.9.0"
@@ -7935,9 +7958,9 @@ jest-snapshot@^25.5.1:
     semver "^6.3.0"
 
 jest-styled-components@^7.0.0:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-7.0.2.tgz#b7711871ea74a04491b12bad123fa35cc65a2a80"
-  integrity sha512-i1Qke8Jfgx0Why31q74ohVj9S2FmMLUE8bNRSoK4DgiurKkXG6HC4NPhcOLAz6VpVd9wXkPn81hOt4aAQedqsA==
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-7.0.3.tgz#cc0b031f910484e68f175568682f3969ff774b2c"
+  integrity sha512-jj9sWyshehUnB0P9WFUaq9Bkh6RKYO8aD8lf3gUrXRwg/MRddTFk7U9D9pC4IAI3v9fbz4vmrMxwaecTpG8NKA==
   dependencies:
     css "^2.2.4"
 
@@ -8088,6 +8111,11 @@ json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+
+json-parse-even-better-errors@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.0.tgz#371873c5ffa44304a6ba12419bcfa95f404ae081"
+  integrity sha512-o3aP+RsWDJZayj1SbHNQAI8x0v3T3SKiGoZlNYfbUP1S3omJQ6i9CnqADqkSPaOAxwua4/1YWx5CM7oiChJt2Q==
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -8986,9 +9014,9 @@ no-case@^3.0.3:
     tslib "^1.10.0"
 
 node-abi@^2.7.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.18.0.tgz#1f5486cfd7d38bd4f5392fa44a4ad4d9a0dffbf4"
-  integrity sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.19.1.tgz#6aa32561d0a5e2fdb6810d8c25641b657a8cea85"
+  integrity sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==
   dependencies:
     semver "^5.4.1"
 
@@ -9196,7 +9224,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.7.0:
+object-inspect@^1.7.0, object-inspect@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
@@ -9311,9 +9339,9 @@ open@^6.3.0:
     is-wsl "^1.1.0"
 
 open@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/open/-/open-7.1.0.tgz#68865f7d3cb238520fa1225a63cf28bcf8368a1c"
-  integrity sha512-lLPI5KgOwEYCDKXf4np7y1PBEkj7HYIyP2DY8mVDRnx0VIIu6bNrRB0R66TuO7Mack6EnTNLm4uvcl1UoklTpA==
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.2.1.tgz#07b0ade11a43f2a8ce718480bdf3d7563a095195"
+  integrity sha512-xbYCJib4spUdmcs0g/2mK1nKo/jO2T7INClWd/beL7PFkXRWgr8B23ssDHX/USPn2M2IjDR5UdpYs6I67SnTSA==
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
@@ -9497,13 +9525,13 @@ parse-json@^4.0.0:
     json-parse-better-errors "^1.0.1"
 
 parse-json@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.0.1.tgz#7cfe35c1ccd641bce3981467e6c2ece61b3b3878"
-  integrity sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.1.0.tgz#f96088cdf24a8faa9aea9a009f2d9d942c999646"
+  integrity sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     error-ex "^1.3.1"
-    json-parse-better-errors "^1.0.1"
+    json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
 parse-passwd@^1.0.0:
@@ -9718,9 +9746,9 @@ polished@^2.3.0:
     "@babel/runtime" "^7.2.0"
 
 polished@^3.3.1, polished@^3.4.1:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/polished/-/polished-3.6.5.tgz#dbefdde64c675935ec55119fe2a2ab627ca82e9c"
-  integrity sha512-VwhC9MlhW7O5dg/z7k32dabcAFW1VI2+7fSe8cE/kXcfL7mVdoa5UxciYGW2sJU78ldDLT6+ROEKIZKFNTnUXQ==
+  version "3.6.6"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-3.6.6.tgz#91ef9eface9be5366c07672b63b736f50c151185"
+  integrity sha512-yiB2ims2DZPem0kCD6V0wnhcVGFEhNh0Iw0axNpKU+oSAgFt6yx6HxIT23Qg0WWvgS379cS35zT4AOyZZRzpQQ==
   dependencies:
     "@babel/runtime" "^7.9.2"
 
@@ -9895,10 +9923,10 @@ pretty-format@^25.1.0, pretty-format@^25.5.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
-pretty-format@^26.4.0:
-  version "26.4.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.4.0.tgz#c08073f531429e9e5024049446f42ecc9f933a3b"
-  integrity sha512-mEEwwpCseqrUtuMbrJG4b824877pM5xald3AkilJ47Po2YLr97/siejYQHqj2oDQBeJNbu+Q0qUuekJ8F0NAPg==
+pretty-format@^26.4.2:
+  version "26.4.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.4.2.tgz#d081d032b398e801e2012af2df1214ef75a81237"
+  integrity sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==
   dependencies:
     "@jest/types" "^26.3.0"
     ansi-regex "^5.0.0"
@@ -10134,9 +10162,9 @@ querystring@0.2.0, querystring@^0.2.0:
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 querystringify@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
-  integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 quick-lru@^4.0.1:
   version "4.0.1"
@@ -10983,11 +11011,6 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
-  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
-
 serialize-javascript@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
@@ -11113,12 +11136,12 @@ shellwords@^0.1.1:
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
 side-channel@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.2.tgz#df5d1abadb4e4bf4af1cd8852bf132d2f7876947"
-  integrity sha512-7rL9YlPHg7Ancea1S96Pa8/QWb4BtXL/TZvS6B8XFetGBeuhAsfmUspK6DokBeZ64+Kj9TCNRD/30pVz1BvQNA==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.3.tgz#cdc46b057550bbab63706210838df5d4c19519c3"
+  integrity sha512-A6+ByhlLkksFoUepsGxfj5x1gTSrs+OydsRptUxeNCabQpCFUvcwIczgOigI8vhY/OJCnPnyE9rGiwgvr9cS1g==
   dependencies:
-    es-abstract "^1.17.0-next.1"
-    object-inspect "^1.7.0"
+    es-abstract "^1.18.0-next.0"
+    object-inspect "^1.8.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
@@ -11671,9 +11694,9 @@ supports-color@^6.1.0:
     has-flag "^3.0.0"
 
 supports-color@^7.0.0, supports-color@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
-  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 
@@ -12042,6 +12065,11 @@ tslib@^1.10.0, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
+tslib@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
+  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -12110,9 +12138,9 @@ type@^1.0.1:
   integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
 
 type@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
-  integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.1.0.tgz#9bdc22c648cf8cf86dd23d32336a41cfb6475e3f"
+  integrity sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==
 
 typed-styles@^0.0.7:
   version "0.0.7"
@@ -12227,9 +12255,9 @@ upath@^1.1.1:
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
 uri-js@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
-  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.3.0.tgz#e16cb9ef7b4036d74be59dc7342258e6f1aca20e"
+  integrity sha512-Q9Q9RlMM08eWfdPPmDDrXd8Ny3R1sY/DaRDR2zTPPneJ6GYiLx3++fPiZobv49ovkYAnHl/P72Ie3HWXIRVVYA==
   dependencies:
     punycode "^2.1.0"
 


### PR DESCRIPTION
This PR updates the class names generated by `styled-components` through the use of Babel macros.

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

1. Removes `babel-plugin-styled-components` and all references to it.
2. Formats the `.babelrc` file.
3. Adds `babel-plugin-macros` and installs it in the `.babelrc` file.
4. Changes all `styled-components` imports so `styled` is imported separately from `styled-components/macro`.
5. Updates Jest snapshots with new class names.

#### Where should the reviewer start?

1. Re-install dependencies, build project.
2. Run all tests, do your due diligence.
3. Review all individual imports separately.
4. Review `.babelrc` formatting changes.

#### What testing has been done on this PR?

All Jest tests have been re-run and snapshots updated successfully.

#### How should this be manually tested?

Check the generated class names are appropriate and haven't significantly changed.

#### Any background context you want to provide?

`styled-components` implemented it's own macro to be used with the `babel-plugin-macros` library as a replacement for `babel-plugin-styled-components`. This makes it so that as a user, you can execute Babel plugins without installing additional dependencies in your project.

Specifically, using this macro will allow Grommet's users to configure the class names generated by `styled-components`  for their components through the use of a config file (as defined in `babel-plugin-macros`).

* https://github.com/kentcdodds/babel-plugin-macros
* https://styled-components.com/docs/tooling#babel-macro
* https://github.com/styled-components/babel-plugin-styled-components

#### What are the relevant issues?

Can't seem to find any; just a few comments in Slack.

#### Screenshots (if appropriate)

None.

#### Do the grommet docs need to be updated?

Possibly; I think there's one specific mention of `babel-plugin-styled-components`.

#### Should this PR be mentioned in the release notes?

Yes.

#### Is this change backwards compatible or is it a breaking change?

Should be backwards compatible, since the snapshots are showing that the hashed class names are merely updated, and that everything else is exactly the same.