### PR TITLE
TS added number option to Select value

### DIFF
--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -1,17 +1,28 @@
-import * as React from "react";
-import { DropProps } from "../Drop";
-import { A11yTitleType, AlignSelfType, GridAreaType, MarginType, PlaceHolderType } from "../../utils";
+import * as React from 'react';
+import { DropProps } from '../Drop';
+import {
+  A11yTitleType,
+  AlignSelfType,
+  GridAreaType,
+  MarginType,
+  PlaceHolderType,
+} from '../../utils';
 
 export interface SelectProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
   gridArea?: GridAreaType;
-  children?: ((...args: any[]) => any);
+  children?: (...args: any[]) => any;
   closeOnChange?: boolean;
   disabled?: boolean | (number | string | object)[];
   disabledKey?: string | ((...args: any[]) => any);
-  dropAlign?: { top?: "top" | "bottom", bottom?: "top" | "bottom", right?: "left" | "right", left?: "left" | "right" };
-  dropHeight?: "xsmall" | "small" | "medium" | "large" | "xlarge" | string;
+  dropAlign?: {
+    top?: 'top' | 'bottom';
+    bottom?: 'top' | 'bottom';
+    right?: 'left' | 'right';
+    left?: 'left' | 'right';
+  };
+  dropHeight?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | string;
   dropTarget?: object;
   dropProps?: DropProps;
   focusIndicator?: boolean;
@@ -22,11 +33,11 @@ export interface SelectProps {
   messages?: { multiple?: string };
   multiple?: boolean;
   name?: string;
-  onChange?: ((...args: any[]) => void);
-  onClose?: ((...args: any[]) => any);
-  onMore?: ((...args: any[]) => any);
-  onOpen?: ((...args: any[]) => any);
-  onSearch?: ((search: string) => void);
+  onChange?: (...args: any[]) => void;
+  onClose?: (...args: any[]) => any;
+  onMore?: (...args: any[]) => any;
+  onOpen?: (...args: any[]) => any;
+  onSearch?: (search: string) => void;
   options: (string | boolean | number | JSX.Element | object)[];
   open?: boolean;
   placeholder?: PlaceHolderType;
@@ -34,10 +45,13 @@ export interface SelectProps {
   replace?: boolean;
   searchPlaceholder?: string;
   selected?: number | number[];
-  size?: "small" | "medium" | "large" | "xlarge" | string;
-  value?: string | JSX.Element | object | (string | object)[];
+  size?: 'small' | 'medium' | 'large' | 'xlarge' | string;
+  value?: string | JSX.Element | object | (string | number | object)[];
   valueLabel?: React.ReactNode;
-  valueKey?: string | { key: string, reduce?: boolean } | ((...args: any[]) => any);
+  valueKey?:
+    | string
+    | { key: string; reduce?: boolean }
+    | ((...args: any[]) => any);
   emptySearchMessage?: string;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
In Select index.d.ts options has the number array type:
`options: (string | boolean | number | JSX.Element | object)[];`
but this array type wasn't included in value.
Changed value to include number type
`value?: string | JSX.Element | number | object | (string | number | object)[];`

**NOTE**
most of the changes in this PR are due to prettier. The only real change is line 49.

#### Where should the reviewer start?
Select index.d.ts

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #4451 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Maybe

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible