### PR TITLE
RadioButtonGroup `gap` prop overrides theme.radioButtonGroup.container.gap

### DIFF
--- a/src/js/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/js/components/RadioButtonGroup/RadioButtonGroup.js
@@ -23,7 +23,7 @@ const RadioButtonGroup = forwardRef(
       onChange,
       options: optionsProp,
       value: valueProp,
-      gap = 'small',
+      gap,
       ...rest
     },
     ref,
@@ -105,8 +105,14 @@ const RadioButtonGroup = forwardRef(
       >
         <Box
           ref={ref}
-          gap={gap}
           {...theme.radioButtonGroup.container}
+          gap={
+            gap ||
+            (theme.radioButtonGroup.container &&
+            theme.radioButtonGroup.container.gap
+              ? theme.radioButtonGroup.container.gap
+              : 'small')
+          }
           {...rest}
         >
           {options.map(


### PR DESCRIPTION

#### What does this PR do?
Previously theme.radioButtonGroup.container.gap would override the `gap` prop for RadioButtonGroup. Now `gap` takes precedence 

#### Where should the reviewer start?

#### What testing has been done on this PR?
storybook
```javascript
import React, { useState } from 'react';
import { storiesOf } from '@storybook/react';

import { Box, Grommet, RadioButtonGroup } from 'grommet';

const customTheme = {
  radioButtonGroup: {
    container: {
      gap: 'xlarge',
    },
  },
};

const CustomRadioButtomGroup = ({ value: initialValue, ...props }) => {
  const [value, setValue] = useState(initialValue);

  return (
    <Grommet theme={customTheme}>git 
      <Box align="center" pad="large">
        <RadioButtonGroup
          gap='medium'
          name="radio"
          options={[
            { label: 'Choice 1', value: 'c1' },
            { label: 'Choice 2', value: 'c2' },
            { label: 'Choice 3', value: 'c3' },
          ]}
          value={value}
          onChange={event => setValue(event.target.value)}
          {...props}
        />
      </Box>
    </Grommet>
  );
};

storiesOf('RadioButtonGroup', module).add('TEST', () => (
  <CustomRadioButtomGroup />
));
```

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #4524 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible (bug fix)
