### PR TITLE
Updated Button kind plain deprecation docs

### DIFF
--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -290,7 +290,9 @@ function
 Whether this is a plain button with no border or pad.
           Non plain button will show both pad and border.
           The plain button has no border and unless the icon prop exist it has 
-          no pad as well.
+          no pad as well. 
+          When using the kind button (i.e. button.default on the theme), 
+          the usage of plain is deprecated.
 
 ```
 boolean

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -100,7 +100,9 @@ with plain Buttons.`,
         `Whether this is a plain button with no border or pad.
           Non plain button will show both pad and border.
           The plain button has no border and unless the icon prop exist it has 
-          no pad as well.`,
+          no pad as well. 
+          When using the kind button (i.e. button.default on the theme), 
+          the usage of plain is deprecated.`,
       )
       .defaultValue(false),
     primary: PropTypes.bool

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -2189,7 +2189,9 @@ function
 Whether this is a plain button with no border or pad.
           Non plain button will show both pad and border.
           The plain button has no border and unless the icon prop exist it has 
-          no pad as well.
+          no pad as well. 
+          When using the kind button (i.e. button.default on the theme), 
+          the usage of plain is deprecated.
 
 \`\`\`
 boolean

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1331,7 +1331,9 @@ background
         "description": "Whether this is a plain button with no border or pad.
           Non plain button will show both pad and border.
           The plain button has no border and unless the icon prop exist it has 
-          no pad as well.",
+          no pad as well. 
+          When using the kind button (i.e. button.default on the theme), 
+          the usage of plain is deprecated.",
         "format": "boolean",
         "name": "plain",
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Updated Button kind `plain` deprecation docs not to be used with kind button.
#### Where should the reviewer start?
doc.js

#### What are the relevant issues?
#4492 

#### Do the grommet docs need to be updated?
Done.
#### Should this PR be mentioned in the release notes?
No.
#### Is this change backwards compatible or is it a breaking change?
backward compatible.