### PR TITLE
Fix Grid columns prop incorrect type warning

### DIFF
--- a/src/js/components/Grid/README.md
+++ b/src/js/components/Grid/README.md
@@ -317,20 +317,23 @@ xlarge
     medium
     large
     xlarge
-    [xsmall
-small
-medium
-large
-xlarge
-full
-1/2
-1/3
-2/3
-1/4
-2/4
-3/4
-flex
-auto]
+    [
+      xsmall
+      small
+      medium
+      large
+      xlarge
+      full
+      1/2
+      1/3
+      2/3
+      1/4
+      2/4
+      3/4
+      flex
+      auto
+      string
+    ]
     string
 }
 string

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -118,7 +118,9 @@ space in the column axis.`,
         ]),
         size: PropTypes.oneOfType([
           PropTypes.oneOf(fixedSizes),
-          PropTypes.arrayOf(PropTypes.oneOf(sizes)),
+          PropTypes.arrayOf(
+            PropTypes.oneOfType([PropTypes.oneOf(sizes), PropTypes.string]),
+          ),
           PropTypes.string,
         ]),
       }),

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -37,18 +37,6 @@ export interface GridProps {
         | '3/4'
         | 'flex'
         | 'auto'
-        | 'xsmall'
-        | 'small'
-        | 'medium'
-        | 'large'
-        | 'xlarge'
-        | 'full'
-        | '1/2'
-        | '1/3'
-        | '2/3'
-        | '1/4'
-        | '2/4'
-        | '3/4'
         | string
         | string[]
       )[]
@@ -60,11 +48,6 @@ export interface GridProps {
     | {
         count?: 'fit' | 'fill' | number;
         size?:
-          | 'xsmall'
-          | 'small'
-          | 'medium'
-          | 'large'
-          | 'xlarge'
           | 'xsmall'
           | 'small'
           | 'medium'
@@ -107,18 +90,6 @@ export interface GridProps {
         | '3/4'
         | 'flex'
         | 'auto'
-        | 'xsmall'
-        | 'small'
-        | 'medium'
-        | 'large'
-        | 'xlarge'
-        | 'full'
-        | '1/2'
-        | '1/3'
-        | '2/3'
-        | '1/4'
-        | '2/4'
-        | '3/4'
         | string
         | string[]
       )[]

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -9105,20 +9105,23 @@ xlarge
     medium
     large
     xlarge
-    [xsmall
-small
-medium
-large
-xlarge
-full
-1/2
-1/3
-2/3
-1/4
-2/4
-3/4
-flex
-auto]
+    [
+      xsmall
+      small
+      medium
+      large
+      xlarge
+      full
+      1/2
+      1/3
+      2/3
+      1/4
+      2/4
+      3/4
+      flex
+      auto
+      string
+    ]
     string
 }
 string

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -4153,20 +4153,23 @@ xlarge
     medium
     large
     xlarge
-    [xsmall
-small
-medium
-large
-xlarge
-full
-1/2
-1/3
-2/3
-1/4
-2/4
-3/4
-flex
-auto]
+    [
+      xsmall
+      small
+      medium
+      large
+      xlarge
+      full
+      1/2
+      1/3
+      2/3
+      1/4
+      2/4
+      3/4
+      flex
+      auto
+      string
+    ]
     string
 }
 string",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

- Fixes Grid `columns` typing warning when using values different from common Grommet sizes.

- Remove type duplicates on Grid interface.

#### Where should the reviewer start?

`src/js/components/Grid/doc.js`

#### What testing has been done on this PR?

Manual testing.

#### How should this be manually tested?

```js
const colors = [
  'forestgreen',
  'orange',
  'wheat',
  'sienna',
  'salmon',
  'lightcoral',
  'olive',
  'thistle',
  'tan',
];

export const AppGrid = () => {
  return (
    <Grommet full theme={grommet}>
      <Grid
        fill
        gap="small"
        rows="min-content"
        columns={{ count: 3, size: ['300px', '400px'] }}
      >
        {colors.map((color, i) => (
          <Box key={color} background={color}>
            <Text>{i % 2 === 0 ? 'foo' : 'bar'}</Text>
          </Box>
        ))}
      </Grid>
    </Grommet>
  );
};
```

Values such as `min-content` and `max-content` could also be used.

#### Any background context you want to provide?

#### What are the relevant issues?

#4767 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

Just typing. Already did.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.