### PR TITLE
Fix Digital Clock breaking with undefined/incomplete size prop

### DIFF
--- a/src/js/components/Clock/README.md
+++ b/src/js/components/Clock/README.md
@@ -407,3 +407,123 @@ Defaults to
 ```
 288px
 ```
+
+**clock.digital.text.xsmall.size**
+
+Defines the font size of the Digital Clock Expects `string`.
+
+Defaults to
+
+```
+10px
+```
+
+**clock.digital.text.xsmall.height**
+
+Defines the line height of the Digital Clock Expects `string`.
+
+Defaults to
+
+```
+1.5
+```
+
+**clock.digital.text.small.size**
+
+Defines the font size of the Digital Clock Expects `string`.
+
+Defaults to
+
+```
+14px
+```
+
+**clock.digital.text.small.height**
+
+Defines the line height of the Digital Clock Expects `string`.
+
+Defaults to
+
+```
+1.43
+```
+
+**clock.digital.text.medium.size**
+
+Defines the font size of the Digital Clock Expects `string`.
+
+Defaults to
+
+```
+18px
+```
+
+**clock.digital.text.medium.height**
+
+Defines the line height of the Digital Clock Expects `string`.
+
+Defaults to
+
+```
+1.375
+```
+
+**clock.digital.text.large.size**
+
+Defines the font size of the Digital Clock Expects `string`.
+
+Defaults to
+
+```
+22px
+```
+
+**clock.digital.text.large.height**
+
+Defines the line height of the Digital Clock Expects `string`.
+
+Defaults to
+
+```
+1.167
+```
+
+**clock.digital.text.xlarge.size**
+
+Defines the font size of the Digital Clock Expects `string`.
+
+Defaults to
+
+```
+26px
+```
+
+**clock.digital.text.xlarge.height**
+
+Defines the line height of the Digital Clock Expects `string`.
+
+Defaults to
+
+```
+1.1875
+```
+
+**clock.digital.text.xxlarge.size**
+
+Defines the font size of the Digital Clock Expects `string`.
+
+Defaults to
+
+```
+34px
+```
+
+**clock.digital.text.xxlarge.height**
+
+Defines the line height of the Digital Clock Expects `string`.
+
+Defaults to
+
+```
+1.125
+```

--- a/src/js/components/Clock/README.md
+++ b/src/js/components/Clock/README.md
@@ -420,7 +420,7 @@ Defaults to
 
 **clock.digital.text.xsmall.height**
 
-Defines the line height of the Digital Clock Expects `string`.
+Defines the line height of the Digital Clock Expects `number`.
 
 Defaults to
 
@@ -440,7 +440,7 @@ Defaults to
 
 **clock.digital.text.small.height**
 
-Defines the line height of the Digital Clock Expects `string`.
+Defines the line height of the Digital Clock Expects `number`.
 
 Defaults to
 
@@ -460,7 +460,7 @@ Defaults to
 
 **clock.digital.text.medium.height**
 
-Defines the line height of the Digital Clock Expects `string`.
+Defines the line height of the Digital Clock Expects `number`.
 
 Defaults to
 
@@ -480,7 +480,7 @@ Defaults to
 
 **clock.digital.text.large.height**
 
-Defines the line height of the Digital Clock Expects `string`.
+Defines the line height of the Digital Clock Expects `number`.
 
 Defaults to
 
@@ -500,7 +500,7 @@ Defaults to
 
 **clock.digital.text.xlarge.height**
 
-Defines the line height of the Digital Clock Expects `string`.
+Defines the line height of the Digital Clock Expects `number`.
 
 Defaults to
 
@@ -520,7 +520,7 @@ Defaults to
 
 **clock.digital.text.xxlarge.height**
 
-Defines the line height of the Digital Clock Expects `string`.
+Defines the line height of the Digital Clock Expects `number`.
 
 Defaults to
 

--- a/src/js/components/Clock/StyledClock.js
+++ b/src/js/components/Clock/StyledClock.js
@@ -37,20 +37,20 @@ const StyledAnalog = styled.svg`
   width: ${props => props.theme.clock.analog.size[props.size]};
   height: ${props => props.theme.clock.analog.size[props.size]};
 
-  ${genericStyles} ${props =>
-    props.theme.clock.analog && props.theme.clock.analog.extend};
+  ${genericStyles}
+  ${props => props.theme.clock.analog && props.theme.clock.analog.extend};
 `;
 
 StyledAnalog.defaultProps = {};
 Object.setPrototypeOf(StyledAnalog.defaultProps, defaultProps);
 
 const sizeStyle = props => {
-  // size is a combination of the level and size properties
+  // size is a combination of the size and height properties
   const size = props.size || 'medium';
-  const data = props.theme.clock.digital.text[size];
+  const data = props.theme.clock.digital.text[size] || {};
   return css`
-    font-size: ${data.size};
-    line-height: ${data.height};
+    font-size: ${data.size || props.theme.clock.digital.text.medium.size};
+    line-height: ${data.height || props.theme.clock.digital.text.medium.height};
   `;
 };
 

--- a/src/js/components/Clock/__tests__/Clock-test.js
+++ b/src/js/components/Clock/__tests__/Clock-test.js
@@ -93,4 +93,26 @@ describe('Clock', () => {
       expect(component.toJSON()).toMatchSnapshot();
     }),
   );
+
+  test('type digital custom size', () => {
+    const override = {
+      clock: {
+        digital: {
+          text: {
+            customSize: {
+              size: '30px',
+              height: 1.234,
+            },
+          },
+        },
+      },
+    };
+
+    const component = renderer.create(
+      <Grommet theme={override}>
+        <Clock type="digital" run={false} time={DURATION} size="customSize" />
+      </Grommet>,
+    );
+    expect(component.toJSON()).toMatchSnapshot();
+  });
 });

--- a/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
+++ b/src/js/components/Clock/__tests__/__snapshots__/Clock-test.js.snap
@@ -2455,6 +2455,98 @@ exports[`Clock type analog precision seconds size xxlarge 1`] = `
 </div>
 `;
 
+exports[`Clock type digital custom size 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  position: relative;
+  width: 0.8em;
+  text-align: center;
+  overflow: hidden;
+  font-size: 30px;
+  line-height: 1.234;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+      size="customSize"
+    >
+      1
+    </div>
+    <div
+      className="c2"
+      size="customSize"
+    >
+      8
+    </div>
+    <div
+      className="c2"
+      size="customSize"
+    >
+      :
+    </div>
+    <div
+      className="c2"
+      size="customSize"
+    >
+      2
+    </div>
+    <div
+      className="c2"
+      size="customSize"
+    >
+      3
+    </div>
+    <div
+      className="c2"
+      size="customSize"
+    >
+      :
+    </div>
+    <div
+      className="c2"
+      size="customSize"
+    >
+      3
+    </div>
+    <div
+      className="c2"
+      size="customSize"
+    >
+      4
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Clock type digital precision hours size large 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/Clock/doc.js
+++ b/src/js/components/Clock/doc.js
@@ -166,4 +166,64 @@ export const themeDoc = {
     type: 'string',
     defaultValue: '288px',
   },
+  'clock.digital.text.xsmall.size': {
+    description: 'Defines the font size of the Digital Clock',
+    type: 'string',
+    defaultValue: '10px',
+  },
+  'clock.digital.text.xsmall.height': {
+    description: 'Defines the line height of the Digital Clock',
+    type: 'string',
+    defaultValue: '1.5',
+  },
+  'clock.digital.text.small.size': {
+    description: 'Defines the font size of the Digital Clock',
+    type: 'string',
+    defaultValue: '14px',
+  },
+  'clock.digital.text.small.height': {
+    description: 'Defines the line height of the Digital Clock',
+    type: 'string',
+    defaultValue: '1.43',
+  },
+  'clock.digital.text.medium.size': {
+    description: 'Defines the font size of the Digital Clock',
+    type: 'string',
+    defaultValue: '18px',
+  },
+  'clock.digital.text.medium.height': {
+    description: 'Defines the line height of the Digital Clock',
+    type: 'string',
+    defaultValue: '1.375',
+  },
+  'clock.digital.text.large.size': {
+    description: 'Defines the font size of the Digital Clock',
+    type: 'string',
+    defaultValue: '22px',
+  },
+  'clock.digital.text.large.height': {
+    description: 'Defines the line height of the Digital Clock',
+    type: 'string',
+    defaultValue: '1.167',
+  },
+  'clock.digital.text.xlarge.size': {
+    description: 'Defines the font size of the Digital Clock',
+    type: 'string',
+    defaultValue: '26px',
+  },
+  'clock.digital.text.xlarge.height': {
+    description: 'Defines the line height of the Digital Clock',
+    type: 'string',
+    defaultValue: '1.1875',
+  },
+  'clock.digital.text.xxlarge.size': {
+    description: 'Defines the font size of the Digital Clock',
+    type: 'string',
+    defaultValue: '34px',
+  },
+  'clock.digital.text.xxlarge.height': {
+    description: 'Defines the line height of the Digital Clock',
+    type: 'string',
+    defaultValue: '1.125',
+  },
 };

--- a/src/js/components/Clock/doc.js
+++ b/src/js/components/Clock/doc.js
@@ -173,7 +173,7 @@ export const themeDoc = {
   },
   'clock.digital.text.xsmall.height': {
     description: 'Defines the line height of the Digital Clock',
-    type: 'string',
+    type: 'number',
     defaultValue: '1.5',
   },
   'clock.digital.text.small.size': {
@@ -183,7 +183,7 @@ export const themeDoc = {
   },
   'clock.digital.text.small.height': {
     description: 'Defines the line height of the Digital Clock',
-    type: 'string',
+    type: 'number',
     defaultValue: '1.43',
   },
   'clock.digital.text.medium.size': {
@@ -193,7 +193,7 @@ export const themeDoc = {
   },
   'clock.digital.text.medium.height': {
     description: 'Defines the line height of the Digital Clock',
-    type: 'string',
+    type: 'number',
     defaultValue: '1.375',
   },
   'clock.digital.text.large.size': {
@@ -203,7 +203,7 @@ export const themeDoc = {
   },
   'clock.digital.text.large.height': {
     description: 'Defines the line height of the Digital Clock',
-    type: 'string',
+    type: 'number',
     defaultValue: '1.167',
   },
   'clock.digital.text.xlarge.size': {
@@ -213,7 +213,7 @@ export const themeDoc = {
   },
   'clock.digital.text.xlarge.height': {
     description: 'Defines the line height of the Digital Clock',
-    type: 'string',
+    type: 'number',
     defaultValue: '1.1875',
   },
   'clock.digital.text.xxlarge.size': {
@@ -223,7 +223,7 @@ export const themeDoc = {
   },
   'clock.digital.text.xxlarge.height': {
     description: 'Defines the line height of the Digital Clock',
-    type: 'string',
+    type: 'number',
     defaultValue: '1.125',
   },
 };

--- a/src/js/components/Clock/stories/Digital.js
+++ b/src/js/components/Clock/stories/Digital.js
@@ -1,12 +1,46 @@
 import React from 'react';
 
-import { Box, Grommet, Clock } from 'grommet';
+import { Box, Grommet, Clock, Text } from 'grommet';
 import { grommet } from 'grommet/themes';
+import { deepMerge } from 'grommet/utils';
+
+const override = {
+  clock: {
+    digital: {
+      text: {
+        customSize: {
+          size: '30px',
+          height: 1.234,
+        },
+      },
+    },
+  },
+};
+
+const theme = deepMerge(grommet, override);
+
+const clockSizes = ['xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge'];
 
 export const Digital = () => (
-  <Grommet theme={grommet}>
-    <Box align="center" justify="start" pad="large">
-      <Clock type="digital" />
+  <Grommet theme={theme}>
+    <Box direction="row" gap="medium" pad="medium">
+      {clockSizes.map(size => (
+        <Box key={size} align="center">
+          <Text>{size}</Text>
+          <Clock type="digital" size={size} />
+        </Box>
+      ))}
+    </Box>
+
+    <Box direction="row" gap="medium" pad="medium">
+      <Box align="center">
+        <Text>Default size (medium)</Text>
+        <Clock type="digital" />
+      </Box>
+      <Box align="center">
+        <Text>Custom size</Text>
+        <Clock type="digital" size="customSize" />
+      </Box>
     </Box>
   </Grommet>
 );

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5474,6 +5474,126 @@ Defaults to
 \`\`\`
 288px
 \`\`\`
+
+**clock.digital.text.xsmall.size**
+
+Defines the font size of the Digital Clock Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+10px
+\`\`\`
+
+**clock.digital.text.xsmall.height**
+
+Defines the line height of the Digital Clock Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+1.5
+\`\`\`
+
+**clock.digital.text.small.size**
+
+Defines the font size of the Digital Clock Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+14px
+\`\`\`
+
+**clock.digital.text.small.height**
+
+Defines the line height of the Digital Clock Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+1.43
+\`\`\`
+
+**clock.digital.text.medium.size**
+
+Defines the font size of the Digital Clock Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+18px
+\`\`\`
+
+**clock.digital.text.medium.height**
+
+Defines the line height of the Digital Clock Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+1.375
+\`\`\`
+
+**clock.digital.text.large.size**
+
+Defines the font size of the Digital Clock Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+22px
+\`\`\`
+
+**clock.digital.text.large.height**
+
+Defines the line height of the Digital Clock Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+1.167
+\`\`\`
+
+**clock.digital.text.xlarge.size**
+
+Defines the font size of the Digital Clock Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+26px
+\`\`\`
+
+**clock.digital.text.xlarge.height**
+
+Defines the line height of the Digital Clock Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+1.1875
+\`\`\`
+
+**clock.digital.text.xxlarge.size**
+
+Defines the font size of the Digital Clock Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+34px
+\`\`\`
+
+**clock.digital.text.xxlarge.height**
+
+Defines the line height of the Digital Clock Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+1.125
+\`\`\`
 ",
   "Collapsible": "## Collapsible
 Expand or collapse animation.

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5499,7 +5499,7 @@ Defaults to
 
 **clock.digital.text.xsmall.height**
 
-Defines the line height of the Digital Clock Expects \`string\`.
+Defines the line height of the Digital Clock Expects \`number\`.
 
 Defaults to
 
@@ -5519,7 +5519,7 @@ Defaults to
 
 **clock.digital.text.small.height**
 
-Defines the line height of the Digital Clock Expects \`string\`.
+Defines the line height of the Digital Clock Expects \`number\`.
 
 Defaults to
 
@@ -5539,7 +5539,7 @@ Defaults to
 
 **clock.digital.text.medium.height**
 
-Defines the line height of the Digital Clock Expects \`string\`.
+Defines the line height of the Digital Clock Expects \`number\`.
 
 Defaults to
 
@@ -5559,7 +5559,7 @@ Defaults to
 
 **clock.digital.text.large.height**
 
-Defines the line height of the Digital Clock Expects \`string\`.
+Defines the line height of the Digital Clock Expects \`number\`.
 
 Defaults to
 
@@ -5579,7 +5579,7 @@ Defaults to
 
 **clock.digital.text.xlarge.height**
 
-Defines the line height of the Digital Clock Expects \`string\`.
+Defines the line height of the Digital Clock Expects \`number\`.
 
 Defaults to
 
@@ -5599,7 +5599,7 @@ Defaults to
 
 **clock.digital.text.xxlarge.height**
 
-Defines the line height of the Digital Clock Expects \`string\`.
+Defines the line height of the Digital Clock Expects \`number\`.
 
 Defaults to
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

The second part of splitting PR #4656

- Fix component breaking when providing undefined or incomplete object size to digital clock. Now, if the size passed as prop doesn't exist, `medium` size will be used. Also, considering that for Digital Clock size is defined as `{ size: "VALUEpx", height: value}`, if any of these props is missing, `medium` size/height will be used instead.

- Add unit test for custom size Digital Clock.

- Add Digital Clock styling properties to docs.

- Update Digital story to showcase all sizes.

#### Where should the reviewer start?

`src/js/components/Clock/StyledClock.js`

#### What testing has been done on this PR?

Storybook and unit testing.

#### How should this be manually tested?

```js
const override = {
  clock: {
    digital: {
      text: {
        customSize: {
          size: '30px',
          height: 1.234,
        },
        customMissingSize: {
          height: 1.234,
        },
        customMissingHeight: {
          size: '30px',
        }
      },
    },
  },
};

const theme = deepMerge(grommet, override);

export const Digital = () => (
  <Grommet theme={theme}>
        <Clock type="digital" />
        <Clock type="digital" size="customSize" />
        <Clock type="digital" size="customMissingSize" />
        <Clock type="digital" size="customMissingHeight" />
  </Grommet>
);
```

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

Already did.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
