### PR TITLE
Enhance CheckBoxGroup theming

### DIFF
--- a/src/js/components/CheckBoxGroup/CheckBoxGroup.js
+++ b/src/js/components/CheckBoxGroup/CheckBoxGroup.js
@@ -1,15 +1,16 @@
 import React, { forwardRef, useContext, useMemo } from 'react';
+import { ThemeContext } from 'styled-components';
 
-import { Box } from '../Box';
 import { CheckBox } from '../CheckBox';
 import { FormContext } from '../Form/FormContext';
+import { StyledCheckBoxGroup } from './StyledCheckBoxGroup';
 
 export const CheckBoxGroup = forwardRef(
   (
     {
       value: valueProp,
       disabled: disabledProp,
-      gap = 'small', // consistent with RadioButtonGroup default
+      gap,
       labelKey,
       valueKey,
       onChange,
@@ -20,6 +21,7 @@ export const CheckBoxGroup = forwardRef(
     ref,
   ) => {
     const formContext = useContext(FormContext);
+    const theme = useContext(ThemeContext) || defaultProps.theme;
 
     // In case option is a string, normalize it to be an object
     const options = useMemo(
@@ -60,7 +62,17 @@ export const CheckBoxGroup = forwardRef(
     };
 
     return (
-      <Box ref={ref} gap={gap} {...rest}>
+      <StyledCheckBoxGroup
+        ref={ref}
+        {...theme.checkBoxGroup.container}
+        gap={
+          gap ||
+          (theme.checkBoxGroup.container && theme.checkBoxGroup.container.gap
+            ? theme.checkBoxGroup.container.gap
+            : 'small') // consistent with RadioButtonGroup default
+        }
+        {...rest}
+      >
         {options.map(option => {
           const optionValue = option.value;
           const label = labelKey ? option[labelKey] : option.label;
@@ -90,7 +102,7 @@ export const CheckBoxGroup = forwardRef(
             />
           );
         })}
-      </Box>
+      </StyledCheckBoxGroup>
     );
   },
 );

--- a/src/js/components/CheckBoxGroup/README.md
+++ b/src/js/components/CheckBoxGroup/README.md
@@ -92,7 +92,7 @@ div
   
 **checkBoxGroup.container**
 
-Any valid Box props for the RadioButtonGroup container. Expects `object`.
+Any valid Box props for the CheckBoxGroup container. Expects `object`.
 
 Defaults to
 

--- a/src/js/components/CheckBoxGroup/README.md
+++ b/src/js/components/CheckBoxGroup/README.md
@@ -88,3 +88,14 @@ string
 ```
 div
 ```
+## Theme
+  
+**checkBoxGroup.container**
+
+Any valid Box props for the RadioButtonGroup container. Expects `object`.
+
+Defaults to
+
+```
+undefined
+```

--- a/src/js/components/CheckBoxGroup/StyledCheckBoxGroup.js
+++ b/src/js/components/CheckBoxGroup/StyledCheckBoxGroup.js
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+import { Box } from '../Box';
+import { defaultProps } from '../../default-props';
+
+const StyledCheckBoxGroup = styled(Box)`
+  ${props =>
+    props.theme.checkBoxGroup &&
+    props.theme.checkBoxGroup.container &&
+    props.theme.checkBoxGroup.container.extend}
+`;
+
+StyledCheckBoxGroup.defaultProps = {};
+Object.setPrototypeOf(StyledCheckBoxGroup.defaultProps, defaultProps);
+
+export { StyledCheckBoxGroup };

--- a/src/js/components/CheckBoxGroup/__tests__/CheckBoxGroup-test.js
+++ b/src/js/components/CheckBoxGroup/__tests__/CheckBoxGroup-test.js
@@ -141,6 +141,32 @@ describe('CheckBoxGroup', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('custom theme', () => {
+    const customTheme = {
+      checkBoxGroup: {
+        container: {
+          gap: 'large',
+          margin: {
+            vertical: 'small',
+          },
+        },
+      },
+    };
+
+    const { container } = render(
+      <Grommet theme={customTheme}>
+        <CheckBoxGroup
+          valueKey="valueKeyTest"
+          options={[
+            { label: 'first-label', valueKeyTest: 'First' },
+            { label: 'second-label', valueKeyTest: 'Second' },
+          ]}
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('no duplicated key error', () => {
     console.error = jest.fn();
     const errorSpy = jest.spyOn(console, 'error');

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
@@ -1,11 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CheckBoxGroup custom theme 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
+>
+  <div
+    class="StyledBox-sc-13pk1d4-0 ftUyAh StyledCheckBoxGroup-sc-2nhc5d-0"
+  >
+    <label
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
+      >
+        <input
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fYuA-Ds"
+          type="checkbox"
+        />
+        <div
+          class="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
+        />
+      </div>
+      <span>
+        first-label
+      </span>
+    </label>
+    <div
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 dLcqZl"
+    />
+    <label
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
+      >
+        <input
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fYuA-Ds"
+          type="checkbox"
+        />
+        <div
+          class="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
+        />
+      </div>
+      <span>
+        second-label
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
 exports[`CheckBoxGroup disabled renders 1`] = `
 <div
   className="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <div
-    className="StyledBox-sc-13pk1d4-0 dYebPD"
+    className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
       checked={false}
@@ -72,7 +122,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     </label>
   </div>
   <div
-    className="StyledBox-sc-13pk1d4-0 dYebPD"
+    className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
       checked={false}
@@ -106,7 +156,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     </label>
   </div>
   <div
-    className="StyledBox-sc-13pk1d4-0 dYebPD"
+    className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
       checked={false}
@@ -147,7 +197,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
   className="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <div
-    className="StyledBox-sc-13pk1d4-0 dYebPD"
+    className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
       checked={false}
@@ -266,7 +316,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 dYebPD"
+    class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
@@ -316,7 +366,7 @@ exports[`CheckBoxGroup onChange 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 dYebPD"
+    class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
@@ -377,7 +427,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 eBvFNX"
+    class="StyledBox-sc-13pk1d4-0 eBvFNX StyledCheckBoxGroup-sc-2nhc5d-0"
     tabindex="0"
   >
     <label
@@ -439,7 +489,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 eBvFNX"
+    class="StyledBox-sc-13pk1d4-0 eBvFNX StyledCheckBoxGroup-sc-2nhc5d-0"
     tabindex="0"
   >
     <label
@@ -490,7 +540,7 @@ exports[`CheckBoxGroup options renders 1`] = `
   className="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <div
-    className="StyledBox-sc-13pk1d4-0 dYebPD"
+    className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
       checked={false}
@@ -556,7 +606,7 @@ exports[`CheckBoxGroup value renders 1`] = `
   className="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <div
-    className="StyledBox-sc-13pk1d4-0 dYebPD"
+    className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
       checked={true}
@@ -634,7 +684,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 dYebPD"
+    class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"

--- a/src/js/components/CheckBoxGroup/doc.js
+++ b/src/js/components/CheckBoxGroup/doc.js
@@ -56,7 +56,7 @@ export const doc = CheckBoxGroup => {
 
 export const themeDoc = {
   'checkBoxGroup.container': {
-    description: 'Any valid Box props for the RadioButtonGroup container.',
+    description: 'Any valid Box props for the CheckBoxGroup container.',
     type: 'object',
     defaultValue: undefined,
   },

--- a/src/js/components/CheckBoxGroup/doc.js
+++ b/src/js/components/CheckBoxGroup/doc.js
@@ -53,3 +53,11 @@ export const doc = CheckBoxGroup => {
 
   return DocumentedCheckBoxGroup;
 };
+
+export const themeDoc = {
+  'checkBoxGroup.container': {
+    description: 'Any valid Box props for the RadioButtonGroup container.',
+    type: 'object',
+    defaultValue: undefined,
+  },
+};

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5069,7 +5069,7 @@ div
   
 **checkBoxGroup.container**
 
-Any valid Box props for the RadioButtonGroup container. Expects \`object\`.
+Any valid Box props for the CheckBoxGroup container. Expects \`object\`.
 
 Defaults to
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5064,7 +5064,19 @@ string
 
 \`\`\`
 div
-\`\`\`",
+\`\`\`
+## Theme
+  
+**checkBoxGroup.container**
+
+Any valid Box props for the RadioButtonGroup container. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+",
   "Clock": "## Clock
 A clock with timezone awareness.
 

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -537,6 +537,9 @@ export interface ThemeType {
       };
     };
   };
+  checkBoxGroup?: {
+    container?: BoxProps;
+  };
   clock?: {
     analog?: {
       extend?: ExtendType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -615,7 +615,10 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
     },
     checkBoxGroup: {
-      // container: {}, // any box props
+      // container: {
+        // any box props
+        // extend: undefined,
+      //},
     },
     clock: {
       analog: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -614,6 +614,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // extend: undefined,
       },
     },
+    checkBoxGroup: {
+      // container: {}, // any box props
+    },
     clock: {
       analog: {
         // extend: undefined,

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -616,9 +616,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     },
     checkBoxGroup: {
       // container: {
-        // any box props
-        // extend: undefined,
-      //},
+      //   // any box props
+      //   extend: undefined,
+      // },
     },
     clock: {
       analog: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds `checkBoxGroup` to theme and supports `checkBoxGroup.container` which accepts all Box props (aligned with `radioButtonGroup.container`. This allows users to control gap, margin, etc. of checkboxgroup from theme. Previously `gap` was only available to be controlled via prop.

#### Where should the reviewer start?
src/js/components/CheckBoxGroup/CheckBoxGroup.js

#### What testing has been done on this PR?
Added jest test and tested locally with storybook.

#### How should this be manually tested?
Create custom theme in storybook.

#### Any background context you want to provide?
Users could only control the gap between checkboxes in checkboxgroup via prop. This is not ideal from applications that want to consistently apply gap across many instances (or for design system usage).

#### What are the relevant issues?
Related to https://github.com/grommet/hpe-design-system/issues/1246

#### Screenshots (if appropriate)
In this example, a margin has been applied to the checkboxgroup itself to create the desired dimensions within a formfield and gap has been removed:

<img width="382" alt="Screen Shot 2020-11-18 at 8 43 47 AM" src="https://user-images.githubusercontent.com/12522275/99568503-57c6cb80-2984-11eb-8474-3a165b489285.png">

#### Do the grommet docs need to be updated?
Yes, updated here.

#### Should this PR be mentioned in the release notes?
Yes. CheckBoxGroup can now be themed using `checkBoxGroup.container` where all Box props are accepted.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.