### PR TITLE
fix-4487 nested obj + aggregate with custom render

### DIFF
--- a/src/js/components/DataTable/Cell.js
+++ b/src/js/components/DataTable/Cell.js
@@ -30,7 +30,7 @@ const Cell = ({
   const context = useContext(TableContext);
 
   let content;
-  if (render) {
+  if (render && datum[property]) {
     content = render(datum);
   } else if (value !== undefined) {
     content = value;

--- a/src/js/components/DataTable/Cell.js
+++ b/src/js/components/DataTable/Cell.js
@@ -16,7 +16,15 @@ const normalizeProp = (name, rowProp, prop) => {
 const Cell = ({
   background: backgroundProp,
   border,
-  column: { align, pin: columnPin, property, render, verticalAlign, size },
+  column: {
+    align,
+    pin: columnPin,
+    footer,
+    property,
+    render,
+    verticalAlign,
+    size,
+  },
   datum,
   index,
   pad,
@@ -28,9 +36,11 @@ const Cell = ({
   const theme = useContext(ThemeContext) || defaultProps.theme;
   const value = datumValue(datum, property);
   const context = useContext(TableContext);
+  const renderContexts =
+    context === 'body' || (context === 'footer' && footer && footer.aggregate);
 
   let content;
-  if (render && datum[property]) {
+  if (render && renderContexts) {
     content = render(datum);
   } else if (value !== undefined) {
     content = value;

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -351,10 +351,15 @@ describe('DataTable', () => {
               aggregate: 'sum',
               footer: { aggregate: true },
             },
+            {
+              property: 'obj2.value',
+              header: 'object 2',
+              render: datum => datum.obj2.value,
+            },
           ]}
           data={[
-            { a: 'one', obj: { value: 1 } },
-            { a: 'two', obj: { value: 2 } },
+            { a: 'one', obj: { value: 1 }, obj2: { value: 10 } },
+            { a: 'two', obj: { value: 2 }, obj2: { value: 20 } },
           ]}
         />
       </Grommet>,

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -859,6 +859,20 @@ exports[`DataTable aggregate with nested object 1`] = `
             </span>
           </div>
         </th>
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              object 2
+            </span>
+          </div>
+        </th>
       </tr>
     </thead>
     <tbody
@@ -894,6 +908,19 @@ exports[`DataTable aggregate with nested object 1`] = `
             </span>
           </div>
         </td>
+        <td
+          class="c7 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              10
+            </span>
+          </div>
+        </td>
       </tr>
       <tr
         class=""
@@ -925,6 +952,19 @@ exports[`DataTable aggregate with nested object 1`] = `
             </span>
           </div>
         </td>
+        <td
+          class="c7 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              20
+            </span>
+          </div>
+        </td>
       </tr>
     </tbody>
     <tfoot
@@ -952,6 +992,13 @@ exports[`DataTable aggregate with nested object 1`] = `
               3
             </span>
           </div>
+        </td>
+        <td
+          class="c10 "
+        >
+          <div
+            class="c8"
+          />
         </td>
       </tr>
     </tfoot>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes data + column configuration which causes app crash.

Closes https://github.com/grommet/grommet/issues/4487
Closes https://github.com/grommet/hpe-design-system/issues/1099

#### Where should the reviewer start?

Review error reproduction: https://codesandbox.io/s/aggregating-on-property-of-nested-object-rs27r?file=/src/App.js

#### What testing has been done on this PR?

Modified unit test to reproduce the error, then placed fix.

#### How should this be manually tested?

Recreate https://codesandbox.io/s/aggregating-on-property-of-nested-object-rs27r?file=/src/App.js

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/4487
https://github.com/grommet/hpe-design-system/issues/1099

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Sure.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.
