### PR TITLE
Fix/datatable units

### DIFF
--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -173,7 +173,7 @@ const Header = forwardRef(
             }) => {
               let content;
               const unitsContent = units ? (
-                <Text {...textProps} {...theme.dataTable.header.units.label}>
+                <Text {...textProps} {...theme.dataTable.header.units}>
                   {units}
                 </Text>
               ) : (
@@ -233,7 +233,7 @@ const Header = forwardRef(
 
               if (unitsContent) {
                 content = (
-                  <Box {...theme.dataTable.header.units.container}>
+                  <Box align="baseline" direction="row">
                     {content}
                     {unitsContent}
                   </Box>

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -112,7 +112,6 @@ const Header = ({
   ...rest
 }) => {
   const theme = useContext(ThemeContext) || defaultProps.theme;
-  console.log(theme);
   const [cellProps, layoutProps, textProps] = separateThemeProps(theme);
   const unitsProps = theme.dataTable.header.units;
 

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -30,6 +30,7 @@ const separateThemeProps = theme => {
     color,
     font,
     gap, // gap is used for space between header cell elements only
+    units: { label: unitsTextProps },
     ...rest
   } = theme.dataTable.header;
 
@@ -38,7 +39,7 @@ const separateThemeProps = theme => {
   const iconProps = { color };
   const layoutProps = { ...rest };
 
-  return [cellProps, layoutProps, textProps, iconProps];
+  return [cellProps, layoutProps, textProps, iconProps, unitsTextProps];
 };
 
 // build up CSS from basic to specific based on the supplied sub-object paths.
@@ -112,8 +113,9 @@ const Header = ({
   ...rest
 }) => {
   const theme = useContext(ThemeContext) || defaultProps.theme;
-  const [cellProps, layoutProps, textProps] = separateThemeProps(theme);
-  const unitsProps = theme.dataTable.header.units;
+  const [cellProps, layoutProps, textProps, , unitsProps] = separateThemeProps(
+    theme,
+  );
 
   let background;
   if (backgroundProp) background = backgroundProp;
@@ -167,7 +169,7 @@ const Header = ({
           }) => {
             let content;
             const unitsContent = units ? (
-              <Text {...textProps} size="xsmall" {...unitsProps}>
+              <Text {...textProps} {...unitsProps}>
                 {units}
               </Text>
             ) : (
@@ -193,7 +195,11 @@ const Header = ({
 
             if (unitsContent) {
               content = (
-                <Box direction="row" align="baseline" gap="xsmall">
+                <Box
+                  direction="row"
+                  align={theme.dataTable.header.units.align}
+                  gap={theme.dataTable.header.units.gap}
+                >
                   {content}
                   {unitsContent}
                 </Box>

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -30,7 +30,7 @@ const separateThemeProps = theme => {
     color,
     font,
     gap, // gap is used for space between header cell elements only
-    units: { label: unitsTextProps },
+    units,
     ...rest
   } = theme.dataTable.header;
 
@@ -39,7 +39,7 @@ const separateThemeProps = theme => {
   const iconProps = { color };
   const layoutProps = { ...rest };
 
-  return [cellProps, layoutProps, textProps, iconProps, unitsTextProps];
+  return [cellProps, layoutProps, textProps, iconProps];
 };
 
 // build up CSS from basic to specific based on the supplied sub-object paths.
@@ -113,9 +113,7 @@ const Header = ({
   ...rest
 }) => {
   const theme = useContext(ThemeContext) || defaultProps.theme;
-  const [cellProps, layoutProps, textProps, , unitsProps] = separateThemeProps(
-    theme,
-  );
+  const [cellProps, layoutProps, textProps] = separateThemeProps(theme);
 
   let background;
   if (backgroundProp) background = backgroundProp;
@@ -169,7 +167,7 @@ const Header = ({
           }) => {
             let content;
             const unitsContent = units ? (
-              <Text {...textProps} {...unitsProps}>
+              <Text {...textProps} {...theme.dataTable.header.units.label}>
                 {units}
               </Text>
             ) : (
@@ -195,11 +193,7 @@ const Header = ({
 
             if (unitsContent) {
               content = (
-                <Box
-                  direction="row"
-                  align={theme.dataTable.header.units.align}
-                  gap={theme.dataTable.header.units.gap}
-                >
+                <Box {...theme.dataTable.header.units.container}>
                   {content}
                   {unitsContent}
                 </Box>

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -112,7 +112,9 @@ const Header = ({
   ...rest
 }) => {
   const theme = useContext(ThemeContext) || defaultProps.theme;
+  console.log(theme);
   const [cellProps, layoutProps, textProps] = separateThemeProps(theme);
+  const unitsProps = theme.dataTable.header.units;
 
   let background;
   if (backgroundProp) background = backgroundProp;
@@ -131,7 +133,6 @@ const Header = ({
             onToggle={onToggle}
           />
         )}
-
         {(selected || onSelect) && (
           <TableCell background={background || cellProps.background}>
             {onSelect && (
@@ -153,7 +154,6 @@ const Header = ({
             )}
           </TableCell>
         )}
-
         {columns.map(
           ({
             property,
@@ -164,8 +164,17 @@ const Header = ({
             sortable,
             verticalAlign,
             size,
+            units,
           }) => {
             let content;
+            const unitsContent = units ? (
+              <Text {...textProps} size="xsmall" {...unitsProps}>
+                {units}
+              </Text>
+            ) : (
+              undefined
+            );
+
             if (typeof header === 'string') {
               content = <Text {...textProps}>{header}</Text>;
               if (
@@ -182,6 +191,15 @@ const Header = ({
                 );
               }
             } else content = header;
+
+            if (unitsContent) {
+              content = (
+                <Box direction="row" align="baseline" gap="xsmall">
+                  {content}
+                  {unitsContent}
+                </Box>
+              );
+            }
 
             if (onSort && sortable !== false) {
               let Icon;

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -862,10 +862,31 @@ Defaults to
 undefined
 ```
 
-**dataTable.header.units**
+**dataTable.header.units.align**
 
-The styles for the units display in the header. This
-    can be any valid Text properties Expects `object`.
+undefined Expects `start | center | end | baseline| stretch`.
+
+Defaults to
+
+```
+baseline
+```
+
+**dataTable.header.units.gap**
+
+undefined Expects `none | xxsmall | xsmall | small |
+       medium | large | xlarge | any css size`.
+
+Defaults to
+
+```
+xsmall
+```
+
+**dataTable.header.units.label**
+
+Any Text component properties for styling the
+    header's units text. Expects `object`.
 
 Defaults to
 

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -881,7 +881,7 @@ Defaults to
 
 ```
 {
-  size: "xsmall",
+  color: "text-xweak",
   margin: { left: "xsmall" }
 }
 ```

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -357,6 +357,7 @@ A description of the data. The order controls the column order.
     1/3
     2/3
     string,
+  units: string,
   verticalAlign: 
     middle
     top
@@ -859,6 +860,17 @@ Defaults to
 
 ```
 undefined
+```
+
+**dataTable.header.units**
+
+The styles for the units display in the header. This
+    can be any valid Text properties Expects `object`.
+
+Defaults to
+
+```
+{ size: "xsmall" }
 ```
 
 **dataTable.resize.hover.color**

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -862,25 +862,19 @@ Defaults to
 undefined
 ```
 
-**dataTable.header.units.align**
+**dataTable.header.units.container**
 
-undefined Expects `start | center | end | baseline| stretch`.
-
-Defaults to
-
-```
-baseline
-```
-
-**dataTable.header.units.gap**
-
-undefined Expects `none | xxsmall | xsmall | small |
-       medium | large | xlarge | any css size`.
+Any Box component properties for styling the combination
+    of the main header content and the units label. Expects `object`.
 
 Defaults to
 
 ```
-xsmall
+{
+  align: "baseline",
+  direction: "row",
+  gap: "xsmall",
+}
 ```
 
 **dataTable.header.units.label**

--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -872,22 +872,7 @@ Defaults to
 undefined
 ```
 
-**dataTable.header.units.container**
-
-Any Box component properties for styling the combination
-    of the main header content and the units label. Expects `object`.
-
-Defaults to
-
-```
-{
-  align: "baseline",
-  direction: "row",
-  gap: "xsmall",
-}
-```
-
-**dataTable.header.units.label**
+**dataTable.header.units**
 
 Any Text component properties for styling the
     header's units text. Expects `object`.
@@ -895,7 +880,10 @@ Any Text component properties for styling the
 Defaults to
 
 ```
-{ size: "xsmall" }
+{
+  size: "xsmall",
+  margin: { left: "xsmall" }
+}
 ```
 
 **dataTable.resize.hover.color**

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -858,6 +858,24 @@ describe('DataTable', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('units', () => {
+    const { container } = render(
+      <Grommet>
+        <DataTable
+          columns={[
+            { property: 'a', header: 'A', footer: 'Total' },
+            { property: 'b', header: 'B', units: '(TiB)' },
+          ]}
+          data={[
+            { a: 'one', b: 1 },
+            { a: 'two', b: 2 },
+          ]}
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('placeholder', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -856,4 +856,23 @@ describe('DataTable', () => {
     fireEvent.mouseOver(getByLabelText('select beta'));
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('units', () => {
+    const { container } = render(
+      <Grommet>
+        <DataTable
+          columns={[
+            { property: 'a', header: 'A' },
+            { property: 'b', header: 'B', units: '(MiB)' },
+          ]}
+          data={[
+            { a: 'zero', b: 0 },
+            { a: 'one', b: 1 },
+            { a: 'two', b: 2 },
+          ]}
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -14414,8 +14414,9 @@ exports[`DataTable units 1`] = `
 
 .c7 {
   margin-left: 6px;
-  font-size: 12px;
-  line-height: 18px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #666666;
 }
 
 .c11 {

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -13929,3 +13929,297 @@ exports[`DataTable themeColumnSizes 1`] = `
   </table>
 </div>
 `;
+
+exports[`DataTable units 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 6px;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c10 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c8 {
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.c12 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c2 {
+  border-spacing: 0;
+  border-collapse: separate;
+  height: auto;
+}
+
+.c9:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    width: 3px;
+  }
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-xrlyjm-3"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c6"
+            >
+              <span
+                class="c5"
+              >
+                B
+              </span>
+              <div
+                class="c7"
+              />
+              <span
+                class="c8"
+              >
+                (MiB)
+              </span>
+            </div>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 c9"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c10 "
+          scope="row"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              zero
+            </span>
+          </div>
+        </th>
+        <td
+          class="c10 "
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c5"
+            >
+              0
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c10 "
+          scope="row"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c10 "
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c5"
+            >
+              1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c10 "
+          scope="row"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c10 "
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c5"
+            >
+              2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -14407,6 +14407,23 @@ exports[`DataTable units 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c7 {
+  margin-left: 6px;
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -14442,7 +14459,7 @@ exports[`DataTable units 1`] = `
   flex-direction: row;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -14454,16 +14471,6 @@ exports[`DataTable units 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c7 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  width: 6px;
 }
 
 .c3 {
@@ -14479,12 +14486,25 @@ exports[`DataTable units 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c9 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c12 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-top: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -14497,36 +14517,15 @@ exports[`DataTable units 1`] = `
   width: inherit;
 }
 
-.c5 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c8 {
-  font-size: 12px;
-  line-height: 18px;
-}
-
-.c12 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
 .c2 {
+  position: relative;
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
 }
 
-.c9:focus {
+.c8:focus {
   outline: 2px solid #6FFFB0;
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    width: 3px;
-  }
 }
 
 @media all and (min--moz-device-pixel-ratio:0) {
@@ -14576,13 +14575,10 @@ exports[`DataTable units 1`] = `
               >
                 B
               </span>
-              <div
-                class="c7"
-              />
               <span
-                class="c8"
+                class="c7"
               >
-                (MiB)
+                (TiB)
               </span>
             </div>
           </div>
@@ -14590,61 +14586,30 @@ exports[`DataTable units 1`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 c9"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 c8"
     >
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <th
-          class="c10 "
+          class="c9 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c10"
           >
             <span
-              class="c12"
-            >
-              zero
-            </span>
-          </div>
-        </th>
-        <td
-          class="c10 "
-        >
-          <div
-            class="c11"
-          >
-            <span
-              class="c5"
-            >
-              0
-            </span>
-          </div>
-        </td>
-      </tr>
-      <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-      >
-        <th
-          class="c10 "
-          scope="row"
-        >
-          <div
-            class="c11"
-          >
-            <span
-              class="c12"
+              class="c11"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c9 "
         >
           <div
-            class="c11"
+            class="c10"
           >
             <span
               class="c5"
@@ -14658,24 +14623,24 @@ exports[`DataTable units 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <th
-          class="c10 "
+          class="c9 "
           scope="row"
         >
           <div
-            class="c11"
+            class="c10"
           >
             <span
-              class="c12"
+              class="c11"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="c10 "
+          class="c9 "
         >
           <div
-            class="c11"
+            class="c10"
           >
             <span
               class="c5"
@@ -14686,6 +14651,34 @@ exports[`DataTable units 1`] = `
         </td>
       </tr>
     </tbody>
+    <tfoot
+      class="StyledTable__StyledTableFooter-sc-1m3u5g-5 "
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2"
+      >
+        <td
+          class="c12 "
+        >
+          <div
+            class="c10"
+          >
+            <span
+              class="c11"
+            >
+              Total
+            </span>
+          </div>
+        </td>
+        <td
+          class="c12 "
+        >
+          <div
+            class="c10"
+          />
+        </td>
+      </tr>
+    </tfoot>
   </table>
 </div>
 `;

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -122,6 +122,7 @@ export const doc = DataTable => {
           ]),
           PropTypes.string,
         ]),
+        units: PropTypes.string,
         verticalAlign: PropTypes.oneOf(['middle', 'top', 'bottom']),
       }),
     ).description(
@@ -392,6 +393,12 @@ export const themeDoc = {
     description: 'The pad around the contents of the header cell.',
     type: 'string | object',
     defaultValue: undefined,
+  },
+  'dataTable.header.units': {
+    description: `The styles for the units display in the header. This
+    can be any valid Text properties`,
+    type: 'object',
+    defaultValue: '{ size: "xsmall" }',
   },
   'dataTable.resize.hover.color': {
     description: 'The color of the resizer when hovered over.',

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -406,7 +406,7 @@ export const themeDoc = {
     header's units text.`,
     type: 'object',
     defaultValue: `{
-  size: "xsmall",
+  color: "text-xweak",
   margin: { left: "xsmall" }
 }`,
   },

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -394,17 +394,15 @@ export const themeDoc = {
     type: 'string | object',
     defaultValue: undefined,
   },
-  'dataTable.header.units.align': {
-    descriptions:
-      'The vertical alignment of the units text in the column header.',
-    type: 'start | center | end | baseline| stretch',
-    defaultValue: 'baseline',
-  },
-  'dataTable.header.units.gap': {
-    descriptions: 'The gap between the header text and units label',
-    type: `none | xxsmall | xsmall | small |
-       medium | large | xlarge | any css size`,
-    defaultValue: 'xsmall',
+  'dataTable.header.units.container': {
+    description: `Any Box component properties for styling the combination
+    of the main header content and the units label.`,
+    type: 'object',
+    defaultValue: `{
+  align: "baseline",
+  direction: "row",
+  gap: "xsmall",
+}`,
   },
   'dataTable.header.units.label': {
     description: `Any Text component properties for styling the

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -401,21 +401,14 @@ export const themeDoc = {
     type: 'string | object',
     defaultValue: undefined,
   },
-  'dataTable.header.units.container': {
-    description: `Any Box component properties for styling the combination
-    of the main header content and the units label.`,
-    type: 'object',
-    defaultValue: `{
-  align: "baseline",
-  direction: "row",
-  gap: "xsmall",
-}`,
-  },
-  'dataTable.header.units.label': {
+  'dataTable.header.units': {
     description: `Any Text component properties for styling the
     header's units text.`,
     type: 'object',
-    defaultValue: '{ size: "xsmall" }',
+    defaultValue: `{
+  size: "xsmall",
+  margin: { left: "xsmall" }
+}`,
   },
   'dataTable.resize.hover.color': {
     description: 'The color of the resizer when hovered over.',

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -394,9 +394,21 @@ export const themeDoc = {
     type: 'string | object',
     defaultValue: undefined,
   },
-  'dataTable.header.units': {
-    description: `The styles for the units display in the header. This
-    can be any valid Text properties`,
+  'dataTable.header.units.align': {
+    descriptions:
+      'The vertical alignment of the units text in the column header.',
+    type: 'start | center | end | baseline| stretch',
+    defaultValue: 'baseline',
+  },
+  'dataTable.header.units.gap': {
+    descriptions: 'The gap between the header text and units label',
+    type: `none | xxsmall | xsmall | small |
+       medium | large | xlarge | any css size`,
+    defaultValue: 'xsmall',
+  },
+  'dataTable.header.units.label': {
+    description: `Any Text component properties for styling the
+    header's units text.`,
     type: 'object',
     defaultValue: '{ size: "xsmall" }',
   },

--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -47,6 +47,7 @@ export interface ColumnConfig<TRowType> {
   search?: boolean;
   sortable?: boolean;
   size?: ColumnSizeType | string;
+  units?: string;
   verticalAlign?: 'middle' | 'top' | 'bottom';
 }
 

--- a/src/js/components/DataTable/stories/DataTable.stories.js
+++ b/src/js/components/DataTable/stories/DataTable.stories.js
@@ -16,6 +16,7 @@ export { SizedDataTable } from './Sized';
 export { Sort } from './Sort';
 export { StyledDataTable } from './Styled';
 export { TunableDataTable } from './Tunable';
+export { UnitsDataTable } from './Units';
 
 export default {
   title: 'Visualizations/DataTable',

--- a/src/js/components/DataTable/stories/Units.js
+++ b/src/js/components/DataTable/stories/Units.js
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import { Grommet, Box, DataTable, Heading } from 'grommet';
+import { grommet } from 'grommet/themes';
+
+export const DATA = [
+  {
+    name: 'Boot',
+    free: 24,
+    size: 4,
+  },
+  {
+    name: 'Backup',
+    free: 30,
+    size: 12,
+  },
+  {
+    name: 'Application',
+    free: 40,
+    size: 23,
+  },
+];
+
+const columns = [
+  { property: 'name', header: 'Disk Name', size: 'small' },
+  {
+    property: 'size',
+    header: 'Size',
+    size: 'xsmall',
+    align: 'end',
+    units: '(TiB)',
+  },
+  {
+    property: 'free',
+    header: 'Free',
+    size: 'xsmall',
+    align: 'end',
+    units: '%',
+  },
+];
+
+export const UnitsDataTable = () => (
+  <Grommet theme={grommet}>
+    <Box align="center" pad="large">
+      <Heading level="3">Table with units in the heading</Heading>
+      <DataTable columns={columns} data={DATA} primaryKey={false} />
+    </Box>
+  </Grommet>
+);
+
+UnitsDataTable.story = {
+  name: 'Units',
+};

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -2220,7 +2220,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
               >
                 <input
                   autocomplete="off"
-                  class="StyledTextInput-sc-1x30a0s-0 kfWKkd Select__SelectTextInput-sc-17idtfo-0 bIurki"
+                  class="StyledTextInput-sc-1x30a0s-0 nnMiQ Select__SelectTextInput-sc-17idtfo-0 bIurki"
                   id="test-select__input"
                   name="test-select"
                   placeholder="test select"

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -7091,25 +7091,19 @@ Defaults to
 undefined
 \`\`\`
 
-**dataTable.header.units.align**
+**dataTable.header.units.container**
 
-undefined Expects \`start | center | end | baseline| stretch\`.
-
-Defaults to
-
-\`\`\`
-baseline
-\`\`\`
-
-**dataTable.header.units.gap**
-
-undefined Expects \`none | xxsmall | xsmall | small |
-       medium | large | xlarge | any css size\`.
+Any Box component properties for styling the combination
+    of the main header content and the units label. Expects \`object\`.
 
 Defaults to
 
 \`\`\`
-xsmall
+{
+  align: \\"baseline\\",
+  direction: \\"row\\",
+  gap: \\"xsmall\\",
+}
 \`\`\`
 
 **dataTable.header.units.label**

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -7110,7 +7110,7 @@ Defaults to
 
 \`\`\`
 {
-  size: \\"xsmall\\",
+  color: \\"text-xweak\\",
   margin: { left: \\"xsmall\\" }
 }
 \`\`\`

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -7101,22 +7101,7 @@ Defaults to
 undefined
 \`\`\`
 
-**dataTable.header.units.container**
-
-Any Box component properties for styling the combination
-    of the main header content and the units label. Expects \`object\`.
-
-Defaults to
-
-\`\`\`
-{
-  align: \\"baseline\\",
-  direction: \\"row\\",
-  gap: \\"xsmall\\",
-}
-\`\`\`
-
-**dataTable.header.units.label**
+**dataTable.header.units**
 
 Any Text component properties for styling the
     header's units text. Expects \`object\`.
@@ -7124,7 +7109,10 @@ Any Text component properties for styling the
 Defaults to
 
 \`\`\`
-{ size: \\"xsmall\\" }
+{
+  size: \\"xsmall\\",
+  margin: { left: \\"xsmall\\" }
+}
 \`\`\`
 
 **dataTable.resize.hover.color**

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -7091,10 +7091,31 @@ Defaults to
 undefined
 \`\`\`
 
-**dataTable.header.units**
+**dataTable.header.units.align**
 
-The styles for the units display in the header. This
-    can be any valid Text properties Expects \`object\`.
+undefined Expects \`start | center | end | baseline| stretch\`.
+
+Defaults to
+
+\`\`\`
+baseline
+\`\`\`
+
+**dataTable.header.units.gap**
+
+undefined Expects \`none | xxsmall | xsmall | small |
+       medium | large | xlarge | any css size\`.
+
+Defaults to
+
+\`\`\`
+xsmall
+\`\`\`
+
+**dataTable.header.units.label**
+
+Any Text component properties for styling the
+    header's units text. Expects \`object\`.
 
 Defaults to
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -6586,6 +6586,7 @@ A description of the data. The order controls the column order.
     1/3
     2/3
     string,
+  units: string,
   verticalAlign: 
     middle
     top
@@ -7088,6 +7089,17 @@ Defaults to
 
 \`\`\`
 undefined
+\`\`\`
+
+**dataTable.header.units**
+
+The styles for the units display in the header. This
+    can be any valid Text properties Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{ size: \\"xsmall\\" }
 \`\`\`
 
 **dataTable.resize.hover.color**

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -626,8 +626,7 @@ export interface ThemeType {
       };
       pad?: PadType;
       units?: {
-        gap?: GapType;
-        align?: string;
+        container?: BoxProps;
         label?: TextProps;
       };
     };

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -625,6 +625,11 @@ export interface ThemeType {
         background?: BackgroundType;
       };
       pad?: PadType;
+      units?: {
+        gap?: GapType;
+        align?: string;
+        label?: TextProps;
+      };
     };
     groupHeader?: {
       border?: {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -625,10 +625,7 @@ export interface ThemeType {
         background?: BackgroundType;
       };
       pad?: PadType;
-      units?: {
-        container?: BoxProps;
-        label?: TextProps;
-      };
+      units?: TextProps;
     };
     groupHeader?: {
       border?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -724,7 +724,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // },
         // pad: undefined,
         units: {
-          size: 'xsmall',
+          color: 'text-xweak',
           margin: { left: 'xsmall' },
         },
       },

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -724,14 +724,8 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // },
         // pad: undefined,
         units: {
-          container: {
-            align: 'baseline',
-            direction: 'row',
-            gap: 'xsmall',
-          },
-          label: {
-            size: 'xsmall',
-          },
+          size: 'xsmall',
+          margin: { left: 'xsmall' },
         },
       },
       icons: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -724,8 +724,11 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // },
         // pad: undefined,
         units: {
-          align: 'baseline',
-          gap: 'xsmall',
+          container: {
+            align: 'baseline',
+            direction: 'row',
+            gap: 'xsmall',
+          },
           label: {
             size: 'xsmall',
           },

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -723,6 +723,13 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         //   background: undefined,
         // },
         // pad: undefined,
+        units: {
+          align: 'baseline',
+          gap: 'xsmall',
+          label: {
+            size: 'xsmall',
+          },
+        },
       },
       icons: {
         ascending: FormDown,


### PR DESCRIPTION
#### What does this PR do?
Adds a `units` string to the column definition for DataTables. This string will be displayed in the header with a default text size of `xsmall` and the same text properties used for the column header. It also will use any properties specified under `datatable.header.units` in the theme for units Text component.

#### Where should the reviewer start?
DataTable/Header.js

#### What testing has been done on this PR?
A 'Units' story has been added to the DataTables storybook.
A Jest test case has been added to the DataTables Jest test.

#### How should this be manually tested?
Look at the Units story in the DataTables storybook.

#### Any background context you want to provide?
See #4610 and #1190

#### What are the relevant issues?
Fixes #4610 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Done

#### Should this PR be mentioned in the release notes?
Sure.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
