### PR TITLE
added to maskedinput docs

### DIFF
--- a/src/js/components/MaskedInput/README.md
+++ b/src/js/components/MaskedInput/README.md
@@ -86,7 +86,8 @@ function
 
 Describes the structure of the mask. If a regexp is provided, it should
       allow both the final full string element as well as partial strings
-      as the user types characters one by one.
+      as the user types characters one by one. When using regexp to match number
+      values make sure that the option values are numbers as well.
 
 ```
 [{

--- a/src/js/components/MaskedInput/doc.js
+++ b/src/js/components/MaskedInput/doc.js
@@ -50,7 +50,8 @@ export const doc = MaskedInput => {
     ).description(
       `Describes the structure of the mask. If a regexp is provided, it should
       allow both the final full string element as well as partial strings
-      as the user types characters one by one.`,
+      as the user types characters one by one. When using regexp to match number
+      values make sure that the option values are numbers as well.`,
     ),
     reverse: PropTypes.bool.description(
       `Whether an icon should be reversed so that the icon is at the

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11012,7 +11012,8 @@ function
 
 Describes the structure of the mask. If a regexp is provided, it should
       allow both the final full string element as well as partial strings
-      as the user types characters one by one.
+      as the user types characters one by one. When using regexp to match number
+      values make sure that the option values are numbers as well.
 
 \`\`\`
 [{

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -5190,7 +5190,8 @@ string",
       Object {
         "description": "Describes the structure of the mask. If a regexp is provided, it should
       allow both the final full string element as well as partial strings
-      as the user types characters one by one.",
+      as the user types characters one by one. When using regexp to match number
+      values make sure that the option values are numbers as well.",
         "format": "[{
   length: 
     number


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Closes #4366 

#### Where should the reviewer start?
Maskedinput docs - mask

#### What testing has been done on this PR?
None, only documentation changes

#### Any background context you want to provide?
https://codesandbox.io/s/grommet-buttons-forked-5i1vc?file=/index.js

When using regex to match number values with options that are strings, a user is unable to input more values when the regex matches the option. If the option values are numbers this will not happen.
#### What are the relevant issues?
#4366 

#### Do the grommet docs need to be updated?
Yes

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards Compatible