### PR TITLE
fix selectMultiple + search

### DIFF
--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -101,10 +101,12 @@ const Select = forwardRef(
         );
       return valueKey && valueKey.reduce ? value : applyKey(value, valueKey);
     }, [value, valueKey]);
+
+    const [initialOptions] = useState(options);
     // the option indexes present in the value
     const optionIndexesInValue = useMemo(() => {
       const result = [];
-      options.forEach((option, index) => {
+      initialOptions.forEach((option, index) => {
         if (selected !== undefined) {
           if (Array.isArray(selected)) {
             if (selected.indexOf(index) !== -1) result.push(index);
@@ -120,7 +122,7 @@ const Select = forwardRef(
         }
       });
       return result;
-    }, [options, selected, valueKey, valuedValue]);
+    }, [initialOptions, selected, valueKey, valuedValue]);
 
     const [open, setOpen] = useState(propOpen);
     useEffect(() => setOpen(propOpen), [propOpen]);

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -182,11 +182,11 @@ const Select = forwardRef(
       if (!selectValue) {
         if (optionIndexesInValue.length === 0) return '';
         if (optionIndexesInValue.length === 1)
-          return applyKey(options[optionIndexesInValue[0]], labelKey);
+          return applyKey(initialOptions[optionIndexesInValue[0]], labelKey);
         return messages.multiple;
       }
       return undefined;
-    }, [labelKey, messages, optionIndexesInValue, options, selectValue]);
+    }, [labelKey, messages, optionIndexesInValue, initialOptions, selectValue]);
 
     const iconColor = normalizeColor(
       theme.select.icons.color || 'control',

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -88,6 +88,7 @@ const SelectContainer = forwardRef(
     const [activeIndex, setActiveIndex] = useState(-1);
     const [keyboardNavigation, setKeyboardNavigation] = useState();
     const [focus, setFocus] = useState(false);
+    const [initialOptions] = useState(options);
     const searchRef = useRef();
     const optionsRef = useRef();
     // adjust activeIndex when options change
@@ -197,16 +198,19 @@ const SelectContainer = forwardRef(
           let nextSelected;
           if (multiple) {
             const nextOptionIndexesInValue = optionIndexesInValue.slice(0);
-            const valueIndex = optionIndexesInValue.indexOf(index);
+            const initialOptionsIndex = initialOptions.indexOf(options[index]);
+            const valueIndex = optionIndexesInValue.indexOf(
+              initialOptionsIndex,
+            );
             if (valueIndex === -1) {
-              nextOptionIndexesInValue.push(index);
+              nextOptionIndexesInValue.push(initialOptionsIndex);
             } else {
               nextOptionIndexesInValue.splice(valueIndex, 1);
             }
             nextValue = nextOptionIndexesInValue.map(i =>
               valueKey && valueKey.reduce
-                ? applyKey(options[i], valueKey)
-                : options[i],
+                ? applyKey(initialOptions[i], valueKey)
+                : initialOptions[i],
             );
             nextSelected = nextOptionIndexesInValue;
           } else {
@@ -223,7 +227,14 @@ const SelectContainer = forwardRef(
           });
         }
       },
-      [multiple, onChange, optionIndexesInValue, options, valueKey],
+      [
+        multiple,
+        onChange,
+        optionIndexesInValue,
+        initialOptions,
+        options,
+        valueKey,
+      ],
     );
 
     const onClear = useCallback(

--- a/src/js/components/Select/stories/Search.js
+++ b/src/js/components/Select/stories/Search.js
@@ -11,16 +11,37 @@ for (let i = 1; i <= 200; i += 1) {
 export const Search = () => {
   const [options, setOptions] = useState(defaultOptions);
   const [value, setValue] = useState('');
+  const [valueMultiple, setValueMultiple] = useState([]);
 
   return (
     <Grommet full theme={grommet}>
-      <Box fill align="center" justify="start" pad="large">
+      <Box pad="large" gap="medium" direction="row">
         <Select
           size="medium"
-          placeholder="Select"
+          placeholder="Select single option"
           value={value}
           options={options}
           onChange={({ option }) => setValue(option)}
+          onClose={() => setOptions(defaultOptions)}
+          onSearch={text => {
+            // The line below escapes regular expression special characters:
+            // [ \ ^ $ . | ? * + ( )
+            const escapedText = text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
+
+            // Create the regular expression with modified value which
+            // handles escaping special characters. Without escaping special
+            // characters, errors will appear in the console
+            const exp = new RegExp(escapedText, 'i');
+            setOptions(defaultOptions.filter(o => exp.test(o)));
+          }}
+        />
+        <Select
+          multiple
+          size="medium"
+          placeholder="Select multiple options"
+          value={valueMultiple}
+          options={options}
+          onChange={({ value: nextValue }) => setValueMultiple(nextValue)}
           onClose={() => setOptions(defaultOptions)}
           onSearch={text => {
             // The line below escapes regular expression special characters:


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
https://github.com/grommet/grommet/issues/2961
Previously it was impossible to select multiple values using search. Fix this case.

The problem was that options change when they are filtered using search. So indexes of selected values are invalid. Now we always use the initial list of options, so the indexes will always be valid.

#### Where should the reviewer start?

#### What testing has been done on this PR?
tested selecting multiple values using search and without using search
#### How should this be manually tested?
```
       <Select
          size="medium"
          placeholder="Select"
          multiple
          value={value}
          options={options}
          closeOnChange={false}
          onChange={({ value: nextValue }) => setValue(nextValue)}
          onClose={() => setOptions(defaultOptions)}
          onSearch={text => {
            const escapedText = text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
            const exp = new RegExp(escapedText, 'i');
            setOptions(defaultOptions.filter(o => exp.test(o)));
          }}
        />
```

e.g. storybook

- simple selection
- searching and then select stores correct values
- multiple select with/without searching
- selecting already selected in multiple select removes the selection
#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/2961

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
No
