### PR TITLE
Menu stories changed to new structure

### DIFF
--- a/src/js/components/Menu/stories/BottomControlButton.js
+++ b/src/js/components/Menu/stories/BottomControlButton.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, Menu } from 'grommet';
 import { grommet } from 'grommet/themes';
 
-const ControlBottom = () => (
+const ControlBottomMenu = () => (
   <Grommet theme={grommet}>
     <Box height="medium" justify="center" align="center" pad="large">
       <Menu
@@ -20,8 +19,10 @@ const ControlBottom = () => (
   </Grommet>
 );
 
-storiesOf('Menu', module).add(
-  'Bottom control button',
-  () => <ControlBottom />,
-  { chromatic: { disable: true } },
-);
+export const BottomControlButton = () => <ControlBottomMenu />;
+BottomControlButton.story = {
+  name: 'Bottom control button',
+  parameters: {
+    chromatic: { disable: true },
+  },
+};

--- a/src/js/components/Menu/stories/ItemWithIcon.js
+++ b/src/js/components/Menu/stories/ItemWithIcon.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, Menu, Text } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -43,4 +42,7 @@ const IconItemsMenu = () => (
   </Grommet>
 );
 
-storiesOf('Menu', module).add('Item with icon', () => <IconItemsMenu />);
+export const ItemWithIcon = () => <IconItemsMenu />;
+ItemWithIcon.story = {
+  name: 'Item with icon',
+};

--- a/src/js/components/Menu/stories/Menu.stories.js
+++ b/src/js/components/Menu/stories/Menu.stories.js
@@ -1,0 +1,10 @@
+export { Children } from './typescript/Children.tsx';
+export { BottomControlButton } from './BottomControlButton';
+export { ItemWithIcon } from './ItemWithIcon';
+export { Reverse } from './Reverse';
+export { Simple } from './Simple';
+export { Themed } from './typescript/Themed.tsx';
+
+export default {
+  title: 'Controls/Menu',
+};

--- a/src/js/components/Menu/stories/Menu.stories.js
+++ b/src/js/components/Menu/stories/Menu.stories.js
@@ -1,5 +1,5 @@
-export { Children } from './typescript/Children.tsx';
 export { BottomControlButton } from './BottomControlButton';
+export { Children } from './typescript/Children.tsx';
 export { ItemWithIcon } from './ItemWithIcon';
 export { Reverse } from './Reverse';
 export { Simple } from './Simple';

--- a/src/js/components/Menu/stories/Reverse.js
+++ b/src/js/components/Menu/stories/Reverse.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, Menu } from 'grommet';
 import { Power, User } from 'grommet-icons';
 import { grommet } from 'grommet/themes';
 
-const Reverse = () => (
+const ReverseMenu = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
       <Menu
@@ -21,6 +20,9 @@ const Reverse = () => (
   </Grommet>
 );
 
-storiesOf('Menu', module).add('Reverse', () => <Reverse />, {
-  chromatic: { disable: true },
-});
+export const Reverse = () => <ReverseMenu />;
+Reverse.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+};

--- a/src/js/components/Menu/stories/Simple.js
+++ b/src/js/components/Menu/stories/Simple.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, Menu } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -23,6 +22,9 @@ const SimpleMenu = () => (
   </Grommet>
 );
 
-storiesOf('Menu', module).add('Simple', () => <SimpleMenu />, {
-  chromatic: { disable: true },
-});
+export const Simple = () => <SimpleMenu />;
+Simple.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+};

--- a/src/js/components/Menu/stories/typescript/Children.tsx
+++ b/src/js/components/Menu/stories/typescript/Children.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, Menu, Text } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -44,4 +43,4 @@ const Example = () => (
   </Grommet>
 );
 
-storiesOf('Menu', module).add('Children', () => <Example />);
+export const Children = () => <Example />;

--- a/src/js/components/Menu/stories/typescript/Themed.tsx
+++ b/src/js/components/Menu/stories/typescript/Themed.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import { storiesOf } from '@storybook/react';
-import isChromatic from 'chromatic/isChromatic';
 
 import { Grommet, Box, Menu, ThemeType } from 'grommet';
 import { FormUp, FormDown } from 'grommet-icons';
 
 // Type annotations can only be used in TypeScript files.
 // Remove ': ThemeType' if you are not using TypeScript.
+
 const customBreakpoints: ThemeType = {
   global: {
     breakpoints: {
@@ -67,7 +66,8 @@ const customBreakpoints: ThemeType = {
     },
   },
 };
-const App = () => {
+
+const ThemedMenu = () => {
   return (
     <Grommet theme={customBreakpoints}>
       <Box align="center" pad="large">
@@ -85,6 +85,9 @@ const App = () => {
   );
 };
 
-if (!isChromatic()) {
-  storiesOf('Menu', module).add('Themed', () => <App />);
-}
+export const Themed = () => <ThemedMenu />;
+Themed.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Menu stories to `Controls/Menu`.

#### Where should the reviewer start?

`components/Menu/stories/Menu.stories.js`

#### What testing has been done on this PR?

Storybook

#### How should this be manually tested?

Visit storybook using PR's branch and check Controls/Menu.

#### Any background context you want to provide?

#### What are the relevant issues?

#4651

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/47114840/97791037-ee397580-1bac-11eb-984a-7ef779fed86d.png)


#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.