### PR TITLE
Removed some stories from chromatic testing

### DIFF
--- a/src/js/components/Anchor/stories/Default.js
+++ b/src/js/components/Anchor/stories/Default.js
@@ -14,4 +14,6 @@ const Default = () => {
   );
 };
 
-storiesOf('Anchor', module).add('Default', () => <Default />);
+storiesOf('Anchor', module).add('Default', () => <Default />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Carousel/stories/Simple.js
+++ b/src/js/components/Carousel/stories/Simple.js
@@ -25,7 +25,9 @@ const SimpleCarousel = ({ initialChild, ...props }) => {
 };
 
 storiesOf('Carousel', module)
-  .add('Simple', () => <SimpleCarousel />)
+  .add('Simple', () => <SimpleCarousel />, {
+    chromatic: { disable: true },
+  })
   .add('Initial child', () => <SimpleCarousel initialChild={1} />)
   .add('Without controls', () => (
     <SimpleCarousel controls={false} play={1500} />

--- a/src/js/components/Form/stories/ControlledInput.js
+++ b/src/js/components/Form/stories/ControlledInput.js
@@ -117,4 +117,7 @@ const Example = () => {
   );
 };
 
-storiesOf('Form', module).add('Controlled input', () => <Example />);
+// chromatic disabled because snapshot is the same as Controlled Input Lazy
+storiesOf('Form', module).add('Controlled input', () => <Example />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Form/stories/ControlledLazy.js
+++ b/src/js/components/Form/stories/ControlledLazy.js
@@ -99,4 +99,7 @@ const Example = () => {
   );
 };
 
-storiesOf('Form', module).add('Controlled lazy', () => <Example />);
+// chromatic disabled because snapshot is the same as Controlled
+storiesOf('Form', module).add('Controlled lazy', () => <Example />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/List/stories/onClickItem.js
+++ b/src/js/components/List/stories/onClickItem.js
@@ -40,4 +40,8 @@ const OnClickItemList = () => {
   );
 };
 
-storiesOf('List', module).add('onClickItem', () => <OnClickItemList />);
+// chromatic disabled because snapshot is covered by jest testing
+// and snapshot is the same as selection
+storiesOf('List', module).add('onClickItem', () => <OnClickItemList />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/MaskedInput/stories/Date.js
+++ b/src/js/components/MaskedInput/stories/Date.js
@@ -49,4 +49,6 @@ const DateMaskedInput = () => {
   );
 };
 
-storiesOf('MaskedInput', module).add('Date', () => <DateMaskedInput />);
+storiesOf('MaskedInput', module).add('Date', () => <DateMaskedInput />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/MaskedInput/stories/Filtered.js
+++ b/src/js/components/MaskedInput/stories/Filtered.js
@@ -60,4 +60,10 @@ const FilteredMaskedInput = () => {
   );
 };
 
-storiesOf('MaskedInput', module).add('Filtered', () => <FilteredMaskedInput />);
+storiesOf('MaskedInput', module).add(
+  'Filtered',
+  () => <FilteredMaskedInput />,
+  {
+    chromatic: { disable: true },
+  },
+);

--- a/src/js/components/MaskedInput/stories/IPv4Address.js
+++ b/src/js/components/MaskedInput/stories/IPv4Address.js
@@ -47,4 +47,10 @@ const IPv4MaskedInput = () => {
   );
 };
 
-storiesOf('MaskedInput', module).add('IPv4 address', () => <IPv4MaskedInput />);
+storiesOf('MaskedInput', module).add(
+  'IPv4 address',
+  () => <IPv4MaskedInput />,
+  {
+    chromatic: { disable: true },
+  },
+);

--- a/src/js/components/MaskedInput/stories/SizeUnits.js
+++ b/src/js/components/MaskedInput/stories/SizeUnits.js
@@ -35,6 +35,10 @@ const SizeUnitsMaskedInput = () => {
   );
 };
 
-storiesOf('MaskedInput', module).add('Size + units', () => (
-  <SizeUnitsMaskedInput />
-));
+storiesOf('MaskedInput', module).add(
+  'Size + units',
+  () => <SizeUnitsMaskedInput />,
+  {
+    chromatic: { disable: true },
+  },
+);

--- a/src/js/components/MaskedInput/stories/URL.js
+++ b/src/js/components/MaskedInput/stories/URL.js
@@ -21,4 +21,6 @@ const UrlMaskedInput = () => {
   );
 };
 
-storiesOf('MaskedInput', module).add('URL', () => <UrlMaskedInput />);
+storiesOf('MaskedInput', module).add('URL', () => <UrlMaskedInput />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/Select/stories/FormSelect.js
+++ b/src/js/components/Select/stories/FormSelect.js
@@ -45,4 +45,4 @@ const FormFieldSelect = () => {
   );
 };
 
-storiesOf('Form', module).add('Select', () => <FormFieldSelect />);
+storiesOf('Select', module).add('Form select', () => <FormFieldSelect />);

--- a/src/js/components/Select/stories/Multiple.js
+++ b/src/js/components/Select/stories/Multiple.js
@@ -25,4 +25,7 @@ const Example = () => {
   );
 };
 
-storiesOf('Select', module).add('Multiple', () => <Example />);
+// chromatic disabled, similar to Object multiple
+storiesOf('Select', module).add('Multiple', () => <Example />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/TextInput/stories/OnSelect.js
+++ b/src/js/components/TextInput/stories/OnSelect.js
@@ -43,6 +43,10 @@ const OnSelect = () => {
   );
 };
 
-storiesOf('TextInput', module).add('onSelect and onSuggestionSelect', () => (
-  <OnSelect />
-));
+storiesOf('TextInput', module).add(
+  'onSelect and onSuggestionSelect',
+  () => <OnSelect />,
+  {
+    chromatic: { disable: true },
+  },
+);

--- a/src/js/components/TextInput/stories/Simple.js
+++ b/src/js/components/TextInput/stories/Simple.js
@@ -20,4 +20,6 @@ const SimpleTextInput = () => {
   );
 };
 
-storiesOf('TextInput', module).add('Simple', () => <SimpleTextInput />);
+storiesOf('TextInput', module).add('Simple', () => <SimpleTextInput />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/WorldMap/stories/Simple.js
+++ b/src/js/components/WorldMap/stories/Simple.js
@@ -14,4 +14,7 @@ const Example = () => {
   );
 };
 
-storiesOf('WorldMap', module).add('Simple', () => <Example />);
+// chromatic disabled because snapshot is the same as SelectPlace
+storiesOf('WorldMap', module).add('Simple', () => <Example />, {
+  chromatic: { disable: true },
+});


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Removes the following stories because snapshots weren't valuable & trying to decrease chromatic numbers

Original list:
**Accordion**
Simple - decided to keep this story because previously we removed 'Dark no animation' and 'Multiple' because they were similar to this story. This story is covered by jest testing but I think that it might be good to have a chromatic test.

**Anchor**
Default

**Carousel**
Simple

**Form**
Controlled input
Controlled lazy

**List**
onClickItem
Selection - kept selection instead of onClickItem

**MaskedInput**
Date
Filtered
IPv4 address
Size + units
URL

**Select**
Multiple

**TextInput**
onSelect and onSuggestionSearch
Simple

**WorldMap**
Simple

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
Number of chromatic snapshots should decrease by 14.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible