### PR TITLE
DateInput `dropProps` fix

### DIFF
--- a/src/js/components/DateInput/DateInput.js
+++ b/src/js/components/DateInput/DateInput.js
@@ -171,6 +171,7 @@ const DateInput = forwardRef(
           align={{ top: 'bottom', left: 'left', ...dropProps }}
           onEsc={() => setOpen(false)}
           onClickOutside={() => setOpen(false)}
+          {...dropProps}
         >
           {calendar}
         </Drop>,


### PR DESCRIPTION
#### What does this PR do?
Previously props that were added to `dropProps` in DateInput were being ignored. See issue #4485 for more info

#### Where should the reviewer start?
Look at this code sandbox, see that the props added to `dropProps` are being ignored
https://codesandbox.io/s/grommet-v2-template-forked-58djv?file=/index.js

#### What testing has been done on this PR?
Storybook

#### How should this be manually tested?
Can be tested with this storybook example:
```javascript
import React from "react";
import { storiesOf } from '@storybook/react';

import { grommet, Box, Grommet, DateInput } from "grommet";

const Example = () => {
    return (
      <Grommet theme={grommet}>
        <Box align="center" pad="large" width="medium" margin={{top: '300px'}}>
            <DateInput
                calendarProps={{
                    size: "small"
                }}
                dropProps={{
                    plain: true,
                    align: {bottom: "top"}
                }}
                format="mm/dd/yyyy"
            />
        </Box>
      </Grommet>
    );
  };
  

storiesOf('DateInput', module).add('TEST', () => <Example />, {
    chromatic: { disable: true },
  });
```

#### Any background context you want to provide?

#### What are the relevant issues?
Closes issue #4485 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Maybe

#### Is this change backwards compatible or is it a breaking change?
Bug fix, so backwards compatible
