### PR TITLE
Changed RadioButton docs to include icons.circle

### DIFF
--- a/src/js/components/RadioButton/README.md
+++ b/src/js/components/RadioButton/README.md
@@ -187,16 +187,6 @@ Defaults to
 undefined
 ```
 
-**radioButton.gap**
-
-The gap between the label and the RadioButton itself. Expects `string`.
-
-Defaults to
-
-```
-small
-```
-
 **radioButton.font.weight**
 
 The font weight of the label. Expects `number | string`.
@@ -207,14 +197,14 @@ Defaults to
 undefined
 ```
 
-**radioButton.size**
+**radioButton.gap**
 
-The size of the RadioButton. Expects `string`.
+The gap between the label and the RadioButton itself. Expects `string`.
 
 Defaults to
 
 ```
-24px
+small
 ```
 
 **radioButton.hover.background.color**
@@ -256,4 +246,24 @@ Defaults to
 
 ```
 undefined
+```
+
+**radioButton.icons.circle**
+
+The icon to replace the inner checked circle. Expects `React.Element`.
+
+Defaults to
+
+```
+undefined
+```
+
+**radioButton.size**
+
+The size of the RadioButton. Expects `string`.
+
+Defaults to
+
+```
+24px
 ```

--- a/src/js/components/RadioButton/doc.js
+++ b/src/js/components/RadioButton/doc.js
@@ -101,20 +101,15 @@ export const themeDoc = {
     description: 'Any additional style for the RadioButton.',
     type: 'string | (props) => {}',
   },
-  'radioButton.gap': {
-    description: 'The gap between the label and the RadioButton itself.',
-    type: 'string',
-    defaultValue: 'small',
-  },
   'radioButton.font.weight': {
     description: 'The font weight of the label.',
     type: 'number | string',
     defaultValue: undefined,
   },
-  'radioButton.size': {
-    description: 'The size of the RadioButton.',
+  'radioButton.gap': {
+    description: 'The gap between the label and the RadioButton itself.',
     type: 'string',
-    defaultValue: '24px',
+    defaultValue: 'small',
   },
   'radioButton.hover.background.color': {
     description: `The background color of the Box surrounding the RadioButton
@@ -134,5 +129,15 @@ export const themeDoc = {
   'radioButton.icon.size': {
     description: 'The size of the icon in the RadioButton.',
     type: 'string',
+  },
+  'radioButton.icons.circle': {
+    description: 'The icon to replace the inner checked circle.',
+    type: 'React.Element',
+    defaultValue: undefined,
+  },
+  'radioButton.size': {
+    description: 'The size of the RadioButton.',
+    type: 'string',
+    defaultValue: '24px',
   },
 };

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -12303,16 +12303,6 @@ Defaults to
 undefined
 \`\`\`
 
-**radioButton.gap**
-
-The gap between the label and the RadioButton itself. Expects \`string\`.
-
-Defaults to
-
-\`\`\`
-small
-\`\`\`
-
 **radioButton.font.weight**
 
 The font weight of the label. Expects \`number | string\`.
@@ -12323,14 +12313,14 @@ Defaults to
 undefined
 \`\`\`
 
-**radioButton.size**
+**radioButton.gap**
 
-The size of the RadioButton. Expects \`string\`.
+The gap between the label and the RadioButton itself. Expects \`string\`.
 
 Defaults to
 
 \`\`\`
-24px
+small
 \`\`\`
 
 **radioButton.hover.background.color**
@@ -12372,6 +12362,26 @@ Defaults to
 
 \`\`\`
 undefined
+\`\`\`
+
+**radioButton.icons.circle**
+
+The icon to replace the inner checked circle. Expects \`React.Element\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**radioButton.size**
+
+The size of the RadioButton. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+24px
 \`\`\`
 ",
   "RadioButtonGroup": "## RadioButtonGroup


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changed RadioButton docs to include icons.circle
#### Where should the reviewer start?
doc.js
#### What testing has been done on this PR?
snapshots created.

#### Any background context you want to provide?
Came across the missing docs via exploring #4465 
Also, I've verified typing works as expected.
#### What are the relevant issues?
Relevant to #4465 

#### Do the grommet docs need to be updated?
done
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
backwards compatible 