### PR TITLE
Update Text doc to clarify global.colors.text usage

### DIFF
--- a/src/js/components/Text/README.md
+++ b/src/js/components/Text/README.md
@@ -223,7 +223,8 @@ span
   
 **global.colors.text**
 
-The text color used for Text. Expects `object | { dark: string, light: string }`.
+The text color used for Text. In order for this to take 
+    effect, global.colors.background needs to be defined. Expects `object | { dark: string, light: string }`.
 
 Defaults to
 

--- a/src/js/components/Text/doc.js
+++ b/src/js/components/Text/doc.js
@@ -77,9 +77,7 @@ export const doc = Text => {
       ]),
       PropTypes.string,
     ])
-      .description(
-        `The font size and line space height of the text.`,
-      )
+      .description(`The font size and line space height of the text.`)
       .defaultValue('medium'),
     tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).description(
       `The DOM tag to use for the element. NOTE: This is deprecated in favor
@@ -123,7 +121,8 @@ contained within a layout component (such as Box or a generic div).`,
 
 export const themeDoc = {
   'global.colors.text': {
-    description: 'The text color used for Text.',
+    description: `The text color used for Text. In order for this to take 
+    effect, global.colors.background needs to be defined.`,
     type: 'object | { dark: string, light: string }',
     defaultValue: "{ dark: '#f8f8f8', light: '#444444' }",
   },

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -15643,7 +15643,8 @@ span
   
 **global.colors.text**
 
-The text color used for Text. Expects \`object | { dark: string, light: string }\`.
+The text color used for Text. In order for this to take 
+    effect, global.colors.background needs to be defined. Expects \`object | { dark: string, light: string }\`.
 
 Defaults to
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Clarifies that for `global.colors.text` to take effect, the theme must also define `global.colors.background`. Some approaches were considered that could try to apply the text color even if no background was defined, however this posed backwards compatibility concerns. Instead, it was decided that clarifying the docs would be sufficient. 

The thread discussion and resolution can be found here: https://github.com/grommet/grommet/issues/4606#issuecomment-729042646

#### Where should the reviewer start?
src/js/components/Text/doc.js

#### What testing has been done on this PR?
Jest snapshots updated.

#### How should this be manually tested?

#### Any background context you want to provide?
Default Text color is applied only when a theme defines theme.global.colors.background.

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/4606

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, updated here.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.