### PR TITLE
Add missing type in GrommetProps

### DIFF
--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -4,6 +4,7 @@ import { BackgroundType } from '../../utils';
 
 export interface GrommetProps {
   background?: BackgroundType;
+  containerTarget?: HTMLElement;
   cssVars?: boolean;
   dir?: 'rtl';
   full?: boolean;


### PR DESCRIPTION
Signed-off-by: Hassan Usman <husseyexplores@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes #4545
Added the missing `containerTarget` type in the type definitions.

#### Where should the reviewer start?
https://github.com/husseyexplores/grommet/commit/6ecfc49ab378795bb8124d85a844128806771003

#### What testing has been done on this PR?
-
#### How should this be manually tested?
-
#### Any background context you want to provide?
-
#### What are the relevant issues?
#4545 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
-
