### PR TITLE
Add Keyboard in Storybook examples

### DIFF
--- a/src/js/components/Keyboard/stories/Keyboard.stories.js
+++ b/src/js/components/Keyboard/stories/Keyboard.stories.js
@@ -1,0 +1,5 @@
+export { OnDocument } from './OnDocument';
+
+export default {
+  title: 'Utilities/Keyboard',
+};

--- a/src/js/components/Keyboard/stories/OnDocument.js
+++ b/src/js/components/Keyboard/stories/OnDocument.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { Box, Grommet, Heading, Keyboard } from 'grommet';
+import { grommet } from 'grommet/themes';
+
+export const OnDocument = () => (
+  <Grommet theme={grommet}>
+    <Keyboard target="document" onEsc={() => alert('You pressed Esc!')}>
+      <Box pad="large" background="light-4">
+        <Heading level="3">Press Esc on me!</Heading>
+      </Box>
+    </Keyboard>
+  </Grommet>
+);
+
+OnDocument.story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+};


### PR DESCRIPTION
#### What does this PR do?
Adds a demo/example of the `Keyboard` component in Storybook, under the **Utilities** section

#### Where should the reviewer start?
`src/js/components/Keyboard/stories`

#### How should this be manually tested?
`npm run storybook`

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/32275394/98260600-b7e56700-1fad-11eb-932b-6ddf17755a36.png)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
