### PR TITLE
fix: remove hover indicator of disabled Styled Button

### DIFF
--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -253,7 +253,8 @@ const StyledButtonKind = styled.button`
     `
     text-align: ${props.align};
     `}
-    ${props => props.hoverIndicator && hoverIndicatorStyle(props)}
+  ${props =>
+    !props.disabled && props.hoverIndicator && hoverIndicatorStyle(props)}
   ${props =>
     props.disabled && disabledStyle(props.theme.button.disabled.opacity)}
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR disables hover styles of Styled Button when it is disabled.

#### Where should the reviewer start?

The only one file in the PR

#### What testing has been done on this PR?

Local environment using a  ` theme.button.default` 

#### How should this be manually tested?

Manually test adding a ` theme.button.default`  and add a button with kind

#### Any background context you want to provide?

https://github.com/grommet/grommet-theme-hpe/pull/110

#### What are the relevant issues?

#4492 
https://github.com/grommet/grommet-theme-hpe/pull/110

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
No