### PR TITLE
TS fixed BorderType for FormField

### DIFF
--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -145,12 +145,16 @@ export type BorderType =
   | BoxSideType
   | {
       color?: ColorType;
+      error?: { color?: ColorType };
+      position?: string;
       side?: BoxSideType;
       size?: BoxSizeType;
       style?: BoxStyleType;
     }
   | {
       color?: ColorType;
+      error?: { color?: ColorType };
+      position?: string;
       side?: BoxSideType;
       size?: BoxSizeType;
       style?: BoxStyleType;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes error on TS theme with formField.border.error.color

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
Test with a TS theme that contains
```
formField: {
    border: {
      color: "border",
      error: { color: { dark: "white", light: "status-critical" } },
      position: "inner",
      side: "bottom"
    },
}
```

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #4519 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible