### PR TITLE
Add primaryKey and secondaryKey event typings

### DIFF
--- a/src/js/components/List/index.d.ts
+++ b/src/js/components/List/index.d.ts
@@ -70,8 +70,8 @@ export interface ListProps {
     | ((event: React.MouseEvent) => void)
     | ((event: { item?: {}; index?: number }) => void);
   pad?: PadType;
-  primaryKey?: string | ((...args: any[]) => any);
-  secondaryKey?: string | ((...args: any[]) => any);
+  primaryKey?: string | ((item: any) => React.ReactElement);
+  secondaryKey?: string | ((item: any) => React.ReactElement);
   step?: number;
   action?: (item: any, index: number) => void;
 }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Update `List` existing typings for event handlers: `primaryKey`, `secondaryKey`

#### Where should the reviewer start?
`src/js/components/List/index.d.ts`

#### What testing has been done on this PR?
This has been tested on a local TS project

#### How should this be manually tested?
Testing the List secondaryKey story in the storybook

#### Any background context you want to provide?

#### What are the relevant issues?
#3165 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
backwards compatible