### PR TITLE
Extend MaskedInput theming

### DIFF
--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
@@ -7905,7 +7905,7 @@ exports[`DateInput select format 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 lcXYAf"
 >
   <div
-    class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 eZPDpF"
+    class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 cdPwB"
   >
     <div
       class="StyledMaskedInput__StyledIcon-sc-99vkfa-2 kqyWRg"
@@ -10266,7 +10266,7 @@ exports[`DateInput select format inline 2`] = `
     class="StyledBox-sc-13pk1d4-0 bFwQzJ"
   >
     <div
-      class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 eZPDpF"
+      class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 cdPwB"
     >
       <div
         class="StyledMaskedInput__StyledIcon-sc-99vkfa-2 kqyWRg"
@@ -12276,7 +12276,7 @@ exports[`DateInput select format inline range 2`] = `
     class="StyledBox-sc-13pk1d4-0 bFwQzJ"
   >
     <div
-      class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 eZPDpF"
+      class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 cdPwB"
     >
       <div
         class="StyledMaskedInput__StyledIcon-sc-99vkfa-2 kqyWRg"
@@ -15357,7 +15357,7 @@ exports[`DateInput type format inline 2`] = `
     class="StyledBox-sc-13pk1d4-0 bFwQzJ"
   >
     <div
-      class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 eZPDpF"
+      class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 cdPwB"
     >
       <div
         class="StyledMaskedInput__StyledIcon-sc-99vkfa-2 kqyWRg"

--- a/src/js/components/MaskedInput/README.md
+++ b/src/js/components/MaskedInput/README.md
@@ -174,6 +174,17 @@ Defaults to
 undefined
 ```
 
+**maskedInput.container.extend**
+
+Any additional style for the container surrounding the input 
+    and, if present, icon. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```
+
 **text.medium**
 
 The size of the text for MaskedInput. Expects `string`.

--- a/src/js/components/MaskedInput/StyledMaskedInput.js
+++ b/src/js/components/MaskedInput/StyledMaskedInput.js
@@ -27,6 +27,11 @@ export const StyledMaskedInput = styled.input`
 export const StyledMaskedInputContainer = styled.div`
   position: relative;
   width: 100%;
+
+  ${props =>
+    props.theme.maskedInput &&
+    props.theme.maskedInput.container &&
+    props.theme.maskedInput.container.extend};
 `;
 
 export const StyledIcon = styled.div`

--- a/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
+++ b/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
@@ -410,4 +410,27 @@ describe('MaskedInput', () => {
     expect(onChange).toHaveBeenCalled();
     expect(onChange).toReturnWith('aa');
   });
+
+  test('custom theme', async () => {
+    const customTheme = {
+      maskedInput: {
+        container: {
+          extend: 'svg { fill: red; stroke: red; }',
+        },
+      },
+    };
+
+    const { container } = render(
+      <Grommet theme={customTheme}>
+        <MaskedInput
+          data-testid="test-input"
+          size="large"
+          id="item"
+          icon={<Search />}
+          name="item"
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -241,6 +241,159 @@ exports[`MaskedInput basic 1`] = `
 </div>
 `;
 
+exports[`MaskedInput custom theme 1`] = `
+.c3 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c3 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c3 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c3 *[stroke*="#"],
+.c3 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c3 *[fill-rule],
+.c3 *[FILL-RULE],
+.c3 *[fill*="#"],
+.c3 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c4 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  font-size: 22px;
+  line-height: 28px;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  padding-left: 48px;
+}
+
+.c4::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c4::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c4:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c4::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c4::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c4:-moz-placeholder,
+.c4::-moz-placeholder {
+  opacity: 1;
+}
+
+.c1 {
+  position: relative;
+  width: 100%;
+}
+
+.c1 svg {
+  fill: red;
+  stroke: red;
+}
+
+.c2 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-packjustify: center;
+  -webkit-justify: center;
+  -ms-flex-packjustify: center;
+  justify: center;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  pointer-events: none;
+  left: 12px;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      <svg
+        aria-label="Search"
+        class="c3"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M15,15 L22,22 L15,15 Z M9.5,17 C13.6421356,17 17,13.6421356 17,9.5 C17,5.35786438 13.6421356,2 9.5,2 C5.35786438,2 2,5.35786438 2,9.5 C2,13.6421356 5.35786438,17 9.5,17 Z"
+          fill="none"
+          stroke="#000"
+          stroke-width="2"
+        />
+      </svg>
+    </div>
+    <input
+      autocomplete="off"
+      class="c4"
+      data-testid="test-input"
+      id="item"
+      name="item"
+      placeholder=""
+      value=""
+    />
+  </div>
+</div>
+`;
+
 exports[`MaskedInput disabled 1`] = `
 .c1 {
   box-sizing: border-box;
@@ -656,7 +809,7 @@ exports[`MaskedInput event target props are available option via mouse 3`] = `""
 
 exports[`MaskedInput event target props are available option via mouse 4`] = `
 <div
-  class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 eZPDpF"
+  class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 cdPwB"
 >
   <input
     autocomplete="off"
@@ -1338,7 +1491,7 @@ exports[`MaskedInput next and previous without options 1`] = `
 
 exports[`MaskedInput next and previous without options 2`] = `
 <div
-  class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 eZPDpF"
+  class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 cdPwB"
 >
   <input
     autocomplete="off"
@@ -1701,7 +1854,7 @@ exports[`MaskedInput option via mouse 3`] = `""`;
 
 exports[`MaskedInput option via mouse 4`] = `
 <div
-  class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 eZPDpF"
+  class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 cdPwB"
 >
   <input
     autocomplete="off"

--- a/src/js/components/MaskedInput/doc.js
+++ b/src/js/components/MaskedInput/doc.js
@@ -89,6 +89,12 @@ export const themeDoc = {
     type: 'string | (props) => {}',
     defaultValue: undefined,
   },
+  'maskedInput.container.extend': {
+    description: `Any additional style for the container surrounding the input 
+    and, if present, icon.`,
+    type: 'string | (props) => {}',
+    defaultValue: undefined,
+  },
   'text.medium': {
     description: 'The size of the text for MaskedInput.',
     type: 'string',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11119,6 +11119,17 @@ Defaults to
 undefined
 \`\`\`
 
+**maskedInput.container.extend**
+
+Any additional style for the container surrounding the input 
+    and, if present, icon. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
 **text.medium**
 
 The size of the text for MaskedInput. Expects \`string\`.

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -914,6 +914,9 @@ export interface ThemeType {
     extend?: ExtendType;
   };
   maskedInput?: {
+    container?: {
+      extend?: ExtendType;
+    };
     extend?: ExtendType;
     disabled?: {
       opacity?: OpacityType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -905,6 +905,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // extend: undefined,
     },
     maskedInput: {
+      // container: {
+      //   extend: undefined,
+      // },
       // extend: undefined,
       // disabled: { opacity: undefined },
     },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds `maskedInput.container.extend` to theming to match what is already implemented in `StyledTextInput`. This allows users to extend styling on the container that wraps both the `input` and the icon (if present). The functionality already exists on TextInput but was not present on MaskedInput.

#### Where should the reviewer start?
src/js/components/MaskedInput/StyledMaskedInput.js

#### What testing has been done on this PR?
Added jest test.

#### How should this be manually tested?
Local storybook with custom theme.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, updated here.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.