### PR TITLE
Updated docker image of node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 defaults: &defaults
   working_directory: ~/grommet-ci
   docker:
-    - image: circleci/node:12
+    - image: circleci/node:14
 
 jobs:
   checkout:


### PR DESCRIPTION
Tests are successfully running locally, but are failing on CircelCi. The node image version in CircelCi might be the reason.