### PR TITLE
removed WorldMap stories Color and SelectPlace from chromatic

### DIFF
--- a/src/js/components/WorldMap/stories/Color.js
+++ b/src/js/components/WorldMap/stories/Color.js
@@ -14,4 +14,6 @@ const Example = () => {
   );
 };
 
-storiesOf('WorldMap', module).add('Color', () => <Example />);
+storiesOf('WorldMap', module).add('Color', () => <Example />, {
+  chromatic: { disable: true },
+});

--- a/src/js/components/WorldMap/stories/SelectPlace.js
+++ b/src/js/components/WorldMap/stories/SelectPlace.js
@@ -20,4 +20,6 @@ const Example = () => {
   );
 };
 
-storiesOf('WorldMap', module).add('Select place', () => <Example />);
+storiesOf('WorldMap', module).add('Select place', () => <Example />, {
+  chromatic: { disable: true },
+});


### PR DESCRIPTION
#### What does this PR do?
Removed chromatic snapshots for WorldMap stories Color and SelectPlace because snapshots were similar to other WorldMap snapshots and we are trying to reduce the number of snapshots

#### Where should the reviewer start?

#### What testing has been done on this PR?
storybook

#### How should this be manually tested?
number of chromatic snapshots should be reduced by 2 (303 -> 301)

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
