### PR TITLE
Updated list theme extend and stories

### DIFF
--- a/src/js/components/DataChart/stories/Simple.js
+++ b/src/js/components/DataChart/stories/Simple.js
@@ -8,7 +8,6 @@ const data = [];
 for (let i = 1; i < 8; i += 1) {
   const v = Math.sin(i / 2.0);
   data.push({
-    date: `2020-07-${((i % 30) + 1).toString().padStart(2, 0)}`,
     percent: Math.abs(v * 100),
   });
 }

--- a/src/js/components/DataTable/stories/ResizableColumns.js
+++ b/src/js/components/DataTable/stories/ResizableColumns.js
@@ -65,7 +65,7 @@ const columnsResize = [
 const ExampleResizable = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
-      <Heading level="3">Table with resizeable & column sizes</Heading>
+      <Heading level="3">Table with resizable & column sizes</Heading>
       <DataTable
         columns={columnsResize}
         data={DATA}
@@ -76,6 +76,6 @@ const ExampleResizable = () => (
   </Grommet>
 );
 
-storiesOf('DataTable', module).add('Column sizes resizeable', () => (
+storiesOf('DataTable', module).add('Resizable columns', () => (
   <ExampleResizable />
 ));

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -31,6 +31,7 @@ const StyledList = styled.ul`
   ${props =>
     props.itemFocus &&
     focusStyle({ forceOutline: true, skipSvgChildren: true })}}
+  ${props => props.theme.list && props.theme.list.extend}}
 `;
 
 const StyledItem = styled(Box)`
@@ -43,6 +44,8 @@ const StyledItem = styled(Box)`
   &:focus {
     ${unfocusStyle({ forceOutline: true, skipSvgChildren: true })}
   }
+  ${props =>
+    props.theme.list && props.theme.list.item && props.theme.list.item.extend}
 `;
 
 const normalize = (item, index, property) => {

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -1649,17 +1649,17 @@ exports[`List events Enter key 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <ul
-    class="List__StyledList-sc-130gdqg-0 iHffYx"
+    class="List__StyledList-sc-130gdqg-0 bVJdKv"
     tabindex="0"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 bGJPsF List__StyledItem-sc-130gdqg-1 lfUyea"
+      class="StyledBox-sc-13pk1d4-0 bGJPsF List__StyledItem-sc-130gdqg-1 fnhxkV"
       tabindex="-1"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 TLEKT List__StyledItem-sc-130gdqg-1 lfUyea"
+      class="StyledBox-sc-13pk1d4-0 TLEKT List__StyledItem-sc-130gdqg-1 fnhxkV"
       tabindex="-1"
     >
       beta
@@ -1828,17 +1828,17 @@ exports[`List events focus and blur 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <ul
-    class="List__StyledList-sc-130gdqg-0 iHffYx"
+    class="List__StyledList-sc-130gdqg-0 bVJdKv"
     tabindex="0"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 bGJPsF List__StyledItem-sc-130gdqg-1 lfUyea"
+      class="StyledBox-sc-13pk1d4-0 bGJPsF List__StyledItem-sc-130gdqg-1 fnhxkV"
       tabindex="-1"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 dwrZcL List__StyledItem-sc-130gdqg-1 lfUyea"
+      class="StyledBox-sc-13pk1d4-0 dwrZcL List__StyledItem-sc-130gdqg-1 fnhxkV"
       tabindex="-1"
     >
       beta
@@ -2006,17 +2006,17 @@ exports[`List events mouse events 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <ul
-    class="List__StyledList-sc-130gdqg-0 iHffYx"
+    class="List__StyledList-sc-130gdqg-0 bVJdKv"
     tabindex="0"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 bGJPsF List__StyledItem-sc-130gdqg-1 lfUyea"
+      class="StyledBox-sc-13pk1d4-0 bGJPsF List__StyledItem-sc-130gdqg-1 fnhxkV"
       tabindex="-1"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 dwrZcL List__StyledItem-sc-130gdqg-1 lfUyea"
+      class="StyledBox-sc-13pk1d4-0 dwrZcL List__StyledItem-sc-130gdqg-1 fnhxkV"
       tabindex="-1"
     >
       beta
@@ -2545,17 +2545,17 @@ exports[`List onClickItem 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <ul
-    class="List__StyledList-sc-130gdqg-0 iHffYx"
+    class="List__StyledList-sc-130gdqg-0 bVJdKv"
     tabindex="0"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 bGJPsF List__StyledItem-sc-130gdqg-1 lfUyea"
+      class="StyledBox-sc-13pk1d4-0 bGJPsF List__StyledItem-sc-130gdqg-1 fnhxkV"
       tabindex="-1"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 dwrZcL List__StyledItem-sc-130gdqg-1 lfUyea"
+      class="StyledBox-sc-13pk1d4-0 dwrZcL List__StyledItem-sc-130gdqg-1 fnhxkV"
       tabindex="-1"
     >
       beta

--- a/src/js/components/List/stories/secondaryKey.js
+++ b/src/js/components/List/stories/secondaryKey.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react';
 import { Grommet, Box, List } from 'grommet';
 import { grommet } from 'grommet/themes';
 
-export const locations = [
+const locations = [
   'Boise',
   'Fort Collins',
   'Los Gatos',
@@ -12,7 +12,7 @@ export const locations = [
   'San Francisco',
 ];
 
-export const data = [];
+const data = [];
 
 for (let i = 0; i < 40; i += 1) {
   data.push({


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
* Implements the already documented behavior of `theme.list.exted` and `theme.list.item.exted`.
* Cleaned up stories

#### Where should the reviewer start?
Anywhere. Snapshot changes are reasonable since StyledList and StyledListItem had changed.
#### What testing has been done on this PR?
jest + storybook
#### How should this be manually tested?
storybook.
I got a separate story to test the list behavior on a separate PR of Tip component #4599 

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Fixed theme `extend` for List 
#### Is this change backwards compatible or is it a breaking change?
backwards compatible