### PR TITLE
Fixes 4463 incorrect date selected and fixes incorrect month display ...

### DIFF
--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -130,6 +130,7 @@ const Calendar = forwardRef(
     );
     const [targetDisplayBounds, setTargetDisplayBounds] = useState();
     const [slide, setSlide] = useState();
+    const [animating, setAnimating] = useState();
 
     // When the reference changes, we need to update the displayBounds.
     // This is easy when we aren't animating. If we are animating,
@@ -149,7 +150,6 @@ const Calendar = forwardRef(
 
     useEffect(() => {
       if (targetDisplayBounds) {
-        let animating;
         if (targetDisplayBounds[0].getTime() < displayBounds[0].getTime()) {
           // only animate if the duration is within a year
           if (
@@ -161,7 +161,7 @@ const Calendar = forwardRef(
               direction: 'down',
               weeks: daysApart(displayBounds[0], targetDisplayBounds[0]) / 7,
             });
-            animating = true;
+            setAnimating(true);
           }
         } else if (
           targetDisplayBounds[1].getTime() > displayBounds[1].getTime()
@@ -175,28 +175,31 @@ const Calendar = forwardRef(
               direction: 'up',
               weeks: daysApart(targetDisplayBounds[1], displayBounds[1]) / 7,
             });
-            animating = true;
+            setAnimating(true);
           }
-        }
-
-        if (animating) {
-          // Wait for animation to finish before cleaning up.
-          const timer = setTimeout(
-            () => {
-              setDisplayBounds(targetDisplayBounds);
-              setTargetDisplayBounds(undefined);
-              setSlide(undefined);
-            },
-            400, // Empirically determined.
-          );
-          return () => clearTimeout(timer);
         }
         return undefined;
       }
 
       setSlide(undefined);
       return undefined;
-    }, [displayBounds, targetDisplayBounds]);
+    }, [animating, displayBounds, targetDisplayBounds]);
+
+    useEffect(() => {
+      if (animating && targetDisplayBounds) {
+        // Wait for animation to finish before cleaning up.
+        const timer = setTimeout(
+          () => {
+            setDisplayBounds(targetDisplayBounds);
+            setTargetDisplayBounds(undefined);
+            setSlide(undefined);
+          },
+          400, // Empirically determined.
+        );
+        return () => clearTimeout(timer);
+      }
+      return undefined;
+    }, [animating, targetDisplayBounds]);
 
     // We have to deal with reference being the end of a month with more
     // days than the month we are changing to. So, we always set reference

--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -185,6 +185,8 @@ const Calendar = forwardRef(
       return undefined;
     }, [animating, displayBounds, targetDisplayBounds]);
 
+    // Last step in updating the displayBounds. Allows for pruning
+    // displayBounds and cleaning up states to occur after animation.
     useEffect(() => {
       if (animating && targetDisplayBounds) {
         // Wait for animation to finish before cleaning up.
@@ -193,6 +195,7 @@ const Calendar = forwardRef(
             setDisplayBounds(targetDisplayBounds);
             setTargetDisplayBounds(undefined);
             setSlide(undefined);
+            setAnimating(false);
           },
           400, // Empirically determined.
         );

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -210,8 +210,6 @@ exports[`Calendar change months 1`] = `
 
 .c10 {
   position: relative;
-  -webkit-animation: iYLtit 0.5s forwards;
-  animation: iYLtit 0.5s forwards;
 }
 
 .c11 {
@@ -266,27 +264,6 @@ exports[`Calendar change months 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-}
-
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 54.857142857142854px;
-  height: 54.857142857142854px;
-  background-color: #7D4CDB;
-  color: #f8f8f8;
-  opacity: 0.5;
-  font-weight: bold;
 }
 
 .c0 {
@@ -1086,470 +1063,6 @@ exports[`Calendar change months 1`] = `
               </button>
             </div>
           </div>
-          <div
-            class="c11"
-          >
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sun Jan 12 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  12
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Mon Jan 13 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  13
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Tue Jan 14 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  14
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Wed Jan 15 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c16"
-                >
-                  15
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Thu Jan 16 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  16
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Fri Jan 17 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  17
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sat Jan 18 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  18
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="c11"
-          >
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sun Jan 19 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  19
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Mon Jan 20 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  20
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Tue Jan 21 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  21
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Wed Jan 22 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  22
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Thu Jan 23 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  23
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Fri Jan 24 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  24
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sat Jan 25 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  25
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="c11"
-          >
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sun Jan 26 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  26
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Mon Jan 27 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  27
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Tue Jan 28 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  28
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Wed Jan 29 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  29
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Thu Jan 30 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  30
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Fri Jan 31 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  31
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sat Feb 01 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  1
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="c11"
-          >
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sun Feb 02 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  2
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Mon Feb 03 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  3
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Tue Feb 04 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  4
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Wed Feb 05 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  5
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Thu Feb 06 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  6
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Fri Feb 07 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  7
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sat Feb 08 2020"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  8
-                </div>
-              </button>
-            </div>
-          </div>
         </div>
       </div>
     </div>
@@ -1626,472 +1139,8 @@ exports[`Calendar change months 2`] = `
         tabindex="0"
       >
         <div
-          class="StyledCalendar__StyledWeeks-sc-1y4xhmp-2 dgnNaa"
+          class="StyledCalendar__StyledWeeks-sc-1y4xhmp-2 lpkhRw"
         >
-          <div
-            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 icsAJN"
-          >
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Sun Dec 01 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  1
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Mon Dec 02 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  2
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Tue Dec 03 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  3
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Wed Dec 04 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  4
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Thu Dec 05 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  5
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Fri Dec 06 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  6
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Sat Dec 07 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  7
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 icsAJN"
-          >
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Sun Dec 08 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  8
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Mon Dec 09 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  9
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Tue Dec 10 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  10
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Wed Dec 11 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  11
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Thu Dec 12 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  12
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Fri Dec 13 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  13
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Sat Dec 14 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  14
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 icsAJN"
-          >
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Sun Dec 15 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  15
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Mon Dec 16 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  16
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Tue Dec 17 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  17
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Wed Dec 18 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  18
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Thu Dec 19 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  19
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Fri Dec 20 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  20
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Sat Dec 21 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  21
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 icsAJN"
-          >
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Sun Dec 22 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  22
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Mon Dec 23 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  23
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Tue Dec 24 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  24
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Wed Dec 25 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  25
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Thu Dec 26 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  26
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Fri Dec 27 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  27
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
-            >
-              <button
-                aria-label="Sat Dec 28 2019"
-                class="StyledButton-sc-323bzc-0 jFJBys"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
-                >
-                  28
-                </div>
-              </button>
-            </div>
-          </div>
           <div
             class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 icsAJN"
           >
@@ -2324,464 +1373,847 @@ exports[`Calendar change months 2`] = `
               </button>
             </div>
           </div>
-          <div
-            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 icsAJN"
+          .c2 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c2:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus > circle,
+.c2:focus > ellipse,
+.c2:focus > line,
+.c2:focus > path,
+.c2:focus > polygon,
+.c2:focus > polyline,
+.c2:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-justify: between;
+  -ms-flex-justify: between;
+  flex-justify: between;
+}
+
+.c1 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  font-weight: bold;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<div
+            class="c0"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Sun Jan 12 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   12
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Mon Jan 13 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   13
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Tue Jan 14 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   14
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Wed Jan 15 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gBUPeV"
+                  class="c4"
                 >
                   15
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Thu Jan 16 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   16
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Fri Jan 17 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   17
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Sat Jan 18 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   18
                 </div>
               </button>
             </div>
           </div>
-          <div
-            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 icsAJN"
+          .c2 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c2:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus > circle,
+.c2:focus > ellipse,
+.c2:focus > line,
+.c2:focus > path,
+.c2:focus > polygon,
+.c2:focus > polyline,
+.c2:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-justify: between;
+  -ms-flex-justify: between;
+  flex-justify: between;
+}
+
+.c1 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<div
+            class="c0"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Sun Jan 19 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   19
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Mon Jan 20 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   20
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Tue Jan 21 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   21
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Wed Jan 22 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   22
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Thu Jan 23 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   23
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Fri Jan 24 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   24
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Sat Jan 25 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   25
                 </div>
               </button>
             </div>
           </div>
-          <div
-            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 icsAJN"
+          .c2 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c2:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus > circle,
+.c2:focus > ellipse,
+.c2:focus > line,
+.c2:focus > path,
+.c2:focus > polygon,
+.c2:focus > polyline,
+.c2:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-justify: between;
+  -ms-flex-justify: between;
+  flex-justify: between;
+}
+
+.c1 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
+  opacity: 0.5;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<div
+            class="c0"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Sun Jan 26 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   26
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Mon Jan 27 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   27
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Tue Jan 28 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   28
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Wed Jan 29 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   29
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Thu Jan 30 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   30
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Fri Jan 31 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 hMtPVo"
+                  class="c3"
                 >
                   31
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Sat Feb 01 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
+                  class="c4"
                 >
                   1
                 </div>
               </button>
             </div>
           </div>
-          <div
-            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 icsAJN"
+          .c2 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c2:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus > circle,
+.c2:focus > ellipse,
+.c2:focus > line,
+.c2:focus > path,
+.c2:focus > polygon,
+.c2:focus > polyline,
+.c2:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-justify: between;
+  -ms-flex-justify: between;
+  flex-justify: between;
+}
+
+.c1 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
+  opacity: 0.5;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<div
+            class="c0"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Sun Feb 02 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
+                  class="c3"
                 >
                   2
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Mon Feb 03 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
+                  class="c3"
                 >
                   3
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Tue Feb 04 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
+                  class="c3"
                 >
                   4
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Wed Feb 05 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
+                  class="c3"
                 >
                   5
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Thu Feb 06 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
+                  class="c3"
                 >
                   6
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Fri Feb 07 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
+                  class="c3"
                 >
                   7
                 </div>
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 fxhDuD"
+              class="c1"
             >
               <button
                 aria-label="Sat Feb 08 2020"
-                class="StyledButton-sc-323bzc-0 jFJBys"
+                class="c2"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 gQiACj"
+                  class="c3"
                 >
                   8
                 </div>


### PR DESCRIPTION
Signed-off-by: Matt Glissmann <mdglissmann@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes https://github.com/grommet/grommet/issues/4463 incorrect date selected and fixes incorrect month display mentioned in [4353](https://github.com/grommet/grommet/issues/4353#issuecomment-683887316)

The incorrect date selected in DateInput was actually a factor of `<Calendar />` not advancing and displaying the proper month's dates.

#### Where should the reviewer start?

Calendar.js

#### What testing has been done on this PR?

Jest + Manual Storybook

#### How should this be manually tested?

Storybook stories for DateInput and Calendar. Follow steps to reproduce mentioned in https://github.com/grommet/grommet/issues/4463.

#### Any background context you want to provide?

Root issue lived in `<Calendar />`. The `displayBounds` state was not being set properly because a timeout function was being cleared before it had a chance to execute.

#### What are the relevant issues?

Closes https://github.com/grommet/grommet/issues/4463

Enables enhancement work to progress on https://github.com/grommet/grommet/issues/4353

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Fixes bug and now performs desired functionality.
