### PR TITLE
Changed DataTable Footer to fix an issue with showing pin background even in non-pinned situations

### DIFF
--- a/src/js/components/DataTable/Footer.js
+++ b/src/js/components/DataTable/Footer.js
@@ -41,7 +41,7 @@ const Footer = ({
             column={column}
             datum={footerValues}
             pad={pad}
-            pin={pin}
+            pin={pin.length ? pin : undefined}
             primaryProperty={primaryProperty}
           />
         );

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -8053,6 +8053,19 @@ exports[`DataTable pin + background 1`] = `
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
+  border-top: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c19 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
@@ -8399,7 +8412,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </td>
         <td
-          class="c15 "
+          class="c18 "
         >
           <div
             class="c11"
@@ -8432,7 +8445,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </th>
         <th
-          class="c18 "
+          class="c19 "
           scope="col"
         >
           <div


### PR DESCRIPTION
#### What does this PR do?

Changed DataTable Footer to fix an issue with showing pin background even in non-pinned situations

#### What testing has been done on this PR?

white-box test with Simple story

#### How should this be manually tested?

Storybook

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
