### PR TITLE
Add border prop to Grid typing

### DIFF
--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -3,6 +3,7 @@ import {
   A11yTitleType,
   AlignContentType,
   AlignSelfType,
+  BorderType,
   FillType,
   GapType,
   GridAreaType,
@@ -19,6 +20,7 @@ export interface GridProps {
   alignContent?: AlignContentType;
   areas?: { name?: string; start?: number[]; end?: number[] }[] | string[][];
   as?: PolymorphicType;
+  border?: BorderType;
   columns?:
     | (
         | 'xsmall'


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

[This PR](https://github.com/grommet/grommet/pull/4612) added border support for Grid. This adds the `border` prop to the Grid typing.

#### Where should the reviewer start?

The Grid component's typing

#### What testing has been done on this PR?

Just making sure it compiles

#### How should this be manually tested?

Try using the Grid component with a border in a typescript app

#### Any background context you want to provide?

Nope

#### What are the relevant issues?

Relevant PR: https://github.com/grommet/grommet/pull/4612

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

Was already mentioned to be updated in the other relevant PR

#### Should this PR be mentioned in the release notes?

Yes

#### Is this change backwards compatible or is it a breaking change?

Nope
