### PR TITLE
Update theme styling options for DataTable header

### DIFF
--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -70,21 +70,18 @@ const basicStyle = props => css`
 `;
 
 // CSS for this sub-object in the theme
-const kindPartStyles = (obj, theme, colorValue) => {
+export const kindPartStyles = (obj, theme, colorValue) => {
   const styles = [];
-  if (obj.padding) {
-    if (obj.padding.vertical || obj.padding.horizontal)
+  if (obj.padding || obj.pad) {
+    // button uses `padding` but other components use Grommet `pad`
+    const pad = obj.padding || obj.pad;
+    if (pad.vertical || pad.horizontal)
       styles.push(
-        `padding: ${theme.global.edgeSize[obj.padding.vertical] ||
-          obj.padding.vertical ||
-          0} ${theme.global.edgeSize[obj.padding.horizontal] ||
-          obj.padding.horizontal ||
-          0};`,
+        `padding: ${theme.global.edgeSize[pad.vertical] ||
+          pad.vertical ||
+          0} ${theme.global.edgeSize[pad.horizontal] || pad.horizontal || 0};`,
       );
-    else
-      styles.push(
-        `padding: ${theme.global.edgeSize[obj.padding] || obj.padding || 0};`,
-      );
+    else styles.push(`padding: ${theme.global.edgeSize[pad] || pad || 0};`);
   }
   if (obj.background)
     styles.push(

--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -2,11 +2,10 @@ import styled, { css } from 'styled-components';
 
 import {
   activeStyle,
-  backgroundStyle,
   disabledStyle,
   focusStyle,
   genericStyles,
-  normalizeColor,
+  kindPartStyles,
 } from '../../utils';
 import { defaultProps } from '../../default-props';
 
@@ -68,78 +67,6 @@ const basicStyle = props => css`
     vertical-align: bottom;
   }
 `;
-
-// CSS for this sub-object in the theme
-export const kindPartStyles = (obj, theme, colorValue) => {
-  const styles = [];
-  if (obj.padding || obj.pad) {
-    // button uses `padding` but other components use Grommet `pad`
-    const pad = obj.padding || obj.pad;
-    if (pad.vertical || pad.horizontal)
-      styles.push(
-        `padding: ${theme.global.edgeSize[pad.vertical] ||
-          pad.vertical ||
-          0} ${theme.global.edgeSize[pad.horizontal] || pad.horizontal || 0};`,
-      );
-    else styles.push(`padding: ${theme.global.edgeSize[pad] || pad || 0};`);
-  }
-  if (obj.background)
-    styles.push(
-      backgroundStyle(
-        colorValue || obj.background,
-        theme,
-        obj.color ||
-          (Object.prototype.hasOwnProperty.call(obj, 'color') &&
-          obj.color === undefined
-            ? false
-            : undefined),
-      ),
-    );
-  else if (obj.color)
-    styles.push(`color: ${normalizeColor(obj.color, theme)};`);
-  if (obj.border) {
-    if (obj.border.width)
-      styles.push(css`
-        border-style: solid;
-        border-width: ${obj.border.width};
-      `);
-    if (obj.border.color)
-      styles.push(css`
-        border-color: ${normalizeColor(
-          (!obj.background && colorValue) || obj.border.color || 'border',
-          theme,
-        )};
-      `);
-    if (obj.border.radius)
-      styles.push(css`
-        border-radius: ${obj.border.radius};
-      `);
-  } else if (obj.border === false) styles.push('border: none;');
-  if (colorValue && !obj.border && !obj.background)
-    styles.push(`color: ${normalizeColor(colorValue, theme)};`);
-  if (obj.font) {
-    if (obj.font.size) {
-      styles.push(
-        `font-size: ${theme.text[obj.font.size].size || obj.font.size};`,
-      );
-    }
-    if (obj.font.height) {
-      styles.push(`line-height: ${obj.font.height};`);
-    }
-    if (obj.font.weight) {
-      styles.push(`font-weight: ${obj.font.weight};`);
-    }
-  }
-  if (obj.opacity) {
-    const opacity =
-      obj.opacity === true
-        ? theme.global.opacity.medium
-        : theme.global.opacity[obj.opacity] || obj.opacity;
-    styles.push(`opacity: ${opacity};`);
-  }
-  if (obj.extend) styles.push(obj.extend);
-  return styles;
-};
 
 // build up CSS from basic to specific based on the supplied sub-object paths
 const kindStyle = ({ colorValue, themePaths, theme }) => {

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -18,7 +18,7 @@ import {
   StyledDataTableRow,
 } from './StyledDataTable';
 import { datumValue } from './buildState';
-import { kindPartStyles } from '../Button/StyledButtonKind';
+import { kindPartStyles } from '../../utils';
 
 // build up CSS from basic to specific based on the supplied sub-object paths.
 // adapted from StyledButtonKind to only include parts relevant for DataTable

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -20,24 +20,31 @@ import {
 import { datumValue } from './buildState';
 import { kindPartStyles } from '../../utils';
 
+// separate theme values into groupings depending on what
+// part of header cell they should style
+const separateThemeProps = theme => {
+  const { background, border, color, font, ...rest } = theme.dataTable.header;
+
+  const cellProps = { background, border };
+  const textProps = { color, ...font };
+  const layoutProps = { ...rest };
+
+  return [cellProps, layoutProps, textProps];
+};
+
 // build up CSS from basic to specific based on the supplied sub-object paths.
 // adapted from StyledButtonKind to only include parts relevant for DataTable
 const buttonStyle = ({ theme }) => {
   const styles = [];
-  // don't apply background or border on button. these
-  // should only apply to the `th`
-  const contentStyles = { ...theme.dataTable.header };
-  delete contentStyles.background;
-  delete contentStyles.border;
 
-  const obj = contentStyles;
-  if (obj) {
-    styles.push(kindPartStyles(obj, theme));
+  const [, layoutProps] = separateThemeProps(theme);
+  if (layoutProps) {
+    styles.push(kindPartStyles(layoutProps, theme));
   }
 
-  if (obj.hover) {
+  if (layoutProps.hover) {
     // CSS for this sub-object in the theme
-    const partStyles = kindPartStyles(obj.hover, theme);
+    const partStyles = kindPartStyles(layoutProps.hover, theme);
     if (partStyles.length > 0)
       styles.push(
         css`
@@ -128,19 +135,18 @@ const Header = ({
             verticalAlign,
             size,
           }) => {
-            // don't apply background or border on other contents of the cell
-            const contentStyles = { ...theme.dataTable.header };
-            delete contentStyles.background;
-            delete contentStyles.border;
+            const [cellProps, layoutProps, textProps] = separateThemeProps(
+              theme,
+            );
 
             let content;
             if (typeof header === 'string') {
-              content = <Text {...contentStyles.font}>{header}</Text>;
-              if (Object.keys(contentStyles).length && sortable === false) {
-                // apply rest of header cell styling if cell is not sortable,
+              content = <Text {...textProps}>{header}</Text>;
+              if (Object.keys(layoutProps).length && sortable === false) {
+                // apply rest of layout styling if cell is not sortable,
                 // otherwise this styling will be applied by
                 // StyledHeaderCellButton
-                content = <Box {...contentStyles}>{content}</Box>;
+                content = <Box {...layoutProps}>{content}</Box>;
               }
             } else content = header;
 
@@ -224,8 +230,8 @@ const Header = ({
                 key={property}
                 align={align}
                 verticalAlign={verticalAlign}
-                background={background || theme.dataTable.header.background}
-                border={border || theme.dataTable.header.border}
+                background={background || cellProps.background}
+                border={border || cellProps.border}
                 pad={pad}
                 pin={pin}
                 plain

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -750,6 +750,97 @@ Defaults to
 {}
 ```
 
+**dataTable.header.background**
+
+Any valid Box background value. Expects `string | 
+    { dark: string, light: string } |
+    { 
+      color: { dark: string, light: string } | string, 
+      dark: bool, 
+      image: string, 
+      position: string, 
+      opacity: bool | string, 
+      repeat: no-repeat | repeat, 
+      size: cover | contain | string
+    }`.
+
+Defaults to
+
+```
+undefined
+```
+
+**dataTable.header.border**
+
+Any valid Box border value. Expects `string | object`.
+
+Defaults to
+
+```
+undefined
+```
+
+**dataTable.header.font.weight**
+
+The font weight for text in header cells. Expects `string`.
+
+Defaults to
+
+```
+undefined
+```
+
+**dataTable.header.font.size**
+
+The font size for text in header cells. Expects `string`.
+
+Defaults to
+
+```
+undefined
+```
+
+**dataTable.header.gap**
+
+The gap between elements within the header cell. Expects `object`.
+
+Defaults to
+
+```
+small
+```
+
+**dataTable.header.hover.background**
+
+The hover background color of the header cell contents, if 
+    clickable. Any valid Box background options apply. Expects `string | 
+    { dark: string, light: string } |
+    { 
+      color: { dark: string, light: string } | string, 
+      dark: bool, 
+      image: string, 
+      position: string, 
+      opacity: bool | string, 
+      repeat: no-repeat | repeat, 
+      size: cover | contain | string
+    }`.
+
+Defaults to
+
+```
+undefined
+```
+
+**dataTable.header.pad**
+
+The pad around the contents of the header cell. Expects `string | object`.
+
+Defaults to
+
+```
+undefined
+```
+
 **dataTable.icons.ascending**
 
 The ascending icon. Expects `React.Element`.

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -628,4 +628,44 @@ describe('DataTable', () => {
     expect(onSelect).toBeCalledWith(expect.arrayContaining(['alpha', 'beta']));
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('custom theme', () => {
+    const customTheme = {
+      dataTable: {
+        header: {
+          background: 'skyblue',
+          border: {
+            color: 'brand',
+            size: 'medium',
+          },
+          gap: 'none',
+          pad: { horizontal: 'small', vertical: 'xsmall' },
+          font: {
+            weight: 'bold',
+          },
+          hover: {
+            background: {
+              color: 'light-2',
+            },
+          },
+        },
+      },
+    };
+
+    const { container, getByLabelText } = render(
+      <Grommet theme={customTheme}>
+        <DataTable
+          columns={[{ property: 'a', header: 'A' }]}
+          data={[{ a: 'alpha' }, { a: 'beta' }]}
+          primaryKey="a"
+          select={['alpha']}
+          sortable
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+
+    fireEvent.mouseOver(getByLabelText('select beta'));
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -10294,7 +10294,7 @@ exports[`DataTable sort nested object 1`] = `
           scope="col"
         >
           <button
-            class="c4"
+            class="c4 "
             type="button"
           >
             <div
@@ -10313,7 +10313,7 @@ exports[`DataTable sort nested object 1`] = `
           scope="col"
         >
           <button
-            class="c4"
+            class="c4 "
             type="button"
           >
             <div
@@ -10652,7 +10652,7 @@ exports[`DataTable sort nested object with onSort 1`] = `
           scope="col"
         >
           <button
-            class="c4"
+            class="c4 "
             type="button"
           >
             <div
@@ -10671,7 +10671,7 @@ exports[`DataTable sort nested object with onSort 1`] = `
           scope="col"
         >
           <button
-            class="c4"
+            class="c4 "
             type="button"
           >
             <div

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2694,7 +2694,6 @@ exports[`DataTable custom theme 1`] = `
 
 .c6 {
   padding: 6px 12px;
-  font-weight: bold;
 }
 
 .c6:hover {
@@ -2886,7 +2885,7 @@ exports[`DataTable custom theme 2`] = `
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 hhnCts"
+            class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 ixwBdO"
             type="button"
           >
             <div

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2192,6 +2192,597 @@ exports[`DataTable click 2`] = `
 </div>
 `;
 
+exports[`DataTable custom theme 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px #7D4CDB;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px rgba(0,0,0,0.15);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.c5 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  height: 100%;
+}
+
+.c5:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c5:focus > circle,
+.c5:focus > ellipse,
+.c5:focus > line,
+.c5:focus > path,
+.c5:focus > polygon,
+.c5:focus > polyline,
+.c5:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c5:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c16 {
+  box-sizing: border-box;
+  stroke-width: 4px;
+  stroke: #7D4CDB;
+  width: 24px;
+  height: 24px;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  opacity: 0.5;
+  cursor: default;
+}
+
+.c11:hover input:not([disabled]) + div,
+.c11:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c14 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+}
+
+.c14:checked + span > span {
+  left: calc( 48px - 24px );
+  background: #7D4CDB;
+}
+
+.c13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  background: skyblue;
+  border: solid 4px #7D4CDB;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c10 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c8 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c2 {
+  border-spacing: 0;
+  border-collapse: separate;
+  height: auto;
+}
+
+.c9:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c6 {
+  padding: 6px 12px;
+  font-weight: bold;
+}
+
+.c6:hover {
+  background-color: rgba(242,242,242,1);
+  color: #444444;
+}
+
+@media only screen and (max-width:768px) {
+  .c15 {
+    border: solid 2px #7D4CDB;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c18 {
+    border: solid 2px rgba(0,0,0,0.15);
+  }
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <td
+          class="c3"
+        />
+        <th
+          class="c4 "
+          scope="col"
+        >
+          <button
+            class="c5 c6"
+            type="button"
+          >
+            <div
+              class="c7"
+            >
+              <span
+                class="c8"
+              >
+                A
+              </span>
+            </div>
+          </button>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c9"
+    >
+      <tr
+        class=""
+      >
+        <td
+          class="c10"
+        >
+          <label
+            aria-label="unselect alpha"
+            class="c11"
+            disabled=""
+          >
+            <div
+              class="c12 c13"
+              disabled=""
+            >
+              <input
+                checked=""
+                class="c14"
+                disabled=""
+                type="checkbox"
+              />
+              <div
+                class="c15 "
+                disabled=""
+              >
+                <svg
+                  class="c16"
+                  disabled=""
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M6,11.3 L10.3,16 L18,6.2"
+                    fill="none"
+                  />
+                </svg>
+              </div>
+              <input
+                type="hidden"
+                value="true"
+              />
+            </div>
+          </label>
+        </td>
+        <th
+          class="c10 "
+          scope="row"
+        >
+          <div
+            class="c17"
+          >
+            <span
+              class="c8"
+            >
+              alpha
+            </span>
+          </div>
+        </th>
+      </tr>
+      <tr
+        class=""
+      >
+        <td
+          class="c10"
+        >
+          <label
+            aria-label="select beta"
+            class="c11"
+            disabled=""
+          >
+            <div
+              class="c12 c13"
+              disabled=""
+            >
+              <input
+                class="c14"
+                disabled=""
+                type="checkbox"
+              />
+              <div
+                class="c18 "
+                disabled=""
+              />
+            </div>
+          </label>
+        </td>
+        <th
+          class="c10 "
+          scope="row"
+        >
+          <div
+            class="c17"
+          >
+            <span
+              class="c8"
+            >
+              beta
+            </span>
+          </div>
+        </th>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable custom theme 2`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
+>
+  <table
+    class="StyledTable-sc-1m3u5g-6 bJymoW StyledDataTable-xrlyjm-0 koBqev"
+  >
+    <thead
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 kdPLsZ StyledDataTable__StyledDataTableHeader-xrlyjm-3 hOGMbn"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
+      >
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI"
+        />
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cYDXOf StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          scope="col"
+        >
+          <button
+            class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 hhnCts"
+            type="button"
+          >
+            <div
+              class="StyledBox-sc-13pk1d4-0 rpWqh"
+            >
+              <span
+                class="StyledText-sc-1sadyjn-0 gmtNWw"
+              >
+                A
+              </span>
+            </div>
+          </button>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 bMdIOJ StyledDataTable__StyledDataTableBody-xrlyjm-2 kERYjL"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
+      >
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK"
+        >
+          <label
+            aria-label="unselect alpha"
+            class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dEVPVv"
+            disabled=""
+          >
+            <div
+              class="StyledBox-sc-13pk1d4-0 fHyGHh StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+              disabled=""
+            >
+              <input
+                checked=""
+                class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 gDJpaa"
+                disabled=""
+                type="checkbox"
+              />
+              <div
+                class="StyledBox-sc-13pk1d4-0 KsQmP StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+                disabled=""
+              >
+                <svg
+                  class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 gHRhNW"
+                  disabled=""
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M6,11.3 L10.3,16 L18,6.2"
+                    fill="none"
+                  />
+                </svg>
+              </div>
+              <input
+                type="hidden"
+                value="true"
+              />
+            </div>
+          </label>
+        </td>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          scope="row"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 gmtNWw"
+            >
+              alpha
+            </span>
+          </div>
+        </th>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 enByxm StyledDataTable__StyledDataTableRow-xrlyjm-1 jKzMJr"
+      >
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK"
+        >
+          <label
+            aria-label="select beta"
+            class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dEVPVv"
+            disabled=""
+          >
+            <div
+              class="StyledBox-sc-13pk1d4-0 fHyGHh StyledCheckBox-sc-1dbk5ju-6 CBoMo"
+              disabled=""
+            >
+              <input
+                class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 gDJpaa"
+                disabled=""
+                type="checkbox"
+              />
+              <div
+                class="StyledBox-sc-13pk1d4-0 gDUCoH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 iEciRS"
+                disabled=""
+              />
+            </div>
+          </label>
+        </td>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bXELjK StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
+          scope="row"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bFwQzJ"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 gmtNWw"
+            >
+              beta
+            </span>
+          </div>
+        </th>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`DataTable empty 1`] = `
 .c0 {
   font-size: 18px;
@@ -4708,7 +5299,7 @@ exports[`DataTable onSort 1`] = `
           scope="col"
         >
           <button
-            class="c4"
+            class="c4 "
             type="button"
           >
             <div
@@ -4727,7 +5318,7 @@ exports[`DataTable onSort 1`] = `
           scope="col"
         >
           <button
-            class="c4"
+            class="c4 "
             type="button"
           >
             <div
@@ -4862,7 +5453,7 @@ exports[`DataTable onSort 2`] = `
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 gCGTKO"
+            class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 hCocKd"
             type="button"
           >
             <div
@@ -4959,7 +5550,7 @@ exports[`DataTable onSort 2`] = `
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 gCGTKO"
+            class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 hCocKd"
             type="button"
           >
             <div
@@ -6963,7 +7554,24 @@ exports[`DataTable resizeable 1`] = `
   justify-content: space-between;
 }
 
-.c7 {
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6983,7 +7591,7 @@ exports[`DataTable resizeable 1`] = `
   padding-bottom: 12px;
 }
 
-.c11 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6997,7 +7605,7 @@ exports[`DataTable resizeable 1`] = `
   flex-direction: column;
 }
 
-.c6 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -7020,7 +7628,7 @@ exports[`DataTable resizeable 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7038,18 +7646,18 @@ exports[`DataTable resizeable 1`] = `
   width: inherit;
 }
 
-.c5 {
+.c6 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c12 {
+.c13 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c8 {
+.c9 {
   cursor: col-resize;
 }
 
@@ -7059,12 +7667,12 @@ exports[`DataTable resizeable 1`] = `
   height: auto;
 }
 
-.c9:focus {
+.c10:focus {
   outline: 2px solid #6FFFB0;
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c7 {
     width: 6px;
   }
 }
@@ -7095,16 +7703,20 @@ exports[`DataTable resizeable 1`] = `
             class="c4"
             style="position: relative;"
           >
-            <span
+            <div
               class="c5"
             >
-              A
-            </span>
+              <span
+                class="c6"
+              >
+                A
+              </span>
+            </div>
             <div
-              class="c6"
+              class="c7"
             />
             <div
-              class="c7 c8"
+              class="c8 c9"
             />
           </div>
         </th>
@@ -7116,49 +7728,53 @@ exports[`DataTable resizeable 1`] = `
             class="c4"
             style="position: relative;"
           >
-            <span
+            <div
               class="c5"
             >
-              B
-            </span>
+              <span
+                class="c6"
+              >
+                B
+              </span>
+            </div>
             <div
-              class="c6"
+              class="c7"
             />
             <div
-              class="c7 c8"
+              class="c8 c9"
             />
           </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c9"
+      class="c10"
     >
       <tr
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c5"
+              class="c6"
             >
               1
             </span>
@@ -7169,27 +7785,27 @@ exports[`DataTable resizeable 1`] = `
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c5"
+              class="c6"
             >
               2
             </span>
@@ -7442,7 +8058,7 @@ exports[`DataTable rowProps 1`] = `
 `;
 
 exports[`DataTable search 1`] = `
-.c8 {
+.c9 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -7453,25 +8069,25 @@ exports[`DataTable search 1`] = `
   stroke: rgba(0,0,0,0.33);
 }
 
-.c8 g {
+.c9 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill="none"] {
+.c9 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
+.c9 *[stroke*="#"],
+.c9 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*="#"],
+.c9 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -7509,7 +8125,24 @@ exports[`DataTable search 1`] = `
   justify-content: space-between;
 }
 
-.c11 {
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7523,7 +8156,7 @@ exports[`DataTable search 1`] = `
   flex-direction: column;
 }
 
-.c6 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -7533,7 +8166,7 @@ exports[`DataTable search 1`] = `
   width: 12px;
 }
 
-.c7 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -7553,28 +8186,28 @@ exports[`DataTable search 1`] = `
   padding: 12px;
 }
 
-.c7:hover {
+.c8:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c7:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -7591,7 +8224,7 @@ exports[`DataTable search 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7609,12 +8242,12 @@ exports[`DataTable search 1`] = `
   width: inherit;
 }
 
-.c5 {
+.c6 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c12 {
+.c13 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -7626,12 +8259,12 @@ exports[`DataTable search 1`] = `
   height: auto;
 }
 
-.c9:focus {
+.c10:focus {
   outline: 2px solid #6FFFB0;
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c7 {
     width: 6px;
   }
 }
@@ -7661,22 +8294,26 @@ exports[`DataTable search 1`] = `
           <div
             class="c4"
           >
-            <span
+            <div
               class="c5"
             >
-              A
-            </span>
+              <span
+                class="c6"
+              >
+                A
+              </span>
+            </div>
             <div
-              class="c6"
+              class="c7"
             />
             <button
               aria-label="focus-search-a"
-              class="c7"
+              class="c8"
               type="button"
             >
               <svg
                 aria-label="FormSearch"
-                class="c8"
+                class="c9"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -7692,20 +8329,20 @@ exports[`DataTable search 1`] = `
       </tr>
     </thead>
     <tbody
-      class="c9"
+      class="c10"
     >
       <tr
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               Alpha
             </span>
@@ -7716,14 +8353,14 @@ exports[`DataTable search 1`] = `
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               beta
             </span>
@@ -7734,14 +8371,14 @@ exports[`DataTable search 1`] = `
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               []
             </span>
@@ -7773,11 +8410,15 @@ exports[`DataTable search 2`] = `
           <div
             class="StyledBox-sc-13pk1d4-0 empHH"
           >
-            <span
-              class="StyledText-sc-1sadyjn-0 hUokoe"
+            <div
+              class="StyledBox-sc-13pk1d4-0 bToxzR"
             >
-              A
-            </span>
+              <span
+                class="StyledText-sc-1sadyjn-0 hUokoe"
+              >
+                A
+              </span>
+            </div>
             <div
               class="StyledBox__StyledBoxGap-sc-13pk1d4-1 bRyuLk"
             />
@@ -8707,7 +9348,7 @@ exports[`DataTable sort 1`] = `
           scope="col"
         >
           <button
-            class="c4"
+            class="c4 "
             type="button"
           >
             <div
@@ -8742,7 +9383,7 @@ exports[`DataTable sort 1`] = `
           scope="col"
         >
           <button
-            class="c4"
+            class="c4 "
             type="button"
           >
             <div
@@ -9066,7 +9707,7 @@ exports[`DataTable sort external 1`] = `
           scope="col"
         >
           <button
-            class="c4"
+            class="c4 "
             type="button"
           >
             <div
@@ -9101,7 +9742,7 @@ exports[`DataTable sort external 1`] = `
           scope="col"
         >
           <button
-            class="c4"
+            class="c4 "
             type="button"
           >
             <div
@@ -9375,7 +10016,7 @@ exports[`DataTable sortable 1`] = `
           scope="col"
         >
           <button
-            class="c4"
+            class="c4 "
             type="button"
           >
             <div
@@ -9394,7 +10035,7 @@ exports[`DataTable sortable 1`] = `
           scope="col"
         >
           <button
-            class="c4"
+            class="c4 "
             type="button"
           >
             <div
@@ -9529,7 +10170,7 @@ exports[`DataTable sortable 2`] = `
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 gCGTKO"
+            class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 hCocKd"
             type="button"
           >
             <div
@@ -9626,7 +10267,7 @@ exports[`DataTable sortable 2`] = `
           scope="col"
         >
           <button
-            class="StyledButton-sc-323bzc-0 gCGTKO"
+            class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 hCocKd"
             type="button"
           >
             <div

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -327,6 +327,63 @@ export const themeDoc = {
     type: 'object',
     defaultValue: '{}',
   },
+  'dataTable.header.background': {
+    description: 'Any valid Box background value.',
+    type: `string | 
+    { dark: string, light: string } |
+    { 
+      color: { dark: string, light: string } | string, 
+      dark: bool, 
+      image: string, 
+      position: string, 
+      opacity: bool | string, 
+      repeat: no-repeat | repeat, 
+      size: cover | contain | string
+    }`,
+    defaultValue: undefined,
+  },
+  'dataTable.header.border': {
+    description: 'Any valid Box border value.',
+    type: 'string | object',
+    defaultValue: undefined,
+  },
+  'dataTable.header.font.weight': {
+    description: 'The font weight for text in header cells.',
+    type: 'string',
+    defaultValue: undefined,
+  },
+  'dataTable.header.font.size': {
+    description: 'The font size for text in header cells.',
+    type: 'string',
+    defaultValue: undefined,
+  },
+  'dataTable.header.gap': {
+    description: 'The gap between elements within the header cell.',
+    type: 'object',
+    defaultValue: 'small',
+  },
+  'dataTable.header.hover.background': {
+    description: `The hover background color of the header cell contents, if 
+    clickable. Any valid Box background options apply.`,
+    type: `string | 
+    { dark: string, light: string } |
+    { 
+      color: { dark: string, light: string } | string, 
+      dark: bool, 
+      image: string, 
+      position: string, 
+      opacity: bool | string, 
+      repeat: no-repeat | repeat, 
+      size: cover | contain | string
+    }`,
+    defaultValue: undefined,
+  },
+
+  'dataTable.header.pad': {
+    description: 'The pad around the contents of the header cell.',
+    type: 'string | object',
+    defaultValue: undefined,
+  },
   'dataTable.icons.ascending': {
     description: 'The ascending icon.',
     type: 'React.Element',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -6635,6 +6635,97 @@ Defaults to
 {}
 \`\`\`
 
+**dataTable.header.background**
+
+Any valid Box background value. Expects \`string | 
+    { dark: string, light: string } |
+    { 
+      color: { dark: string, light: string } | string, 
+      dark: bool, 
+      image: string, 
+      position: string, 
+      opacity: bool | string, 
+      repeat: no-repeat | repeat, 
+      size: cover | contain | string
+    }\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**dataTable.header.border**
+
+Any valid Box border value. Expects \`string | object\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**dataTable.header.font.weight**
+
+The font weight for text in header cells. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**dataTable.header.font.size**
+
+The font size for text in header cells. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**dataTable.header.gap**
+
+The gap between elements within the header cell. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+small
+\`\`\`
+
+**dataTable.header.hover.background**
+
+The hover background color of the header cell contents, if 
+    clickable. Any valid Box background options apply. Expects \`string | 
+    { dark: string, light: string } |
+    { 
+      color: { dark: string, light: string } | string, 
+      dark: bool, 
+      image: string, 
+      position: string, 
+      opacity: bool | string, 
+      repeat: no-repeat | repeat, 
+      size: cover | contain | string
+    }\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**dataTable.header.pad**
+
+The pad around the contents of the header cell. Expects \`string | object\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
 **dataTable.icons.ascending**
 
 The ascending icon. Expects \`React.Element\`.

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -596,7 +596,19 @@ export interface ThemeType {
     body?: {
       extend?: ExtendType;
     };
-    header?: {};
+    header?: {
+      background?: BackgroundType;
+      border?: BorderType;
+      font?: {
+        weight?: string;
+        size?: string;
+      };
+      gap?: GapType;
+      hover?: {
+        background?: BackgroundType;
+      };
+      pad?: PadType;
+    };
     groupHeader?: {
       border?: {
         side?: string;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -679,7 +679,19 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       groupEnd: {
         border: { side: 'bottom', size: 'xsmall' },
       },
-      header: {},
+      header: {
+        // background: undefined,
+        // border: undefined,
+        // font: {
+        //   weight: undefined,
+        //   size: undefined,
+        // },
+        gap: 'small',
+        // hover: {
+        //   background: undefined,
+        // },
+        // pad: undefined,
+      },
       icons: {
         ascending: FormDown,
         contract: FormUp,

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -531,3 +531,75 @@ export const plainInputStyle = css`
   outline: none;
   border: none;
 `;
+
+// CSS for this sub-object in the theme
+export const kindPartStyles = (obj, theme, colorValue) => {
+  const styles = [];
+  if (obj.padding || obj.pad) {
+    // button uses `padding` but other components use Grommet `pad`
+    const pad = obj.padding || obj.pad;
+    if (pad.vertical || pad.horizontal)
+      styles.push(
+        `padding: ${theme.global.edgeSize[pad.vertical] ||
+          pad.vertical ||
+          0} ${theme.global.edgeSize[pad.horizontal] || pad.horizontal || 0};`,
+      );
+    else styles.push(`padding: ${theme.global.edgeSize[pad] || pad || 0};`);
+  }
+  if (obj.background)
+    styles.push(
+      backgroundStyle(
+        colorValue || obj.background,
+        theme,
+        obj.color ||
+          (Object.prototype.hasOwnProperty.call(obj, 'color') &&
+          obj.color === undefined
+            ? false
+            : undefined),
+      ),
+    );
+  else if (obj.color)
+    styles.push(`color: ${normalizeColor(obj.color, theme)};`);
+  if (obj.border) {
+    if (obj.border.width)
+      styles.push(css`
+        border-style: solid;
+        border-width: ${obj.border.width};
+      `);
+    if (obj.border.color)
+      styles.push(css`
+        border-color: ${normalizeColor(
+          (!obj.background && colorValue) || obj.border.color || 'border',
+          theme,
+        )};
+      `);
+    if (obj.border.radius)
+      styles.push(css`
+        border-radius: ${obj.border.radius};
+      `);
+  } else if (obj.border === false) styles.push('border: none;');
+  if (colorValue && !obj.border && !obj.background)
+    styles.push(`color: ${normalizeColor(colorValue, theme)};`);
+  if (obj.font) {
+    if (obj.font.size) {
+      styles.push(
+        `font-size: ${theme.text[obj.font.size].size || obj.font.size};`,
+      );
+    }
+    if (obj.font.height) {
+      styles.push(`line-height: ${obj.font.height};`);
+    }
+    if (obj.font.weight) {
+      styles.push(`font-weight: ${obj.font.weight};`);
+    }
+  }
+  if (obj.opacity) {
+    const opacity =
+      obj.opacity === true
+        ? theme.global.opacity.medium
+        : theme.global.opacity[obj.opacity] || obj.opacity;
+    styles.push(`opacity: ${opacity};`);
+  }
+  if (obj.extend) styles.push(obj.extend);
+  return styles;
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR extends theming capabilities of data table header cells. The contents of this cell can include a label (clickable if column is sortable, otherwise just text/custom render), a search button (not encouraged but already exists and left untouched), and a resizer. The `theme.dataTable.header` structure now supports:
```
         background: undefined,
         border: undefined,
         font: {
           weight: undefined,
           size: undefined,
         },
        gap: 'small', // previously defined inline, but now giving users to style via theme and setting inline value as default
         hover: {
           background: undefined,
        },
        pad: undefined,
```
`background` and `border` will apply to the overall `th`, but the remaining will affect the styling of the content instead. In the case that the content is just a Text, then it will be applied to the Box surrounding the Text. In the case that the content is sortable and becomes a Button, then the theming will be applied to that Button. Additionally, the column label (whether Text or Button) now has `flex="grow"` which allows it to take up any remaining space in the column.

#### Where should the reviewer start?
src/js/components/DataTable/Header.js

#### What testing has been done on this PR?
Added a jest test. 

#### How should this be manually tested?
In storybook for DataTable Sort, apply the following theme locally:
```
const customTheme = {
      dataTable: {
        header: {
          background: 'skyblue',
          border: {
            color: 'green',
            size: 'medium',
          },
          gap: 'none',
          pad: { horizontal: 'small', vertical: 'xsmall' },
          font: {
            weight: 'bold',
          },
          hover: {
            background: {
              color: 'light-2',
            },
          },
        },
      },
    };
```
You should see the following as a result (the grey background was where the mouse was hovered over):
<img width="1680" alt="Screen Shot 2020-09-22 at 4 01 35 PM" src="https://user-images.githubusercontent.com/12522275/93946414-0e446200-fcee-11ea-9a3d-0db8b852f4c9.png">

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/4454

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, updated here.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.