### PR TITLE
Add  prop 'fill' to Heading

### DIFF
--- a/src/js/components/Heading/Heading.js
+++ b/src/js/components/Heading/Heading.js
@@ -2,24 +2,29 @@ import React, { forwardRef } from 'react';
 
 import { StyledHeading } from './StyledHeading';
 
-const Heading = forwardRef((props, ref) => {
-  const {
-    color, // munged to avoid styled-components putting it in the DOM
-    level,
-    ...rest
-  } = props;
-
-  // enforce level to be a number
-  return (
-    <StyledHeading
-      as={`h${level}`}
-      colorProp={color}
-      level={+level}
-      {...rest}
-      ref={ref}
-    />
-  );
-});
+const Heading = forwardRef(
+  (
+    {
+      color, // munged to avoid styled-components putting it in the DOM
+      fill,
+      level,
+      ...rest
+    },
+    ref,
+  ) => {
+    // enforce level to be a number
+    return (
+      <StyledHeading
+        as={`h${level}`}
+        colorProp={color}
+        fillProp={fill}
+        level={+level}
+        {...rest}
+        ref={ref}
+      />
+    );
+  },
+);
 
 Heading.displayName = 'Heading';
 Heading.defaultProps = {

--- a/src/js/components/Heading/README.md
+++ b/src/js/components/Heading/README.md
@@ -136,6 +136,14 @@ string
 }
 ```
 
+**fill**
+
+Whether the width should fill the container.
+
+```
+boolean
+```
+
 **level**
 
 The heading level. It corresponds to the number after the 'H' for
@@ -285,16 +293,16 @@ undefined
 
 **heading.level**
 
-The level that impacts line-height, max-width, font size, 
-weight and family of the Heading. Heading styling is automatically adjusted at 
-different screen sizes. When the heading.responsiveBreakpoint is hit ("small" 
-by default), all heading styles will automatically be adjusted. A heading of 
-level 1, for example, will use the styling defined in heading level 2; a 
-heading of level 2 will use the styling defined in heading level 3 and so 
-forth. The tag in the DOM is not adjusted. A heading of level 1 remains an h1. 
-The styling adjustment is intended to aid readability on smaller screens but 
-will not semantically affect your application structure. If you do not want 
-this responsive styling to occur, you can set header.responsiveBreakpoint to 
+The level that impacts line-height, max-width, font size,
+weight and family of the Heading. Heading styling is automatically adjusted at
+different screen sizes. When the heading.responsiveBreakpoint is hit ("small"
+by default), all heading styles will automatically be adjusted. A heading of
+level 1, for example, will use the styling defined in heading level 2; a
+heading of level 2 will use the styling defined in heading level 3 and so
+forth. The tag in the DOM is not adjusted. A heading of level 1 remains an h1.
+The styling adjustment is intended to aid readability on smaller screens but
+will not semantically affect your application structure. If you do not want
+this responsive styling to occur, you can set header.responsiveBreakpoint to
 undefined. Expects `object`.
 
 Defaults to
@@ -337,7 +345,7 @@ undefined
 
 **heading.responsiveBreakpoint**
 
-The breakpoint to trigger changes in the Heading layout. 
+The breakpoint to trigger changes in the Heading layout.
 The actual values will be derived from global.breakpoints. Expects `string`.
 
 Defaults to

--- a/src/js/components/Heading/StyledHeading.js
+++ b/src/js/components/Heading/StyledHeading.js
@@ -14,7 +14,9 @@ const sizeStyle = props => {
       css`
         font-size: ${data ? data.size : size};
         line-height: ${data ? data.height : 'normal'};
-        max-width: ${data ? data.maxWidth : levelStyle.medium.maxWidth};
+        max-width: ${(props.fillProp && 'none') ||
+          (data && data.maxWidth) ||
+          levelStyle.medium.maxWidth};
         font-weight: ${levelStyle.font.weight || headingTheme.weight};
       `,
     ];
@@ -32,7 +34,7 @@ const sizeStyle = props => {
               `
             font-size: ${responsiveData.size};
             line-height: ${responsiveData.height};
-            max-width: ${responsiveData.maxWidth};
+            max-width: ${(props.fillProp && 'none') || responsiveData.maxWidth};
           `,
             ),
           );

--- a/src/js/components/Heading/__tests__/Heading-test.js
+++ b/src/js/components/Heading/__tests__/Heading-test.js
@@ -228,3 +228,13 @@ test('Throws a warning when heading.level is undefined in the theme.', () => {
   const consoleMsg = 'Heading level 6 is not defined in your theme.';
   expect(global.console.warn).toHaveBeenCalledWith(consoleMsg);
 });
+
+test('Heading fill renders', () => {
+  const component = renderer.create(
+    <Grommet>
+      <Heading fill />
+    </Grommet>,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -71,6 +71,41 @@ exports[`Heading color renders 1`] = `
 </div>
 `;
 
+exports[`Heading fill renders 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  font-size: 50px;
+  line-height: 56px;
+  max-width: none;
+  font-weight: 600;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    font-size: 34px;
+    line-height: 40px;
+    max-width: none;
+  }
+}
+
+<div
+  className="c0"
+>
+  <h1
+    className="c1"
+  />
+</div>
+`;
+
 exports[`Heading level renders 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/Heading/doc.js
+++ b/src/js/components/Heading/doc.js
@@ -19,6 +19,9 @@ export const doc = Heading => {
     color: colorPropType.description(
       'A color identifier to use for the text color.',
     ),
+    fill: PropTypes.bool
+      .description('Whether the width should fill the container.')
+      .defaultValue(false),
     level: PropTypes.oneOf([1, 2, 3, 4, 5, 6, '1', '2', '3', '4', '5', '6'])
       .description(
         `The heading level. It corresponds to the number after the 'H' for
@@ -68,16 +71,16 @@ export const themeDoc = {
     defaultValue: undefined,
   },
   'heading.level': {
-    description: `The level that impacts line-height, max-width, font size, 
-weight and family of the Heading. Heading styling is automatically adjusted at 
-different screen sizes. When the heading.responsiveBreakpoint is hit ("small" 
-by default), all heading styles will automatically be adjusted. A heading of 
-level 1, for example, will use the styling defined in heading level 2; a 
-heading of level 2 will use the styling defined in heading level 3 and so 
-forth. The tag in the DOM is not adjusted. A heading of level 1 remains an h1. 
-The styling adjustment is intended to aid readability on smaller screens but 
-will not semantically affect your application structure. If you do not want 
-this responsive styling to occur, you can set header.responsiveBreakpoint to 
+    description: `The level that impacts line-height, max-width, font size,
+weight and family of the Heading. Heading styling is automatically adjusted at
+different screen sizes. When the heading.responsiveBreakpoint is hit ("small"
+by default), all heading styles will automatically be adjusted. A heading of
+level 1, for example, will use the styling defined in heading level 2; a
+heading of level 2 will use the styling defined in heading level 3 and so
+forth. The tag in the DOM is not adjusted. A heading of level 1 remains an h1.
+The styling adjustment is intended to aid readability on smaller screens but
+will not semantically affect your application structure. If you do not want
+this responsive styling to occur, you can set header.responsiveBreakpoint to
 undefined.`,
     type: 'object',
     defaultValue: `
@@ -107,7 +110,7 @@ undefined.`,
     defaultValue: undefined,
   },
   'heading.responsiveBreakpoint': {
-    description: `The breakpoint to trigger changes in the Heading layout. 
+    description: `The breakpoint to trigger changes in the Heading layout.
 The actual values will be derived from global.breakpoints.`,
     type: 'string',
     defaultValue: 'small',

--- a/src/js/components/Heading/doc.js
+++ b/src/js/components/Heading/doc.js
@@ -21,7 +21,7 @@ export const doc = Heading => {
     ),
     fill: PropTypes.bool
       .description('Whether the width should fill the container.')
-      .defaultValue(false),
+      .defaultValue(undefined),
     level: PropTypes.oneOf([1, 2, 3, 4, 5, 6, '1', '2', '3', '4', '5', '6'])
       .description(
         `The heading level. It corresponds to the number after the 'H' for

--- a/src/js/components/Heading/index.d.ts
+++ b/src/js/components/Heading/index.d.ts
@@ -16,6 +16,7 @@ export interface HeadingProps {
   as?: PolymorphicType;
   color?: ColorType;
   gridArea?: GridAreaType;
+  fill?: boolean;
   level?: '1' | '2' | '3' | '4' | '5' | '6' | 1 | 2 | 3 | 4 | 5 | 6;
   margin?: MarginType;
   responsive?: boolean;

--- a/src/js/components/Heading/stories/All.js
+++ b/src/js/components/Heading/stories/All.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react';
 import { Grommet, Grid, Heading } from 'grommet';
 import { grommet } from 'grommet/themes';
 
-const paragraphFiller = `
+const headingFiller = `
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua.
 `;
@@ -40,7 +40,7 @@ const All = () => (
       <Set size="large" />
       <Set size="xlarge" />
     </Grid>
-    <Heading fill>{paragraphFiller}</Heading>
+    <Heading fill>{headingFiller}</Heading>
   </Grommet>
 );
 

--- a/src/js/components/Heading/stories/All.js
+++ b/src/js/components/Heading/stories/All.js
@@ -4,6 +4,11 @@ import { storiesOf } from '@storybook/react';
 import { Grommet, Grid, Heading } from 'grommet';
 import { grommet } from 'grommet/themes';
 
+const paragraphFiller = `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua.
+`;
+
 const H = ({ level, size }) => (
   <Heading level={level} size={size}>
     {`Heading ${level} ${size}`}
@@ -35,6 +40,7 @@ const All = () => (
       <Set size="large" />
       <Set size="xlarge" />
     </Grid>
+    <Heading fill>{paragraphFiller}</Heading>
   </Grommet>
 );
 

--- a/src/js/components/Paragraph/doc.js
+++ b/src/js/components/Paragraph/doc.js
@@ -21,7 +21,7 @@ export const doc = Paragraph => {
     ),
     fill: PropTypes.bool
       .description('Whether the width should fill the container.')
-      .defaultValue(false),
+      .defaultValue(undefined),
     responsive: PropTypes.bool
       .description(`Whether margin should be scaled for mobile environments.`)
       .defaultValue(true),

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -9424,6 +9424,14 @@ string
 }
 \`\`\`
 
+**fill**
+
+Whether the width should fill the container.
+
+\`\`\`
+boolean
+\`\`\`
+
 **level**
 
 The heading level. It corresponds to the number after the 'H' for
@@ -9573,16 +9581,16 @@ undefined
 
 **heading.level**
 
-The level that impacts line-height, max-width, font size, 
-weight and family of the Heading. Heading styling is automatically adjusted at 
-different screen sizes. When the heading.responsiveBreakpoint is hit (\\"small\\" 
-by default), all heading styles will automatically be adjusted. A heading of 
-level 1, for example, will use the styling defined in heading level 2; a 
-heading of level 2 will use the styling defined in heading level 3 and so 
-forth. The tag in the DOM is not adjusted. A heading of level 1 remains an h1. 
-The styling adjustment is intended to aid readability on smaller screens but 
-will not semantically affect your application structure. If you do not want 
-this responsive styling to occur, you can set header.responsiveBreakpoint to 
+The level that impacts line-height, max-width, font size,
+weight and family of the Heading. Heading styling is automatically adjusted at
+different screen sizes. When the heading.responsiveBreakpoint is hit (\\"small\\"
+by default), all heading styles will automatically be adjusted. A heading of
+level 1, for example, will use the styling defined in heading level 2; a
+heading of level 2 will use the styling defined in heading level 3 and so
+forth. The tag in the DOM is not adjusted. A heading of level 1 remains an h1.
+The styling adjustment is intended to aid readability on smaller screens but
+will not semantically affect your application structure. If you do not want
+this responsive styling to occur, you can set header.responsiveBreakpoint to
 undefined. Expects \`object\`.
 
 Defaults to
@@ -9625,7 +9633,7 @@ undefined
 
 **heading.responsiveBreakpoint**
 
-The breakpoint to trigger changes in the Heading layout. 
+The breakpoint to trigger changes in the Heading layout.
 The actual values will be derived from global.breakpoints. Expects \`string\`.
 
 Defaults to

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -4385,7 +4385,7 @@ string",
         "name": "color",
       },
       Object {
-        "defaultValue": false,
+        "defaultValue": undefined,
         "description": "Whether the width should fill the container.",
         "format": "boolean",
         "name": "fill",

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -5785,7 +5785,7 @@ string",
         "name": "color",
       },
       Object {
-        "defaultValue": false,
+        "defaultValue": undefined,
         "description": "Whether the width should fill the container.",
         "format": "boolean",
         "name": "fill",

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -4385,6 +4385,12 @@ string",
         "name": "color",
       },
       Object {
+        "defaultValue": false,
+        "description": "Whether the width should fill the container.",
+        "format": "boolean",
+        "name": "fill",
+      },
+      Object {
         "defaultValue": 1,
         "description": "The heading level. It corresponds to the number after the 'H' for
 the DOM tag. Set the level for semantic accuracy and accessibility.


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Addresses #4593 :

- Add prop `fill` to Heading -> `Heading.js` and `StyledHeading.js`
- Remove `const {...} = props` from `Heading.js`. Instead, pass props as object.
- Add prop `fill` to docs: `doc.js` (prettier also removed some spacing) and type to `index.d.ts`
- Add storybook example (`All.js`) and unit test (`Heading-test.js`)
- `doc.js` reflected changes on `Heading/README.md`
- Updated snapshots changed in the process

#### Where should the reviewer start?

 `Heading.js` and `StyledHeading.js`

#### What testing has been done on this PR?

Storybook, unit test (Jest) and manual testing.

#### How should this be manually tested?
Add `fill` prop to a Heading component. It should have style `max-width: none`.
Also check reducing the screen to a width smaller than 768px. It should have the same prop.

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #4593 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

Yep. Already done.

#### Should this PR be mentioned in the release notes?


#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.