### PR TITLE
Dont restrict scroll when layerTarget present

### DIFF
--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -163,7 +163,7 @@ const LayerContainer = forwardRef(
       content = (
         <FocusedContainer
           hidden={position === 'hidden'}
-          restrictScroll
+          restrictScroll={!layerTarget ? true : undefined}
           trapFocus
         >
           {content}

--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -163,6 +163,9 @@ const LayerContainer = forwardRef(
       content = (
         <FocusedContainer
           hidden={position === 'hidden'}
+          // if layer has a target, do not restrict scroll.
+          // restricting scroll  could inhibit the user's
+          // ability to scroll the page while the layer is open.
           restrictScroll={!layerTarget ? true : undefined}
           trapFocus
         >


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Does not restrict page scroll when a layerTarget is present. A previously merged PR monitored for scroll event and that was working for the tested implementation. However, if a `Grommet` component is provided with `height="auto"` (to properly calculate the height of the entire page), suddenly the page still would not scroll. In order to overcome this, we need to adjust the `restrictScroll` prop, that is used internally for Layer in modal cases, to only be true if a Layer does not have a target.

#### Where should the reviewer start?
src/js/components/Layer/LayerContainer.js

#### What testing has been done on this PR?
Tested locally with a long page with Layer with a target on a Box contained in the page. Grommet component of the example was given `style={{height: 'auto'}}`. 

#### How should this be manually tested?
Same as above.

#### Any background context you want to provide?
Modal layer + target was restricting scroll on pages with height="auto".

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/1115

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.