### PR TITLE
fix: Video prop and component types

### DIFF
--- a/src/js/components/Video/index.d.ts
+++ b/src/js/components/Video/index.d.ts
@@ -11,7 +11,7 @@ export interface VideoProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
   autoPlay?: boolean;
-  controls?: 'false' | 'over' | 'below';
+  controls?: false | 'over' | 'below';
   fit?: 'cover' | 'contain';
   gridArea?: GridAreaType;
   loop?: boolean;
@@ -32,7 +32,6 @@ export interface VideoProps {
 }
 
 declare const Video: React.ComponentClass<VideoProps &
-  JSX.IntrinsicElements['video'] &
   Omit<JSX.IntrinsicElements['video'], 'controls'>>;
 
 export { Video };


### PR DESCRIPTION
Signed-off-by: Ray Knight <array.knight+github@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fix the Typescript types for the Video component and its props

#### Where should the reviewer start?

src/js/components/Video/index.d.ts

#### What testing has been done on this PR?

None

#### How should this be manually tested?

See: https://github.com/grommet/grommet/issues/4746

#### Any background context you want to provide?

Only effects Typescript types

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/4746

#### Do the grommet docs need to be updated?

No, they're accurate

#### Should this PR be mentioned in the release notes?

Yes? It's a minor fix but worth surfacing

#### Is this change backwards compatible or is it a breaking change?

Yes
