### PR TITLE
Fix: TS types for the onChange event in DateInput component

### DIFF
--- a/src/js/components/DateInput/index.d.ts
+++ b/src/js/components/DateInput/index.d.ts
@@ -15,7 +15,7 @@ export interface DateInputProps {
   inline?: boolean;
   inputProps?: MaskedInputType;
   name?: string;
-  onChange?: (event: { target: { value: string | string[] } }) => void;
+  onChange?: (event: { value: string | string[] }) => void;
   value?: string | string[];
 }
 


### PR DESCRIPTION
Signed-off-by: Arthur Sakemi <arthursakemi@gmail.com>

#### What does this PR do?
Fix the TS types for the onChange event in DateInput component
described on issue #4738

#### Where should the reviewer start?
src/js/components/DateInput/index.d.ts

#### What testing has been done on this PR?
None

#### How should this be manually tested?

#### Any background context you want to provide?
Only effects Typescript types 

#### What are the relevant issues?
#4738

#### Do the grommet docs need to be updated?
No, the current docs are accurate

#### Should this PR be mentioned in the release notes?
Don't think so

#### Is this change backwards compatible or is it a breaking change?
Backwards Compatible