### PR TITLE
Improve Test Coverage for Main component

### DIFF
--- a/src/js/components/Main/__tests__/Main-test.js
+++ b/src/js/components/Main/__tests__/Main-test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import 'jest-styled-components';
+import 'jest-axe/extend-expect';
+import 'regenerator-runtime/runtime';
+
+import { axe } from 'jest-axe';
+import { render, cleanup } from '@testing-library/react';
+
+import { Grommet, Main } from '../..';
+
+describe('Main', () => {
+  afterEach(cleanup);
+
+  test('should have no accessibility violations', async () => {
+    const { container } = render(
+      <Grommet>
+        <Main />
+      </Grommet>,
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/js/components/Main/__tests__/__snapshots__/Main-test.js.snap
+++ b/src/js/components/Main/__tests__/__snapshots__/Main-test.js.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Main should have no accessibility violations 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  height: 100%;
+  overflow: auto;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <main
+      class="c1"
+    />
+  </div>
+</div>
+`;


### PR DESCRIPTION
Signed-off-by: Evan Silverman <es4753@nyu.edu>

#### What does this PR do?
Introduce testing for Main component because there was none previously.

#### Where should the reviewer start?
`/src/js/components/Main/__tests__/Main-test.js`

#### What testing has been done on this PR?
Run `yarn test` to ensure that all tests pass and view coverage

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#4539

#### Screenshots (if appropriate)

Before (80% coverage):
<img width="1679" alt="Screen Shot 2020-10-05 at 9 08 05 PM" src="https://user-images.githubusercontent.com/24704789/95147712-7f086700-074f-11eb-968b-53179c820400.png">

After (100% coverage):
<img width="1664" alt="Screen Shot 2020-10-05 at 9 07 53 PM" src="https://user-images.githubusercontent.com/24704789/95147722-8760a200-074f-11eb-9841-ad31e2b919b4.png">


#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards Compatible
