### PR TITLE
Changed DataChart to fix an issue with stacked bars colors

### DIFF
--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -107,7 +107,9 @@ const DataChart = forwardRef(
                 // such that they line up appropriately.
                 const totals = [];
                 return property.map(cp => {
-                  const values = seriesValues[cp];
+                  // handle object or string
+                  const aProperty = cp.property || cp;
+                  const values = seriesValues[aProperty];
                   if (!values) return undefined; // property name isn't valid
                   return values.map((v, i) => {
                     const base = totals[i] || 0;
@@ -300,8 +302,9 @@ const DataChart = forwardRef(
           const props = Array.isArray(property) ? property : [property];
           props.forEach(prop => {
             const p = prop.property || prop;
+            const pColor = prop.color || color;
             if (!result[p]) result[p] = {};
-            if (color && !result[p].color) result[p].color = color;
+            if (pColor && !result[p].color) result[p].color = pColor;
             if (point && !result[p].point) result[p].point = point;
             else if (type === 'point') result[p].point = false;
             if ((thickness || calcThickness) && !result[p].thickness)
@@ -471,21 +474,24 @@ const DataChart = forwardRef(
           if (type === 'bars') {
             // reverse to ensure area Charts are stacked in the right order
             return prop
-              .map((cProp, j) => (
-                <Chart
-                  // eslint-disable-next-line react/no-array-index-key
-                  key={j}
-                  // when property name isn't valid, send empty array
-                  values={chartValues[i][j] || []}
-                  overflow
-                  {...seriesStyles[cProp]}
-                  {...chartProps[i]}
-                  {...chartRest}
-                  type="bar"
-                  size={size}
-                  pad={pad}
-                />
-              ))
+              .map((cProp, j) => {
+                const pProp = cProp.property || cProp;
+                return (
+                  <Chart
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={j}
+                    // when property name isn't valid, send empty array
+                    values={chartValues[i][j] || []}
+                    overflow
+                    {...seriesStyles[pProp]}
+                    {...chartProps[i]}
+                    {...chartRest}
+                    type="bar"
+                    size={size}
+                    pad={pad}
+                  />
+                );
+              })
               .reverse();
           }
           return (

--- a/src/js/components/DataChart/__tests__/DataChart-test.js
+++ b/src/js/components/DataChart/__tests__/DataChart-test.js
@@ -227,6 +227,30 @@ describe('DataChart', () => {
     warnSpy.mockRestore();
   });
 
+  test('bars colors', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const component = renderer.create(
+      <Grommet>
+        <DataChart
+          data={data}
+          series={['a', 'c']}
+          chart={[
+            {
+              property: [
+                { property: 'a', color: 'graph-1' },
+                { property: 'c', color: 'graph-3' },
+              ],
+              type: 'bars',
+            },
+          ]}
+        />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+    warnSpy.mockRestore();
+  });
+
   test('bars invalid', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const component = renderer.create(

--- a/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
+++ b/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
@@ -2342,6 +2342,300 @@ exports[`DataChart bars 1`] = `
 </div>
 `;
 
+exports[`DataChart bars colors 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: yAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 1;
+  -ms-flex: 0 1;
+  flex: 0 1;
+  -webkit-flex-basis: 96px;
+  -ms-flex-preferred-size: 96px;
+  flex-basis: 96px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: xAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+}
+
+.c8 {
+  display: block;
+  max-width: 100%;
+  overflow: visible;
+}
+
+.c6 {
+  position: relative;
+  grid-area: charts;
+}
+
+.c7 {
+  position: relative;
+  display: block;
+}
+
+.c9 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <div
+          className="c4"
+        >
+          240K
+        </div>
+        <div
+          className="c4"
+        >
+          0K
+        </div>
+      </div>
+      <div
+        className="c5"
+      />
+    </div>
+    <div
+      className="c2"
+    >
+      <div
+        className="c6"
+      >
+        <div
+          className="c7"
+        >
+          <svg
+            className="c8"
+            height={192}
+            preserveAspectRatio="none"
+            viewBox="0 0 384 192"
+            width={384}
+          >
+            <g
+              fill="none"
+              stroke="#00739D"
+              strokeLinecap="butt"
+              strokeLinejoin="miter"
+              strokeWidth={96}
+            >
+              <g
+                fill="none"
+              >
+                <title />
+                <path
+                  d="M 48,143.9996 L 48,99.5552"
+                />
+              </g>
+              <g
+                fill="none"
+              >
+                <title />
+                <path
+                  d="M 336,143.9992 L 336,55.1104"
+                />
+              </g>
+            </g>
+          </svg>
+        </div>
+        <div
+          className="c9"
+        >
+          <svg
+            className="c8"
+            height={192}
+            preserveAspectRatio="none"
+            viewBox="0 0 384 192"
+            width={384}
+          >
+            <g
+              fill="none"
+              stroke="#00873D"
+              strokeLinecap="butt"
+              strokeLinejoin="miter"
+              strokeWidth={96}
+            >
+              <g
+                fill="none"
+              >
+                <title />
+                <path
+                  d="M 48,144 L 48,143.9996"
+                />
+              </g>
+              <g
+                fill="none"
+              >
+                <title />
+                <path
+                  d="M 336,144 L 336,143.9992"
+                />
+              </g>
+            </g>
+          </svg>
+        </div>
+      </div>
+      <div
+        className="c10"
+      >
+        <div
+          className="c11"
+        >
+          0
+        </div>
+        <div
+          className="c11"
+        >
+          1
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DataChart bars invalid 1`] = `
 .c0 {
   font-size: 18px;


### PR DESCRIPTION
#### What does this PR do?

Changed DataChart to fix an issue with stacked bars colors.
You can see how typescript allows `property={[{ property: 'a', color: 'graph-1' }, ...]}`.
This fixes DataChart to be able to handle it.

#### Where should the reviewer start?

DataChart.js

#### What testing has been done on this PR?

added a unit test
ran a custom story to validate as well

#### Do the grommet docs need to be updated?

well, eventually the DataChart docs need some overhaul.

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
