### PR TITLE
fixes wandering date in calendar test snapshot

### DIFF
--- a/src/js/components/Calendar/__tests__/Calendar-test.js
+++ b/src/js/components/Calendar/__tests__/Calendar-test.js
@@ -166,7 +166,7 @@ describe('Calendar', () => {
   test('children', () => {
     const component = renderer.create(
       <Grommet>
-        <Calendar fill animate={false}>
+        <Calendar date={DATE} fill animate={false}>
           {({ day }) => <Box>{day}</Box>}
         </Calendar>
       </Grommet>,

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -2487,14 +2487,14 @@ exports[`Calendar children 1`] = `
             className="c5"
             size="medium"
           >
-            September 2020
+            January 2020
           </h3>
         </div>
         <div
           className="c6"
         >
           <button
-            aria-label="August 2020"
+            aria-label="December 2019"
             className="c7"
             disabled={false}
             onBlur={[Function]}
@@ -2519,7 +2519,7 @@ exports[`Calendar children 1`] = `
             </svg>
           </button>
           <button
-            aria-label="October 2020"
+            aria-label="February 2020"
             className="c7"
             disabled={false}
             onBlur={[Function]}
@@ -2557,6 +2557,15 @@ exports[`Calendar children 1`] = `
           <div
             className="c11"
           >
+            <div
+              className="c12"
+            >
+              <div
+                className="c13"
+              >
+                29
+              </div>
+            </div>
             <div
               className="c12"
             >
@@ -2611,6 +2620,10 @@ exports[`Calendar children 1`] = `
                 4
               </div>
             </div>
+          </div>
+          <div
+            className="c11"
+          >
             <div
               className="c12"
             >
@@ -2620,10 +2633,6 @@ exports[`Calendar children 1`] = `
                 5
               </div>
             </div>
-          </div>
-          <div
-            className="c11"
-          >
             <div
               className="c12"
             >
@@ -2678,6 +2687,10 @@ exports[`Calendar children 1`] = `
                 11
               </div>
             </div>
+          </div>
+          <div
+            className="c11"
+          >
             <div
               className="c12"
             >
@@ -2687,10 +2700,6 @@ exports[`Calendar children 1`] = `
                 12
               </div>
             </div>
-          </div>
-          <div
-            className="c11"
-          >
             <div
               className="c12"
             >
@@ -2745,6 +2754,10 @@ exports[`Calendar children 1`] = `
                 18
               </div>
             </div>
+          </div>
+          <div
+            className="c11"
+          >
             <div
               className="c12"
             >
@@ -2754,10 +2767,6 @@ exports[`Calendar children 1`] = `
                 19
               </div>
             </div>
-          </div>
-          <div
-            className="c11"
-          >
             <div
               className="c12"
             >
@@ -2812,6 +2821,10 @@ exports[`Calendar children 1`] = `
                 25
               </div>
             </div>
+          </div>
+          <div
+            className="c11"
+          >
             <div
               className="c12"
             >
@@ -2821,10 +2834,6 @@ exports[`Calendar children 1`] = `
                 26
               </div>
             </div>
-          </div>
-          <div
-            className="c11"
-          >
             <div
               className="c12"
             >
@@ -2867,9 +2876,22 @@ exports[`Calendar children 1`] = `
               <div
                 className="c13"
               >
+                31
+              </div>
+            </div>
+            <div
+              className="c12"
+            >
+              <div
+                className="c13"
+              >
                 1
               </div>
             </div>
+          </div>
+          <div
+            className="c11"
+          >
             <div
               className="c12"
             >
@@ -2888,10 +2910,6 @@ exports[`Calendar children 1`] = `
                 3
               </div>
             </div>
-          </div>
-          <div
-            className="c11"
-          >
             <div
               className="c12"
             >
@@ -2935,24 +2953,6 @@ exports[`Calendar children 1`] = `
                 className="c13"
               >
                 8
-              </div>
-            </div>
-            <div
-              className="c12"
-            >
-              <div
-                className="c13"
-              >
-                9
-              </div>
-            </div>
-            <div
-              className="c12"
-            >
-              <div
-                className="c13"
-              >
-                10
               </div>
             </div>
           </div>


### PR DESCRIPTION
Signed-off-by: Matt Glissmann <mdglissmann@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

#### Where should the reviewer start?

Adds a fixed reference date to a Calendar test to prevent the snapshot and test breaking when a new month arrives.

#### What testing has been done on this PR?

Jest

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

None.

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.