### PR TITLE
chore: Updates index.d.ts with Tip export

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -64,6 +64,7 @@ export * from './components/Tabs';
 export * from './components/Text';
 export * from './components/TextArea';
 export * from './components/TextInput';
+export * from './components/Tip';
 export * from './components/Video';
 export * from './components/WorldMap';
 export * from './contexts/AnnounceContext';


### PR DESCRIPTION
#### What does this PR do?
Adds missing `Tip` TypeScript export

#### What testing has been done on this PR?
Tested/confirmed on local dev ENV.

#### How should this be manually tested?
Attempt to `import { Tip } from 'grommet';`

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/31909523/100487804-62d5d600-30bf-11eb-936a-10b7aae98942.png)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
