### PR TITLE
Updating yarn.lock with latest grommet-icons

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6517,8 +6517,8 @@ grommet-icons@^4.2.0:
     grommet-styles "^0.2.0"
 
 "grommet-icons@https://github.com/grommet/grommet-icons/tarball/stable":
-  version "4.4.0"
-  resolved "https://github.com/grommet/grommet-icons/tarball/stable#61edce8fd17d26c15db3c1826d011b4c62950dd4"
+  version "4.5.0"
+  resolved "https://github.com/grommet/grommet-icons/tarball/stable#f1641de85a77bee07e8db0556c9338c288cf42cb"
   dependencies:
     grommet-styles "^0.2.0"
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Updates yarn.lock integrity check for grommet-icons stable branch.

#### Where should the reviewer start?

yarn.lock

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

At first I thought including the stable branch of grommet-icons was a mistake because the package.json specifies "^4.2.0", but then realized that it is being included because of grommet-theme-hpe.
![Screen Shot 2020-09-28 at 3 35 19 PM](https://user-images.githubusercontent.com/1756948/94489685-26aaf580-01a2-11eb-9efa-e1b315fdbdfa.png)

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.