### PR TITLE
Add global.input.extend to theme

### DIFF
--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
@@ -7925,7 +7925,7 @@ exports[`DateInput select format 2`] = `
     </div>
     <input
       autocomplete="off"
-      class="StyledMaskedInput-sc-99vkfa-0 eoroCF"
+      class="StyledMaskedInput-sc-99vkfa-0 TGSYh"
       id="item"
       name="item"
       placeholder="mm/dd/yyyy"
@@ -10286,7 +10286,7 @@ exports[`DateInput select format inline 2`] = `
       </div>
       <input
         autocomplete="off"
-        class="StyledMaskedInput-sc-99vkfa-0 dyBLro"
+        class="StyledMaskedInput-sc-99vkfa-0 cSNjJM"
         id="item"
         name="item"
         placeholder="mm/dd/yyyy"
@@ -12296,7 +12296,7 @@ exports[`DateInput select format inline range 2`] = `
       </div>
       <input
         autocomplete="off"
-        class="StyledMaskedInput-sc-99vkfa-0 dyBLro"
+        class="StyledMaskedInput-sc-99vkfa-0 cSNjJM"
         id="item"
         name="item"
         placeholder="mm/dd/yyyy-mm/dd/yyyy"
@@ -15377,7 +15377,7 @@ exports[`DateInput type format inline 2`] = `
       </div>
       <input
         autocomplete="off"
-        class="StyledMaskedInput-sc-99vkfa-0 dyBLro"
+        class="StyledMaskedInput-sc-99vkfa-0 cSNjJM"
         id="item"
         name="item"
         placeholder="mm/dd/yyyy"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -203,7 +203,7 @@ exports[`Form controlled controlled 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             name="test"
             placeholder="test input"
             value="v"
@@ -237,7 +237,7 @@ exports[`Form controlled controlled 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             name="test"
             placeholder="test input"
             value="v"
@@ -479,7 +479,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             id="test"
             name="test"
             value="v"
@@ -519,7 +519,7 @@ exports[`Form controlled controlled FormField deprecated 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             id="test"
             name="test"
             value="v"
@@ -740,7 +740,7 @@ exports[`Form controlled controlled input 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             name="test"
             placeholder="test input"
             value="v"
@@ -774,7 +774,7 @@ exports[`Form controlled controlled input 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             name="test"
             placeholder="test input"
             value="v"
@@ -995,7 +995,7 @@ exports[`Form controlled controlled input lazy 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             name="test"
             placeholder="test input"
             value="v"
@@ -1029,7 +1029,7 @@ exports[`Form controlled controlled input lazy 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             name="test"
             placeholder="test input"
             value="v"
@@ -1250,7 +1250,7 @@ exports[`Form controlled controlled lazy 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             name="test"
             placeholder="test input"
             value="v"
@@ -1284,7 +1284,7 @@ exports[`Form controlled controlled lazy 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             name="test"
             placeholder="test input"
             value="v"
@@ -1692,7 +1692,7 @@ exports[`Form controlled controlled onValidate 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             name="test"
             placeholder="test input"
             value=""
@@ -1940,7 +1940,7 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             name="test"
             placeholder="test input"
             value=""
@@ -2188,7 +2188,7 @@ exports[`Form controlled controlled onValidate custom info 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             name="test"
             placeholder="test input"
             value=""

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -1532,7 +1532,7 @@ exports[`Form uncontrolled uncontrolled 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             name="test"
             placeholder="test input"
             value=""
@@ -1566,7 +1566,7 @@ exports[`Form uncontrolled uncontrolled 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             name="test"
             placeholder="test input"
             value=""
@@ -1787,7 +1787,7 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             name="test"
             placeholder="test input"
             value=""
@@ -2035,7 +2035,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             name="test"
             placeholder="test input"
             value=""
@@ -2283,7 +2283,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD"
             name="test"
             placeholder="test input"
             value=""

--- a/src/js/components/MaskedInput/README.md
+++ b/src/js/components/MaskedInput/README.md
@@ -316,3 +316,13 @@ Defaults to
 ```
 12px
 ```
+
+**global.input.extend**
+
+Any additional style for an input. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -660,7 +660,7 @@ exports[`MaskedInput event target props are available option via mouse 4`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 cDlpsY"
+    class="StyledMaskedInput-sc-99vkfa-0 dKNsqQ"
     data-testid="test-input"
     id="item"
     name="item"
@@ -1342,7 +1342,7 @@ exports[`MaskedInput next and previous without options 2`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 dqSfNA"
+    class="StyledMaskedInput-sc-99vkfa-0 dFKMxk"
     data-testid="test-input"
     id="item"
     name="item"
@@ -1705,7 +1705,7 @@ exports[`MaskedInput option via mouse 4`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 cDlpsY"
+    class="StyledMaskedInput-sc-99vkfa-0 dKNsqQ"
     data-testid="test-input"
     id="item"
     name="item"

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -1524,7 +1524,7 @@ exports[`Select complex options and children 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 fVbmbP Select__SelectTextInput-sc-17idtfo-0 VIYrI"
+          class="StyledTextInput-sc-1x30a0s-0 eGpyWD Select__SelectTextInput-sc-17idtfo-0 VIYrI"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -2034,7 +2034,7 @@ exports[`Select disabled 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 fVbmbP Select__SelectTextInput-sc-17idtfo-0 nFqJk"
+          class="StyledTextInput-sc-1x30a0s-0 eGpyWD Select__SelectTextInput-sc-17idtfo-0 nFqJk"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -5849,7 +5849,7 @@ exports[`Select prop: onOpen 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 fVbmbP Select__SelectTextInput-sc-17idtfo-0 VIYrI"
+          class="StyledTextInput-sc-1x30a0s-0 eGpyWD Select__SelectTextInput-sc-17idtfo-0 VIYrI"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -6714,7 +6714,7 @@ exports[`Select renders custom up and down icons 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fVbmbP Select__SelectTextInput-sc-17idtfo-0 VIYrI"
+            class="StyledTextInput-sc-1x30a0s-0 eGpyWD Select__SelectTextInput-sc-17idtfo-0 VIYrI"
             placeholder="Select..."
             readonly=""
             tabindex="-1"
@@ -8629,7 +8629,7 @@ exports[`Select search 3`] = `
 exports[`Select search 4`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 fFeaOm"
+  class="StyledTextInput-sc-1x30a0s-0 bSfUHy"
   type="search"
   value=""
 />
@@ -8638,7 +8638,7 @@ exports[`Select search 4`] = `
 exports[`Select search 5`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 fFeaOm"
+  class="StyledTextInput-sc-1x30a0s-0 bSfUHy"
   type="search"
   value="o"
 />

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -2895,7 +2895,7 @@ exports[`Select Controlled multiple values 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 fVbmbP Select__SelectTextInput-sc-17idtfo-0 VIYrI"
+          class="StyledTextInput-sc-1x30a0s-0 eGpyWD Select__SelectTextInput-sc-17idtfo-0 VIYrI"
           id="test-select__input"
           placeholder="test select"
           readonly=""

--- a/src/js/components/TextArea/README.md
+++ b/src/js/components/TextArea/README.md
@@ -287,6 +287,16 @@ Defaults to
 12px
 ```
 
+**global.input.extend**
+
+Any additional style for an input. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```
+
 **global.control.disabled.opacity**
 
 The opacity when a component is disabled. Expects `number`.

--- a/src/js/components/TextInput/README.md
+++ b/src/js/components/TextInput/README.md
@@ -502,3 +502,13 @@ Defaults to
 ```
 12px
 ```
+
+**global.input.extend**
+
+Any additional style for an input. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -411,7 +411,7 @@ exports[`TextInput calls onSuggestionsClose 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 jfUATO"
+      class="StyledTextInput-sc-1x30a0s-0 XSrhW"
       data-testid="test-input"
       id="item"
       name="item"
@@ -916,7 +916,7 @@ exports[`TextInput close suggestion drop 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 jfUATO"
+      class="StyledTextInput-sc-1x30a0s-0 XSrhW"
       data-testid="test-input"
       id="item"
       name="item"
@@ -1355,7 +1355,7 @@ exports[`TextInput handles next and previous without suggestion 2`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 hsswYj"
+      class="StyledTextInput-sc-1x30a0s-0 kyHaGr"
       data-testid="test-input"
       id="item"
       name="item"
@@ -2479,7 +2479,7 @@ exports[`TextInput select suggestion 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 deAfJe"
+      class="StyledTextInput-sc-1x30a0s-0 cjSUvm"
       data-testid="test-input"
       id="item"
       name="item"

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11261,6 +11261,16 @@ Defaults to
 \`\`\`
 12px
 \`\`\`
+
+**global.input.extend**
+
+Any additional style for an input. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
 ",
   "Menu": "## Menu
 A control that opens a Drop containing plain Buttons.
@@ -15784,6 +15794,16 @@ Defaults to
 12px
 \`\`\`
 
+**global.input.extend**
+
+Any additional style for an input. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
 **global.control.disabled.opacity**
 
 The opacity when a component is disabled. Expects \`number\`.
@@ -16297,6 +16317,16 @@ Defaults to
 
 \`\`\`
 12px
+\`\`\`
+
+**global.input.extend**
+
+Any additional style for an input. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
 \`\`\`
 ",
   "Video": "## Video

--- a/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
+++ b/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
@@ -295,6 +295,18 @@ exports[`Grommet custom theme 1`] = `
   opacity: 1;
 }
 
+.c12::-webkit-input-placeholder {
+  font-weight: normal;
+}
+
+.c12::-moz-placeholder {
+  font-weight: normal;
+}
+
+.c12:-ms-input-placeholder {
+  font-weight: normal;
+}
+
 .c11 {
   position: relative;
   width: 100%;

--- a/src/js/themes/__tests__/theme-test.js
+++ b/src/js/themes/__tests__/theme-test.js
@@ -74,6 +74,19 @@ const customTheme = {
         size: 'large',
         weight: 'bold',
       },
+      extend: `
+        &::-webkit-input-placeholder {
+          font-weight: normal;
+        }
+
+        &::-moz-placeholder {
+          font-weight: normal;
+        }
+
+        &:-ms-input-placeholder {
+          font-weight: normal;
+        }
+      `,
     },
     colors: {
       custom: '#cc6633',

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -275,6 +275,7 @@ export interface ThemeType {
       color?: ColorType;
     };
     input?: {
+      extend?: ExtendType;
       padding?:
         | string
         | {

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -479,7 +479,7 @@ export const inputStyle = css`
     opacity: 1;
   }
 
-  ${props => props.theme.global.input.extend && props.theme.global.input.extend}
+  ${props => props.theme.global.input.extend}
 `;
 
 export const overflowStyle = overflowProp => {

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -478,6 +478,8 @@ export const inputStyle = css`
   &::-moz-placeholder { // FF 19+
     opacity: 1;
   }
+
+  ${props => props.theme.global.input.extend && props.theme.global.input.extend}
 `;
 
 export const overflowStyle = overflowProp => {

--- a/src/js/utils/themeDocUtils.js
+++ b/src/js/utils/themeDocUtils.js
@@ -131,6 +131,11 @@ export const themeDocUtils = {
         string, horizontal: string, vertical: string }`,
       defaultValue: '12px',
     },
+    'global.input.extend': {
+      description: 'Any additional style for an input.',
+      type: 'string | (props) => {}',
+      defaultValue: undefined,
+    },
   },
   placeholderStyle: {
     'global.colors.placeholder': {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Add `extend` to global.input in theme. This will allow users to add extended styling across inputs (TextInput, MaskedInput)

#### Where should the reviewer start?
src/js/utils/styles.js

#### What testing has been done on this PR?
Added jest test.

#### How should this be manually tested?
Local storybook testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes, updated here.

#### Should this PR be mentioned in the release notes?
no.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.