### PR TITLE
Storybook restructure Type components

### DIFF
--- a/src/js/components/Heading/stories/All.js
+++ b/src/js/components/Heading/stories/All.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { storiesOf } from '@storybook/react';
 import { Grommet, Grid, Heading } from 'grommet';
 import { grommet } from 'grommet/themes';
 
@@ -32,7 +31,7 @@ Set.propTypes = {
   size: PropTypes.string.isRequired,
 };
 
-const All = () => (
+export const All = () => (
   <Grommet theme={grommet}>
     <Grid columns="large" gap="medium">
       <Set size="medium" />
@@ -43,5 +42,3 @@ const All = () => (
     <Heading fill>{headingFiller}</Heading>
   </Grommet>
 );
-
-storiesOf('Heading', module).add('All', () => <All />);

--- a/src/js/components/Heading/stories/Color.js
+++ b/src/js/components/Heading/stories/Color.js
@@ -1,12 +1,9 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { Grommet, Heading } from 'grommet';
 import { grommet } from 'grommet/themes';
 
-const Color = () => (
+export const Color = () => (
   <Grommet theme={grommet}>
     <Heading color="accent-1">Colored Heading</Heading>
   </Grommet>
 );
-
-storiesOf('Heading', module).add('Color', () => <Color />);

--- a/src/js/components/Heading/stories/CustomHeading.js
+++ b/src/js/components/Heading/stories/CustomHeading.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { Grommet, Heading } from 'grommet';
 import { grommet } from 'grommet/themes';
 import { deepMerge } from 'grommet/utils';
@@ -25,7 +24,7 @@ const customlevel = deepMerge(grommet, {
     extend: props => `color: ${props.theme.global.colors.brand}`,
   },
 });
-const CustomHeading = () => (
+export const Custom = () => (
   <Grommet theme={customlevel}>
     <Heading level={5} size="small">
       Heading level 5 small
@@ -38,5 +37,3 @@ const CustomHeading = () => (
     </Heading>
   </Grommet>
 );
-
-storiesOf('Heading', module).add('Custom', () => <CustomHeading />);

--- a/src/js/components/Heading/stories/Extend.js
+++ b/src/js/components/Heading/stories/Extend.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { Grommet, Heading } from 'grommet';
 import { deepMerge } from 'grommet/utils';
 import { grommet } from 'grommet/themes';
@@ -29,7 +28,7 @@ const customTheme = deepMerge(grommet, {
   heading: { extend: props => `${letterSpacing(props)}` },
 });
 
-const HeadingExtend = () => (
+export const Extend = () => (
   <Grommet theme={customTheme}>
     <Heading level="1" size="large">
       This is using the extend property on Heading
@@ -42,5 +41,3 @@ const HeadingExtend = () => (
     </Heading>
   </Grommet>
 );
-
-storiesOf('Heading', module).add('Extend', () => <HeadingExtend />);

--- a/src/js/components/Heading/stories/Heading.stories.js
+++ b/src/js/components/Heading/stories/Heading.stories.js
@@ -1,0 +1,8 @@
+export { All } from './All';
+export { Color } from './Color';
+export { Custom } from './CustomHeading';
+export { Extend } from './Extend';
+
+export default {
+  title: 'Type/Heading',
+};

--- a/src/js/components/Markdown/markdown.stories.js
+++ b/src/js/components/Markdown/markdown.stories.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import styled from 'styled-components';
 
 import { Box, Grommet, Markdown } from 'grommet';
@@ -28,7 +27,7 @@ import { Grommet } from 'grommet';
   1 | 2 | 3
 `;
 
-const SimpleMarkdown = () => (
+export const Simple = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
       <Markdown>{CONTENT}</Markdown>
@@ -40,7 +39,7 @@ const StyledPre = styled.pre`
   background-color: #7d4cdb;
 `;
 
-const ComponentOverrideMarkdown = () => (
+export const ComponentOverrideMarkdown = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
       <Markdown components={{ pre: StyledPre }}>{CONTENT}</Markdown>
@@ -48,6 +47,10 @@ const ComponentOverrideMarkdown = () => (
   </Grommet>
 );
 
-storiesOf('Markdown', module)
-  .add('Simple', () => <SimpleMarkdown />)
-  .add('Component override markdown', () => <ComponentOverrideMarkdown />);
+ComponentOverrideMarkdown.story = {
+  name: 'Component override markdown',
+};
+
+export default {
+  title: 'Type/Markdown',
+};

--- a/src/js/components/Paragraph/stories/All.js
+++ b/src/js/components/Paragraph/stories/All.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Paragraph } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -11,7 +10,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua.
 `;
 
-const All = () => (
+export const All = () => (
   <Grommet theme={grommet}>
     {sizes.map(size => (
       <Paragraph key={size} size={size}>
@@ -26,5 +25,3 @@ const All = () => (
     </Paragraph>
   </Grommet>
 );
-
-storiesOf('Paragraph', module).add('All', () => <All />);

--- a/src/js/components/Paragraph/stories/Paragraph.stories.js
+++ b/src/js/components/Paragraph/stories/Paragraph.stories.js
@@ -1,0 +1,6 @@
+export { All } from './All';
+export { Themed } from './Themed';
+
+export default {
+  title: 'Type/Paragraph',
+};

--- a/src/js/components/Paragraph/stories/Themed.js
+++ b/src/js/components/Paragraph/stories/Themed.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Paragraph } from 'grommet';
 import { deepMerge } from 'grommet/utils';
@@ -13,7 +12,7 @@ const customTheme = deepMerge(grommet, {
   },
 });
 
-const All = () => (
+export const Themed = () => (
   <Grommet theme={customTheme}>
     <Paragraph>
       The font family for this paragraph is being defined by a custom theme.
@@ -22,6 +21,8 @@ const All = () => (
 );
 
 // disabling chromatic because snapshot doesn't capture font
-storiesOf('Paragraph', module).add('Themed', () => <All />, {
-  chromatic: { disable: true },
-});
+Themed.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+};

--- a/src/js/components/Text/stories/All.js
+++ b/src/js/components/Text/stories/All.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Box, Grommet, Text } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -14,7 +13,7 @@ const sizes = [
   '77px',
 ];
 
-const All = () => (
+export const All = () => (
   <Grommet theme={grommet}>
     <>
       {sizes.map(size => (
@@ -30,5 +29,3 @@ const All = () => (
     </>
   </Grommet>
 );
-
-storiesOf('Text', module).add('All', () => <All />);

--- a/src/js/components/Text/stories/Color.js
+++ b/src/js/components/Text/stories/Color.js
@@ -1,13 +1,10 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Text } from 'grommet';
 import { grommet } from 'grommet/themes';
 
-const Color = () => (
+export const Color = () => (
   <Grommet theme={grommet}>
     <Text color="accent-1">Colored Text</Text>
   </Grommet>
 );
-
-storiesOf('Text', module).add('Color', () => <Color />);

--- a/src/js/components/Text/stories/Text.stories.js
+++ b/src/js/components/Text/stories/Text.stories.js
@@ -1,0 +1,7 @@
+export { All } from './All';
+export { Color } from './Color';
+export { WordBreak } from './WordBreak';
+
+export default {
+  title: 'Type/Text',
+};

--- a/src/js/components/Text/stories/WordBreak.js
+++ b/src/js/components/Text/stories/WordBreak.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Box, Grommet, Text, Heading } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -7,7 +6,7 @@ import { grommet } from 'grommet/themes';
 const wordBreakValues = ['normal', 'break-all', 'keep-all', 'break-word'];
 
 /* eslint-disable max-len */
-const WordBreak = () => (
+export const WordBreak = () => (
   <Grommet theme={grommet}>
     {wordBreakValues.map(value => (
       <Box key={value} margin="small" width="medium">
@@ -22,5 +21,6 @@ const WordBreak = () => (
   </Grommet>
 );
 /* eslint-enable max-len */
-
-storiesOf('Text', module).add('Word break', () => <WordBreak />);
+WordBreak.story = {
+  name: 'Word break',
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changes Type components (Heading, Markdown, Paragraph, Text) stories to be organized under Type in storybook

#### Where should the reviewer start?

#### What testing has been done on this PR?
Storybook

#### How should this be manually tested?
Storybook

#### Any background context you want to provide?

#### What are the relevant issues?
#4651 

#### Screenshots (if appropriate)
<img width="183" alt="Screen Shot 2020-11-04 at 10 30 42 AM" src="https://user-images.githubusercontent.com/54560994/98146523-d9006780-1e88-11eb-8822-bcd8226cf28f.png">


#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible