### PR TITLE
Improve Anchor Component Test Coverage

### DIFF
--- a/src/js/components/Anchor/__tests__/Anchor-test.js
+++ b/src/js/components/Anchor/__tests__/Anchor-test.js
@@ -97,13 +97,27 @@ describe('Anchor', () => {
   });
 
   test('focus renders', () => {
+    const onFocus = jest.fn();
     const { container, getByText } = render(
       <Grommet>
-        <Anchor href="#" label="Test" />
+        <Anchor href="#" label="Test" onFocus={onFocus} />
       </Grommet>,
     );
     fireEvent.focus(getByText('Test'));
     expect(container.firstChild).toMatchSnapshot();
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+
+  test('blur renders', () => {
+    const onBlur = jest.fn();
+    const { container, getByText } = render(
+      <Grommet>
+        <Anchor href="#" label="Test" onBlur={onBlur} />
+      </Grommet>,
+    );
+    fireEvent.blur(getByText('Test'));
+    expect(container.firstChild).toMatchSnapshot();
+    expect(onBlur).toHaveBeenCalledTimes(1);
   });
 
   test('disabled renders', () => {
@@ -130,6 +144,21 @@ describe('Anchor', () => {
     const component = renderer.create(
       <Grommet>
         <Anchor reverse icon={<svg />} label="Test" onClick={() => {}} />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('size renders', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Anchor size="xsmall" />
+        <Anchor size="small" />
+        <Anchor size="medium" />
+        <Anchor size="large" />
+        <Anchor size="xlarge" />
+        <Anchor size="xxlarge" />
       </Grommet>,
     );
     const tree = component.toJSON();

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Anchor blur renders 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  box-sizing: border-box;
+  font-size: inherit;
+  line-height: inherit;
+  color: #7D4CDB;
+  font-weight: 600;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.c1:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+<div
+  class="c0"
+>
+  <a
+    class="c1"
+    href="#"
+  >
+    Test
+  </a>
+</div>
+`;
+
 exports[`Anchor disabled renders 1`] = `
 .c0 {
   font-size: 18px;
@@ -460,6 +499,155 @@ exports[`Anchor should have no accessibility violations 1`] = `
       Link
     </a>
   </div>
+</div>
+`;
+
+exports[`Anchor size renders 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  box-sizing: border-box;
+  font-size: 12px;
+  line-height: 18px;
+  color: #7D4CDB;
+  font-weight: 600;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.c1:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c2 {
+  box-sizing: border-box;
+  font-size: 14px;
+  line-height: 20px;
+  color: #7D4CDB;
+  font-weight: 600;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c3 {
+  box-sizing: border-box;
+  font-size: 18px;
+  line-height: 24px;
+  color: #7D4CDB;
+  font-weight: 600;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.c3:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c4 {
+  box-sizing: border-box;
+  font-size: 22px;
+  line-height: 28px;
+  color: #7D4CDB;
+  font-weight: 600;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.c4:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c5 {
+  box-sizing: border-box;
+  font-size: 26px;
+  line-height: 32px;
+  color: #7D4CDB;
+  font-weight: 600;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.c5:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c6 {
+  box-sizing: border-box;
+  font-size: 34px;
+  line-height: 40px;
+  color: #7D4CDB;
+  font-weight: 600;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.c6:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+<div
+  className="c0"
+>
+  <a
+    className="c1"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    size="xsmall"
+  />
+  <a
+    className="c2"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    size="small"
+  />
+  <a
+    className="c3"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    size="medium"
+  />
+  <a
+    className="c4"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    size="large"
+  />
+  <a
+    className="c5"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    size="xlarge"
+  />
+  <a
+    className="c6"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    size="xxlarge"
+  />
 </div>
 `;
 


### PR DESCRIPTION
Signed-off-by: Evan Silverman <es4753@nyu.edu>

#### What does this PR do?

Add testing for `size` prop, `onFocus`, and `onBlur` to raise coverage to 100%.

#### Where should the reviewer start?

`/src/js/components/Anchor/__tests__/Anchor-test.js`

#### What testing has been done on this PR?

Run `yarn test` to ensure that all tests pass and view coverage

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#4539 

#### Screenshots (if appropriate)
Before (82.93%)
<img width="1666" alt="Screen Shot 2020-10-05 at 10 40 19 PM" src="https://user-images.githubusercontent.com/24704789/95240521-8759b400-07da-11eb-910a-9fb5d14b538b.png">

After (100%)
<img width="1343" alt="Screen Shot 2020-10-06 at 1 41 09 PM" src="https://user-images.githubusercontent.com/24704789/95240577-9d677480-07da-11eb-900a-267c97a28ccb.png">

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Backwards Compatible