### PR TITLE
Tabs stories changed to new structure

### DIFF
--- a/src/js/components/Tabs/stories/AlignControls.js
+++ b/src/js/components/Tabs/stories/AlignControls.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+
 import { Attraction, Car, TreeOption } from 'grommet-icons';
 import { Box, Grommet, grommet, Tab, Tabs } from 'grommet';
 import { deepMerge } from 'grommet/utils';
@@ -28,7 +28,7 @@ const myTheme = deepMerge(grommet, {
   },
 });
 
-const AlignControls = () => (
+const AlignControlsTabs = () => (
   <Grommet theme={myTheme} full>
     <Tabs justify="start" alignControls="start">
       <Tab title="Tab 1">
@@ -50,4 +50,4 @@ const AlignControls = () => (
   </Grommet>
 );
 
-storiesOf('Tabs', module).add('Align controls', () => <AlignControls />);
+export const AlignControls = () => <AlignControlsTabs />;

--- a/src/js/components/Tabs/stories/AlignControls.js
+++ b/src/js/components/Tabs/stories/AlignControls.js
@@ -51,3 +51,6 @@ const AlignControlsTabs = () => (
 );
 
 export const AlignControls = () => <AlignControlsTabs />;
+AlignControls.story = {
+  name: 'Align controls',
+};

--- a/src/js/components/Tabs/stories/Custom.js
+++ b/src/js/components/Tabs/stories/Custom.js
@@ -1,9 +1,7 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { css } from 'styled-components';
 
 import { CircleInformation, Currency } from 'grommet-icons';
-
 import { Grommet, FormField, Tab, Tabs, TextInput } from 'grommet';
 import { grommet } from 'grommet/themes';
 import { deepMerge } from 'grommet/utils';
@@ -100,4 +98,4 @@ const CustomTabs = () => (
   </Grommet>
 );
 
-storiesOf('Tabs', module).add('Custom theme', () => <CustomTabs />);
+export const Custom = () => <CustomTabs />;

--- a/src/js/components/Tabs/stories/Icon.js
+++ b/src/js/components/Tabs/stories/Icon.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from 'styled-components';
-import { storiesOf } from '@storybook/react';
+
 import { Attraction, Car, TreeOption } from 'grommet-icons';
 import { Box, Grommet, Tab, Tabs } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -37,7 +37,7 @@ const customTheme = deepMerge(grommet, {
     `,
   },
 });
-const Icon = () => (
+const IconTabs = () => (
   <Grommet theme={customTheme} full>
     <Box pad="medium" fill>
       <Tabs flex>
@@ -61,4 +61,4 @@ const Icon = () => (
   </Grommet>
 );
 
-storiesOf('Tabs', module).add('Icon', () => <Icon />);
+export const Icon = () => <IconTabs />;

--- a/src/js/components/Tabs/stories/Responsive.js
+++ b/src/js/components/Tabs/stories/Responsive.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { storiesOf } from '@storybook/react';
+
 import { Attraction, Car, TreeOption } from 'grommet-icons';
 import { Box, Grommet, Tab, Tabs } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -117,4 +117,4 @@ const ResponsiveTabs = () => {
   );
 };
 
-storiesOf('Tabs', module).add('Responsive', () => <ResponsiveTabs />);
+export const Responsive = () => <ResponsiveTabs />;

--- a/src/js/components/Tabs/stories/Rich.js
+++ b/src/js/components/Tabs/stories/Rich.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { storiesOf } from '@storybook/react';
+
 import { CircleInformation, Currency } from 'grommet-icons';
 import { Box, Grommet, FormField, Tab, Tabs, Text, TextInput } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -47,6 +47,6 @@ RichTabTitle.propTypes = {
   label: PropTypes.string.isRequired,
 };
 
-storiesOf('Tabs', module).add('Rich', () => <RichTabs />);
-
 export { RichTabTitle };
+
+export const Rich = () => <RichTabs />;

--- a/src/js/components/Tabs/stories/Scrollable.js
+++ b/src/js/components/Tabs/stories/Scrollable.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+
 import { TreeOption } from 'grommet-icons';
 import { Box, Heading, Grommet, Tab, Tabs } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -48,4 +48,4 @@ const ScrollableTabs = () => (
   </Grommet>
 );
 
-storiesOf('Tabs', module).add('Scrollable', () => <ScrollableTabs />);
+export const Scrollable = () => <ScrollableTabs />;

--- a/src/js/components/Tabs/stories/States.js
+++ b/src/js/components/Tabs/stories/States.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { storiesOf } from '@storybook/react';
+
 import { Box, Grommet, Tab, Tabs, Text, ThemeContext } from 'grommet';
 import { grommet } from 'grommet/themes';
 
@@ -109,7 +109,7 @@ const TabStates = () => {
         </ThemeContext.Extend>
         <ThemeContext.Extend value={customThemeWithButtonDefault}>
           <TabsExample
-            label="Customized Disabled State with 
+            label="Customized Disabled State with
             'theme.button.default' Defined"
           />
         </ThemeContext.Extend>
@@ -118,4 +118,4 @@ const TabStates = () => {
   );
 };
 
-storiesOf('Tabs', module).add('States', () => <TabStates />);
+export const States = () => <TabStates />;

--- a/src/js/components/Tabs/stories/Tabs.stories.js
+++ b/src/js/components/Tabs/stories/Tabs.stories.js
@@ -1,0 +1,14 @@
+export { AlignControls } from './AlignControls';
+export { Controlled } from './typescript/Controlled.tsx';
+export { Custom } from './Custom';
+export { Icon } from './Icon';
+export { Plain } from './Uncontrolled';
+export { Responsive } from './Responsive';
+export { Rich } from './Rich';
+export { Scrollable } from './Scrollable';
+export { States } from './States';
+export { Uncontrolled } from './Uncontrolled';
+
+export default {
+  title: 'Controls/Tabs',
+};

--- a/src/js/components/Tabs/stories/Uncontrolled.js
+++ b/src/js/components/Tabs/stories/Uncontrolled.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { storiesOf } from '@storybook/react';
+
 import { Attraction, Car, TreeOption } from 'grommet-icons';
 import { Box, Grommet, Tab, Tabs } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -33,6 +33,5 @@ UncontrolledTabs.propTypes = {
   plain: PropTypes.bool, // eslint-disable-line react/require-default-props
 };
 
-storiesOf('Tabs', module)
-  .add('Uncontrolled', () => <UncontrolledTabs />)
-  .add('Plain', () => <UncontrolledTabs plain />);
+export const Uncontrolled = () => <UncontrolledTabs />;
+export const Plain = () => <UncontrolledTabs plain />;

--- a/src/js/components/Tabs/stories/typescript/Controlled.tsx
+++ b/src/js/components/Tabs/stories/typescript/Controlled.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+
 import { Attraction, Car, TreeOption } from 'grommet-icons';
 import { Box, Grommet, Tab, Tabs } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -34,4 +34,4 @@ const ControlledTabs = () => {
   );
 };
 
-storiesOf('Tabs', module).add('Controlled', () => <ControlledTabs />);
+export const Controlled = () => <ControlledTabs />;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Tabs stories to Controls/Tabs.

#### Where should the reviewer start?

`components/Tabs/stories/Tabs.stories.js`

#### What testing has been done on this PR?

Storybook

#### How should this be manually tested?

Visit storybook using PR's branch and check Controls/Tabs.

#### Any background context you want to provide?

#### What are the relevant issues?

#4651

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/47114840/97792272-f9939d80-1bba-11eb-8692-526949c85d31.png)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.