### PR TITLE
Update DataTable hover theme convention

### DIFF
--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -49,9 +49,9 @@ const buttonStyle = ({ theme }) => {
     styles.push(kindPartStyles(layoutProps, theme));
   }
 
-  if (layoutProps.hover) {
+  if (theme.dataTable.hover && theme.dataTable.hover.header) {
     // CSS for this sub-object in the theme
-    const partStyles = kindPartStyles(layoutProps.hover, theme);
+    const partStyles = kindPartStyles(theme.dataTable.hover.header, theme);
     if (partStyles.length > 0)
       styles.push(
         css`

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -810,7 +810,7 @@ Defaults to
 small
 ```
 
-**dataTable.header.hover.background**
+**dataTable.hover.header.background**
 
 The hover background color of the header cell contents, if 
     clickable. Any valid Box background options apply. Expects `string | 

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -788,7 +788,9 @@ describe('DataTable', () => {
           font: {
             weight: 'bold',
           },
-          hover: {
+        },
+        hover: {
+          header: {
             background: {
               color: 'light-2',
             },

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -362,7 +362,7 @@ export const themeDoc = {
     type: 'object',
     defaultValue: 'small',
   },
-  'dataTable.header.hover.background': {
+  'dataTable.hover.header.background': {
     description: `The hover background color of the header cell contents, if 
     clickable. Any valid Box background options apply.`,
     type: `string | 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -6767,7 +6767,7 @@ Defaults to
 small
 \`\`\`
 
-**dataTable.header.hover.background**
+**dataTable.hover.header.background**
 
 The hover background color of the header cell contents, if 
     clickable. Any valid Box background options apply. Expects \`string | 

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -143,10 +143,12 @@ interface ButtonKindType {
 export interface ThemeType {
   global?: {
     active?: {
-      background?: ColorType | {
-        color?: ColorType;
-        opacity?: OpacityType;
-      };
+      background?:
+        | ColorType
+        | {
+            color?: ColorType;
+            opacity?: OpacityType;
+          };
       color?: ColorType;
     };
     animation?: {
@@ -612,10 +614,12 @@ export interface ThemeType {
         size?: string;
       };
       gap?: GapType;
-      hover?: {
+      pad?: PadType;
+    };
+    hover?: {
+      header?: {
         background?: BackgroundType;
       };
-      pad?: PadType;
     };
     groupHeader?: {
       border?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -708,11 +708,13 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         //   size: undefined,
         // },
         gap: 'small',
-        // hover: {
-        //   background: undefined,
-        // },
         // pad: undefined,
       },
+      // hover: {
+      //   header: {
+      //     background: undefined,
+      //   },
+      // },
       icons: {
         ascending: FormDown,
         contract: FormUp,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Swaps the DataTable hover convention from `dataTable.header.hover.background` to `dataTable.hover.header.background`. This aligns with the newer direction of defining themes via `component.state.[thing to be styled]`.

#### Where should the reviewer start?
src/js/components/DataTable/Header.js

#### What testing has been done on this PR?
Test locally in storybook with HPE Design System theme and updated jest test.

#### How should this be manually tested?
In storybook, create a custom theme.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.