### PR TITLE
Removed chromatic snapshots of some stories

### DIFF
--- a/src/js/components/Accordion/stories/Simple.js
+++ b/src/js/components/Accordion/stories/Simple.js
@@ -35,7 +35,11 @@ const SimpleAccordion = props => {
 
 storiesOf('Accordion', module)
   .add('Simple', () => <SimpleAccordion />)
-  .add('Dark no animation', () => (
-    <SimpleAccordion animate={false} background="dark-2" />
-  ))
-  .add('Multiple', () => <SimpleAccordion multiple />);
+  .add(
+    'Dark no animation',
+    () => <SimpleAccordion animate={false} background="dark-2" />,
+    { chromatic: { disable: true } },
+  )
+  .add('Multiple', () => <SimpleAccordion multiple />, {
+    chromatic: { disable: true },
+  });

--- a/src/js/components/DataTable/stories/typescript/Clickable.tsx
+++ b/src/js/components/DataTable/stories/typescript/Clickable.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import isChromatic from 'chromatic/isChromatic';
 
 import { Grommet, Box, DataTable, Meter, Text } from 'grommet';
 import { grommet } from 'grommet/themes';

--- a/src/js/components/Drop/stories/Lazy.js
+++ b/src/js/components/Drop/stories/Lazy.js
@@ -121,4 +121,6 @@ const LazyDrop = () => {
   );
 };
 
-storiesOf('Drop', module).add('Lazy', () => <LazyDrop />);
+storiesOf('Drop', module).add('Lazy', () => <LazyDrop />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Drop/stories/Multiple.js
+++ b/src/js/components/Drop/stories/Multiple.js
@@ -70,4 +70,6 @@ const MultipleDrop = () => {
   );
 };
 
-storiesOf('Drop', module).add('Multiple', () => <MultipleDrop />);
+storiesOf('Drop', module).add('Multiple', () => <MultipleDrop />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Drop/stories/Overflow.js
+++ b/src/js/components/Drop/stories/Overflow.js
@@ -61,4 +61,6 @@ const OverflowDrop = () => {
   );
 };
 
-storiesOf('Drop', module).add('Overflow', () => <OverflowDrop />);
+storiesOf('Drop', module).add('Overflow', () => <OverflowDrop />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Drop/stories/Plain.js
+++ b/src/js/components/Drop/stories/Plain.js
@@ -35,4 +35,6 @@ const PlainDrop = () => {
   );
 };
 
-storiesOf('Drop', module).add('Plain', () => <PlainDrop />);
+storiesOf('Drop', module).add('Plain', () => <PlainDrop />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Drop/stories/Progressive.js
+++ b/src/js/components/Drop/stories/Progressive.js
@@ -68,4 +68,6 @@ const ProgressiveDrop = () => {
   );
 };
 
-storiesOf('Drop', module).add('Progressive', () => <ProgressiveDrop />);
+storiesOf('Drop', module).add('Progressive', () => <ProgressiveDrop />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Drop/stories/Simple.js
+++ b/src/js/components/Drop/stories/Simple.js
@@ -37,4 +37,6 @@ const SimpleDrop = () => {
   );
 };
 
-storiesOf('Drop', module).add('Simple', () => <SimpleDrop />);
+storiesOf('Drop', module).add('Simple', () => <SimpleDrop />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Drop/stories/Tooltip.js
+++ b/src/js/components/Drop/stories/Tooltip.js
@@ -51,4 +51,6 @@ const Tooltip = () => {
   );
 };
 
-storiesOf('Drop', module).add('Tooltip', () => <Tooltip />);
+storiesOf('Drop', module).add('Tooltip', () => <Tooltip />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Select/stories/LazyLoading.js
+++ b/src/js/components/Select/stories/LazyLoading.js
@@ -76,4 +76,6 @@ const LazyLoading = () => {
   );
 };
 
-storiesOf('Select', module).add('Lazy Loading options', () => <LazyLoading />);
+storiesOf('Select', module).add('Lazy Loading options', () => <LazyLoading />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Select/stories/ManyOptions.js
+++ b/src/js/components/Select/stories/ManyOptions.js
@@ -69,4 +69,6 @@ const ManyOptions = () => {
   );
 };
 
-storiesOf('Select', module).add('Lots of options', () => <ManyOptions />);
+storiesOf('Select', module).add('Lots of options', () => <ManyOptions />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Select/stories/ObjectOptions.js
+++ b/src/js/components/Select/stories/ObjectOptions.js
@@ -42,4 +42,6 @@ const Example = () => {
   );
 };
 
-storiesOf('Select', module).add('Object options', () => <Example />);
+storiesOf('Select', module).add('Object options', () => <Example />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Select/stories/Search.js
+++ b/src/js/components/Select/stories/Search.js
@@ -40,4 +40,6 @@ const SearchSelect = () => {
   );
 };
 
-storiesOf('Select', module).add('Search', () => <SearchSelect />);
+storiesOf('Select', module).add('Search', () => <SearchSelect />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Select/stories/Uncontrolled.js
+++ b/src/js/components/Select/stories/Uncontrolled.js
@@ -20,4 +20,6 @@ const Example = () => {
   );
 };
 
-storiesOf('Select', module).add('Uncontrolled', () => <Example />);
+storiesOf('Select', module).add('Uncontrolled', () => <Example />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/TextInput/stories/Suggestion.js
+++ b/src/js/components/TextInput/stories/Suggestion.js
@@ -31,6 +31,8 @@ const SuggestionsTextInput = () => {
   );
 };
 
-storiesOf('TextInput', module).add('Suggestions', () => (
-  <SuggestionsTextInput />
-));
+storiesOf('TextInput', module).add(
+  'Suggestions',
+  () => <SuggestionsTextInput />,
+  { chromatic: { disable: true } },
+);

--- a/src/js/components/TextInput/stories/Uncontrolled.js
+++ b/src/js/components/TextInput/stories/Uncontrolled.js
@@ -18,4 +18,6 @@ const Example = () => {
   );
 };
 
-storiesOf('TextInput', module).add('Uncontrolled', () => <Example />);
+storiesOf('TextInput', module).add('Uncontrolled', () => <Example />, {
+  chromatic: { disable: true },
+});


### PR DESCRIPTION
#### What does this PR do?
Removed the following stories from chromatic stories as discussed with shimi because their snapshots were not showing anything valuable.

**Accordion:**
Dark no animation
Multiple

**Drop:**
Lazy,
Multiple,
Overflow,
Plain,
Progressive,
Simple,
Tooltip

**Select:**
Lazy loading options
Lots of options
Object options
Search
Uncontrolled

**TextInput:**
Suggestions
Uncontrolled

#### Where should the reviewer start?
Look at the chromatic snapshots of the stories to see that the snapshot isn't capturing anything valuable.

#### What testing has been done on this PR?

#### How should this be manually tested?
Number of chromatic snapshots should decrease by 16

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible