### PR TITLE
Fix 1128 - Allows DataTable footer to be pinned on Safari

### DIFF
--- a/src/js/components/DataTable/Footer.js
+++ b/src/js/components/DataTable/Footer.js
@@ -22,7 +22,7 @@ const Footer = ({
   selected,
   ...rest
 }) => (
-  <StyledDataTableFooter fillProp={fill} {...rest}>
+  <StyledDataTableFooter fillProp={fill} pin={tablePin} {...rest}>
     <TableRow>
       {groups && (
         <TableCell plain size="xxsmall" pad="none" verticalAlign="top" />

--- a/src/js/components/DataTable/StyledDataTable.js
+++ b/src/js/components/DataTable/StyledDataTable.js
@@ -118,6 +118,14 @@ const StyledDataTableFooter = styled(TableFooter)`
     width: 100%;
     table-layout: fixed;
   `}
+  ${props =>
+    props.pin &&
+    `
+      /* Safari needs the relative positioning of tfoot specified */
+      position: sticky;
+      bottom: 0;
+      z-index: 1;
+  `}
 `;
 
 StyledDataTableFooter.defaultProps = {};

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -5835,7 +5835,7 @@ exports[`DataTable pin 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c13 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -5875,6 +5875,13 @@ exports[`DataTable pin 1`] = `
   outline: 2px solid #6FFFB0;
 }
 
+.c12 {
+  position: -webkit-sticky;
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+}
+
 .c4 {
   position: -webkit-sticky;
   position: sticky;
@@ -5897,7 +5904,7 @@ exports[`DataTable pin 1`] = `
   z-index: 1;
 }
 
-.c13 {
+.c14 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0;
@@ -5905,7 +5912,7 @@ exports[`DataTable pin 1`] = `
   z-index: 2;
 }
 
-.c14 {
+.c15 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0;
@@ -6019,13 +6026,13 @@ exports[`DataTable pin 1`] = `
       </tr>
     </tbody>
     <tfoot
-      class=""
+      class="c12"
     >
       <tr
         class=""
       >
         <td
-          class="c12 c13"
+          class="c13 c14"
         >
           <div
             class="c10"
@@ -6038,7 +6045,7 @@ exports[`DataTable pin 1`] = `
           </div>
         </td>
         <td
-          class="c12 c14"
+          class="c13 c15"
         >
           <div
             class="c10"
@@ -6151,7 +6158,7 @@ exports[`DataTable pin 1`] = `
         class=""
       >
         <td
-          class="c12 c9"
+          class="c13 c9"
         >
           <div
             class="c10"
@@ -6164,7 +6171,7 @@ exports[`DataTable pin 1`] = `
           </div>
         </td>
         <td
-          class="c12 "
+          class="c13 "
         >
           <div
             class="c10"
@@ -6271,13 +6278,13 @@ exports[`DataTable pin 1`] = `
       </tr>
     </tbody>
     <tfoot
-      class=""
+      class="c12"
     >
       <tr
         class=""
       >
         <td
-          class="c12 c13"
+          class="c13 c14"
         >
           <div
             class="c10"
@@ -6290,7 +6297,7 @@ exports[`DataTable pin 1`] = `
           </div>
         </td>
         <td
-          class="c12 c14"
+          class="c13 c15"
         >
           <div
             class="c10"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -7206,7 +7206,7 @@ exports[`DataTable pin + background 1`] = `
   padding-bottom: 6px;
 }
 
-.c14 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7221,7 +7221,7 @@ exports[`DataTable pin + background 1`] = `
   padding-bottom: 6px;
 }
 
-.c17 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7261,6 +7261,13 @@ exports[`DataTable pin + background 1`] = `
   outline: 2px solid #6FFFB0;
 }
 
+.c14 {
+  position: -webkit-sticky;
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+}
+
 .c4 {
   position: -webkit-sticky;
   position: sticky;
@@ -7283,7 +7290,7 @@ exports[`DataTable pin + background 1`] = `
   z-index: 1;
 }
 
-.c15 {
+.c16 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0;
@@ -7291,7 +7298,7 @@ exports[`DataTable pin + background 1`] = `
   z-index: 2;
 }
 
-.c16 {
+.c17 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0;
@@ -7413,13 +7420,13 @@ exports[`DataTable pin + background 1`] = `
       </tr>
     </tbody>
     <tfoot
-      class=""
+      class="c14"
     >
       <tr
         class=""
       >
         <td
-          class="c14 c15"
+          class="c15 c16"
         >
           <div
             class="c11"
@@ -7432,7 +7439,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </td>
         <td
-          class="c14 c16"
+          class="c15 c17"
         >
           <div
             class="c11"
@@ -7553,7 +7560,7 @@ exports[`DataTable pin + background 1`] = `
         class=""
       >
         <td
-          class="c14 c10"
+          class="c15 c10"
         >
           <div
             class="c11"
@@ -7566,7 +7573,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </td>
         <td
-          class="c14 "
+          class="c15 "
         >
           <div
             class="c11"
@@ -7599,7 +7606,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </th>
         <th
-          class="c17 "
+          class="c18 "
           scope="col"
         >
           <div
@@ -7681,13 +7688,13 @@ exports[`DataTable pin + background 1`] = `
       </tr>
     </tbody>
     <tfoot
-      class=""
+      class="c14"
     >
       <tr
         class=""
       >
         <td
-          class="c14 c15"
+          class="c15 c16"
         >
           <div
             class="c11"
@@ -7700,7 +7707,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </td>
         <td
-          class="c14 c16"
+          class="c15 c17"
         >
           <div
             class="c11"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Allows DataTable footer to be pinned on Safari by applying relative positioning to `tfoot`.

#### Where should the reviewer start?

DataTable/Footer.js
DataTable/StyledDataTable.js

#### What testing has been done on this PR?

Storybook DataTable / "Fill and pin" on Safari (13), FF(78), Chrome/Edge (84)

#### How should this be manually tested?

Storybook DataTable / "Fill and pin" on Safari (13), FF(78), Chrome/Edge (84)

#### Any background context you want to provide?

Primary implementation of pinned behavior applies to th/td in DataTable cells (largely b/c of a [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=702927) which does not allow for relative positioning on thead). `td/th` in `tfoot` in Safari is not behaving in the same manner, thus the need to apply the relative positioning at the `tfoot` level.

#### What are the relevant issues?

https://github.com/grommet/hpe-design-system/issues/1133

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

Sure.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
