### PR TITLE
Disable yarn lint warning on Keyboard story

### DIFF
--- a/src/js/components/Keyboard/stories/OnDocument.js
+++ b/src/js/components/Keyboard/stories/OnDocument.js
@@ -5,6 +5,7 @@ import { grommet } from 'grommet/themes';
 
 export const OnDocument = () => (
   <Grommet theme={grommet}>
+    {/* eslint-disable no-alert */}
     <Keyboard target="document" onEsc={() => alert('You pressed Esc!')}>
       <Box pad="large" background="light-4">
         <Heading level="3">Press Esc on me!</Heading>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
The OnDocument story for Keyboard creates a lint warning because of alert (line 9). This PR disables the lint warning for this story.

#### Where should the reviewer start?
OnDocument.js

#### What testing has been done on this PR?
yarn lint

#### How should this be manually tested?
yarn lint

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
<img width="523" alt="Screen Shot 2020-11-06 at 9 58 00 AM" src="https://user-images.githubusercontent.com/54560994/98393483-8f458780-2016-11eb-8046-4c35d8b88de5.png">

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards Compatible