### PR TITLE
Select does not display initial option if key is present and option is not an object

### DIFF
--- a/src/js/components/Select/utils.js
+++ b/src/js/components/Select/utils.js
@@ -2,6 +2,6 @@ export const applyKey = (option, key) => {
   if (option === undefined) return undefined;
   if (typeof key === 'object') return applyKey(option, key.key);
   if (typeof key === 'function') return key(option);
-  if (key !== undefined) return option[key];
+  if (key !== undefined && typeof option === 'object') return option[key];
   return option;
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
closes #4335 

#### Where should the reviewer start?
Select/utils.js

#### What testing has been done on this PR?
Storybook using
```
import React, { useState } from 'react';
import { storiesOf } from '@storybook/react';
import { Grommet, Select, Form, FormField } from 'grommet';

const OPTIONS = [
  { id: '1', name: 'Option 1' },
  { id: '2', name: 'Option 2' },
  { id: '3', name: 'Option 3' },
];

const SimpleSelect = () => {
  const [value, setValue] = useState('1'); //2.13 and above requires useState({.id: '1  }) to display an initial value
  const [options] = useState(OPTIONS);
  return (
    <Grommet>
      <Select
        value={value}
        valueKey="id"
        labelKey="name"
        placeholder="Please select a option"
        onChange={event => setValue(event.value)}
        options={options}
      />
    </Grommet>
  );
};

storiesOf('Select', module).add('Simple', () => <SimpleSelect />);

```

#### How should this be manually tested?
Storybook

#### Any background context you want to provide?
Before 2.13 when valueKey was present users could pass down a value that was not an object through to select.

current scenario using code example from above:
the initial value of option is '2' and the value of key is 'id'
```
export const applyKey = (option, key) => {
  if (option === undefined) return undefined;
  if (typeof key === 'object') return applyKey(option, key.key);
  if (typeof key === 'function') return key(option);
  if (key !== undefined) return option[key]; // reaches this codeblock evaluates ['2']['id'] and returns undefined
  return option;
};
```

my fix
```
export const applyKey = (option, key) => {
  if (option === undefined) return undefined;
  if (typeof key === 'object') return applyKey(option, key.key);
  if (typeof key === 'function') return key(option);
  if (key !== undefined typeof option === 'object' return option[key]; // checks if option is an object
  return option; // reaches this instead
};
```

My only issue with this is that, this fix really only applies to the initial render. onChange will make the value { id: 1 }. I think allowing incorrect option shapes in value promotes bad practices with grommet.

This is mostly to make users coming from pre 2.13 not experience any bugs if they upgrade to 2.15 and have this syntax already implemented. 

#### What are the relevant issues?
#4335 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Backward compatible