### PR TITLE
Content should fill any available space in header cell

### DIFF
--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -181,6 +181,9 @@ const Header = ({
               );
             }
 
+            // content should fill any available space in cell
+            content = <Box flex="grow">{content}</Box>;
+
             if (search || onResize) {
               const resizer = onResize ? (
                 <Resizer property={property} onResize={onResize} />
@@ -204,8 +207,7 @@ const Header = ({
                   fill="vertical"
                   style={onResize ? { position: 'relative' } : undefined}
                 >
-                  {/* content should fill any available space in cell */}
-                  <Box flex="grow">{content}</Box>
+                  {content}
                   {searcher && resizer ? (
                     <Box
                       flex="shrink"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -11,7 +11,24 @@ exports[`DataTable !primaryKey 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c7 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -38,7 +55,7 @@ exports[`DataTable !primaryKey 1`] = `
   padding-bottom: 6px;
 }
 
-.c6 {
+.c7 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -56,7 +73,7 @@ exports[`DataTable !primaryKey 1`] = `
   width: inherit;
 }
 
-.c4 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
@@ -67,7 +84,7 @@ exports[`DataTable !primaryKey 1`] = `
   height: auto;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -93,51 +110,59 @@ exports[`DataTable !primaryKey 1`] = `
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            B
-          </span>
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c5"
+      class="c6"
     >
       <tr
         class=""
       >
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               one
             </span>
           </div>
         </td>
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               1
             </span>
@@ -148,26 +173,26 @@ exports[`DataTable !primaryKey 1`] = `
         class=""
       >
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               two
             </span>
           </div>
         </td>
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               2
             </span>
@@ -190,7 +215,24 @@ exports[`DataTable absoluteColumnSizes 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -220,7 +262,7 @@ exports[`DataTable absoluteColumnSizes 1`] = `
   padding-bottom: 6px;
 }
 
-.c5 {
+.c6 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -236,7 +278,7 @@ exports[`DataTable absoluteColumnSizes 1`] = `
   padding-bottom: 6px;
 }
 
-.c7 {
+.c8 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -251,7 +293,7 @@ exports[`DataTable absoluteColumnSizes 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -272,7 +314,232 @@ exports[`DataTable absoluteColumnSizes 1`] = `
   width: inherit;
 }
 
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c10 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c2 {
+  border-spacing: 0;
+  border-collapse: separate;
+  height: auto;
+}
+
+.c7:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c6 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c7"
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c8 "
+          scope="row"
+        >
+          <div
+            class="c9"
+          >
+            <span
+              class="c10"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c11 "
+        >
+          <div
+            class="c9"
+          >
+            <span
+              class="c5"
+            >
+              1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class=""
+      >
+        <th
+          class="c8 "
+          scope="row"
+        >
+          <div
+            class="c9"
+          >
+            <span
+              class="c10"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c11 "
+        >
+          <div
+            class="c9"
+          >
+            <span
+              class="c5"
+            >
+              2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable aggregate 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c7 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c10 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-top: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
@@ -315,21 +582,29 @@ exports[`DataTable absoluteColumnSizes 1`] = `
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
-          class="c5 "
+          class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            B
-          </span>
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
@@ -354,13 +629,13 @@ exports[`DataTable absoluteColumnSizes 1`] = `
           </div>
         </th>
         <td
-          class="c10 "
+          class="c7 "
         >
           <div
             class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               1
             </span>
@@ -385,213 +660,13 @@ exports[`DataTable absoluteColumnSizes 1`] = `
           </div>
         </th>
         <td
-          class="c10 "
+          class="c7 "
         >
           <div
             class="c8"
           >
             <span
-              class="c4"
-            >
-              2
-            </span>
-          </div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-`;
-
-exports[`DataTable aggregate 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c6 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c9 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  border-top: solid 1px rgba(0,0,0,0.33);
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c1 {
-  border-spacing: 0;
-  border-collapse: collapse;
-  width: inherit;
-}
-
-.c4 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c8 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c2 {
-  border-spacing: 0;
-  border-collapse: separate;
-  height: auto;
-}
-
-.c5:focus {
-  outline: 2px solid #6FFFB0;
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-  .c1 {
-    table-layout: fixed;
-  }
-}
-
-<div
-  class="c0"
->
-  <table
-    class="c1 c2"
-  >
-    <thead
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c3 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            A
-          </span>
-        </th>
-        <th
-          class="c3 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            B
-          </span>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class="c5"
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c6 "
-          scope="row"
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              one
-            </span>
-          </div>
-        </th>
-        <td
-          class="c6 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
-            >
-              1
-            </span>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class=""
-      >
-        <th
-          class="c6 "
-          scope="row"
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              two
-            </span>
-          </div>
-        </th>
-        <td
-          class="c6 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
+              class="c5"
             >
               2
             </span>
@@ -606,20 +681,20 @@ exports[`DataTable aggregate 1`] = `
         class=""
       >
         <td
-          class="c9 "
+          class="c10 "
         >
           <div
-            class="c7"
+            class="c8"
           />
         </td>
         <td
-          class="c9 "
+          class="c10 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               3
             </span>
@@ -642,7 +717,24 @@ exports[`DataTable aggregate with nested object 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c7 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -669,7 +761,7 @@ exports[`DataTable aggregate with nested object 1`] = `
   padding-bottom: 6px;
 }
 
-.c6 {
+.c7 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -681,7 +773,7 @@ exports[`DataTable aggregate with nested object 1`] = `
   padding-bottom: 6px;
 }
 
-.c9 {
+.c10 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -700,12 +792,12 @@ exports[`DataTable aggregate with nested object 1`] = `
   width: inherit;
 }
 
-.c4 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c8 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -717,7 +809,7 @@ exports[`DataTable aggregate with nested object 1`] = `
   height: auto;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -743,52 +835,60 @@ exports[`DataTable aggregate with nested object 1`] = `
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            object
-          </span>
+            <span
+              class="c5"
+            >
+              object
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c5"
+      class="c6"
     >
       <tr
         class=""
       >
         <th
-          class="c6 "
+          class="c7 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               1
             </span>
@@ -799,27 +899,27 @@ exports[`DataTable aggregate with nested object 1`] = `
         class=""
       >
         <th
-          class="c6 "
+          class="c7 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               2
             </span>
@@ -834,20 +934,20 @@ exports[`DataTable aggregate with nested object 1`] = `
         class=""
       >
         <td
-          class="c9 "
+          class="c10 "
         >
           <div
-            class="c7"
+            class="c8"
           />
         </td>
         <td
-          class="c9 "
+          class="c10 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               3
             </span>
@@ -870,7 +970,24 @@ exports[`DataTable background 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c7 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -899,7 +1016,7 @@ exports[`DataTable background 1`] = `
   padding-bottom: 6px;
 }
 
-.c6 {
+.c7 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -913,7 +1030,7 @@ exports[`DataTable background 1`] = `
   padding-bottom: 6px;
 }
 
-.c9 {
+.c10 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -928,7 +1045,7 @@ exports[`DataTable background 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -941,7 +1058,7 @@ exports[`DataTable background 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c12 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -955,7 +1072,7 @@ exports[`DataTable background 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c13 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -968,7 +1085,7 @@ exports[`DataTable background 1`] = `
   padding-bottom: 6px;
 }
 
-.c13 {
+.c14 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -989,12 +1106,12 @@ exports[`DataTable background 1`] = `
   width: inherit;
 }
 
-.c4 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c8 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -1006,7 +1123,7 @@ exports[`DataTable background 1`] = `
   height: auto;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -1032,52 +1149,60 @@ exports[`DataTable background 1`] = `
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            B
-          </span>
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c5"
+      class="c6"
     >
       <tr
         class=""
       >
         <th
-          class="c6 "
+          class="c7 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               1
             </span>
@@ -1088,27 +1213,27 @@ exports[`DataTable background 1`] = `
         class=""
       >
         <th
-          class="c6 "
+          class="c7 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               2
             </span>
@@ -1123,23 +1248,23 @@ exports[`DataTable background 1`] = `
         class=""
       >
         <td
-          class="c9 "
+          class="c10 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               Total
             </span>
           </div>
         </td>
         <td
-          class="c9 "
+          class="c10 "
         >
           <div
-            class="c7"
+            class="c8"
           />
         </td>
       </tr>
@@ -1155,55 +1280,63 @@ exports[`DataTable background 1`] = `
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
-          class="c10 "
+          class="c11 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            B
-          </span>
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c5"
+      class="c6"
     >
       <tr
         class=""
       >
         <th
-          class="c6 "
+          class="c7 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               1
             </span>
@@ -1214,153 +1347,27 @@ exports[`DataTable background 1`] = `
         class=""
       >
         <th
-          class="c11 "
+          class="c12 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c11 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
-            >
-              2
-            </span>
-          </div>
-        </td>
-      </tr>
-    </tbody>
-    <tfoot
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <td
           class="c12 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
-            >
-              Total
-            </span>
-          </div>
-        </td>
-        <td
-          class="c12 "
-        >
-          <div
-            class="c7"
-          />
-        </td>
-      </tr>
-    </tfoot>
-  </table>
-  <table
-    class="c1 c2"
-  >
-    <thead
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c3 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            A
-          </span>
-        </th>
-        <th
-          class="c3 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            B
-          </span>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class="c5"
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c11 "
-          scope="row"
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              one
-            </span>
-          </div>
-        </th>
-        <td
-          class="c11 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
-            >
-              1
-            </span>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class=""
-      >
-        <th
-          class="c11 "
-          scope="row"
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              two
-            </span>
-          </div>
-        </th>
-        <td
-          class="c11 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
+              class="c5"
             >
               2
             </span>
@@ -1378,10 +1385,10 @@ exports[`DataTable background 1`] = `
           class="c13 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               Total
             </span>
@@ -1391,7 +1398,141 @@ exports[`DataTable background 1`] = `
           class="c13 "
         >
           <div
-            class="c7"
+            class="c8"
+          />
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c6"
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c12 "
+          scope="row"
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c12 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class=""
+      >
+        <th
+          class="c12 "
+          scope="row"
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c12 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <td
+          class="c14 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              Total
+            </span>
+          </div>
+        </td>
+        <td
+          class="c14 "
+        >
+          <div
+            class="c8"
           />
         </td>
       </tr>
@@ -1411,7 +1552,24 @@ exports[`DataTable basic 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c7 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1438,7 +1596,7 @@ exports[`DataTable basic 1`] = `
   padding-bottom: 6px;
 }
 
-.c6 {
+.c7 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1456,12 +1614,12 @@ exports[`DataTable basic 1`] = `
   width: inherit;
 }
 
-.c4 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c8 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -1473,7 +1631,7 @@ exports[`DataTable basic 1`] = `
   height: auto;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -1499,52 +1657,60 @@ exports[`DataTable basic 1`] = `
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            B
-          </span>
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c5"
+      class="c6"
     >
       <tr
         class=""
       >
         <th
-          class="c6 "
+          class="c7 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               1
             </span>
@@ -1555,27 +1721,27 @@ exports[`DataTable basic 1`] = `
         class=""
       >
         <th
-          class="c6 "
+          class="c7 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               2
             </span>
@@ -1598,7 +1764,24 @@ exports[`DataTable border 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c6 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1625,7 +1808,7 @@ exports[`DataTable border 1`] = `
   padding-bottom: 6px;
 }
 
-.c8 {
+.c9 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1638,7 +1821,7 @@ exports[`DataTable border 1`] = `
   padding-bottom: 6px;
 }
 
-.c9 {
+.c10 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1657,12 +1840,12 @@ exports[`DataTable border 1`] = `
   width: inherit;
 }
 
-.c4 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c7 {
+.c8 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -1674,7 +1857,7 @@ exports[`DataTable border 1`] = `
   height: auto;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -1700,26 +1883,34 @@ exports[`DataTable border 1`] = `
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            B
-          </span>
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c5"
+      class="c6"
     >
       <tr
         class=""
@@ -1729,10 +1920,10 @@ exports[`DataTable border 1`] = `
           scope="row"
         >
           <div
-            class="c6"
+            class="c7"
           >
             <span
-              class="c7"
+              class="c8"
             >
               one
             </span>
@@ -1742,10 +1933,10 @@ exports[`DataTable border 1`] = `
           class="c3 "
         >
           <div
-            class="c6"
+            class="c7"
           >
             <span
-              class="c4"
+              class="c5"
             >
               1
             </span>
@@ -1760,10 +1951,10 @@ exports[`DataTable border 1`] = `
           scope="row"
         >
           <div
-            class="c6"
+            class="c7"
           >
             <span
-              class="c7"
+              class="c8"
             >
               two
             </span>
@@ -1773,10 +1964,10 @@ exports[`DataTable border 1`] = `
           class="c3 "
         >
           <div
-            class="c6"
+            class="c7"
           >
             <span
-              class="c4"
+              class="c5"
             >
               2
             </span>
@@ -1794,10 +1985,10 @@ exports[`DataTable border 1`] = `
           class="c3 "
         >
           <div
-            class="c6"
+            class="c7"
           >
             <span
-              class="c7"
+              class="c8"
             >
               Total
             </span>
@@ -1807,133 +1998,7 @@ exports[`DataTable border 1`] = `
           class="c3 "
         >
           <div
-            class="c6"
-          />
-        </td>
-      </tr>
-    </tfoot>
-  </table>
-  <table
-    class="c1 c2"
-  >
-    <thead
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c8 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            A
-          </span>
-        </th>
-        <th
-          class="c8 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            B
-          </span>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class="c5"
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c8 "
-          scope="row"
-        >
-          <div
-            class="c6"
-          >
-            <span
-              class="c7"
-            >
-              one
-            </span>
-          </div>
-        </th>
-        <td
-          class="c8 "
-        >
-          <div
-            class="c6"
-          >
-            <span
-              class="c4"
-            >
-              1
-            </span>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class=""
-      >
-        <th
-          class="c8 "
-          scope="row"
-        >
-          <div
-            class="c6"
-          >
-            <span
-              class="c7"
-            >
-              two
-            </span>
-          </div>
-        </th>
-        <td
-          class="c8 "
-        >
-          <div
-            class="c6"
-          >
-            <span
-              class="c4"
-            >
-              2
-            </span>
-          </div>
-        </td>
-      </tr>
-    </tbody>
-    <tfoot
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <td
-          class="c8 "
-        >
-          <div
-            class="c6"
-          >
-            <span
-              class="c7"
-            >
-              Total
-            </span>
-          </div>
-        </td>
-        <td
-          class="c8 "
-        >
-          <div
-            class="c6"
+            class="c7"
           />
         </td>
       </tr>
@@ -1952,26 +2017,34 @@ exports[`DataTable border 1`] = `
           class="c9 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
           class="c9 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            B
-          </span>
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c5"
+      class="c6"
     >
       <tr
         class=""
@@ -1981,10 +2054,10 @@ exports[`DataTable border 1`] = `
           scope="row"
         >
           <div
-            class="c6"
+            class="c7"
           >
             <span
-              class="c7"
+              class="c8"
             >
               one
             </span>
@@ -1994,10 +2067,10 @@ exports[`DataTable border 1`] = `
           class="c9 "
         >
           <div
-            class="c6"
+            class="c7"
           >
             <span
-              class="c4"
+              class="c5"
             >
               1
             </span>
@@ -2012,10 +2085,10 @@ exports[`DataTable border 1`] = `
           scope="row"
         >
           <div
-            class="c6"
+            class="c7"
           >
             <span
-              class="c7"
+              class="c8"
             >
               two
             </span>
@@ -2025,10 +2098,10 @@ exports[`DataTable border 1`] = `
           class="c9 "
         >
           <div
-            class="c6"
+            class="c7"
           >
             <span
-              class="c4"
+              class="c5"
             >
               2
             </span>
@@ -2046,10 +2119,10 @@ exports[`DataTable border 1`] = `
           class="c9 "
         >
           <div
-            class="c6"
+            class="c7"
           >
             <span
-              class="c7"
+              class="c8"
             >
               Total
             </span>
@@ -2059,7 +2132,7 @@ exports[`DataTable border 1`] = `
           class="c9 "
         >
           <div
-            class="c6"
+            class="c7"
           />
         </td>
       </tr>
@@ -2075,55 +2148,63 @@ exports[`DataTable border 1`] = `
         class=""
       >
         <th
-          class="c8 "
+          class="c10 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
-          class="c8 "
+          class="c10 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            B
-          </span>
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c5"
+      class="c6"
     >
       <tr
         class=""
       >
         <th
-          class="c9 "
+          class="c10 "
           scope="row"
         >
           <div
-            class="c6"
+            class="c7"
           >
             <span
-              class="c7"
+              class="c8"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c9 "
+          class="c10 "
         >
           <div
-            class="c6"
+            class="c7"
           >
             <span
-              class="c4"
+              class="c5"
             >
               1
             </span>
@@ -2134,27 +2215,27 @@ exports[`DataTable border 1`] = `
         class=""
       >
         <th
-          class="c9 "
+          class="c10 "
           scope="row"
         >
           <div
-            class="c6"
+            class="c7"
           >
             <span
-              class="c7"
+              class="c8"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c9 "
+          class="c10 "
         >
           <div
-            class="c6"
+            class="c7"
           >
             <span
-              class="c4"
+              class="c5"
             >
               2
             </span>
@@ -2169,23 +2250,157 @@ exports[`DataTable border 1`] = `
         class=""
       >
         <td
-          class="c8 "
+          class="c10 "
         >
           <div
-            class="c6"
+            class="c7"
           >
             <span
-              class="c7"
+              class="c8"
             >
               Total
             </span>
           </div>
         </td>
         <td
-          class="c8 "
+          class="c10 "
         >
           <div
-            class="c6"
+            class="c7"
+          />
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c9 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c9 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c6"
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c10 "
+          scope="row"
+        >
+          <div
+            class="c7"
+          >
+            <span
+              class="c8"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c10 "
+        >
+          <div
+            class="c7"
+          >
+            <span
+              class="c5"
+            >
+              1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class=""
+      >
+        <th
+          class="c10 "
+          scope="row"
+        >
+          <div
+            class="c7"
+          >
+            <span
+              class="c8"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c10 "
+        >
+          <div
+            class="c7"
+          >
+            <span
+              class="c5"
+            >
+              2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <td
+          class="c9 "
+        >
+          <div
+            class="c7"
+          >
+            <span
+              class="c8"
+            >
+              Total
+            </span>
+          </div>
+        </td>
+        <td
+          class="c9 "
+        >
+          <div
+            class="c7"
           />
         </td>
       </tr>
@@ -2205,7 +2420,24 @@ exports[`DataTable click 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2232,7 +2464,7 @@ exports[`DataTable click 1`] = `
   padding-bottom: 6px;
 }
 
-.c7 {
+.c8 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -2250,12 +2482,12 @@ exports[`DataTable click 1`] = `
   width: inherit;
 }
 
-.c4 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c9 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -2267,11 +2499,11 @@ exports[`DataTable click 1`] = `
   height: auto;
 }
 
-.c6 {
+.c7 {
   cursor: pointer;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -2297,30 +2529,34 @@ exports[`DataTable click 1`] = `
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c5"
+      class="c6"
       tabindex="0"
     >
       <tr
-        class="c6"
+        class="c7"
       >
         <th
-          class="c7 "
+          class="c8 "
           scope="row"
         >
           <div
-            class="c8"
+            class="c9"
           >
             <span
-              class="c9"
+              class="c10"
             >
               alpha
             </span>
@@ -2328,17 +2564,17 @@ exports[`DataTable click 1`] = `
         </th>
       </tr>
       <tr
-        class="c6"
+        class="c7"
       >
         <th
-          class="c7 "
+          class="c8 "
           scope="row"
         >
           <div
-            class="c8"
+            class="c9"
           >
             <span
-              class="c9"
+              class="c10"
             >
               beta
             </span>
@@ -2367,11 +2603,15 @@ exports[`DataTable click 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
-          <span
-            class="StyledText-sc-1sadyjn-0 hUokoe"
+          <div
+            class="StyledBox-sc-13pk1d4-0 bToxzR"
           >
-            A
-          </span>
+            <span
+              class="StyledText-sc-1sadyjn-0 hUokoe"
+            >
+              A
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
@@ -2431,7 +2671,24 @@ exports[`DataTable custom theme 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c7 {
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2449,7 +2706,7 @@ exports[`DataTable custom theme 1`] = `
   flex-direction: row;
 }
 
-.c12 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2471,7 +2728,7 @@ exports[`DataTable custom theme 1`] = `
   justify-content: center;
 }
 
-.c15 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2497,7 +2754,7 @@ exports[`DataTable custom theme 1`] = `
   border-radius: 4px;
 }
 
-.c17 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2511,7 +2768,7 @@ exports[`DataTable custom theme 1`] = `
   flex-direction: column;
 }
 
-.c18 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2537,7 +2794,7 @@ exports[`DataTable custom theme 1`] = `
   border-radius: 4px;
 }
 
-.c5 {
+.c6 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2556,27 +2813,27 @@ exports[`DataTable custom theme 1`] = `
   height: 100%;
 }
 
-.c5:focus {
+.c6:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c6:focus > circle,
+.c6:focus > ellipse,
+.c6:focus > line,
+.c6:focus > path,
+.c6:focus > polygon,
+.c6:focus > polyline,
+.c6:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c6:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c16 {
+.c17 {
   box-sizing: border-box;
   stroke-width: 4px;
   stroke: #7D4CDB;
@@ -2584,7 +2841,7 @@ exports[`DataTable custom theme 1`] = `
   height: 24px;
 }
 
-.c11 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2607,12 +2864,12 @@ exports[`DataTable custom theme 1`] = `
   cursor: default;
 }
 
-.c11:hover input:not([disabled]) + div,
-.c11:hover input:not([disabled]) + span {
+.c12:hover input:not([disabled]) + div,
+.c12:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c14 {
+.c15 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -2620,12 +2877,12 @@ exports[`DataTable custom theme 1`] = `
   margin: 0;
 }
 
-.c14:checked + span > span {
+.c15:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c13 {
+.c14 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -2658,7 +2915,7 @@ exports[`DataTable custom theme 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -2676,7 +2933,7 @@ exports[`DataTable custom theme 1`] = `
   width: inherit;
 }
 
-.c8 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -2688,27 +2945,27 @@ exports[`DataTable custom theme 1`] = `
   height: auto;
 }
 
-.c9:focus {
+.c10:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c6 {
+.c7 {
   padding: 6px 12px;
 }
 
-.c6:hover {
+.c7:hover {
   background-color: rgba(242,242,242,1);
   color: #444444;
 }
 
 @media only screen and (max-width:768px) {
-  .c15 {
+  .c16 {
     border: solid 2px #7D4CDB;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c18 {
+  .c19 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
@@ -2738,53 +2995,57 @@ exports[`DataTable custom theme 1`] = `
           class="c4 "
           scope="col"
         >
-          <button
-            class="c5 c6"
-            type="button"
+          <div
+            class="c5"
           >
-            <div
-              class="c7"
+            <button
+              class="c6 c7"
+              type="button"
             >
-              <span
+              <div
                 class="c8"
               >
-                A
-              </span>
-            </div>
-          </button>
+                <span
+                  class="c9"
+                >
+                  A
+                </span>
+              </div>
+            </button>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c9"
+      class="c10"
     >
       <tr
         class=""
       >
         <td
-          class="c10"
+          class="c11"
         >
           <label
             aria-label="unselect alpha"
-            class="c11"
+            class="c12"
             disabled=""
           >
             <div
-              class="c12 c13"
+              class="c13 c14"
               disabled=""
             >
               <input
                 checked=""
-                class="c14"
+                class="c15"
                 disabled=""
                 type="checkbox"
               />
               <div
-                class="c15 "
+                class="c16 "
                 disabled=""
               >
                 <svg
-                  class="c16"
+                  class="c17"
                   disabled=""
                   preserveAspectRatio="xMidYMid meet"
                   viewBox="0 0 24 24"
@@ -2803,14 +3064,14 @@ exports[`DataTable custom theme 1`] = `
           </label>
         </td>
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c17"
+            class="c18"
           >
             <span
-              class="c8"
+              class="c9"
             >
               alpha
             </span>
@@ -2821,38 +3082,38 @@ exports[`DataTable custom theme 1`] = `
         class=""
       >
         <td
-          class="c10"
+          class="c11"
         >
           <label
             aria-label="select beta"
-            class="c11"
+            class="c12"
             disabled=""
           >
             <div
-              class="c12 c13"
+              class="c13 c14"
               disabled=""
             >
               <input
-                class="c14"
+                class="c15"
                 disabled=""
                 type="checkbox"
               />
               <div
-                class="c18 "
+                class="c19 "
                 disabled=""
               />
             </div>
           </label>
         </td>
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c17"
+            class="c18"
           >
             <span
-              class="c8"
+              class="c9"
             >
               beta
             </span>
@@ -2884,20 +3145,24 @@ exports[`DataTable custom theme 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 cYDXOf StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
-          <button
-            class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 ixwBdO"
-            type="button"
+          <div
+            class="StyledBox-sc-13pk1d4-0 bToxzR"
           >
-            <div
-              class="StyledBox-sc-13pk1d4-0 rpWqh"
+            <button
+              class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 ixwBdO"
+              type="button"
             >
-              <span
-                class="StyledText-sc-1sadyjn-0 gmtNWw"
+              <div
+                class="StyledBox-sc-13pk1d4-0 rpWqh"
               >
-                A
-              </span>
-            </div>
-          </button>
+                <span
+                  class="StyledText-sc-1sadyjn-0 gmtNWw"
+                >
+                  A
+                </span>
+              </div>
+            </button>
+          </div>
         </th>
       </tr>
     </thead>
@@ -3074,7 +3339,24 @@ exports[`DataTable fill 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c7 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3101,7 +3383,7 @@ exports[`DataTable fill 1`] = `
   padding-bottom: 6px;
 }
 
-.c6 {
+.c7 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -3113,7 +3395,7 @@ exports[`DataTable fill 1`] = `
   padding-bottom: 6px;
 }
 
-.c9 {
+.c10 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -3132,12 +3414,12 @@ exports[`DataTable fill 1`] = `
   width: inherit;
 }
 
-.c4 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c8 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -3151,21 +3433,21 @@ exports[`DataTable fill 1`] = `
   height: 100%;
 }
 
-.c10 {
+.c11 {
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
   width: 100%;
 }
 
-.c11 {
+.c12 {
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
   height: 100%;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -3191,52 +3473,60 @@ exports[`DataTable fill 1`] = `
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            B
-          </span>
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c5"
+      class="c6"
     >
       <tr
         class=""
       >
         <th
-          class="c6 "
+          class="c7 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               1
             </span>
@@ -3247,27 +3537,27 @@ exports[`DataTable fill 1`] = `
         class=""
       >
         <th
-          class="c6 "
+          class="c7 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               2
             </span>
@@ -3282,149 +3572,23 @@ exports[`DataTable fill 1`] = `
         class=""
       >
         <td
-          class="c9 "
+          class="c10 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               Total
             </span>
           </div>
         </td>
         <td
-          class="c9 "
+          class="c10 "
         >
           <div
-            class="c7"
-          />
-        </td>
-      </tr>
-    </tfoot>
-  </table>
-  <table
-    class="c1 c10"
-  >
-    <thead
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c3 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            A
-          </span>
-        </th>
-        <th
-          class="c3 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            B
-          </span>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class="c5"
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c6 "
-          scope="row"
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              one
-            </span>
-          </div>
-        </th>
-        <td
-          class="c6 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
-            >
-              1
-            </span>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class=""
-      >
-        <th
-          class="c6 "
-          scope="row"
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              two
-            </span>
-          </div>
-        </th>
-        <td
-          class="c6 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
-            >
-              2
-            </span>
-          </div>
-        </td>
-      </tr>
-    </tbody>
-    <tfoot
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <td
-          class="c9 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              Total
-            </span>
-          </div>
-        </td>
-        <td
-          class="c9 "
-        >
-          <div
-            class="c7"
+            class="c8"
           />
         </td>
       </tr>
@@ -3443,52 +3607,60 @@ exports[`DataTable fill 1`] = `
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            B
-          </span>
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c5"
+      class="c6"
     >
       <tr
         class=""
       >
         <th
-          class="c6 "
+          class="c7 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               1
             </span>
@@ -3499,27 +3671,27 @@ exports[`DataTable fill 1`] = `
         class=""
       >
         <th
-          class="c6 "
+          class="c7 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               2
             </span>
@@ -3534,23 +3706,157 @@ exports[`DataTable fill 1`] = `
         class=""
       >
         <td
-          class="c9 "
+          class="c10 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               Total
             </span>
           </div>
         </td>
         <td
-          class="c9 "
+          class="c10 "
         >
           <div
-            class="c7"
+            class="c8"
+          />
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+  <table
+    class="c1 c12"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c6"
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c7 "
+          scope="row"
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c7 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class=""
+      >
+        <th
+          class="c7 "
+          scope="row"
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c7 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <td
+          class="c10 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              Total
+            </span>
+          </div>
+        </td>
+        <td
+          class="c10 "
+        >
+          <div
+            class="c8"
           />
         </td>
       </tr>
@@ -3570,7 +3876,24 @@ exports[`DataTable footer 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c7 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3597,7 +3920,7 @@ exports[`DataTable footer 1`] = `
   padding-bottom: 6px;
 }
 
-.c6 {
+.c7 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -3609,7 +3932,7 @@ exports[`DataTable footer 1`] = `
   padding-bottom: 6px;
 }
 
-.c9 {
+.c10 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -3628,12 +3951,12 @@ exports[`DataTable footer 1`] = `
   width: inherit;
 }
 
-.c4 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c8 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -3645,7 +3968,7 @@ exports[`DataTable footer 1`] = `
   height: auto;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -3671,52 +3994,60 @@ exports[`DataTable footer 1`] = `
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            B
-          </span>
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c5"
+      class="c6"
     >
       <tr
         class=""
       >
         <th
-          class="c6 "
+          class="c7 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               1
             </span>
@@ -3727,27 +4058,27 @@ exports[`DataTable footer 1`] = `
         class=""
       >
         <th
-          class="c6 "
+          class="c7 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               2
             </span>
@@ -3762,23 +4093,23 @@ exports[`DataTable footer 1`] = `
         class=""
       >
         <td
-          class="c9 "
+          class="c10 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               Total
             </span>
           </div>
         </td>
         <td
-          class="c9 "
+          class="c10 "
         >
           <div
-            class="c7"
+            class="c8"
           />
         </td>
       </tr>
@@ -3851,7 +4182,24 @@ exports[`DataTable groupBy 1`] = `
   padding: 6px;
 }
 
-.c12 {
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3941,7 +4289,7 @@ exports[`DataTable groupBy 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -3954,7 +4302,7 @@ exports[`DataTable groupBy 1`] = `
   padding: 0px;
 }
 
-.c11 {
+.c12 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -3972,7 +4320,7 @@ exports[`DataTable groupBy 1`] = `
   width: inherit;
 }
 
-.c8 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
 }
@@ -3983,7 +4331,7 @@ exports[`DataTable groupBy 1`] = `
   height: auto;
 }
 
-.c9:focus {
+.c10:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -4041,32 +4389,40 @@ exports[`DataTable groupBy 1`] = `
           class="c7 "
           scope="col"
         >
-          <span
+          <div
             class="c8"
           >
-            A
-          </span>
+            <span
+              class="c9"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
           class="c7 "
           scope="col"
         >
-          <span
+          <div
             class="c8"
           >
-            B
-          </span>
+            <span
+              class="c9"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c9"
+      class="c10"
     >
       <tr
         class=""
       >
         <td
-          class="c10"
+          class="c11"
         >
           <button
             aria-label="expand"
@@ -4092,24 +4448,24 @@ exports[`DataTable groupBy 1`] = `
           </button>
         </td>
         <th
-          class="c11 "
+          class="c12 "
           scope="row"
         >
           <div
-            class="c12"
+            class="c13"
           >
             <span
-              class="c8"
+              class="c9"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c11 "
+          class="c12 "
         >
           <div
-            class="c12"
+            class="c13"
           />
         </td>
       </tr>
@@ -4117,7 +4473,7 @@ exports[`DataTable groupBy 1`] = `
         class=""
       >
         <td
-          class="c10"
+          class="c11"
         >
           <button
             aria-label="expand"
@@ -4143,24 +4499,24 @@ exports[`DataTable groupBy 1`] = `
           </button>
         </td>
         <th
-          class="c11 "
+          class="c12 "
           scope="row"
         >
           <div
-            class="c12"
+            class="c13"
           >
             <span
-              class="c8"
+              class="c9"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c11 "
+          class="c12 "
         >
           <div
-            class="c12"
+            class="c13"
           />
         </td>
       </tr>
@@ -4212,21 +4568,29 @@ exports[`DataTable groupBy 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
-          <span
-            class="StyledText-sc-1sadyjn-0 hUokoe"
+          <div
+            class="StyledBox-sc-13pk1d4-0 bToxzR"
           >
-            A
-          </span>
+            <span
+              class="StyledText-sc-1sadyjn-0 hUokoe"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
-          <span
-            class="StyledText-sc-1sadyjn-0 hUokoe"
+          <div
+            class="StyledBox-sc-13pk1d4-0 bToxzR"
           >
-            B
-          </span>
+            <span
+              class="StyledText-sc-1sadyjn-0 hUokoe"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
@@ -4404,7 +4768,24 @@ exports[`DataTable groupBy expand 1`] = `
   padding: 6px;
 }
 
-.c12 {
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4494,7 +4875,7 @@ exports[`DataTable groupBy expand 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -4507,7 +4888,7 @@ exports[`DataTable groupBy expand 1`] = `
   padding: 0px;
 }
 
-.c11 {
+.c12 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -4519,7 +4900,7 @@ exports[`DataTable groupBy expand 1`] = `
   padding-bottom: 6px;
 }
 
-.c13 {
+.c14 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -4538,7 +4919,7 @@ exports[`DataTable groupBy expand 1`] = `
   width: inherit;
 }
 
-.c8 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
 }
@@ -4549,7 +4930,7 @@ exports[`DataTable groupBy expand 1`] = `
   height: auto;
 }
 
-.c9:focus {
+.c10:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -4607,32 +4988,40 @@ exports[`DataTable groupBy expand 1`] = `
           class="c7 "
           scope="col"
         >
-          <span
+          <div
             class="c8"
           >
-            A
-          </span>
+            <span
+              class="c9"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
           class="c7 "
           scope="col"
         >
-          <span
+          <div
             class="c8"
           >
-            B
-          </span>
+            <span
+              class="c9"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c9"
+      class="c10"
     >
       <tr
         class=""
       >
         <td
-          class="c10"
+          class="c11"
         >
           <button
             aria-label="collapse"
@@ -4659,24 +5048,24 @@ exports[`DataTable groupBy expand 1`] = `
           </button>
         </td>
         <th
-          class="c11 "
+          class="c12 "
           scope="row"
         >
           <div
-            class="c12"
+            class="c13"
           >
             <span
-              class="c8"
+              class="c9"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c11 "
+          class="c12 "
         >
           <div
-            class="c12"
+            class="c13"
           />
         </td>
       </tr>
@@ -4684,33 +5073,33 @@ exports[`DataTable groupBy expand 1`] = `
         class=""
       >
         <td
-          class="c10"
+          class="c11"
         >
           <div
             class="c5"
           />
         </td>
         <td
-          class="c11 "
+          class="c12 "
         >
           <div
-            class="c12"
+            class="c13"
           >
             <span
-              class="c8"
+              class="c9"
             >
               one
             </span>
           </div>
         </td>
         <td
-          class="c11 "
+          class="c12 "
         >
           <div
-            class="c12"
+            class="c13"
           >
             <span
-              class="c8"
+              class="c9"
             >
               1.1
             </span>
@@ -4721,33 +5110,33 @@ exports[`DataTable groupBy expand 1`] = `
         class=""
       >
         <td
-          class="c13"
+          class="c14"
         >
           <div
             class="c5"
           />
         </td>
         <td
-          class="c11 "
+          class="c12 "
         >
           <div
-            class="c12"
+            class="c13"
           >
             <span
-              class="c8"
+              class="c9"
             >
               one
             </span>
           </div>
         </td>
         <td
-          class="c11 "
+          class="c12 "
         >
           <div
-            class="c12"
+            class="c13"
           >
             <span
-              class="c8"
+              class="c9"
             >
               1.2
             </span>
@@ -4758,7 +5147,7 @@ exports[`DataTable groupBy expand 1`] = `
         class=""
       >
         <td
-          class="c10"
+          class="c11"
         >
           <button
             aria-label="expand"
@@ -4784,24 +5173,24 @@ exports[`DataTable groupBy expand 1`] = `
           </button>
         </td>
         <th
-          class="c11 "
+          class="c12 "
           scope="row"
         >
           <div
-            class="c12"
+            class="c13"
           >
             <span
-              class="c8"
+              class="c9"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c11 "
+          class="c12 "
         >
           <div
-            class="c12"
+            class="c13"
           />
         </td>
       </tr>
@@ -4880,7 +5269,24 @@ exports[`DataTable groupBy property 1`] = `
   padding: 6px;
 }
 
-.c12 {
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4970,7 +5376,7 @@ exports[`DataTable groupBy property 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -4983,7 +5389,7 @@ exports[`DataTable groupBy property 1`] = `
   padding: 0px;
 }
 
-.c11 {
+.c12 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -5001,7 +5407,7 @@ exports[`DataTable groupBy property 1`] = `
   width: inherit;
 }
 
-.c8 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
 }
@@ -5012,7 +5418,7 @@ exports[`DataTable groupBy property 1`] = `
   height: auto;
 }
 
-.c9:focus {
+.c10:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -5070,32 +5476,40 @@ exports[`DataTable groupBy property 1`] = `
           class="c7 "
           scope="col"
         >
-          <span
+          <div
             class="c8"
           >
-            A
-          </span>
+            <span
+              class="c9"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
           class="c7 "
           scope="col"
         >
-          <span
+          <div
             class="c8"
           >
-            B
-          </span>
+            <span
+              class="c9"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c9"
+      class="c10"
     >
       <tr
         class=""
       >
         <td
-          class="c10"
+          class="c11"
         >
           <button
             aria-label="expand"
@@ -5121,24 +5535,24 @@ exports[`DataTable groupBy property 1`] = `
           </button>
         </td>
         <th
-          class="c11 "
+          class="c12 "
           scope="row"
         >
           <div
-            class="c12"
+            class="c13"
           >
             <span
-              class="c8"
+              class="c9"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c11 "
+          class="c12 "
         >
           <div
-            class="c12"
+            class="c13"
           />
         </td>
       </tr>
@@ -5146,7 +5560,7 @@ exports[`DataTable groupBy property 1`] = `
         class=""
       >
         <td
-          class="c10"
+          class="c11"
         >
           <button
             aria-label="expand"
@@ -5172,24 +5586,24 @@ exports[`DataTable groupBy property 1`] = `
           </button>
         </td>
         <th
-          class="c11 "
+          class="c12 "
           scope="row"
         >
           <div
-            class="c12"
+            class="c13"
           >
             <span
-              class="c8"
+              class="c9"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c11 "
+          class="c12 "
         >
           <div
-            class="c12"
+            class="c13"
           />
         </td>
       </tr>
@@ -5241,21 +5655,29 @@ exports[`DataTable groupBy property 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
-          <span
-            class="StyledText-sc-1sadyjn-0 hUokoe"
+          <div
+            class="StyledBox-sc-13pk1d4-0 bToxzR"
           >
-            A
-          </span>
+            <span
+              class="StyledText-sc-1sadyjn-0 hUokoe"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
-          <span
-            class="StyledText-sc-1sadyjn-0 hUokoe"
+          <div
+            class="StyledBox-sc-13pk1d4-0 bToxzR"
           >
-            B
-          </span>
+            <span
+              class="StyledText-sc-1sadyjn-0 hUokoe"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
@@ -5380,7 +5802,24 @@ exports[`DataTable onSort 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c5 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5398,7 +5837,7 @@ exports[`DataTable onSort 1`] = `
   flex-direction: row;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5412,7 +5851,7 @@ exports[`DataTable onSort 1`] = `
   flex-direction: column;
 }
 
-.c4 {
+.c5 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5431,23 +5870,23 @@ exports[`DataTable onSort 1`] = `
   height: 100%;
 }
 
-.c4:focus {
+.c5:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c5:focus > circle,
+.c5:focus > ellipse,
+.c5:focus > line,
+.c5:focus > path,
+.c5:focus > polygon,
+.c5:focus > polyline,
+.c5:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c5:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -5464,7 +5903,7 @@ exports[`DataTable onSort 1`] = `
   padding-bottom: 6px;
 }
 
-.c8 {
+.c9 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -5482,12 +5921,12 @@ exports[`DataTable onSort 1`] = `
   width: inherit;
 }
 
-.c6 {
+.c7 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c10 {
+.c11 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -5499,7 +5938,7 @@ exports[`DataTable onSort 1`] = `
   height: auto;
 }
 
-.c7:focus {
+.c8:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -5525,70 +5964,78 @@ exports[`DataTable onSort 1`] = `
           class="c3 "
           scope="col"
         >
-          <button
-            class="c4 "
-            type="button"
+          <div
+            class="c4"
           >
-            <div
-              class="c5"
+            <button
+              class="c5 "
+              type="button"
             >
-              <span
+              <div
                 class="c6"
               >
-                A
-              </span>
-            </div>
-          </button>
+                <span
+                  class="c7"
+                >
+                  A
+                </span>
+              </div>
+            </button>
+          </div>
         </th>
         <th
           class="c3 "
           scope="col"
         >
-          <button
-            class="c4 "
-            type="button"
+          <div
+            class="c4"
           >
-            <div
-              class="c5"
+            <button
+              class="c5 "
+              type="button"
             >
-              <span
+              <div
                 class="c6"
               >
-                B
-              </span>
-            </div>
-          </button>
+                <span
+                  class="c7"
+                >
+                  B
+                </span>
+              </div>
+            </button>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c7"
+      class="c8"
     >
       <tr
         class=""
       >
         <th
-          class="c8 "
+          class="c9 "
           scope="row"
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c10"
+              class="c11"
             >
               zero
             </span>
           </div>
         </th>
         <td
-          class="c8 "
+          class="c9 "
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c6"
+              class="c7"
             >
               0
             </span>
@@ -5599,27 +6046,27 @@ exports[`DataTable onSort 1`] = `
         class=""
       >
         <th
-          class="c8 "
+          class="c9 "
           scope="row"
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c10"
+              class="c11"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c8 "
+          class="c9 "
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c6"
+              class="c7"
             >
               1
             </span>
@@ -5630,27 +6077,27 @@ exports[`DataTable onSort 1`] = `
         class=""
       >
         <th
-          class="c8 "
+          class="c9 "
           scope="row"
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c10"
+              class="c11"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c8 "
+          class="c9 "
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c6"
+              class="c7"
             >
               2
             </span>
@@ -5679,19 +6126,22 @@ exports[`DataTable onSort 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
-          <button
-            class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 hCocKd"
-            type="button"
+          <div
+            class="StyledBox-sc-13pk1d4-0 bToxzR"
           >
-            <div
-              class="StyledBox-sc-13pk1d4-0 rpWqh"
+            <button
+              class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 hCocKd"
+              type="button"
             >
-              <span
-                class="StyledText-sc-1sadyjn-0 hUokoe"
+              <div
+                class="StyledBox-sc-13pk1d4-0 rpWqh"
               >
-                A
-              </span>
-              .c0 {
+                <span
+                  class="StyledText-sc-1sadyjn-0 hUokoe"
+                >
+                  A
+                </span>
+                .c0 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -5712,9 +6162,9 @@ exports[`DataTable onSort 2`] = `
 }
 
 <div
-                class="c0"
-              />
-              .c0 {
+                  class="c0"
+                />
+                .c0 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -5757,39 +6207,44 @@ exports[`DataTable onSort 2`] = `
 }
 
 <svg
-                aria-label="FormUp"
-                class="c0"
-                viewBox="0 0 24 24"
-              >
-                <polyline
-                  fill="none"
-                  points="18 9 12 15 6 9"
-                  stroke="#000"
-                  stroke-width="2"
-                  transform="matrix(1 0 0 -1 0 24)"
-                />
-              </svg>
-            </div>
-          </button>
+                  aria-label="FormUp"
+                  class="c0"
+                  viewBox="0 0 24 24"
+                >
+                  <polyline
+                    fill="none"
+                    points="18 9 12 15 6 9"
+                    stroke="#000"
+                    stroke-width="2"
+                    transform="matrix(1 0 0 -1 0 24)"
+                  />
+                </svg>
+              </div>
+            </button>
+          </div>
         </th>
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
-          <button
-            class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 hCocKd"
-            type="button"
+          <div
+            class="StyledBox-sc-13pk1d4-0 bToxzR"
           >
-            <div
-              class="StyledBox-sc-13pk1d4-0 rpWqh"
+            <button
+              class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 hCocKd"
+              type="button"
             >
-              <span
-                class="StyledText-sc-1sadyjn-0 hUokoe"
+              <div
+                class="StyledBox-sc-13pk1d4-0 rpWqh"
               >
-                B
-              </span>
-            </div>
-          </button>
+                <span
+                  class="StyledText-sc-1sadyjn-0 hUokoe"
+                >
+                  B
+                </span>
+              </div>
+            </button>
+          </div>
         </th>
       </tr>
     </thead>
@@ -5905,7 +6360,24 @@ exports[`DataTable pad 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c7 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5929,7 +6401,7 @@ exports[`DataTable pad 1`] = `
   padding: 12px;
 }
 
-.c6 {
+.c7 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -5938,7 +6410,7 @@ exports[`DataTable pad 1`] = `
   padding: 12px;
 }
 
-.c9 {
+.c10 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -5948,7 +6420,7 @@ exports[`DataTable pad 1`] = `
   padding: 12px;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -5961,25 +6433,12 @@ exports[`DataTable pad 1`] = `
   padding-bottom: 12px;
 }
 
-.c11 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 24px;
-  padding-right: 24px;
-  padding-top: 12px;
-  padding-bottom: 12px;
-}
-
 .c12 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
-  border-top: solid 1px rgba(0,0,0,0.33);
   padding-left: 24px;
   padding-right: 24px;
   padding-top: 12px;
@@ -5993,1177 +6452,19 @@ exports[`DataTable pad 1`] = `
   text-align: inherit;
   text-align: start;
   border-top: solid 1px rgba(0,0,0,0.33);
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c1 {
-  border-spacing: 0;
-  border-collapse: collapse;
-  width: inherit;
-}
-
-.c4 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c8 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c2 {
-  border-spacing: 0;
-  border-collapse: separate;
-  height: auto;
-}
-
-.c5:focus {
-  outline: 2px solid #6FFFB0;
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-  .c1 {
-    table-layout: fixed;
-  }
-}
-
-<div
-  class="c0"
->
-  <table
-    class="c1 c2"
-  >
-    <thead
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c3 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            A
-          </span>
-        </th>
-        <th
-          class="c3 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            B
-          </span>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class="c5"
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c6 "
-          scope="row"
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              one
-            </span>
-          </div>
-        </th>
-        <td
-          class="c6 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
-            >
-              1
-            </span>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class=""
-      >
-        <th
-          class="c6 "
-          scope="row"
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              two
-            </span>
-          </div>
-        </th>
-        <td
-          class="c6 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
-            >
-              2
-            </span>
-          </div>
-        </td>
-      </tr>
-    </tbody>
-    <tfoot
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <td
-          class="c9 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              Total
-            </span>
-          </div>
-        </td>
-        <td
-          class="c9 "
-        >
-          <div
-            class="c7"
-          />
-        </td>
-      </tr>
-    </tfoot>
-  </table>
-  <table
-    class="c1 c2"
-  >
-    <thead
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c10 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            A
-          </span>
-        </th>
-        <th
-          class="c10 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            B
-          </span>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class="c5"
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c11 "
-          scope="row"
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              one
-            </span>
-          </div>
-        </th>
-        <td
-          class="c11 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
-            >
-              1
-            </span>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class=""
-      >
-        <th
-          class="c11 "
-          scope="row"
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              two
-            </span>
-          </div>
-        </th>
-        <td
-          class="c11 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
-            >
-              2
-            </span>
-          </div>
-        </td>
-      </tr>
-    </tbody>
-    <tfoot
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <td
-          class="c12 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              Total
-            </span>
-          </div>
-        </td>
-        <td
-          class="c12 "
-        >
-          <div
-            class="c7"
-          />
-        </td>
-      </tr>
-    </tfoot>
-  </table>
-  <table
-    class="c1 c2"
-  >
-    <thead
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c3 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            A
-          </span>
-        </th>
-        <th
-          class="c3 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            B
-          </span>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class="c5"
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c11 "
-          scope="row"
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              one
-            </span>
-          </div>
-        </th>
-        <td
-          class="c11 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
-            >
-              1
-            </span>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class=""
-      >
-        <th
-          class="c11 "
-          scope="row"
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              two
-            </span>
-          </div>
-        </th>
-        <td
-          class="c11 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
-            >
-              2
-            </span>
-          </div>
-        </td>
-      </tr>
-    </tbody>
-    <tfoot
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <td
-          class="c13 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              Total
-            </span>
-          </div>
-        </td>
-        <td
-          class="c13 "
-        >
-          <div
-            class="c7"
-          />
-        </td>
-      </tr>
-    </tfoot>
-  </table>
-</div>
-`;
-
-exports[`DataTable paths 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c6 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c1 {
-  border-spacing: 0;
-  border-collapse: collapse;
-  width: inherit;
-}
-
-.c4 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c8 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c2 {
-  border-spacing: 0;
-  border-collapse: separate;
-  height: auto;
-}
-
-.c5:focus {
-  outline: 2px solid #6FFFB0;
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-  .c1 {
-    table-layout: fixed;
-  }
-}
-
-<div
-  class="c0"
->
-  <table
-    class="c1 c2"
-  >
-    <thead
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c3 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            A
-          </span>
-        </th>
-        <th
-          class="c3 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            B
-          </span>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class="c5"
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c6 "
-          scope="row"
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              one
-            </span>
-          </div>
-        </th>
-        <td
-          class="c6 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
-            >
-              1
-            </span>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class=""
-      >
-        <th
-          class="c6 "
-          scope="row"
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              two
-            </span>
-          </div>
-        </th>
-        <td
-          class="c6 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
-            >
-              2
-            </span>
-          </div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-`;
-
-exports[`DataTable pin 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c8 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c12 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  border-top: solid 1px rgba(0,0,0,0.33);
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c1 {
-  border-spacing: 0;
-  border-collapse: collapse;
-  width: inherit;
-}
-
-.c5 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c11 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c2 {
-  border-spacing: 0;
-  border-collapse: separate;
-  height: auto;
-}
-
-.c7:focus {
-  outline: 2px solid #6FFFB0;
-}
-
-.c4 {
-  position: -webkit-sticky;
-  position: sticky;
-  top: 0;
-  left: 0;
-  z-index: 2;
-}
-
-.c6 {
-  position: -webkit-sticky;
-  position: sticky;
-  top: 0;
-  z-index: 1;
-}
-
-.c9 {
-  position: -webkit-sticky;
-  position: sticky;
-  left: 0;
-  z-index: 1;
-}
-
-.c13 {
-  position: -webkit-sticky;
-  position: sticky;
-  bottom: 0;
-  left: 0;
-  z-index: 2;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
 }
 
 .c14 {
-  position: -webkit-sticky;
-  position: sticky;
-  bottom: 0;
-  z-index: 1;
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-  .c1 {
-    table-layout: fixed;
-  }
-}
-
-<div
-  class="c0"
->
-  <table
-    class="c1 c2"
-  >
-    <thead
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c3 c4"
-          scope="col"
-        >
-          <span
-            class="c5"
-          >
-            A
-          </span>
-        </th>
-        <th
-          class="c3 c6"
-          scope="col"
-        >
-          <span
-            class="c5"
-          >
-            B
-          </span>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class="c7"
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c8 c9"
-          scope="row"
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c11"
-            >
-              one
-            </span>
-          </div>
-        </th>
-        <td
-          class="c8 "
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c5"
-            >
-              1
-            </span>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class=""
-      >
-        <th
-          class="c8 c9"
-          scope="row"
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c11"
-            >
-              two
-            </span>
-          </div>
-        </th>
-        <td
-          class="c8 "
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c5"
-            >
-              2
-            </span>
-          </div>
-        </td>
-      </tr>
-    </tbody>
-    <tfoot
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <td
-          class="c12 c13"
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c11"
-            >
-              Total
-            </span>
-          </div>
-        </td>
-        <td
-          class="c12 c14"
-        >
-          <div
-            class="c10"
-          />
-        </td>
-      </tr>
-    </tfoot>
-  </table>
-  <table
-    class="c1 c2"
-  >
-    <thead
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c3 c4"
-          scope="col"
-        >
-          <span
-            class="c5"
-          >
-            A
-          </span>
-        </th>
-        <th
-          class="c3 c6"
-          scope="col"
-        >
-          <span
-            class="c5"
-          >
-            B
-          </span>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class="c7"
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c8 c9"
-          scope="row"
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c11"
-            >
-              one
-            </span>
-          </div>
-        </th>
-        <td
-          class="c8 "
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c5"
-            >
-              1
-            </span>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class=""
-      >
-        <th
-          class="c8 c9"
-          scope="row"
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c11"
-            >
-              two
-            </span>
-          </div>
-        </th>
-        <td
-          class="c8 "
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c5"
-            >
-              2
-            </span>
-          </div>
-        </td>
-      </tr>
-    </tbody>
-    <tfoot
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <td
-          class="c12 c9"
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c11"
-            >
-              Total
-            </span>
-          </div>
-        </td>
-        <td
-          class="c12 "
-        >
-          <div
-            class="c10"
-          />
-        </td>
-      </tr>
-    </tfoot>
-  </table>
-  <table
-    class="c1 c2"
-  >
-    <thead
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c3 c9"
-          scope="col"
-        >
-          <span
-            class="c5"
-          >
-            A
-          </span>
-        </th>
-        <th
-          class="c3 "
-          scope="col"
-        >
-          <span
-            class="c5"
-          >
-            B
-          </span>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class="c7"
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c8 c9"
-          scope="row"
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c11"
-            >
-              one
-            </span>
-          </div>
-        </th>
-        <td
-          class="c8 "
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c5"
-            >
-              1
-            </span>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class=""
-      >
-        <th
-          class="c8 c9"
-          scope="row"
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c11"
-            >
-              two
-            </span>
-          </div>
-        </th>
-        <td
-          class="c8 "
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c5"
-            >
-              2
-            </span>
-          </div>
-        </td>
-      </tr>
-    </tbody>
-    <tfoot
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <td
-          class="c12 c13"
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c11"
-            >
-              Total
-            </span>
-          </div>
-        </td>
-        <td
-          class="c12 c14"
-        >
-          <div
-            class="c10"
-          />
-        </td>
-      </tr>
-    </tfoot>
-  </table>
-</div>
-`;
-
-exports[`DataTable primaryKey 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c6 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
+  border-top: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -7174,233 +6475,9 @@ exports[`DataTable primaryKey 1`] = `
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
-}
-
-.c4 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c8 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c2 {
-  border-spacing: 0;
-  border-collapse: separate;
-  height: auto;
-}
-
-.c5:focus {
-  outline: 2px solid #6FFFB0;
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-  .c1 {
-    table-layout: fixed;
-  }
-}
-
-<div
-  class="c0"
->
-  <table
-    class="c1 c2"
-  >
-    <thead
-      class=""
-    >
-      <tr
-        class=""
-      >
-        <th
-          class="c3 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            A
-          </span>
-        </th>
-        <th
-          class="c3 "
-          scope="col"
-        >
-          <span
-            class="c4"
-          >
-            B
-          </span>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class="c5"
-    >
-      <tr
-        class=""
-      >
-        <td
-          class="c6 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
-            >
-              one
-            </span>
-          </div>
-        </td>
-        <th
-          class="c6 "
-          scope="row"
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              1
-            </span>
-          </div>
-        </th>
-      </tr>
-      <tr
-        class=""
-      >
-        <td
-          class="c6 "
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c4"
-            >
-              two
-            </span>
-          </div>
-        </td>
-        <th
-          class="c6 "
-          scope="row"
-        >
-          <div
-            class="c7"
-          >
-            <span
-              class="c8"
-            >
-              2
-            </span>
-          </div>
-        </th>
-      </tr>
-    </tbody>
-  </table>
-</div>
-`;
-
-exports[`DataTable relativeColumnSizes 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  width: 66.66%;
-  max-width: 66.66%;
-  overflow: hidden;
-  text-align: start;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
 }
 
 .c5 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  width: 33.33%;
-  max-width: 33.33%;
-  overflow: hidden;
-  text-align: start;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c7 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  width: 66.66%;
-  max-width: 66.66%;
-  overflow: hidden;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c10 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  width: 33.33%;
-  max-width: 33.33%;
-  overflow: hidden;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c1 {
-  border-spacing: 0;
-  border-collapse: collapse;
-  width: inherit;
-}
-
-.c4 {
   font-size: 18px;
   line-height: 24px;
 }
@@ -7443,21 +6520,29 @@ exports[`DataTable relativeColumnSizes 1`] = `
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
-          class="c5 "
+          class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            B
-          </span>
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
@@ -7482,13 +6567,13 @@ exports[`DataTable relativeColumnSizes 1`] = `
           </div>
         </th>
         <td
-          class="c10 "
+          class="c7 "
         >
           <div
             class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               1
             </span>
@@ -7513,13 +6598,1540 @@ exports[`DataTable relativeColumnSizes 1`] = `
           </div>
         </th>
         <td
+          class="c7 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <td
           class="c10 "
         >
           <div
             class="c8"
           >
             <span
-              class="c4"
+              class="c9"
+            >
+              Total
+            </span>
+          </div>
+        </td>
+        <td
+          class="c10 "
+        >
+          <div
+            class="c8"
+          />
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c11 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c11 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c6"
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c12 "
+          scope="row"
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c12 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class=""
+      >
+        <th
+          class="c12 "
+          scope="row"
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c12 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <td
+          class="c13 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              Total
+            </span>
+          </div>
+        </td>
+        <td
+          class="c13 "
+        >
+          <div
+            class="c8"
+          />
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c6"
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c12 "
+          scope="row"
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c12 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class=""
+      >
+        <th
+          class="c12 "
+          scope="row"
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c12 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <td
+          class="c14 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              Total
+            </span>
+          </div>
+        </td>
+        <td
+          class="c14 "
+        >
+          <div
+            class="c8"
+          />
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+`;
+
+exports[`DataTable paths 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c7 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c2 {
+  border-spacing: 0;
+  border-collapse: separate;
+  height: auto;
+}
+
+.c6:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c6"
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c7 "
+          scope="row"
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c7 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class=""
+      >
+        <th
+          class="c7 "
+          scope="row"
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c7 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable pin 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c9 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c13 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-top: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c12 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c2 {
+  border-spacing: 0;
+  border-collapse: separate;
+  height: auto;
+}
+
+.c8:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c4 {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  left: 0;
+  z-index: 2;
+}
+
+.c7 {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.c10 {
+  position: -webkit-sticky;
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
+
+.c14 {
+  position: -webkit-sticky;
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+}
+
+.c15 {
+  position: -webkit-sticky;
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c3 c4"
+          scope="col"
+        >
+          <div
+            class="c5"
+          >
+            <span
+              class="c6"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c3 c7"
+          scope="col"
+        >
+          <div
+            class="c5"
+          >
+            <span
+              class="c6"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c8"
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c9 c10"
+          scope="row"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c9 "
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c6"
+            >
+              1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class=""
+      >
+        <th
+          class="c9 c10"
+          scope="row"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c9 "
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c6"
+            >
+              2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <td
+          class="c13 c14"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              Total
+            </span>
+          </div>
+        </td>
+        <td
+          class="c13 c15"
+        >
+          <div
+            class="c11"
+          />
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c3 c4"
+          scope="col"
+        >
+          <div
+            class="c5"
+          >
+            <span
+              class="c6"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c3 c7"
+          scope="col"
+        >
+          <div
+            class="c5"
+          >
+            <span
+              class="c6"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c8"
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c9 c10"
+          scope="row"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c9 "
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c6"
+            >
+              1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class=""
+      >
+        <th
+          class="c9 c10"
+          scope="row"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c9 "
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c6"
+            >
+              2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <td
+          class="c13 c10"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              Total
+            </span>
+          </div>
+        </td>
+        <td
+          class="c13 "
+        >
+          <div
+            class="c11"
+          />
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c3 c10"
+          scope="col"
+        >
+          <div
+            class="c5"
+          >
+            <span
+              class="c6"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c5"
+          >
+            <span
+              class="c6"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c8"
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c9 c10"
+          scope="row"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c9 "
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c6"
+            >
+              1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class=""
+      >
+        <th
+          class="c9 c10"
+          scope="row"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c9 "
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c6"
+            >
+              2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <td
+          class="c13 c14"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              Total
+            </span>
+          </div>
+        </td>
+        <td
+          class="c13 c15"
+        >
+          <div
+            class="c11"
+          />
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+`;
+
+exports[`DataTable primaryKey 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c7 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c2 {
+  border-spacing: 0;
+  border-collapse: separate;
+  height: auto;
+}
+
+.c6:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c6"
+    >
+      <tr
+        class=""
+      >
+        <td
+          class="c7 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              one
+            </span>
+          </div>
+        </td>
+        <th
+          class="c7 "
+          scope="row"
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              1
+            </span>
+          </div>
+        </th>
+      </tr>
+      <tr
+        class=""
+      >
+        <td
+          class="c7 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              two
+            </span>
+          </div>
+        </td>
+        <th
+          class="c7 "
+          scope="row"
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              2
+            </span>
+          </div>
+        </th>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable relativeColumnSizes 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  width: 66.66%;
+  max-width: 66.66%;
+  overflow: hidden;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c6 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  width: 33.33%;
+  max-width: 33.33%;
+  overflow: hidden;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c8 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  width: 66.66%;
+  max-width: 66.66%;
+  overflow: hidden;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c11 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  width: 33.33%;
+  max-width: 33.33%;
+  overflow: hidden;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c10 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c2 {
+  border-spacing: 0;
+  border-collapse: separate;
+  height: auto;
+}
+
+.c7:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c6 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="c7"
+    >
+      <tr
+        class=""
+      >
+        <th
+          class="c8 "
+          scope="row"
+        >
+          <div
+            class="c9"
+          >
+            <span
+              class="c10"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c11 "
+        >
+          <div
+            class="c9"
+          >
+            <span
+              class="c5"
+            >
+              1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class=""
+      >
+        <th
+          class="c8 "
+          scope="row"
+        >
+          <div
+            class="c9"
+          >
+            <span
+              class="c10"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c11 "
+        >
+          <div
+            class="c9"
+          >
+            <span
+              class="c5"
             >
               2
             </span>
@@ -7542,7 +8154,24 @@ exports[`DataTable replace 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c7 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7556,7 +8185,7 @@ exports[`DataTable replace 1`] = `
   flex-direction: column;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7587,7 +8216,7 @@ exports[`DataTable replace 1`] = `
   padding-bottom: 6px;
 }
 
-.c6 {
+.c7 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7605,12 +8234,12 @@ exports[`DataTable replace 1`] = `
   width: inherit;
 }
 
-.c4 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c8 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -7622,7 +8251,7 @@ exports[`DataTable replace 1`] = `
   height: auto;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -7648,52 +8277,60 @@ exports[`DataTable replace 1`] = `
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            B
-          </span>
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c5"
+      class="c6"
     >
       <tr
         class=""
       >
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               one
             </span>
           </div>
         </td>
         <th
-          class="c6 "
+          class="c7 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               1.1
             </span>
@@ -7704,27 +8341,27 @@ exports[`DataTable replace 1`] = `
         class=""
       >
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               one
             </span>
           </div>
         </td>
         <th
-          class="c6 "
+          class="c7 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               1.2
             </span>
@@ -7735,10 +8372,10 @@ exports[`DataTable replace 1`] = `
         class=""
       >
         <td
-          class="c6"
+          class="c7"
         >
           <div
-            class="c9"
+            class="c10"
           />
         </td>
       </tr>
@@ -8055,7 +8692,24 @@ exports[`DataTable rowProps 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c7 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8082,7 +8736,7 @@ exports[`DataTable rowProps 1`] = `
   padding-bottom: 6px;
 }
 
-.c6 {
+.c7 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8094,7 +8748,7 @@ exports[`DataTable rowProps 1`] = `
   padding: 48px;
 }
 
-.c9 {
+.c10 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8106,7 +8760,7 @@ exports[`DataTable rowProps 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8125,12 +8779,12 @@ exports[`DataTable rowProps 1`] = `
   width: inherit;
 }
 
-.c4 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c8 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -8142,7 +8796,7 @@ exports[`DataTable rowProps 1`] = `
   height: auto;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -8168,52 +8822,60 @@ exports[`DataTable rowProps 1`] = `
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            B
-          </span>
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c5"
+      class="c6"
     >
       <tr
         class=""
       >
         <th
-          class="c6 "
+          class="c7 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c6 "
+          class="c7 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               1
             </span>
@@ -8224,27 +8886,27 @@ exports[`DataTable rowProps 1`] = `
         class=""
       >
         <th
-          class="c9 "
+          class="c10 "
           scope="row"
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c9 "
+          class="c10 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c4"
+              class="c5"
             >
               2
             </span>
@@ -8259,23 +8921,23 @@ exports[`DataTable rowProps 1`] = `
         class=""
       >
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c7"
+            class="c8"
           >
             <span
-              class="c8"
+              class="c9"
             >
               Total
             </span>
           </div>
         </td>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c7"
+            class="c8"
           />
         </td>
       </tr>
@@ -8851,7 +9513,24 @@ exports[`DataTable select 1`] = `
   border-radius: 4px;
 }
 
-.c13 {
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8877,7 +9556,7 @@ exports[`DataTable select 1`] = `
   border-radius: 4px;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8959,7 +9638,7 @@ exports[`DataTable select 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c13 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8977,12 +9656,12 @@ exports[`DataTable select 1`] = `
   width: inherit;
 }
 
-.c10 {
+.c11 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c15 {
+.c16 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -8994,7 +9673,7 @@ exports[`DataTable select 1`] = `
   height: auto;
 }
 
-.c11:focus {
+.c12:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -9005,7 +9684,7 @@ exports[`DataTable select 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c14 {
     border: solid 2px #7D4CDB;
   }
 }
@@ -9062,22 +9741,26 @@ exports[`DataTable select 1`] = `
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c10"
           >
-            A
-          </span>
+            <span
+              class="c11"
+            >
+              A
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c11"
+      class="c12"
     >
       <tr
         class=""
       >
         <td
-          class="c12"
+          class="c13"
         >
           <label
             aria-label="unselect alpha"
@@ -9092,7 +9775,7 @@ exports[`DataTable select 1`] = `
                 type="checkbox"
               />
               <div
-                class="c13 "
+                class="c14 "
               >
                 <svg
                   class="c9"
@@ -9109,14 +9792,14 @@ exports[`DataTable select 1`] = `
           </label>
         </td>
         <th
-          class="c12 "
+          class="c13 "
           scope="row"
         >
           <div
-            class="c14"
+            class="c15"
           >
             <span
-              class="c15"
+              class="c16"
             >
               alpha
             </span>
@@ -9127,7 +9810,7 @@ exports[`DataTable select 1`] = `
         class=""
       >
         <td
-          class="c12"
+          class="c13"
         >
           <label
             aria-label="select beta"
@@ -9147,14 +9830,14 @@ exports[`DataTable select 1`] = `
           </label>
         </td>
         <th
-          class="c12 "
+          class="c13 "
           scope="row"
         >
           <div
-            class="c14"
+            class="c15"
           >
             <span
-              class="c15"
+              class="c16"
             >
               beta
             </span>
@@ -9233,11 +9916,15 @@ exports[`DataTable select 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
-          <span
-            class="StyledText-sc-1sadyjn-0 hUokoe"
+          <div
+            class="StyledBox-sc-13pk1d4-0 bToxzR"
           >
-            A
-          </span>
+            <span
+              class="StyledText-sc-1sadyjn-0 hUokoe"
+            >
+              A
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
@@ -9369,7 +10056,7 @@ exports[`DataTable select 2`] = `
 `;
 
 exports[`DataTable sort 1`] = `
-.c8 {
+.c9 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -9380,25 +10067,25 @@ exports[`DataTable sort 1`] = `
   stroke: #666666;
 }
 
-.c8 g {
+.c9 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill="none"] {
+.c9 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
+.c9 *[stroke*="#"],
+.c9 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*="#"],
+.c9 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -9413,7 +10100,24 @@ exports[`DataTable sort 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c5 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9431,7 +10135,7 @@ exports[`DataTable sort 1`] = `
   flex-direction: row;
 }
 
-.c11 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9445,7 +10149,7 @@ exports[`DataTable sort 1`] = `
   flex-direction: column;
 }
 
-.c7 {
+.c8 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -9455,7 +10159,7 @@ exports[`DataTable sort 1`] = `
   width: 6px;
 }
 
-.c4 {
+.c5 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -9474,23 +10178,23 @@ exports[`DataTable sort 1`] = `
   height: 100%;
 }
 
-.c4:focus {
+.c5:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c5:focus > circle,
+.c5:focus > ellipse,
+.c5:focus > line,
+.c5:focus > path,
+.c5:focus > polygon,
+.c5:focus > polyline,
+.c5:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c5:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -9507,7 +10211,7 @@ exports[`DataTable sort 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -9525,12 +10229,12 @@ exports[`DataTable sort 1`] = `
   width: inherit;
 }
 
-.c6 {
+.c7 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c12 {
+.c13 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -9542,12 +10246,12 @@ exports[`DataTable sort 1`] = `
   height: auto;
 }
 
-.c9:focus {
+.c10:focus {
   outline: 2px solid #6FFFB0;
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     width: 3px;
   }
 }
@@ -9574,86 +10278,94 @@ exports[`DataTable sort 1`] = `
           class="c3 "
           scope="col"
         >
-          <button
-            class="c4 "
-            type="button"
+          <div
+            class="c4"
           >
-            <div
-              class="c5"
+            <button
+              class="c5 "
+              type="button"
             >
-              <span
+              <div
                 class="c6"
               >
-                A
-              </span>
-              <div
-                class="c7"
-              />
-              <svg
-                aria-label="FormUp"
-                class="c8"
-                viewBox="0 0 24 24"
-              >
-                <polyline
-                  fill="none"
-                  points="18 9 12 15 6 9"
-                  stroke="#000"
-                  stroke-width="2"
-                  transform="matrix(1 0 0 -1 0 24)"
+                <span
+                  class="c7"
+                >
+                  A
+                </span>
+                <div
+                  class="c8"
                 />
-              </svg>
-            </div>
-          </button>
+                <svg
+                  aria-label="FormUp"
+                  class="c9"
+                  viewBox="0 0 24 24"
+                >
+                  <polyline
+                    fill="none"
+                    points="18 9 12 15 6 9"
+                    stroke="#000"
+                    stroke-width="2"
+                    transform="matrix(1 0 0 -1 0 24)"
+                  />
+                </svg>
+              </div>
+            </button>
+          </div>
         </th>
         <th
           class="c3 "
           scope="col"
         >
-          <button
-            class="c4 "
-            type="button"
+          <div
+            class="c4"
           >
-            <div
-              class="c5"
+            <button
+              class="c5 "
+              type="button"
             >
-              <span
+              <div
                 class="c6"
               >
-                B
-              </span>
-            </div>
-          </button>
+                <span
+                  class="c7"
+                >
+                  B
+                </span>
+              </div>
+            </button>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c9"
+      class="c10"
     >
       <tr
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c6"
+              class="c7"
             >
               1
             </span>
@@ -9664,27 +10376,27 @@ exports[`DataTable sort 1`] = `
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c6"
+              class="c7"
             >
               2
             </span>
@@ -9695,27 +10407,27 @@ exports[`DataTable sort 1`] = `
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               zero
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c6"
+              class="c7"
             >
               0
             </span>
@@ -9728,7 +10440,7 @@ exports[`DataTable sort 1`] = `
 `;
 
 exports[`DataTable sort external 1`] = `
-.c8 {
+.c9 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -9739,25 +10451,25 @@ exports[`DataTable sort external 1`] = `
   stroke: #666666;
 }
 
-.c8 g {
+.c9 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill="none"] {
+.c9 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
+.c9 *[stroke*="#"],
+.c9 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*="#"],
+.c9 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -9772,7 +10484,24 @@ exports[`DataTable sort external 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c5 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9790,7 +10519,7 @@ exports[`DataTable sort external 1`] = `
   flex-direction: row;
 }
 
-.c11 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9804,7 +10533,7 @@ exports[`DataTable sort external 1`] = `
   flex-direction: column;
 }
 
-.c7 {
+.c8 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -9814,7 +10543,7 @@ exports[`DataTable sort external 1`] = `
   width: 6px;
 }
 
-.c4 {
+.c5 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -9833,23 +10562,23 @@ exports[`DataTable sort external 1`] = `
   height: 100%;
 }
 
-.c4:focus {
+.c5:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c5:focus > circle,
+.c5:focus > ellipse,
+.c5:focus > line,
+.c5:focus > path,
+.c5:focus > polygon,
+.c5:focus > polyline,
+.c5:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c5:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -9866,7 +10595,7 @@ exports[`DataTable sort external 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -9884,12 +10613,12 @@ exports[`DataTable sort external 1`] = `
   width: inherit;
 }
 
-.c6 {
+.c7 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c12 {
+.c13 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -9901,12 +10630,12 @@ exports[`DataTable sort external 1`] = `
   height: auto;
 }
 
-.c9:focus {
+.c10:focus {
   outline: 2px solid #6FFFB0;
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     width: 3px;
   }
 }
@@ -9933,86 +10662,94 @@ exports[`DataTable sort external 1`] = `
           class="c3 "
           scope="col"
         >
-          <button
-            class="c4 "
-            type="button"
+          <div
+            class="c4"
           >
-            <div
-              class="c5"
+            <button
+              class="c5 "
+              type="button"
             >
-              <span
+              <div
                 class="c6"
               >
-                A
-              </span>
-              <div
-                class="c7"
-              />
-              <svg
-                aria-label="FormUp"
-                class="c8"
-                viewBox="0 0 24 24"
-              >
-                <polyline
-                  fill="none"
-                  points="18 9 12 15 6 9"
-                  stroke="#000"
-                  stroke-width="2"
-                  transform="matrix(1 0 0 -1 0 24)"
+                <span
+                  class="c7"
+                >
+                  A
+                </span>
+                <div
+                  class="c8"
                 />
-              </svg>
-            </div>
-          </button>
+                <svg
+                  aria-label="FormUp"
+                  class="c9"
+                  viewBox="0 0 24 24"
+                >
+                  <polyline
+                    fill="none"
+                    points="18 9 12 15 6 9"
+                    stroke="#000"
+                    stroke-width="2"
+                    transform="matrix(1 0 0 -1 0 24)"
+                  />
+                </svg>
+              </div>
+            </button>
+          </div>
         </th>
         <th
           class="c3 "
           scope="col"
         >
-          <button
-            class="c4 "
-            type="button"
+          <div
+            class="c4"
           >
-            <div
-              class="c5"
+            <button
+              class="c5 "
+              type="button"
             >
-              <span
+              <div
                 class="c6"
               >
-                B
-              </span>
-            </div>
-          </button>
+                <span
+                  class="c7"
+                >
+                  B
+                </span>
+              </div>
+            </button>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c9"
+      class="c10"
     >
       <tr
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               zero
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c6"
+              class="c7"
             >
               0
             </span>
@@ -10023,27 +10760,27 @@ exports[`DataTable sort external 1`] = `
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c6"
+              class="c7"
             >
               1
             </span>
@@ -10054,27 +10791,27 @@ exports[`DataTable sort external 1`] = `
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c6"
+              class="c7"
             >
               2
             </span>
@@ -10087,7 +10824,7 @@ exports[`DataTable sort external 1`] = `
 `;
 
 exports[`DataTable sort nested object 1`] = `
-.c8 {
+.c9 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -10098,25 +10835,25 @@ exports[`DataTable sort nested object 1`] = `
   stroke: #666666;
 }
 
-.c8 g {
+.c9 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill="none"] {
+.c9 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
+.c9 *[stroke*="#"],
+.c9 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*="#"],
+.c9 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -10131,7 +10868,24 @@ exports[`DataTable sort nested object 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c5 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10149,7 +10903,7 @@ exports[`DataTable sort nested object 1`] = `
   flex-direction: row;
 }
 
-.c11 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10163,7 +10917,7 @@ exports[`DataTable sort nested object 1`] = `
   flex-direction: column;
 }
 
-.c7 {
+.c8 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -10173,7 +10927,7 @@ exports[`DataTable sort nested object 1`] = `
   width: 6px;
 }
 
-.c4 {
+.c5 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -10192,23 +10946,23 @@ exports[`DataTable sort nested object 1`] = `
   height: 100%;
 }
 
-.c4:focus {
+.c5:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c5:focus > circle,
+.c5:focus > ellipse,
+.c5:focus > line,
+.c5:focus > path,
+.c5:focus > polygon,
+.c5:focus > polyline,
+.c5:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c5:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -10225,7 +10979,7 @@ exports[`DataTable sort nested object 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -10243,12 +10997,12 @@ exports[`DataTable sort nested object 1`] = `
   width: inherit;
 }
 
-.c6 {
+.c7 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c12 {
+.c13 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -10260,12 +11014,12 @@ exports[`DataTable sort nested object 1`] = `
   height: auto;
 }
 
-.c9:focus {
+.c10:focus {
   outline: 2px solid #6FFFB0;
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     width: 3px;
   }
 }
@@ -10292,85 +11046,93 @@ exports[`DataTable sort nested object 1`] = `
           class="c3 "
           scope="col"
         >
-          <button
-            class="c4 "
-            type="button"
+          <div
+            class="c4"
           >
-            <div
-              class="c5"
+            <button
+              class="c5 "
+              type="button"
             >
-              <span
+              <div
                 class="c6"
               >
-                A
-              </span>
-            </div>
-          </button>
+                <span
+                  class="c7"
+                >
+                  A
+                </span>
+              </div>
+            </button>
+          </div>
         </th>
         <th
           class="c3 "
           scope="col"
         >
-          <button
-            class="c4 "
-            type="button"
+          <div
+            class="c4"
           >
-            <div
-              class="c5"
+            <button
+              class="c5 "
+              type="button"
             >
-              <span
+              <div
                 class="c6"
               >
-                Value
-              </span>
-              <div
-                class="c7"
-              />
-              <svg
-                aria-label="FormDown"
-                class="c8"
-                viewBox="0 0 24 24"
-              >
-                <polyline
-                  fill="none"
-                  points="18 9 12 15 6 9"
-                  stroke="#000"
-                  stroke-width="2"
+                <span
+                  class="c7"
+                >
+                  Value
+                </span>
+                <div
+                  class="c8"
                 />
-              </svg>
-            </div>
-          </button>
+                <svg
+                  aria-label="FormDown"
+                  class="c9"
+                  viewBox="0 0 24 24"
+                >
+                  <polyline
+                    fill="none"
+                    points="18 9 12 15 6 9"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+            </button>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c9"
+      class="c10"
     >
       <tr
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c6"
+              class="c7"
             >
               3
             </span>
@@ -10381,27 +11143,27 @@ exports[`DataTable sort nested object 1`] = `
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c6"
+              class="c7"
             >
               2
             </span>
@@ -10412,27 +11174,27 @@ exports[`DataTable sort nested object 1`] = `
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               zero
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c6"
+              class="c7"
             >
               1
             </span>
@@ -10445,7 +11207,7 @@ exports[`DataTable sort nested object 1`] = `
 `;
 
 exports[`DataTable sort nested object with onSort 1`] = `
-.c8 {
+.c9 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -10456,25 +11218,25 @@ exports[`DataTable sort nested object with onSort 1`] = `
   stroke: #666666;
 }
 
-.c8 g {
+.c9 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill="none"] {
+.c9 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
+.c9 *[stroke*="#"],
+.c9 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*="#"],
+.c9 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -10489,7 +11251,24 @@ exports[`DataTable sort nested object with onSort 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c5 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10507,7 +11286,7 @@ exports[`DataTable sort nested object with onSort 1`] = `
   flex-direction: row;
 }
 
-.c11 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10521,7 +11300,7 @@ exports[`DataTable sort nested object with onSort 1`] = `
   flex-direction: column;
 }
 
-.c7 {
+.c8 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -10531,7 +11310,7 @@ exports[`DataTable sort nested object with onSort 1`] = `
   width: 6px;
 }
 
-.c4 {
+.c5 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -10550,23 +11329,23 @@ exports[`DataTable sort nested object with onSort 1`] = `
   height: 100%;
 }
 
-.c4:focus {
+.c5:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c5:focus > circle,
+.c5:focus > ellipse,
+.c5:focus > line,
+.c5:focus > path,
+.c5:focus > polygon,
+.c5:focus > polyline,
+.c5:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c5:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -10583,7 +11362,7 @@ exports[`DataTable sort nested object with onSort 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -10601,12 +11380,12 @@ exports[`DataTable sort nested object with onSort 1`] = `
   width: inherit;
 }
 
-.c6 {
+.c7 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c12 {
+.c13 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -10618,12 +11397,12 @@ exports[`DataTable sort nested object with onSort 1`] = `
   height: auto;
 }
 
-.c9:focus {
+.c10:focus {
   outline: 2px solid #6FFFB0;
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     width: 3px;
   }
 }
@@ -10650,85 +11429,93 @@ exports[`DataTable sort nested object with onSort 1`] = `
           class="c3 "
           scope="col"
         >
-          <button
-            class="c4 "
-            type="button"
+          <div
+            class="c4"
           >
-            <div
-              class="c5"
+            <button
+              class="c5 "
+              type="button"
             >
-              <span
+              <div
                 class="c6"
               >
-                A
-              </span>
-            </div>
-          </button>
+                <span
+                  class="c7"
+                >
+                  A
+                </span>
+              </div>
+            </button>
+          </div>
         </th>
         <th
           class="c3 "
           scope="col"
         >
-          <button
-            class="c4 "
-            type="button"
+          <div
+            class="c4"
           >
-            <div
-              class="c5"
+            <button
+              class="c5 "
+              type="button"
             >
-              <span
+              <div
                 class="c6"
               >
-                Value
-              </span>
-              <div
-                class="c7"
-              />
-              <svg
-                aria-label="FormDown"
-                class="c8"
-                viewBox="0 0 24 24"
-              >
-                <polyline
-                  fill="none"
-                  points="18 9 12 15 6 9"
-                  stroke="#000"
-                  stroke-width="2"
+                <span
+                  class="c7"
+                >
+                  Value
+                </span>
+                <div
+                  class="c8"
                 />
-              </svg>
-            </div>
-          </button>
+                <svg
+                  aria-label="FormDown"
+                  class="c9"
+                  viewBox="0 0 24 24"
+                >
+                  <polyline
+                    fill="none"
+                    points="18 9 12 15 6 9"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+            </button>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c9"
+      class="c10"
     >
       <tr
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c6"
+              class="c7"
             >
               3
             </span>
@@ -10739,27 +11526,27 @@ exports[`DataTable sort nested object with onSort 1`] = `
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c6"
+              class="c7"
             >
               2
             </span>
@@ -10770,27 +11557,27 @@ exports[`DataTable sort nested object with onSort 1`] = `
         class=""
       >
         <th
-          class="c10 "
+          class="c11 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c12"
+              class="c13"
             >
               zero
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c11"
+            class="c12"
           >
             <span
-              class="c6"
+              class="c7"
             >
               1
             </span>
@@ -10813,7 +11600,24 @@ exports[`DataTable sortable 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c5 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10831,7 +11635,7 @@ exports[`DataTable sortable 1`] = `
   flex-direction: row;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10845,7 +11649,7 @@ exports[`DataTable sortable 1`] = `
   flex-direction: column;
 }
 
-.c4 {
+.c5 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -10864,23 +11668,23 @@ exports[`DataTable sortable 1`] = `
   height: 100%;
 }
 
-.c4:focus {
+.c5:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c5:focus > circle,
+.c5:focus > ellipse,
+.c5:focus > line,
+.c5:focus > path,
+.c5:focus > polygon,
+.c5:focus > polyline,
+.c5:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c5:focus::-moz-focus-inner {
   border: 0;
 }
 
@@ -10897,7 +11701,7 @@ exports[`DataTable sortable 1`] = `
   padding-bottom: 6px;
 }
 
-.c8 {
+.c9 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -10915,12 +11719,12 @@ exports[`DataTable sortable 1`] = `
   width: inherit;
 }
 
-.c6 {
+.c7 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c10 {
+.c11 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -10932,7 +11736,7 @@ exports[`DataTable sortable 1`] = `
   height: auto;
 }
 
-.c7:focus {
+.c8:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -10958,70 +11762,78 @@ exports[`DataTable sortable 1`] = `
           class="c3 "
           scope="col"
         >
-          <button
-            class="c4 "
-            type="button"
+          <div
+            class="c4"
           >
-            <div
-              class="c5"
+            <button
+              class="c5 "
+              type="button"
             >
-              <span
+              <div
                 class="c6"
               >
-                A
-              </span>
-            </div>
-          </button>
+                <span
+                  class="c7"
+                >
+                  A
+                </span>
+              </div>
+            </button>
+          </div>
         </th>
         <th
           class="c3 "
           scope="col"
         >
-          <button
-            class="c4 "
-            type="button"
+          <div
+            class="c4"
           >
-            <div
-              class="c5"
+            <button
+              class="c5 "
+              type="button"
             >
-              <span
+              <div
                 class="c6"
               >
-                B
-              </span>
-            </div>
-          </button>
+                <span
+                  class="c7"
+                >
+                  B
+                </span>
+              </div>
+            </button>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c7"
+      class="c8"
     >
       <tr
         class=""
       >
         <th
-          class="c8 "
+          class="c9 "
           scope="row"
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c10"
+              class="c11"
             >
               zero
             </span>
           </div>
         </th>
         <td
-          class="c8 "
+          class="c9 "
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c6"
+              class="c7"
             >
               0
             </span>
@@ -11032,27 +11844,27 @@ exports[`DataTable sortable 1`] = `
         class=""
       >
         <th
-          class="c8 "
+          class="c9 "
           scope="row"
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c10"
+              class="c11"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c8 "
+          class="c9 "
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c6"
+              class="c7"
             >
               1
             </span>
@@ -11063,27 +11875,27 @@ exports[`DataTable sortable 1`] = `
         class=""
       >
         <th
-          class="c8 "
+          class="c9 "
           scope="row"
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c10"
+              class="c11"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c8 "
+          class="c9 "
         >
           <div
-            class="c9"
+            class="c10"
           >
             <span
-              class="c6"
+              class="c7"
             >
               2
             </span>
@@ -11112,19 +11924,22 @@ exports[`DataTable sortable 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
-          <button
-            class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 hCocKd"
-            type="button"
+          <div
+            class="StyledBox-sc-13pk1d4-0 bToxzR"
           >
-            <div
-              class="StyledBox-sc-13pk1d4-0 rpWqh"
+            <button
+              class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 hCocKd"
+              type="button"
             >
-              <span
-                class="StyledText-sc-1sadyjn-0 hUokoe"
+              <div
+                class="StyledBox-sc-13pk1d4-0 rpWqh"
               >
-                A
-              </span>
-              .c0 {
+                <span
+                  class="StyledText-sc-1sadyjn-0 hUokoe"
+                >
+                  A
+                </span>
+                .c0 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -11145,9 +11960,9 @@ exports[`DataTable sortable 2`] = `
 }
 
 <div
-                class="c0"
-              />
-              .c0 {
+                  class="c0"
+                />
+                .c0 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -11190,39 +12005,44 @@ exports[`DataTable sortable 2`] = `
 }
 
 <svg
-                aria-label="FormUp"
-                class="c0"
-                viewBox="0 0 24 24"
-              >
-                <polyline
-                  fill="none"
-                  points="18 9 12 15 6 9"
-                  stroke="#000"
-                  stroke-width="2"
-                  transform="matrix(1 0 0 -1 0 24)"
-                />
-              </svg>
-            </div>
-          </button>
+                  aria-label="FormUp"
+                  class="c0"
+                  viewBox="0 0 24 24"
+                >
+                  <polyline
+                    fill="none"
+                    points="18 9 12 15 6 9"
+                    stroke="#000"
+                    stroke-width="2"
+                    transform="matrix(1 0 0 -1 0 24)"
+                  />
+                </svg>
+              </div>
+            </button>
+          </div>
         </th>
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 kLEWHI StyledDataTable__StyledDataTableCell-xrlyjm-5 kxeYJI"
           scope="col"
         >
-          <button
-            class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 hCocKd"
-            type="button"
+          <div
+            class="StyledBox-sc-13pk1d4-0 bToxzR"
           >
-            <div
-              class="StyledBox-sc-13pk1d4-0 rpWqh"
+            <button
+              class="StyledButton-sc-323bzc-0 gCGTKO Header__StyledHeaderCellButton-sc-1baku5q-0 hCocKd"
+              type="button"
             >
-              <span
-                class="StyledText-sc-1sadyjn-0 hUokoe"
+              <div
+                class="StyledBox-sc-13pk1d4-0 rpWqh"
               >
-                B
-              </span>
-            </div>
-          </button>
+                <span
+                  class="StyledText-sc-1sadyjn-0 hUokoe"
+                >
+                  B
+                </span>
+              </div>
+            </button>
+          </div>
         </th>
       </tr>
     </thead>
@@ -11338,7 +12158,24 @@ exports[`DataTable themeColumnSizes 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11368,7 +12205,7 @@ exports[`DataTable themeColumnSizes 1`] = `
   padding-bottom: 6px;
 }
 
-.c5 {
+.c6 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -11384,7 +12221,7 @@ exports[`DataTable themeColumnSizes 1`] = `
   padding-bottom: 6px;
 }
 
-.c7 {
+.c8 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -11399,7 +12236,7 @@ exports[`DataTable themeColumnSizes 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -11420,12 +12257,12 @@ exports[`DataTable themeColumnSizes 1`] = `
   width: inherit;
 }
 
-.c4 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c9 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -11437,7 +12274,7 @@ exports[`DataTable themeColumnSizes 1`] = `
   height: auto;
 }
 
-.c6:focus {
+.c7:focus {
   outline: 2px solid #6FFFB0;
 }
 
@@ -11463,52 +12300,60 @@ exports[`DataTable themeColumnSizes 1`] = `
           class="c3 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            A
-          </span>
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
         </th>
         <th
-          class="c5 "
+          class="c6 "
           scope="col"
         >
-          <span
+          <div
             class="c4"
           >
-            B
-          </span>
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
         </th>
       </tr>
     </thead>
     <tbody
-      class="c6"
+      class="c7"
     >
       <tr
         class=""
       >
         <th
-          class="c7 "
+          class="c8 "
           scope="row"
         >
           <div
-            class="c8"
+            class="c9"
           >
             <span
-              class="c9"
+              class="c10"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c8"
+            class="c9"
           >
             <span
-              class="c4"
+              class="c5"
             >
               1
             </span>
@@ -11519,27 +12364,27 @@ exports[`DataTable themeColumnSizes 1`] = `
         class=""
       >
         <th
-          class="c7 "
+          class="c8 "
           scope="row"
         >
           <div
-            class="c8"
+            class="c9"
           >
             <span
-              class="c9"
+              class="c10"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c11 "
         >
           <div
-            class="c8"
+            class="c9"
           >
             <span
-              class="c4"
+              class="c5"
             >
               2
             </span>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
A quick enhancement/fix to this [recently merged PR](https://github.com/grommet/grommet/pull/4542). We want the header content to flex="grow" to fill any available space even when there is no `search` or `resizer` -- in the previous implementation the logic only applied when resizing or searching was present in the header cell. There are cases where a header cell has a sortable button (but is not searchable or resizeable) and we would still want the button to take up any available space. This just shifts where the content becomes wrapped.

#### Where should the reviewer start?
src/js/components/DataTable/Header.js

#### What testing has been done on this PR?
Jest tests updated.

#### How should this be manually tested?
Tested on `Sort` story with and removed any `search` and `resizeable` from the DataTable
```
const customTheme = {
      dataTable: {
        header: {
          background: 'skyblue',
          border: {
            color: 'green',
            size: 'medium',
          },
          gap: 'none',
          pad: { horizontal: 'small', vertical: 'xsmall' },
          font: {
            weight: 'bold',
          },
          hover: {
            background: {
              color: 'light-2',
            },
          },
        },
      },
    };
```
#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes.