### PR TITLE
Class components don't receive updated refs - Don't merge

### DIFF
--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -106,6 +106,9 @@ const TextInput = forwardRef(
     const theme = useContext(ThemeContext) || defaultProps.theme;
     const announce = useContext(AnnounceContext);
     const formContext = useContext(FormContext);
+
+    // custom hook useForwardedRef seems to cause issues with class components.
+    // createRef always returns null, even with componentDidUpdate.
     const inputRef = useForwardedRef(ref);
     const dropRef = useRef();
     const suggestionsRef = useRef();

--- a/src/js/components/TextInput/stories/Test.js
+++ b/src/js/components/TextInput/stories/Test.js
@@ -1,0 +1,52 @@
+import React, { Component, createRef } from 'react';
+import { storiesOf } from '@storybook/react';
+import {
+  Box,
+  TextInput,
+  Button,
+  Form,
+  Grommet,
+  grommet,
+  FormField,
+} from 'grommet';
+
+class Test extends Component {
+  constructor() {
+    super();
+    this.textInput = createRef();
+    this.focusTextInput = this.focusTextInput.bind(this);
+  }
+
+  focusTextInput() {
+    this.textInput.current.focus();
+  }
+
+  componentDidMount() {
+    // this.textInput.focus()
+    // focusing on mount is the standard way when using class
+    // always null, does not get the updated ref
+    // I assume it's because useForwardedRef is not done evaluating
+    // or it's because grommet is using a custom hook
+    console.log(this.textInput);
+  }
+
+  render() {
+    return (
+      <Grommet theme={grommet}>
+        <Box align="start" width="medium" gap="small">
+          <Form>
+            <FormField>
+              <TextInput placeholder="..." ref={this.textInput} />
+            </FormField>
+          </Form>
+          {{
+            /* This will work because we get the ref after mount */
+          }}
+          <Button label="click me to focus" onClick={this.focusTextInput} />
+        </Box>
+      </Grommet>
+    );
+  }
+}
+
+storiesOf('TextInput', module).add('Test', () => <Test />);

--- a/src/js/components/TextInput/stories/Test2.js
+++ b/src/js/components/TextInput/stories/Test2.js
@@ -1,0 +1,47 @@
+import React, { Component } from 'react';
+import { storiesOf } from '@storybook/react';
+import { Box, TextInput, Form, Grommet, grommet, FormField } from 'grommet';
+
+// This is a possible workaround for the issue.
+// I'm not sure if we want to accept this as the main fix.
+
+class Test2 extends Component {
+  constructor() {
+    super();
+    this.state = {
+      inputRef: '',
+    };
+
+    this.setInputRef = this.setInputRef.bind(this);
+  }
+
+  setInputRef(ref) {
+    const { inputRef } = this.state;
+    if (!inputRef) {
+      this.setState({ inputRef: ref }, () => console.log(this.state));
+    }
+  }
+
+  componentDidUpdate() {
+    const { inputRef } = this.state;
+    if (inputRef) {
+      inputRef.focus();
+    }
+  }
+
+  render() {
+    return (
+      <Grommet theme={grommet}>
+        <Box align="start" width="medium" gap="small">
+          <Form>
+            <FormField>
+              <TextInput placeholder="..." ref={ref => this.setInputRef(ref)} />
+            </FormField>
+          </Form>
+        </Box>
+      </Grommet>
+    );
+  }
+}
+
+storiesOf('TextInput', module).add('Test2', () => <Test2 />);


### PR DESCRIPTION
#### What does this PR do?
Mostly addresses issue #4092 to start a conversation about fixes

#### Where should the reviewer start?
I have two storybook examples in TextInput, Test.js, and Test2.js, with comments.
Test.js shows the issue, and Test2.js shows a workaround.
There are also, some comments in TextInput.js on line 110
```
    // custom hook useForwardedRef seems to cause issues with class components.
    // createRef always returns null, even with componentDidUpdate.
    const inputRef = useForwardedRef(ref);
```

#### What testing has been done on this PR?
No testing, as no changes have been made yet.


#### How should this be manually tested?
Same as above

#### Any background context you want to provide?
Class based components will not receive updated refs, at least when it comes to TextInput. 
TextInput refs are passed through a custom hook that evaluates the ref and returns it.
#### What are the relevant issues?
#4092 

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
No changes yet