### PR TITLE
Organized Header stories structure

### DIFF
--- a/src/js/components/Header/stories/Header.stories.js
+++ b/src/js/components/Header/stories/Header.stories.js
@@ -1,0 +1,6 @@
+export { Simple } from './typescript/Simple.tsx';
+export { Responsive } from './Responsive';
+
+export default {
+  title: 'Layout/Header',
+};

--- a/src/js/components/Header/stories/Responsive.js
+++ b/src/js/components/Header/stories/Responsive.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Header, Anchor, Box, ResponsiveContext, Menu } from 'grommet';
 import { Grommet as GrommetIcon, Menu as MenuIcon } from 'grommet-icons';
 import { grommet } from 'grommet/themes';
 
-const Responsive = () => (
+export const Responsive = () => (
   <Grommet theme={grommet}>
     <Header background="light-4" pad="medium" height="xsmall">
       <Anchor
@@ -47,5 +46,3 @@ const Responsive = () => (
     </Header>
   </Grommet>
 );
-
-storiesOf('Header', module).add('Responsive', () => <Responsive />);

--- a/src/js/components/Header/stories/typescript/Simple.tsx
+++ b/src/js/components/Header/stories/typescript/Simple.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Avatar, Anchor, Nav, Grommet, Header } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -7,7 +6,7 @@ import { grommet } from 'grommet/themes';
 const gravatarLink =
   '//s.gravatar.com/avatar/b7fb138d53ba0f573212ccce38a7c43b?s=80';
 
-const Simple = () => (
+export const Simple = () => (
   <Grommet theme={grommet}>
     <Header background="light-4" pad="small">
       <Avatar src={gravatarLink} />
@@ -18,5 +17,3 @@ const Simple = () => (
     </Header>
   </Grommet>
 );
-
-storiesOf('Header', module).add('Simple', () => <Simple />);


### PR DESCRIPTION

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Organized the `Header/stories` by type of its component which is Layout.

#### Where should the reviewer start?

`src/js/components/Header/stories/Header.stories.js`

#### What testing has been done on this PR?

- `yarn storybook`
- `yarn test`
- `yarn prettier`
- `yarn lint`

#### How should this be manually tested?
`yarn storybook`
#### Any background context you want to provide?
No
#### What are the relevant issues?
#4651 
#### Screenshots (if appropriate)
<img width="201" alt="image" src="https://user-images.githubusercontent.com/64912621/97922706-e1db2700-1d2a-11eb-947e-c3c86458428b.png">

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
This change is backwards compatible.