### PR TITLE
Updated loader of storybook to include context stories and 'All' stories

### DIFF
--- a/storybook/main.js
+++ b/storybook/main.js
@@ -1,9 +1,11 @@
 module.exports = {
   addons: ['@storybook/addon-storysource'],
   stories: [
+    '../src/js/components/**/stories/typescript/*.tsx',
     '../src/js/components/**/stories/*.(ts|tsx|js|jsx)',
     '../src/js/components/**/*stories.js',
     '../src/js/contexts/**/*stories.js',
+    '../src/js/contexts/**/stories/typescript/*.tsx',
     '../src/js/contexts/**/stories/*.(ts|tsx|js|jsx)',
     '../src/js/all/**/stories/*.(ts|tsx|js|jsx)',
   ],

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -1,4 +1,10 @@
 module.exports = {
   addons: ['@storybook/addon-storysource'],
-  stories: ['../src/js/components/**/stories/*.(ts|tsx|js|jsx)'],
+  stories: [
+    '../src/js/components/**/stories/*.(ts|tsx|js|jsx)',
+    '../src/js/components/**/*stories.js',
+    '../src/js/contexts/**/*stories.js',
+    '../src/js/contexts/**/stories/*.(ts|tsx|js|jsx)',
+    '../src/js/all/**/stories/*.(ts|tsx|js|jsx)',
+  ],
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Updated loader of storybook to include 46 missing stories: 
1. Context stories '../src/js/contexts/**/*stories.js',
2. All stories '../src/js/all/**/stories/*.(ts|tsx|js|jsx)',
3. stories with the format file of `stories.js` '../src/js/components/**/*stories.js', '../src/js/contexts/**/*stories.js',
4. Added missing typescript stories under stories/typescript/*.tsx

#### Where should the reviewer start?
main.js
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
storybook imports all the stories mentioned above.
#### Any background context you want to provide?
Related to PR #4651 
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backward compatible