### PR TITLE
Storybook organized remaining Layout components

### DIFF
--- a/src/js/components/Main/stories/Main.stories.js
+++ b/src/js/components/Main/stories/Main.stories.js
@@ -1,0 +1,5 @@
+export { Simple } from './typescript/Simple.tsx';
+
+export default {
+  title: 'Layout/Main',
+};

--- a/src/js/components/Main/stories/typescript/Simple.tsx
+++ b/src/js/components/Main/stories/typescript/Simple.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Header, Main, Text } from 'grommet';
 import { grommet } from 'grommet/themes';
 
-const Simple = () => (
+export const Simple = () => (
   <Grommet theme={grommet}>
     <Header background="light-4" pad="small">
       <Text size="small">Header</Text>
@@ -14,5 +13,3 @@ const Simple = () => (
     </Main>
   </Grommet>
 );
-
-storiesOf('Main', module).add('Simple', () => <Simple />);

--- a/src/js/components/Sidebar/stories/Labels.js
+++ b/src/js/components/Sidebar/stories/Labels.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import {
   Avatar,
@@ -83,5 +82,3 @@ export const Labels = () => (
     </Box>
   </Grommet>
 );
-
-storiesOf('Sidebar', module).add('Labels', () => <Labels />);

--- a/src/js/components/Sidebar/stories/Sidebar.stories.js
+++ b/src/js/components/Sidebar/stories/Sidebar.stories.js
@@ -1,0 +1,7 @@
+export { SidebarIcons } from './typescript/Simple.tsx';
+export { Labels } from './Labels';
+export { TooltipsSidebar } from './Tooltips';
+
+export default {
+  title: 'Layout/Sidebar',
+};

--- a/src/js/components/Sidebar/stories/Tooltips.js
+++ b/src/js/components/Sidebar/stories/Tooltips.js
@@ -1,5 +1,4 @@
 import React, { useRef, useState } from 'react';
-import { storiesOf } from '@storybook/react';
 
 import {
   Avatar,
@@ -144,4 +143,6 @@ export const TooltipsSidebar = () => (
   </Grommet>
 );
 
-storiesOf('Sidebar', module).add('Tooltips', () => <TooltipsSidebar />);
+TooltipsSidebar.story = {
+  name: 'Tooltips',
+};

--- a/src/js/components/Sidebar/stories/typescript/Simple.tsx
+++ b/src/js/components/Sidebar/stories/typescript/Simple.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Avatar, Button, Box, grommet, Grommet, Nav, Sidebar } from 'grommet';
 
@@ -57,4 +56,6 @@ export const SidebarIcons = () => (
   </Grommet>
 );
 
-storiesOf('Sidebar', module).add('Icons', () => <SidebarIcons />);
+SidebarIcons.story = {
+  name: 'Icons',
+};

--- a/src/js/components/Stack/stack.stories.js
+++ b/src/js/components/Stack/stack.stories.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { Grommet, Box, Stack } from 'grommet';
 import { grommet } from 'grommet/themes';
 
-const SimpleStack = () => (
+export const Simple = () => (
   <Grommet>
     <Stack anchor="center">
       <Box pad="large" background="neutral-1" />
@@ -13,7 +12,7 @@ const SimpleStack = () => (
   </Grommet>
 );
 
-const FillStack = () => (
+export const Fill = () => (
   <Grommet theme={grommet} full>
     <Stack fill>
       <Box background="brand" fill>
@@ -23,6 +22,6 @@ const FillStack = () => (
   </Grommet>
 );
 
-storiesOf('Stack', module)
-  .add('Simple', () => <SimpleStack />)
-  .add('Fill', () => <FillStack />);
+export default {
+  title: 'Layout/Stack',
+};


### PR DESCRIPTION
#### What does this PR do?
Organized storybook stories for Main, Sidebar, and Stack to be under 'Layout' section

#### Where should the reviewer start?

#### What testing has been done on this PR?
Storybook

#### How should this be manually tested?
Storybook

#### Any background context you want to provide?

#### What are the relevant issues?
#4651 

#### Screenshots (if appropriate)
<img width="205" alt="Screen Shot 2020-11-06 at 10 27 03 AM" src="https://user-images.githubusercontent.com/54560994/98396216-a0909300-201a-11eb-8e37-7711817fe68a.png">

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards Compatible