### PR TITLE
Allow truncation with end aligned text to work

### DIFF
--- a/src/js/components/Text/StyledText.js
+++ b/src/js/components/Text/StyledText.js
@@ -30,6 +30,7 @@ const textAlignStyle = css`
 
 const truncateStyle = `
   white-space: nowrap;
+  max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
 `;

--- a/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
+++ b/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
@@ -343,6 +343,7 @@ exports[`renders truncate 1`] = `
   font-size: 18px;
   line-height: 24px;
   white-space: nowrap;
+  max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/src/js/components/Text/stories/All.js
+++ b/src/js/components/Text/stories/All.js
@@ -16,11 +16,18 @@ const sizes = [
 
 const All = () => (
   <Grommet theme={grommet}>
-    {sizes.map(size => (
-      <Box key={size} margin="small">
-        <Text size={size}>{`Text ${size}`}</Text>
+    <>
+      {sizes.map(size => (
+        <Box key={size} margin="small">
+          <Text size={size}>{`Text ${size}`}</Text>
+        </Box>
+      ))}
+      <Box background="light-3" align="start" width="small" pad="small">
+        <Text truncate>
+          This is a long truncated string of text that is aligned to the end.
+        </Text>
       </Box>
-    ))}
+    </>
   </Grommet>
 );
 

--- a/src/js/components/Text/stories/All.js
+++ b/src/js/components/Text/stories/All.js
@@ -22,7 +22,7 @@ const All = () => (
           <Text size={size}>{`Text ${size}`}</Text>
         </Box>
       ))}
-      <Box background="light-3" align="start" width="small" pad="small">
+      <Box background="light-3" align="end" width="small" pad="small">
         <Text truncate>
           This is a long truncated string of text that is aligned to the end.
         </Text>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds a `max-width: 100%;` to Text span when truncation is applied. This is to ensure that even when text is end-aligned in its surrounding Box that the text can be truncated. Currently, if a Box applies `align="end"`, the truncation will not apply and instead the text will attempt to expand out of the bounds of the Box.

#### Where should the reviewer start?
src/js/components/Text/StyledText.js

#### What testing has been done on this PR?
Jest test and added storybook test so that it can captured by Chromatic.

#### How should this be manually tested?
```
<Box align="end" width="small" pad="small">
   <Text truncate>Hi this is a very very long string</Text>
</Box>
```

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
Before:
<img width="201" alt="Screen Shot 2020-10-12 at 2 21 09 PM" src="https://user-images.githubusercontent.com/12522275/95791746-d732f200-0c96-11eb-9f95-d4a73bd9a700.png">

After:
<img width="206" alt="Screen Shot 2020-10-12 at 2 19 58 PM" src="https://user-images.githubusercontent.com/12522275/95791737-d4d09800-0c96-11eb-85ff-8e4401daf089.png">

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.