### PR TITLE
Storybook story organization for Table and routing fix

### DIFF
--- a/src/js/components/Table/README.md
+++ b/src/js/components/Table/README.md
@@ -1,7 +1,7 @@
 ## Table
 A table of data organized in cells.
 
-[![](https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png)](https://storybook.grommet.io/?selectedKind=Table&full=0&addons=0&stories=1&panelRight=0) [![](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=/table&module=%2Fsrc%2FTable.js)
+[![](https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png)](https://storybook.grommet.io/?selectedKind=Visualizations-Table&full=0&addons=0&stories=1&panelRight=0) [![](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=/visualizations-table&module=%2Fsrc%2FVisualizations-Table.js)
 ## Usage
 
 ```javascript

--- a/src/js/components/Table/doc.js
+++ b/src/js/components/Table/doc.js
@@ -6,7 +6,7 @@ import { themeDocUtils } from '../../utils/themeDocUtils';
 
 export const doc = Table => {
   const DocumentedTable = describe(Table)
-    .availableAt(getAvailableAtBadge('Table'))
+    .availableAt(getAvailableAtBadge('Visualizations-Table'))
     .description('A table of data organized in cells.')
     .usage(
       // eslint-disable-next-line max-len

--- a/src/js/components/Table/stories/Custom.js
+++ b/src/js/components/Table/stories/Custom.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import {
   Box,
@@ -47,7 +46,7 @@ const customTheme = {
   },
 };
 
-const CustomThemeTable = () => (
+export const Custom = () => (
   <Grommet theme={customTheme}>
     <Box align="center" pad="large">
       <Table caption="Custom Theme Table">
@@ -84,5 +83,3 @@ const CustomThemeTable = () => (
     </Box>
   </Grommet>
 );
-
-storiesOf('Table', module).add('Custom', () => <CustomThemeTable />);

--- a/src/js/components/Table/stories/Default.js
+++ b/src/js/components/Table/stories/Default.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import {
   Box,
@@ -15,7 +14,7 @@ import {
 import { grommet } from 'grommet/themes';
 import { data, columns } from './data';
 
-const DefaultTable = () => (
+export const Default = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
       <Table caption="Default Table">
@@ -52,5 +51,3 @@ const DefaultTable = () => (
     </Box>
   </Grommet>
 );
-
-storiesOf('Table', module).add('Default', () => <DefaultTable />);

--- a/src/js/components/Table/stories/InfiniteScrollInTable.js
+++ b/src/js/components/Table/stories/InfiniteScrollInTable.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { storiesOf } from '@storybook/react';
 
 import {
   Box,
@@ -15,7 +14,7 @@ import {
   Text,
 } from 'grommet';
 
-const InfiniteScrollInTable = () => {
+export const InfiniteScrollInTable = () => {
   const step = 25;
   const [results, setResults] = useState(
     Array.from({ length: 50 }, () => Math.floor(Math.random() * 1000000)),
@@ -84,10 +83,9 @@ const InfiniteScrollInTable = () => {
   );
 };
 
-storiesOf('Table', module).add(
-  'InfiniteScroll',
-  () => <InfiniteScrollInTable />,
-  {
+InfiniteScrollInTable.story = {
+  name: 'InfiniteScroll',
+  parameters: {
     chromatic: { disable: true },
   },
-);
+};

--- a/src/js/components/Table/stories/MeterInTable.js
+++ b/src/js/components/Table/stories/MeterInTable.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import {
   Box,
@@ -16,7 +15,7 @@ import { grommet } from 'grommet/themes';
 
 const values = [20, 40, 60, 80, 100];
 
-const MeterInTable = () => (
+export const MeterInTable = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="large">
       <Box border pad={{ top: 'xsmall' }}>
@@ -46,4 +45,6 @@ const MeterInTable = () => (
   </Grommet>
 );
 
-storiesOf('Table', module).add('Meter inside table', () => <MeterInTable />);
+MeterInTable.story = {
+  name: 'Meter inside table',
+};

--- a/src/js/components/Table/stories/Table.stories.js
+++ b/src/js/components/Table/stories/Table.stories.js
@@ -1,0 +1,8 @@
+export { Custom } from './Custom';
+export { Default } from './Default';
+export { InfiniteScrollInTable } from './InfiniteScrollInTable';
+export { MeterInTable } from './MeterInTable';
+
+export default {
+  title: 'Visualizations/Table',
+};

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -14548,7 +14548,7 @@ Defaults to
   "Table": "## Table
 A table of data organized in cells.
 
-[![](https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png)](https://storybook.grommet.io/?selectedKind=Table&full=0&addons=0&stories=1&panelRight=0) [![](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=/table&module=%2Fsrc%2FTable.js)
+[![](https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png)](https://storybook.grommet.io/?selectedKind=Visualizations-Table&full=0&addons=0&stories=1&panelRight=0) [![](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=/visualizations-table&module=%2Fsrc%2FVisualizations-Table.js)
 ## Usage
 
 \`\`\`javascript


### PR DESCRIPTION
#### What does this PR do?
Organized storybook stories for Table to be under 'Visualizations' section

Fixed the link to Table stories in the grommet documentation (related to https://github.com/grommet/grommet-site/issues/185)

#### Where should the reviewer start?

#### What testing has been done on this PR?
Storybook

#### How should this be manually tested?
Storybook
And test link https://storybook.grommet.io/?selectedKind=${availableAt}&full=0&addons=0&stories=1&panelRight=0 with ${avaliableAt} set to one of the stories that has already been changed (format for avaliableAt is type-component) to updated structure or with Table on localhost

#### Any background context you want to provide?

#### What are the relevant issues?
#4651 

#### Screenshots (if appropriate)a
<img width="211" alt="Screen Shot 2020-11-13 at 11 04 56 AM" src="https://user-images.githubusercontent.com/54560994/99105609-1313ec80-25a0-11eb-9d75-f9c8e98ec443.png">

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards Compatible