### PR TITLE
modify calendar test to avoid drifting date snapshot

### DIFF
--- a/src/js/components/Calendar/__tests__/Calendar-test.js
+++ b/src/js/components/Calendar/__tests__/Calendar-test.js
@@ -42,9 +42,13 @@ describe('Calendar', () => {
   });
 
   test('disabled', () => {
+    // need to set the date to avoid snapshot drift over time
+    // have disabled date be distinct from selected date
+    const disabledDate = new Date(DATE);
+    disabledDate.setDate(disabledDate.getDate() + 1);
     const component = renderer.create(
       <Grommet>
-        <Calendar disabled={[DATE]} />
+        <Calendar date={DATE} disabled={[disabledDate.toDateString()]} />
       </Grommet>,
     );
     const tree = component.toJSON();

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -6999,6 +6999,46 @@ exports[`Calendar disabled 1`] = `
   border: 0;
 }
 
+.c17 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+}
+
+.c17:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c17:focus > circle,
+.c17:focus > ellipse,
+.c17:focus > line,
+.c17:focus > path,
+.c17:focus > polygon,
+.c17:focus > polyline,
+.c17:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c17:focus::-moz-focus-inner {
+  border: 0;
+}
+
 .c5 {
   margin: 0px;
   font-size: 26px;
@@ -7076,6 +7116,26 @@ exports[`Calendar disabled 1`] = `
   height: 54.857142857142854px;
 }
 
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  font-weight: bold;
+}
+
 .c0 {
   font-size: 18px;
   line-height: 24px;
@@ -7126,14 +7186,14 @@ exports[`Calendar disabled 1`] = `
             className="c5"
             size="medium"
           >
-            August 2020
+            January 2020
           </h3>
         </div>
         <div
           className="c6"
         >
           <button
-            aria-label="July 2020"
+            aria-label="December 2019"
             className="c7"
             disabled={false}
             onBlur={[Function]}
@@ -7158,7 +7218,7 @@ exports[`Calendar disabled 1`] = `
             </svg>
           </button>
           <button
-            aria-label="September 2020"
+            aria-label="February 2020"
             className="c7"
             disabled={false}
             onBlur={[Function]}
@@ -7200,70 +7260,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Sun Jul 26 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c14"
-                >
-                  26
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Mon Jul 27 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c14"
-                >
-                  27
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Tue Jul 28 2020"
-                className="c13"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                tabIndex={-1}
-                type="button"
-              >
-                <div
-                  className="c14"
-                >
-                  28
-                </div>
-              </button>
-            </div>
-            <div
-              className="c12"
-            >
-              <button
-                aria-label="Wed Jul 29 2020"
+                aria-label="Sun Dec 29 2019"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7284,7 +7281,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Thu Jul 30 2020"
+                aria-label="Mon Dec 30 2019"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7305,7 +7302,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Fri Jul 31 2020"
+                aria-label="Tue Dec 31 2019"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7326,7 +7323,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Sat Aug 01 2020"
+                aria-label="Wed Jan 01 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7343,15 +7340,11 @@ exports[`Calendar disabled 1`] = `
                 </div>
               </button>
             </div>
-          </div>
-          <div
-            className="c11"
-          >
             <div
               className="c12"
             >
               <button
-                aria-label="Sun Aug 02 2020"
+                aria-label="Thu Jan 02 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7372,7 +7365,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Mon Aug 03 2020"
+                aria-label="Fri Jan 03 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7393,7 +7386,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Tue Aug 04 2020"
+                aria-label="Sat Jan 04 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7410,11 +7403,15 @@ exports[`Calendar disabled 1`] = `
                 </div>
               </button>
             </div>
+          </div>
+          <div
+            className="c11"
+          >
             <div
               className="c12"
             >
               <button
-                aria-label="Wed Aug 05 2020"
+                aria-label="Sun Jan 05 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7435,7 +7432,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Thu Aug 06 2020"
+                aria-label="Mon Jan 06 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7456,7 +7453,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Fri Aug 07 2020"
+                aria-label="Tue Jan 07 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7477,7 +7474,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Sat Aug 08 2020"
+                aria-label="Wed Jan 08 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7494,15 +7491,11 @@ exports[`Calendar disabled 1`] = `
                 </div>
               </button>
             </div>
-          </div>
-          <div
-            className="c11"
-          >
             <div
               className="c12"
             >
               <button
-                aria-label="Sun Aug 09 2020"
+                aria-label="Thu Jan 09 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7523,7 +7516,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Mon Aug 10 2020"
+                aria-label="Fri Jan 10 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7544,7 +7537,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Tue Aug 11 2020"
+                aria-label="Sat Jan 11 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7561,11 +7554,15 @@ exports[`Calendar disabled 1`] = `
                 </div>
               </button>
             </div>
+          </div>
+          <div
+            className="c11"
+          >
             <div
               className="c12"
             >
               <button
-                aria-label="Wed Aug 12 2020"
+                aria-label="Sun Jan 12 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7586,7 +7583,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Thu Aug 13 2020"
+                aria-label="Mon Jan 13 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7607,7 +7604,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Fri Aug 14 2020"
+                aria-label="Tue Jan 14 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7628,7 +7625,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Sat Aug 15 2020"
+                aria-label="Wed Jan 15 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7639,22 +7636,19 @@ exports[`Calendar disabled 1`] = `
                 type="button"
               >
                 <div
-                  className="c15"
+                  className="c16"
                 >
                   15
                 </div>
               </button>
             </div>
-          </div>
-          <div
-            className="c11"
-          >
             <div
               className="c12"
             >
               <button
-                aria-label="Sun Aug 16 2020"
-                className="c13"
+                aria-label="Thu Jan 16 2020"
+                className="c17"
+                disabled={true}
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -7674,7 +7668,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Mon Aug 17 2020"
+                aria-label="Fri Jan 17 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7695,7 +7689,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Tue Aug 18 2020"
+                aria-label="Sat Jan 18 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7712,11 +7706,15 @@ exports[`Calendar disabled 1`] = `
                 </div>
               </button>
             </div>
+          </div>
+          <div
+            className="c11"
+          >
             <div
               className="c12"
             >
               <button
-                aria-label="Wed Aug 19 2020"
+                aria-label="Sun Jan 19 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7737,7 +7735,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Thu Aug 20 2020"
+                aria-label="Mon Jan 20 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7758,7 +7756,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Fri Aug 21 2020"
+                aria-label="Tue Jan 21 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7779,7 +7777,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Sat Aug 22 2020"
+                aria-label="Wed Jan 22 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7796,15 +7794,11 @@ exports[`Calendar disabled 1`] = `
                 </div>
               </button>
             </div>
-          </div>
-          <div
-            className="c11"
-          >
             <div
               className="c12"
             >
               <button
-                aria-label="Sun Aug 23 2020"
+                aria-label="Thu Jan 23 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7825,7 +7819,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Mon Aug 24 2020"
+                aria-label="Fri Jan 24 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7846,7 +7840,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Tue Aug 25 2020"
+                aria-label="Sat Jan 25 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7863,11 +7857,15 @@ exports[`Calendar disabled 1`] = `
                 </div>
               </button>
             </div>
+          </div>
+          <div
+            className="c11"
+          >
             <div
               className="c12"
             >
               <button
-                aria-label="Wed Aug 26 2020"
+                aria-label="Sun Jan 26 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7888,7 +7886,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Thu Aug 27 2020"
+                aria-label="Mon Jan 27 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7909,7 +7907,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Fri Aug 28 2020"
+                aria-label="Tue Jan 28 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7930,7 +7928,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Sat Aug 29 2020"
+                aria-label="Wed Jan 29 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7947,15 +7945,11 @@ exports[`Calendar disabled 1`] = `
                 </div>
               </button>
             </div>
-          </div>
-          <div
-            className="c11"
-          >
             <div
               className="c12"
             >
               <button
-                aria-label="Sun Aug 30 2020"
+                aria-label="Thu Jan 30 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7976,7 +7970,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Mon Aug 31 2020"
+                aria-label="Fri Jan 31 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -7997,7 +7991,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Tue Sep 01 2020"
+                aria-label="Sat Feb 01 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -8014,11 +8008,15 @@ exports[`Calendar disabled 1`] = `
                 </div>
               </button>
             </div>
+          </div>
+          <div
+            className="c11"
+          >
             <div
               className="c12"
             >
               <button
-                aria-label="Wed Sep 02 2020"
+                aria-label="Sun Feb 02 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -8039,7 +8037,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Thu Sep 03 2020"
+                aria-label="Mon Feb 03 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -8060,7 +8058,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Fri Sep 04 2020"
+                aria-label="Tue Feb 04 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -8081,7 +8079,7 @@ exports[`Calendar disabled 1`] = `
               className="c12"
             >
               <button
-                aria-label="Sat Sep 05 2020"
+                aria-label="Wed Feb 05 2020"
                 className="c13"
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -8095,6 +8093,69 @@ exports[`Calendar disabled 1`] = `
                   className="c14"
                 >
                   5
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Thu Feb 06 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c14"
+                >
+                  6
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Fri Feb 07 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c14"
+                >
+                  7
+                </div>
+              </button>
+            </div>
+            <div
+              className="c12"
+            >
+              <button
+                aria-label="Sat Feb 08 2020"
+                className="c13"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                tabIndex={-1}
+                type="button"
+              >
+                <div
+                  className="c14"
+                >
+                  8
                 </div>
               </button>
             </div>


### PR DESCRIPTION
Signed-off-by: Matt Glissmann <mdglissmann@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes Jest test where date drift results in failed match snapshot. Sets a selected date on the `disabled` story so that the snapshot will be static going forward.

#### Where should the reviewer start?

Calendar-test.js

#### What testing has been done on this PR?

Jest

#### How should this be manually tested?


#### Any background context you want to provide?

Calendar "disabled" story snapshot was created in the Month of Aug 2020. Being September 1, the rendered component no longer matched the August snapshot. Plus, the snapshot was not accurately capturing the disabled state of Jan 15, 2020.

#### What are the relevant issues?


#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.
