### PR TITLE
Update Menu Button logic to account for default button

### DIFF
--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -225,6 +225,7 @@ const Menu = forwardRef((props, ref) => {
         plain={plain}
         onClick={onDropClose}
         onFocus={() => setActiveItemIndex(controlButtonIndex)}
+        reverse={theme.button.default && !children ? true : undefined}
         // On first tab into menu, the control button should not
         // be able to receive tab focus because the focus should
         // go to the first menu item instead.
@@ -261,7 +262,7 @@ const Menu = forwardRef((props, ref) => {
         open={isOpen}
         onOpen={onDropOpen}
         onClose={onDropClose}
-        reverse={theme.button.default ? true : undefined}
+        reverse={theme.button.default && !children ? true : undefined}
         dropContent={
           <Keyboard
             onTab={event =>

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -230,13 +230,13 @@ const Menu = forwardRef((props, ref) => {
         active={activeItemIndex === controlButtonIndex}
         focusIndicator={false}
         hoverIndicator="background"
-        {...buttonProps}
         onClick={onDropClose}
         onFocus={() => setActiveItemIndex(controlButtonIndex)}
         // On first tab into menu, the control button should not
         // be able to receive tab focus because the focus should
         // go to the first menu item instead.
         tabIndex={activeItemIndex === constants.none ? '-1' : undefined}
+        {...buttonProps}
       >
         {typeof content === 'function'
           ? () => content({ ...props, drop: true })
@@ -258,12 +258,12 @@ const Menu = forwardRef((props, ref) => {
       <DropButton
         ref={ref}
         {...rest}
+        {...buttonProps}
         a11yTitle={a11yTitle || messages.openMenu || 'Open Menu'}
         disabled={disabled}
         dropAlign={align}
         dropTarget={dropTarget}
         dropProps={dropProps}
-        {...buttonProps}
         open={isOpen}
         onOpen={onDropOpen}
         onClose={onDropClose}

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -184,20 +184,30 @@ const Menu = forwardRef((props, ref) => {
     }
   };
 
-  const content = children || (
-    <Box
-      direction="row"
-      justify={justifyContent}
-      align="center"
-      pad={theme.button.default ? undefined : 'small'}
-      gap={label && icon !== false ? 'small' : undefined}
-    >
-      <Text size={size}>{label}</Text>
-      {icon !== false
-        ? (icon !== true && icon) || <MenuIcon color={iconColor} size={size} />
-        : null}
-    </Box>
-  );
+  const menuLabel = <Text size={size}>{label}</Text>;
+  const menuIcon =
+    icon !== false
+      ? (icon !== true && icon) || <MenuIcon color={iconColor} size={size} />
+      : null;
+
+  let content;
+  if (children) content = children;
+  else if (!theme.button.default) {
+    content = (
+      <Box
+        direction="row"
+        justify={justifyContent}
+        align="center"
+        pad="small"
+        gap={label && icon !== false ? 'small' : undefined}
+      >
+        {menuLabel}
+        {menuIcon}
+      </Box>
+    );
+  } else {
+    content = undefined;
+  }
 
   const controlMirror = (
     <Box flex={false}>
@@ -210,6 +220,8 @@ const Menu = forwardRef((props, ref) => {
         active={activeItemIndex === controlButtonIndex}
         focusIndicator={false}
         hoverIndicator="background"
+        label={theme.button.default && !children ? menuLabel : undefined}
+        icon={theme.button.default && !children ? menuIcon : undefined}
         plain={plain}
         onClick={onDropClose}
         onFocus={() => setActiveItemIndex(controlButtonIndex)}
@@ -243,10 +255,13 @@ const Menu = forwardRef((props, ref) => {
         dropAlign={align}
         dropTarget={dropTarget}
         dropProps={dropProps}
+        label={theme.button.default && !children ? menuLabel : undefined}
+        icon={theme.button.default && !children ? menuIcon : undefined}
         plain={plain}
         open={isOpen}
         onOpen={onDropOpen}
         onClose={onDropClose}
+        reverse={theme.button.default ? true : undefined}
         dropContent={
           <Keyboard
             onTab={event =>

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -184,23 +184,16 @@ const Menu = forwardRef((props, ref) => {
     }
   };
 
-  const menuLabel = <Text size={size}>{label}</Text>;
   const menuIcon =
     icon !== false
       ? (icon !== true && icon) || <MenuIcon color={iconColor} size={size} />
       : null;
 
-  const isDefaultButton = theme.button.default && !children;
-  const buttonProps = {
-    icon: isDefaultButton ? menuIcon : undefined,
-    label: isDefaultButton ? menuLabel : undefined,
-    reverse: isDefaultButton,
-    plain,
-  };
-
+  let buttonProps = { plain, size };
   let content;
-  if (children) content = children;
-  else if (!theme.button.default) {
+  if (children) {
+    content = children;
+  } else if (!theme.button.default) {
     content = (
       <Box
         direction="row"
@@ -209,13 +202,20 @@ const Menu = forwardRef((props, ref) => {
         pad="small"
         gap={label && icon !== false ? 'small' : undefined}
       >
-        {menuLabel}
+        <Text size={size}>{label}</Text>
         {menuIcon}
       </Box>
     );
   } else {
     // when a theme has theme.button.default, keep content as
     // undefined so we can rely on Button label & icon props
+    buttonProps = {
+      icon: menuIcon,
+      label,
+      plain,
+      reverse: true,
+      size,
+    };
     content = undefined;
   }
 

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -190,6 +190,14 @@ const Menu = forwardRef((props, ref) => {
       ? (icon !== true && icon) || <MenuIcon color={iconColor} size={size} />
       : null;
 
+  const isDefaultButton = theme.button.default && !children;
+  const buttonProps = {
+    icon: isDefaultButton ? menuIcon : undefined,
+    label: isDefaultButton ? menuLabel : undefined,
+    reverse: isDefaultButton,
+    plain,
+  };
+
   let content;
   if (children) content = children;
   else if (!theme.button.default) {
@@ -206,6 +214,8 @@ const Menu = forwardRef((props, ref) => {
       </Box>
     );
   } else {
+    // when a theme has theme.button.default, keep content as
+    // undefined so we can rely on Button label & icon props
     content = undefined;
   }
 
@@ -220,12 +230,9 @@ const Menu = forwardRef((props, ref) => {
         active={activeItemIndex === controlButtonIndex}
         focusIndicator={false}
         hoverIndicator="background"
-        label={theme.button.default && !children ? menuLabel : undefined}
-        icon={theme.button.default && !children ? menuIcon : undefined}
-        plain={plain}
+        {...buttonProps}
         onClick={onDropClose}
         onFocus={() => setActiveItemIndex(controlButtonIndex)}
-        reverse={theme.button.default && !children ? true : undefined}
         // On first tab into menu, the control button should not
         // be able to receive tab focus because the focus should
         // go to the first menu item instead.
@@ -256,13 +263,10 @@ const Menu = forwardRef((props, ref) => {
         dropAlign={align}
         dropTarget={dropTarget}
         dropProps={dropProps}
-        label={theme.button.default && !children ? menuLabel : undefined}
-        icon={theme.button.default && !children ? menuIcon : undefined}
-        plain={plain}
+        {...buttonProps}
         open={isOpen}
         onOpen={onDropOpen}
         onClose={onDropClose}
-        reverse={theme.button.default && !children ? true : undefined}
         dropContent={
           <Keyboard
             onTab={event =>

--- a/src/js/components/Menu/__tests__/Menu-test.js
+++ b/src/js/components/Menu/__tests__/Menu-test.js
@@ -547,4 +547,15 @@ describe('Menu', () => {
     );
     expect(component.toJSON()).toMatchSnapshot();
   });
+
+  test('menu with children when custom theme has default button', () => {
+    const component = renderer.create(
+      <Grommet theme={defaultButtonTheme}>
+        <Menu items={[{ label: 'Item 1' }, { label: 'Item 2' }]}>
+          {() => <>Test Menu</>}
+        </Menu>
+      </Grommet>,
+    );
+    expect(component.toJSON()).toMatchSnapshot();
+  });
 });

--- a/src/js/components/Menu/__tests__/Menu-test.js
+++ b/src/js/components/Menu/__tests__/Menu-test.js
@@ -20,6 +20,19 @@ const customTheme = {
   },
 };
 
+const defaultButtonTheme = {
+  button: {
+    default: {
+      color: 'text-strong',
+      border: undefined,
+      padding: {
+        horizontal: '12px',
+        vertical: '6px',
+      },
+    },
+  },
+};
+
 describe('Menu', () => {
   beforeEach(createPortal);
 
@@ -514,6 +527,18 @@ describe('Menu', () => {
   test('custom theme icon color', () => {
     const component = renderer.create(
       <Grommet theme={customTheme}>
+        <Menu
+          label="Test Menu"
+          items={[{ label: 'Item 1' }, { label: 'Item 2' }]}
+        />
+      </Grommet>,
+    );
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  test('custom theme with default button', () => {
+    const component = renderer.create(
+      <Grommet theme={defaultButtonTheme}>
         <Menu
           label="Test Menu"
           items={[{ label: 'Item 1' }, { label: 'Item 2' }]}

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -1323,6 +1323,182 @@ exports[`Menu custom theme icon color 1`] = `
 </div>
 `;
 
+exports[`Menu custom theme with default button 1`] = `
+.c5 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c5 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c5 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c5 *[stroke*="#"],
+.c5 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c5 *[fill-rule],
+.c5 *[FILL-RULE],
+.c5 *[fill*="#"],
+.c5 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c4 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 12px;
+}
+
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 18px;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  padding: 6px 12px;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c1 > svg {
+  vertical-align: bottom;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus > circle,
+.c1:focus > ellipse,
+.c1:focus > line,
+.c1:focus > path,
+.c1:focus > polygon,
+.c1:focus > polyline,
+.c1:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+  className="c0"
+>
+  <button
+    aria-label="Open Menu"
+    className="c1"
+    kind="default"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
+    type="button"
+  >
+    <div
+      className="c2"
+    >
+      <span
+        className="c3"
+      >
+        Test Menu
+      </span>
+      <div
+        className="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        className="c5"
+        viewBox="0 0 24 24"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          strokeWidth="2"
+        />
+      </svg>
+    </div>
+  </button>
+</div>
+`;
+
 exports[`Menu disabled 1`] = `
 .c5 {
   display: inline-block;

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -1324,7 +1324,7 @@ exports[`Menu custom theme icon color 1`] = `
 `;
 
 exports[`Menu custom theme with default button 1`] = `
-.c5 {
+.c4 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -1335,25 +1335,25 @@ exports[`Menu custom theme with default button 1`] = `
   stroke: #7D4CDB;
 }
 
-.c5 g {
+.c4 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c5 *:not([stroke])[fill="none"] {
+.c4 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c5 *[stroke*="#"],
-.c5 *[STROKE*="#"] {
+.c4 *[stroke*="#"],
+.c4 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c5 *[fill-rule],
-.c5 *[FILL-RULE],
-.c5 *[fill*="#"],
-.c5 *[FILL*="#"] {
+.c4 *[fill-rule],
+.c4 *[FILL-RULE],
+.c4 *[fill*="#"],
+.c4 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -1380,7 +1380,7 @@ exports[`Menu custom theme with default button 1`] = `
   justify-content: center;
 }
 
-.c4 {
+.c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -1441,11 +1441,6 @@ exports[`Menu custom theme with default button 1`] = `
   border: 0;
 }
 
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c0 {
   font-size: 18px;
   line-height: 24px;
@@ -1474,17 +1469,13 @@ exports[`Menu custom theme with default button 1`] = `
     <div
       className="c2"
     >
-      <span
-        className="c3"
-      >
-        Test Menu
-      </span>
+      Test Menu
       <div
-        className="c4"
+        className="c3"
       />
       <svg
         aria-label="FormDown"
-        className="c5"
+        className="c4"
         viewBox="0 0 24 24"
       >
         <polyline

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -2355,6 +2355,88 @@ exports[`Menu justify content 1`] = `
 </div>
 `;
 
+exports[`Menu menu with children when custom theme has default button 1`] = `
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 18px;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  padding: 6px 12px;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c1 > svg {
+  vertical-align: bottom;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus > circle,
+.c1:focus > ellipse,
+.c1:focus > line,
+.c1:focus > path,
+.c1:focus > polygon,
+.c1:focus > polyline,
+.c1:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+  className="c0"
+>
+  <button
+    aria-label="Open Menu"
+    className="c1"
+    kind="default"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
+    type="button"
+  >
+    Test Menu
+  </button>
+</div>
+`;
+
 exports[`Menu navigate through suggestions and select 1`] = `
 .c5 {
   display: inline-block;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR updates the internal logic of Menu so that if a theme defines `theme.button.default`, then the Menu button will use the default button styling for its control as opposed to a `plain` button. The existing issue was that if Button has children, it acts as plain, so a Menu button was built by creating a Box (with direction row) and adding in the label/icon to appear like a Button. However, any button hover styles etc. no longer apply.

It makes more sense that the button control would not rely on children/plain (as this is a practice we want to avoid when possible) and instead relied on the `label` and `icon` props. This approach enhances the logic so that if a theme has `theme.button.default`, the menu control will inherit all the stylings of default button. This seemed like a more swift solution than try to extend all of the styling options into menu's theme object, particularly because Menu button was currently being implemented as a Box.

This new behavior applies only when `theme.button.default` is defined in the theme, but for backwards compatibility all of the previous logic remains as is.

#### Where should the reviewer start?
src/js/components/Menu/Menu.js

#### What testing has been done on this PR?
Tested `grommet-theme-hpe` locally in Menu stories. Added a jest test.

#### How should this be manually tested?
Apply a customTheme with `theme.button.default` styles defined (or use grommet-theme-hpe). Then, create a menu.

#### Any background context you want to provide?

#### What are the relevant issues?
Related to https://github.com/grommet/hpe-design-system/issues/1199

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.