### PR TITLE
Changed LayerContainer to use trapFocus

### DIFF
--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -156,7 +156,11 @@ const LayerContainer = forwardRef(
     }
     if (modal) {
       content = (
-        <FocusedContainer hidden={position === 'hidden'} restrictScroll>
+        <FocusedContainer
+          hidden={position === 'hidden'}
+          restrictScroll
+          trapFocus
+        >
           {content}
         </FocusedContainer>
       );


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changed LayerContainer to use trapFocus by default, so the background of the modal won't trap the focus.

#### Where should the reviewer start?
LayerContainer
#### What testing has been done on this PR?
Storybook https://storybook.grommet.io/?path=/story/layout-layer--corner-layer

#### How should this be manually tested?
Storybook https://storybook.grommet.io/?path=/story/layout-layer--corner-layer
#### Any background context you want to provide?
The root-cause was https://github.com/grommet/grommet/pull/4378
#### What are the relevant issues?
Closes #4721 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
b/c