### PR TITLE
Fix: Spelling fix in Box docs

### DIFF
--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -451,7 +451,7 @@ boolean
 The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
         will not wrap gracefully. If a child is a Fragment,
-        Box will not add a gap between the choldren of the Fragment.
+        Box will not add a gap between the children of the Fragment.
 
 ```
 none

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -179,7 +179,7 @@ export const doc = Box => {
     ]).description(`The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
         will not wrap gracefully. If a child is a Fragment,
-        Box will not add a gap between the choldren of the Fragment.`),
+        Box will not add a gap between the children of the Fragment.`),
     height: PropTypes.oneOfType([
       PropTypes.oneOf([
         'xxsmall',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1367,7 +1367,7 @@ boolean
 The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
         will not wrap gracefully. If a child is a Fragment,
-        Box will not add a gap between the choldren of the Fragment.
+        Box will not add a gap between the children of the Fragment.
 
 \`\`\`
 none

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -796,7 +796,7 @@ boolean",
         "description": "The amount of spacing between child elements. This
         should not be used in conjunction with 'wrap' as the gap elements
         will not wrap gracefully. If a child is a Fragment,
-        Box will not add a gap between the choldren of the Fragment.",
+        Box will not add a gap between the children of the Fragment.",
         "format": "none
 xxsmall
 xsmall


### PR DESCRIPTION
Signed-off-by: Zack Urben <zackurben@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes spelling issue in the Box component docs

#### Where should the reviewer start?

Looking at the diff or [live docs](https://v2.grommet.io/box#gap)

#### What testing has been done on this PR?

None, cant figure out the proper way to build the docs site.

#### How should this be manually tested?

Build the docs site and check the spelling

#### Any background context you want to provide?

I made this patch in the Web IDE - I may need to fix the sign-off statement.

#### What are the relevant issues?

N/A

#### Screenshots (if appropriate)

N/A

#### Do the grommet docs need to be updated?

Yes

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

Backwards Compatible