### PR TITLE
Refactor datatable stories to new format

### DIFF
--- a/src/js/components/DataTable/stories/Clickable.js
+++ b/src/js/components/DataTable/stories/Clickable.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, DataTable } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -8,7 +7,7 @@ import { grommet } from 'grommet/themes';
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
 import { columns, DATA } from './data';
 
-const ClickableDataTable = () => (
+export const Clickable = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
       {/* eslint-disable no-alert */}
@@ -21,5 +20,3 @@ const ClickableDataTable = () => (
     </Box>
   </Grommet>
 );
-
-storiesOf('DataTable', module).add('Clickable', () => <ClickableDataTable />);

--- a/src/js/components/DataTable/stories/ColumnSize.js
+++ b/src/js/components/DataTable/stories/ColumnSize.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, DataTable, Heading } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -93,7 +92,7 @@ const columnsDefault = [
   { property: 'paid', header: 'Paid', align: 'end' },
 ];
 
-const Example = () => (
+export const ColumnSize = () => (
   <Grommet theme={grommet}>
     <Box fill="horizontal" pad="medium">
       <Heading level="3"> Default DataTable</Heading>
@@ -153,4 +152,6 @@ const Example = () => (
   </Grommet>
 );
 
-storiesOf('DataTable', module).add('Column sizes', () => <Example />);
+ColumnSize.story = {
+  name: 'Column sizes',
+};

--- a/src/js/components/DataTable/stories/Controlled.js
+++ b/src/js/components/DataTable/stories/Controlled.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, DataTable, CheckBox } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -14,7 +13,7 @@ delete controlledColumns[3].footer;
 delete controlledColumns[4].footer;
 delete controlledColumns[4].aggregate;
 
-const ControlledDataTable = () => {
+export const ControlledDataTable = () => {
   const [checked, setChecked] = React.useState([]);
 
   const onCheck = (event, value) => {
@@ -64,4 +63,6 @@ const ControlledDataTable = () => {
   );
 };
 
-storiesOf('DataTable', module).add('Controlled', () => <ControlledDataTable />);
+ControlledDataTable.story = {
+  name: 'Controlled',
+};

--- a/src/js/components/DataTable/stories/ControlledGrouped.js
+++ b/src/js/components/DataTable/stories/ControlledGrouped.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, DataTable } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -15,7 +14,7 @@ groupColumns[1] = { ...first };
 groupColumns[0].footer = groupColumns[1].footer;
 delete groupColumns[1].footer;
 
-const ControlledGroupedDataTable = () => {
+export const ControlledGroupedDataTable = () => {
   const [expandedGroups, setExpandedGroups] = useState([DATA[2].location]);
 
   return (
@@ -34,6 +33,6 @@ const ControlledGroupedDataTable = () => {
   );
 };
 
-storiesOf('DataTable', module).add('Controlled grouped', () => (
-  <ControlledGroupedDataTable />
-));
+ControlledGroupedDataTable.story = {
+  name: 'Controlled grouped',
+};

--- a/src/js/components/DataTable/stories/Custom.js
+++ b/src/js/components/DataTable/stories/Custom.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Box, Grommet, DataTable } from 'grommet';
 import { Blank } from 'grommet-icons';
@@ -47,7 +46,7 @@ const customTheme = {
   },
 };
 
-const Example = () => {
+export const Custom = () => {
   const [sort, setSort] = React.useState({
     property: 'name',
     direction: 'desc',
@@ -66,5 +65,3 @@ const Example = () => {
     </Grommet>
   );
 };
-
-storiesOf('DataTable', module).add('Custom', () => <Example />);

--- a/src/js/components/DataTable/stories/DataTable.stories.js
+++ b/src/js/components/DataTable/stories/DataTable.stories.js
@@ -1,0 +1,22 @@
+export { Clickable } from './Clickable';
+export { ClickableDataTable } from './typescript/Clickable.tsx';
+export { ColumnSize } from './ColumnSize';
+export { ControlledDataTable } from './Controlled';
+export { ControlledGroupedDataTable } from './ControlledGrouped';
+export { Custom } from './Custom';
+export { Fill } from './Fill';
+export { GroupedDataTable } from './Grouped';
+export { InfiniteScrollDataTable } from './InfiniteScrollDataTable';
+export { NoPrimaryKeyDataTable } from './NoPrimary';
+export { ResizableDataTable } from './ResizableColumns';
+export { Select } from './Select';
+export { ServedDataTable } from './Served';
+export { Simple } from './Simple';
+export { SizedDataTable } from './Sized';
+export { Sort } from './Sort';
+export { StyledDataTable } from './Styled';
+export { TunableDataTable } from './Tunable';
+
+export default {
+  title: 'Visualizations/DataTable',
+};

--- a/src/js/components/DataTable/stories/Fill.js
+++ b/src/js/components/DataTable/stories/Fill.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { Grommet, Box, DataTable } from 'grommet';
 import { grommet } from 'grommet/themes';
 import { deepMerge } from 'grommet/utils';
@@ -40,7 +39,7 @@ const myTheme = deepMerge(grommet, {
   },
 });
 
-const Example = () => (
+export const Fill = () => (
   <Grommet theme={myTheme} full>
     <Box fill="vertical">
       <DataTable
@@ -57,4 +56,6 @@ const Example = () => (
   </Grommet>
 );
 
-storiesOf('DataTable', module).add('Fill and pin', () => <Example />);
+Fill.story = {
+  name: 'Fill and pin',
+};

--- a/src/js/components/DataTable/stories/Grouped.js
+++ b/src/js/components/DataTable/stories/Grouped.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, DataTable } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -15,7 +14,7 @@ groupColumns[1] = { ...first };
 groupColumns[0].footer = groupColumns[1].footer;
 delete groupColumns[1].footer;
 
-const GroupedDataTable = () => (
+export const GroupedDataTable = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
       <DataTable
@@ -28,4 +27,6 @@ const GroupedDataTable = () => (
   </Grommet>
 );
 
-storiesOf('DataTable', module).add('Grouped', () => <GroupedDataTable />);
+GroupedDataTable.story = {
+  name: 'Grouped',
+};

--- a/src/js/components/DataTable/stories/InfiniteScrollDataTable.js
+++ b/src/js/components/DataTable/stories/InfiniteScrollDataTable.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, DataTable, Heading, Meter, Text } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -303,7 +302,7 @@ const DATA = [
   },
 ];
 
-const InfiniteScrollDataTable = () => {
+export const InfiniteScrollDataTable = () => {
   const step = 10;
 
   const load = () => {
@@ -332,6 +331,6 @@ const InfiniteScrollDataTable = () => {
   );
 };
 
-storiesOf('DataTable', module).add('Infinitescroll', () => (
-  <InfiniteScrollDataTable />
-));
+InfiniteScrollDataTable.story = {
+  name: 'Infinite Scroll',
+};

--- a/src/js/components/DataTable/stories/NoPrimary.js
+++ b/src/js/components/DataTable/stories/NoPrimary.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, DataTable } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -13,7 +12,7 @@ const columns = [
   { property: 'location', header: 'Location' },
 ];
 
-const Example = () => (
+export const NoPrimaryKeyDataTable = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
       <DataTable columns={columns} data={DATA} step={10} primaryKey={false} />
@@ -21,4 +20,6 @@ const Example = () => (
   </Grommet>
 );
 
-storiesOf('DataTable', module).add('No primary', () => <Example />);
+NoPrimaryKeyDataTable.story = {
+  name: 'No primary',
+};

--- a/src/js/components/DataTable/stories/ResizableColumns.js
+++ b/src/js/components/DataTable/stories/ResizableColumns.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, DataTable, Heading } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -62,7 +61,7 @@ const columnsResize = [
   { property: 'paid', header: 'Paid', size: 'xsmall', align: 'end' },
 ];
 
-const ExampleResizable = () => (
+export const ResizableDataTable = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
       <Heading level="3">Table with resizable & column sizes</Heading>
@@ -76,6 +75,6 @@ const ExampleResizable = () => (
   </Grommet>
 );
 
-storiesOf('DataTable', module).add('Resizable columns', () => (
-  <ExampleResizable />
-));
+ResizableDataTable.story = {
+  name: 'Resizable columns',
+};

--- a/src/js/components/DataTable/stories/Select.js
+++ b/src/js/components/DataTable/stories/Select.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, DataTable } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -8,7 +7,7 @@ import { grommet } from 'grommet/themes';
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
 import { columns, DATA } from './data';
 
-const Example = () => {
+export const Select = () => {
   const [select, setSelect] = React.useState([]);
   return (
     <Grommet theme={grommet}>
@@ -24,5 +23,3 @@ const Example = () => {
     </Grommet>
   );
 };
-
-storiesOf('DataTable', module).add('Select', () => <Example />);

--- a/src/js/components/DataTable/stories/Served.js
+++ b/src/js/components/DataTable/stories/Served.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, DataTable } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -8,7 +7,7 @@ import { grommet } from 'grommet/themes';
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
 import { columns, DATA } from './data';
 
-const ServedDataTable = () => {
+export const ServedDataTable = () => {
   const [data2, setData2] = React.useState(DATA);
 
   const onSearch = search => {
@@ -53,4 +52,6 @@ const ServedDataTable = () => {
   );
 };
 
-storiesOf('DataTable', module).add('Served', () => <ServedDataTable />);
+ServedDataTable.story = {
+  name: 'Served',
+};

--- a/src/js/components/DataTable/stories/Simple.js
+++ b/src/js/components/DataTable/stories/Simple.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, DataTable } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -8,12 +7,10 @@ import { grommet } from 'grommet/themes';
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
 import { columns, DATA } from './data';
 
-const Example = () => (
+export const Simple = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
       <DataTable columns={columns} data={DATA} step={10} />
     </Box>
   </Grommet>
 );
-
-storiesOf('DataTable', module).add('Simple', () => <Example />);

--- a/src/js/components/DataTable/stories/Sized.js
+++ b/src/js/components/DataTable/stories/Sized.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, DataTable } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -8,7 +7,7 @@ import { grommet } from 'grommet/themes';
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
 import { columns, data } from './data';
 
-const SizedDataTable = () => (
+export const SizedDataTable = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
       <DataTable columns={columns} data={data} size="medium" />
@@ -16,4 +15,6 @@ const SizedDataTable = () => (
   </Grommet>
 );
 
-storiesOf('DataTable', module).add('Sized', () => <SizedDataTable />);
+SizedDataTable.story = {
+  name: 'Sized',
+};

--- a/src/js/components/DataTable/stories/Sort.js
+++ b/src/js/components/DataTable/stories/Sort.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, DataTable } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -8,7 +7,7 @@ import { grommet } from 'grommet/themes';
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
 import { columns, DATA } from './data';
 
-const Example = () => {
+export const Sort = () => {
   const [sort, setSort] = React.useState({
     property: 'name',
     direction: 'desc',
@@ -30,5 +29,3 @@ const Example = () => {
     </Grommet>
   );
 };
-
-storiesOf('DataTable', module).add('Sort', () => <Example />);

--- a/src/js/components/DataTable/stories/Styled.js
+++ b/src/js/components/DataTable/stories/Styled.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, DataTable } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -8,7 +7,7 @@ import { grommet } from 'grommet/themes';
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
 import { columns, DATA } from './data';
 
-const StyledDataTable = () => (
+export const StyledDataTable = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
       <DataTable
@@ -28,4 +27,6 @@ const StyledDataTable = () => (
   </Grommet>
 );
 
-storiesOf('DataTable', module).add('Styled', () => <StyledDataTable />);
+StyledDataTable.story = {
+  name: 'Styled',
+};

--- a/src/js/components/DataTable/stories/Tunable.js
+++ b/src/js/components/DataTable/stories/Tunable.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, DataTable } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -8,7 +7,7 @@ import { grommet } from 'grommet/themes';
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
 import { columns, DATA } from './data';
 
-const TunableDataTable = () => (
+export const TunableDataTable = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
       <DataTable
@@ -24,4 +23,6 @@ const TunableDataTable = () => (
   </Grommet>
 );
 
-storiesOf('DataTable', module).add('Tunable', () => <TunableDataTable />);
+TunableDataTable.story = {
+  name: 'Tunable',
+};

--- a/src/js/components/DataTable/stories/typescript/Clickable.tsx
+++ b/src/js/components/DataTable/stories/typescript/Clickable.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, DataTable, Meter, Text } from 'grommet';
 import { grommet } from 'grommet/themes';
@@ -135,7 +134,7 @@ export const DATA: RowType[] = [
   },
 ];
 
-const ClickableDataTable = () => (
+export const ClickableDataTable = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
       {/* eslint-disable no-alert */}
@@ -149,6 +148,6 @@ const ClickableDataTable = () => (
   </Grommet>
 );
 
-storiesOf('DataTable', module).add('TS-Clickable', () => (
-  <ClickableDataTable />
-));
+ClickableDataTable.story = {
+  name: '[TS] Clickable',
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Organize the datatable storybook stories in Visualizations type

#### Where should the reviewer start?
`src/js/components/DataTable/stories/DataTable.stories.js`

#### What testing has been done on this PR?
Tests on Storybook Dashboard

#### How should this be manually tested?
`yarn storybook`

#### Any background context you want to provide?

#### What are the relevant issues?
#4651 

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30840709/98311995-853c6e00-1faf-11eb-86a1-888c9378ac40.png)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
backwards compatible