### PR TITLE
Feat(Box): support width value on width object prop

### DIFF
--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -739,6 +739,15 @@ xlarge
 xxlarge
 string
 {
+  width: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
   min: 
     xxsmall
     xsmall

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -502,6 +502,11 @@ const widthObjectStyle = css`
     css`
       min-width: ${getSize(props, props.widthProp.min)};
     `};
+  ${props =>
+    props.widthProp.width &&
+    css`
+      width: ${getSize(props, props.widthProp.width)};
+    `};
 `;
 
 const widthStyle = css`

--- a/src/js/components/Box/__tests__/Box-test.js
+++ b/src/js/components/Box/__tests__/Box-test.js
@@ -535,6 +535,16 @@ describe('Box', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  test('width object', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Box width={{ width: '100px' }} />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   test('height', () => {
     const component = renderer.create(
       <Grommet>

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -4530,6 +4530,41 @@ exports[`Box width 1`] = `
 </div>
 `;
 
+exports[`Box width object 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100px;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  />
+</div>
+`;
+
 exports[`Box wrap 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -323,6 +323,18 @@ of indicating the DOM tag via the 'as' property.`,
       ]),
       PropTypes.string,
       PropTypes.shape({
+        width: PropTypes.oneOfType([
+          PropTypes.oneOf([
+            'xxsmall',
+            'xsmall',
+            'small',
+            'medium',
+            'large',
+            'xlarge',
+            'xxlarge',
+          ]),
+          PropTypes.string,
+        ]),
         min: PropTypes.oneOfType([
           PropTypes.oneOf([
             'xxsmall',

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -158,6 +158,15 @@ export interface BoxProps {
     | 'xxlarge'
     | string
     | {
+        width?:
+          | 'xxsmall'
+          | 'xsmall'
+          | 'small'
+          | 'medium'
+          | 'large'
+          | 'xlarge'
+          | 'xxlarge'
+          | string;
         max?:
           | 'xxsmall'
           | 'xsmall'

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1645,6 +1645,15 @@ xlarge
 xxlarge
 string
 {
+  width: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
   min: 
     xxsmall
     xsmall

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1049,6 +1049,15 @@ xlarge
 xxlarge
 string
 {
+  width: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
   min: 
     xxsmall
     xsmall


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?A
Adds support to set width in width object prop.
#### Where should the reviewer start?
`src/js/components/Box/StyledBox.js`
#### What testing has been done on this PR?
Unit
#### How should this be manually tested?
Storybook
#### Any background context you want to provide?

#### What are the relevant issues?
#4591
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
I don't think so
#### Should this PR be mentioned in the release notes?
I don't think so
#### Is this change backwards compatible or is it a breaking change?
backwards compatible