### PR TITLE
Fix "min" aggregate function in DataTable

### DIFF
--- a/src/js/components/DataTable/buildState.js
+++ b/src/js/components/DataTable/buildState.js
@@ -93,6 +93,12 @@ const reducers = {
   sum: sumReducer,
 };
 
+const reducersInitValues = {
+	min : Number.MAX_VALUE,
+	max : Number.MIN_VALUE,
+	sum : 0
+}
+
 // aggregate a single column
 const aggregateColumn = (column, data) => {
   let value;
@@ -102,7 +108,7 @@ const aggregateColumn = (column, data) => {
   } else {
     value = data
       .map(d => datumValue(d, column.property))
-      .reduce(reducers[column.aggregate], column.aggregate === 'min' ? Number.MAX_VALUE : (column.aggregate === 'max' ? Number.MIN_VALUE : 0));
+      .reduce(reducers[column.aggregate], reducersInitValues[column.aggregate]);
   }
   return value;
 };

--- a/src/js/components/DataTable/buildState.js
+++ b/src/js/components/DataTable/buildState.js
@@ -97,7 +97,7 @@ const reducers = {
 const reducersInitValues = {
 	min : Number.MAX_VALUE,
 	max : Number.MIN_VALUE,
-	sum : 0
+	sum : 0,
 };
 
 // aggregate a single column

--- a/src/js/components/DataTable/buildState.js
+++ b/src/js/components/DataTable/buildState.js
@@ -93,11 +93,12 @@ const reducers = {
   sum: sumReducer,
 };
 
+// aggregate reducers init values
 const reducersInitValues = {
 	min : Number.MAX_VALUE,
 	max : Number.MIN_VALUE,
 	sum : 0
-}
+};
 
 // aggregate a single column
 const aggregateColumn = (column, data) => {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
It solves problem when use has applied aggregate function as "min" in DataTable
#### Where should the reviewer start?
Issue can be duplicated by having negative value in data and apply aggregate function as min on that data, it will provide value 0 instead of negative value which is lowest
#### What testing has been done on this PR?
Tested with local data setup by running buildState.js file by providing sample data and columns
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
Yes backward compatible.