### PR TITLE
Add RangeInput specs for events

### DIFF
--- a/src/js/components/RangeInput/__tests__/RangeInput-test.js
+++ b/src/js/components/RangeInput/__tests__/RangeInput-test.js
@@ -5,7 +5,7 @@ import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
 import { axe } from 'jest-axe';
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, render, fireEvent } from '@testing-library/react';
 import { Grommet } from '../../Grommet';
 import { RangeInput } from '..';
 
@@ -64,5 +64,45 @@ describe('RangeInput', () => {
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  test('onFocus', () => {
+    const onFocus = jest.fn();
+    const { container, getByDisplayValue } = render(
+      <Grommet>
+        <RangeInput min={0} max={10} step={1} value={5} onFocus={onFocus} />
+      </Grommet>,
+    );
+    fireEvent.focus(getByDisplayValue('5'));
+    expect(container.firstChild).toMatchSnapshot();
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+
+  test('onBlur', () => {
+    const onBlur = jest.fn();
+    const { container, getByDisplayValue } = render(
+      <Grommet>
+        <RangeInput min={0} max={10} step={1} value={5} onBlur={onBlur} />
+      </Grommet>,
+    );
+    fireEvent.blur(getByDisplayValue('5'));
+    expect(container.firstChild).toMatchSnapshot();
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+
+  test('onChange', () => {
+    const onChange = jest.fn();
+    const { container, getByDisplayValue } = render(
+      <Grommet>
+        <RangeInput min={0} max={10} step={1} value={5} onChange={onChange} />
+      </Grommet>,
+    );
+    fireEvent.change(getByDisplayValue('5'), {
+      target: {
+        value: '10',
+      },
+    });
+    expect(container.firstChild).toMatchSnapshot();
+    expect(onChange).toBeCalledTimes(1);
   });
 });

--- a/src/js/components/RangeInput/__tests__/__snapshots__/RangeInput-test.js.snap
+++ b/src/js/components/RangeInput/__tests__/__snapshots__/RangeInput-test.js.snap
@@ -1,5 +1,421 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RangeInput onBlur 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  box-sizing: border-box;
+  position: relative;
+  -webkit-appearance: none;
+  border-color: transparent;
+  height: 24px;
+  width: 100%;
+  padding: 0px;
+  cursor: pointer;
+  background: transparent;
+}
+
+.c1::-moz-focus-inner {
+  border: none;
+}
+
+.c1::-moz-focus-outer {
+  border: none;
+}
+
+.c1::-webkit-slider-runnable-track {
+  box-sizing: border-box;
+  width: 100%;
+  height: 4px;
+  background: rgba(0,0,0,0.2);
+}
+
+.c1::-webkit-slider-thumb {
+  margin-top: -10px;
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+}
+
+.c1::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c1::-moz-range-track {
+  box-sizing: border-box;
+  width: 100%;
+  height: 4px;
+  background: rgba(0,0,0,0.2);
+}
+
+.c1::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  margin-top: 0px;
+  height: 24px;
+  width: 24px;
+}
+
+.c1::-ms-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  margin-top: 0px;
+  height: 24px;
+  width: 24px;
+}
+
+.c1:hover::-moz-range-thumb {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c1:hover::-ms-thumb {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c1::-ms-track {
+  box-sizing: border-box;
+  width: 100%;
+  height: 4px;
+  background: rgba(0,0,0,0.2);
+  border-color: transparent;
+  color: transparent;
+}
+
+.c1::-ms-fill-lower {
+  background: rgba(0,0,0,0.2);
+  border-color: transparent;
+}
+
+.c1::-ms-fill-upper {
+  background: rgba(0,0,0,0.2);
+  border-color: transparent;
+}
+
+<div
+  class="c0"
+>
+  <input
+    class="c1"
+    max="10"
+    min="0"
+    step="1"
+    type="range"
+    value="5"
+  />
+</div>
+`;
+
+exports[`RangeInput onChange 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  box-sizing: border-box;
+  position: relative;
+  -webkit-appearance: none;
+  border-color: transparent;
+  height: 24px;
+  width: 100%;
+  padding: 0px;
+  cursor: pointer;
+  background: transparent;
+}
+
+.c1::-moz-focus-inner {
+  border: none;
+}
+
+.c1::-moz-focus-outer {
+  border: none;
+}
+
+.c1::-webkit-slider-runnable-track {
+  box-sizing: border-box;
+  width: 100%;
+  height: 4px;
+  background: rgba(0,0,0,0.2);
+}
+
+.c1::-webkit-slider-thumb {
+  margin-top: -10px;
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+}
+
+.c1::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c1::-moz-range-track {
+  box-sizing: border-box;
+  width: 100%;
+  height: 4px;
+  background: rgba(0,0,0,0.2);
+}
+
+.c1::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  margin-top: 0px;
+  height: 24px;
+  width: 24px;
+}
+
+.c1::-ms-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  margin-top: 0px;
+  height: 24px;
+  width: 24px;
+}
+
+.c1:hover::-moz-range-thumb {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c1:hover::-ms-thumb {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c1::-ms-track {
+  box-sizing: border-box;
+  width: 100%;
+  height: 4px;
+  background: rgba(0,0,0,0.2);
+  border-color: transparent;
+  color: transparent;
+}
+
+.c1::-ms-fill-lower {
+  background: rgba(0,0,0,0.2);
+  border-color: transparent;
+}
+
+.c1::-ms-fill-upper {
+  background: rgba(0,0,0,0.2);
+  border-color: transparent;
+}
+
+<div
+  class="c0"
+>
+  <input
+    class="c1"
+    max="10"
+    min="0"
+    step="1"
+    type="range"
+    value="5"
+  />
+</div>
+`;
+
+exports[`RangeInput onFocus 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  box-sizing: border-box;
+  position: relative;
+  -webkit-appearance: none;
+  border-color: transparent;
+  height: 24px;
+  width: 100%;
+  padding: 0px;
+  cursor: pointer;
+  background: transparent;
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1::-moz-focus-inner {
+  border: none;
+}
+
+.c1::-moz-focus-outer {
+  border: none;
+}
+
+.c1::-webkit-slider-runnable-track {
+  box-sizing: border-box;
+  width: 100%;
+  height: 4px;
+  background: rgba(0,0,0,0.2);
+}
+
+.c1::-webkit-slider-thumb {
+  margin-top: -10px;
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+}
+
+.c1::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c1::-moz-range-track {
+  box-sizing: border-box;
+  width: 100%;
+  height: 4px;
+  background: rgba(0,0,0,0.2);
+}
+
+.c1::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  margin-top: 0px;
+  height: 24px;
+  width: 24px;
+}
+
+.c1::-ms-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  margin-top: 0px;
+  height: 24px;
+  width: 24px;
+}
+
+.c1:hover::-moz-range-thumb {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c1:hover::-ms-thumb {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c1::-ms-track {
+  box-sizing: border-box;
+  width: 100%;
+  height: 4px;
+  background: rgba(0,0,0,0.2);
+  border-color: transparent;
+  color: transparent;
+}
+
+.c1::-ms-fill-lower {
+  background: rgba(0,0,0,0.2);
+  border-color: transparent;
+}
+
+.c1::-ms-fill-upper {
+  background: rgba(0,0,0,0.2);
+  border-color: transparent;
+}
+
+.c1 > circle,
+.c1 > ellipse,
+.c1 > line,
+.c1 > path,
+.c1 > polygon,
+.c1 > polyline,
+.c1 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1::-moz-focus-inner {
+  border: 0;
+}
+
+<div
+  class="c0"
+>
+  <input
+    class="c1"
+    max="10"
+    min="0"
+    step="1"
+    type="range"
+    value="5"
+  />
+</div>
+`;
+
 exports[`RangeInput renders 1`] = `
 .c0 {
   font-size: 18px;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Add specs for `RangeInput` when users fire events like: `onFocus`, `onBlur` and `onChange` 

#### Where should the reviewer start?
`src/js/components/RangeInput/__tests__/RangeInput-test.js`

#### What testing has been done on this PR?
Run `yarn test` to ensure that all tests pass and view coverage

#### How should this be manually tested?

#### Any background context you want to provide?
No
#### What are the relevant issues?
See #4539 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backwards compatible