### PR TITLE
improve coverage for Image

### DIFF
--- a/src/js/components/Image/__tests__/Image-test.js
+++ b/src/js/components/Image/__tests__/Image-test.js
@@ -4,7 +4,7 @@ import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
-import { cleanup, render } from '@testing-library/react';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { Grommet } from '../../Grommet';
 import { Image } from '..';
@@ -80,4 +80,19 @@ test('Image fillProp renders', () => {
   );
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
+});
+
+test('Image onError', () => {
+  const onError = jest.fn();
+  const { getByAltText } = render(
+    <Grommet>
+      <Image alt="test" onError={onError} />
+    </Grommet>,
+  );
+
+  act(() => {
+    fireEvent(getByAltText('test'), new Event('error'));
+  });
+
+  expect(onError).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
improve coverage for Image to %100
#### Where should the reviewer start?
`src/js/components/Image/__tests__/Image-test.js`
#### What testing has been done on this PR?
yarn test
#### How should this be manually tested?
yarn test
#### Any background context you want to provide?
No
#### What are the relevant issues?
#4539
#### Screenshots (if appropriate)
From 75%

![Screen Shot 2020-10-29 at 9 12 11 PM](https://user-images.githubusercontent.com/14626506/97658624-64fe3380-1a32-11eb-8e4a-f3acd5d98c69.png)

To 100%

![Screen Shot 2020-10-29 at 9 55 58 PM](https://user-images.githubusercontent.com/14626506/97658626-6891ba80-1a32-11eb-9929-9bbbdde3aded.png)
#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
backwards compatible