### PR TITLE
Fix aria-label for DataTable searcher

### DIFF
--- a/src/js/components/DataTable/Searcher.js
+++ b/src/js/components/DataTable/Searcher.js
@@ -28,6 +28,7 @@ const Searcher = ({ filtering, filters, onFilter, onFiltering, property }) => {
       <Box width={{ min: 'xsmall' }} flex pad={{ horizontal: 'small' }}>
         <TextInput
           name={`search-${property}`}
+          a11yTitle={`Search by ${property}`}
           ref={inputRef}
           value={filters[property]}
           onChange={event => onFilter(property, event.target.value)}
@@ -48,7 +49,7 @@ const Searcher = ({ filtering, filters, onFilter, onFiltering, property }) => {
         </Box>
       ) : null}
       <Button
-        a11yTitle={`focus-search-${property}`}
+        a11yTitle={`Open search by ${property}`}
         icon={
           <FormSearch
             color={normalizeColor(

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -288,7 +288,7 @@ describe('DataTable', () => {
       </Grommet>,
     );
     expect(container.firstChild).toMatchSnapshot();
-    fireEvent.click(container.querySelector('[aria-label="focus-search-a"]'));
+    fireEvent.click(container.querySelector('[aria-label="Open search by a"]'));
     const searchInput = container.querySelector('[name="search-a"]');
     expect(document.activeElement).toBe(searchInput);
     fireEvent.change(searchInput, {

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -10125,7 +10125,7 @@ exports[`DataTable search 1`] = `
               class="c7"
             />
             <button
-              aria-label="focus-search-a"
+              aria-label="Open search by a"
               class="c8"
               type="button"
             >
@@ -10346,6 +10346,7 @@ exports[`DataTable search 2`] = `
                 class="c1"
               >
                 <input
+                  aria-label="Search by a"
                   autocomplete="off"
                   class="c2"
                   name="search-a"


### PR DESCRIPTION
#### What does this PR do?
- Add missing `aria-label` to the search field in `DataTable`
- Update `aria-label` for the search button in `DataTable`
- Update query selector to find the search button in `DataTable` test
- `__snapshot__` automatically updated

#### Where should the reviewer start?
`Searcher.js`

#### What testing has been done on this PR?
Storybook, jest, manual. Verified using WAVE tool (see screenshot below).

#### How should this be manually tested?
Verify that correct `aria-labels` are set.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #4347

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/26581738/96348282-d4c20500-10a7-11eb-8361-40b7aa25d1f7.png)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Meh

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible