### PR TITLE
Fix DataTable onSelect type

### DIFF
--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -100,7 +100,7 @@ export interface DataTableProps<TRowType = any> {
 }
 
 declare class DataTable<TRowType = any> extends React.Component<
-  DataTableProps<TRowType> & JSX.IntrinsicElements['table']
+  DataTableProps<TRowType> & Omit<JSX.IntrinsicElements['table'], 'onSelect'>
 > {}
 
 export { DataTable };

--- a/src/js/components/DataTable/stories/DataTable.stories.js
+++ b/src/js/components/DataTable/stories/DataTable.stories.js
@@ -7,6 +7,7 @@ export { Custom } from './Custom';
 export { Fill } from './Fill';
 export { GroupedDataTable } from './Grouped';
 export { InfiniteScrollDataTable } from './InfiniteScrollDataTable';
+export { OnSelectDataTable } from './typescript/OnSelect.tsx';
 export { NoPrimaryKeyDataTable } from './NoPrimary';
 export { ResizableDataTable } from './ResizableColumns';
 export { Select } from './Select';

--- a/src/js/components/DataTable/stories/typescript/OnSelect.tsx
+++ b/src/js/components/DataTable/stories/typescript/OnSelect.tsx
@@ -1,0 +1,157 @@
+import React, { ReactText, useState } from 'react';
+
+import { Grommet, Box, DataTable, Meter, Text } from 'grommet';
+import { grommet } from 'grommet/themes';
+
+import { ColumnConfig } from '../..';
+
+// This story uses TypeScript
+const amountFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+});
+
+export const columns: ColumnConfig<RowType>[] = [
+  {
+    property: 'name',
+    header: <Text>Name with extra</Text>,
+    primary: true,
+    footer: 'Total',
+  },
+  {
+    property: 'location',
+    header: 'Location',
+  },
+  {
+    property: 'date',
+    header: 'Date',
+    render: datum =>
+      datum.date && new Date(datum.date).toLocaleDateString('en-US'),
+    align: 'end',
+  },
+  {
+    property: 'percent',
+    header: 'Percent Complete',
+    render: datum => (
+      <Box pad={{ vertical: 'xsmall' }}>
+        <Meter
+          values={[{ value: datum.percent }]}
+          thickness="small"
+          size="small"
+        />
+      </Box>
+    ),
+  },
+  {
+    property: 'paid',
+    header: 'Paid',
+    render: datum => amountFormatter.format(datum.paid / 100),
+    align: 'end',
+    aggregate: 'sum',
+    footer: { aggregate: true },
+  },
+];
+
+const locations = ['Boise', 'Fort Collins', 'Bay Area', 'Houston'];
+
+export const data = [];
+
+for (let i = 0; i < 40; i += 1) {
+  data.push({
+    name: `Name ${i + 1}`,
+    location: locations[i % locations.length],
+    date: `2018-07-${(i % 30) + 1}`,
+    percent: (i % 11) * 10,
+    paid: ((i + 1) * 17) % 1000,
+  });
+}
+
+interface RowType {
+  name: string;
+  location: string;
+  date: string;
+  percent: number;
+  paid: number;
+}
+
+export const DATA: RowType[] = [
+  {
+    name: 'Shimi',
+    location: '',
+    date: '',
+    percent: 0,
+    paid: 0,
+  },
+  {
+    name: 'Bryan',
+    location: 'Fort Collins',
+    date: '2018-06-10',
+    percent: 30,
+    paid: 1234,
+  },
+  {
+    name: 'Chris',
+    location: 'Bay Area',
+    date: '2018-06-09',
+    percent: 40,
+    paid: 2345,
+  },
+  {
+    name: 'Eric',
+    location: 'Bay Area',
+    date: '2018-06-11',
+    percent: 80,
+    paid: 3456,
+  },
+  {
+    name: 'Matt',
+    location: 'Fort Collins',
+    date: '2018-06-10',
+    percent: 60,
+    paid: 1234,
+  },
+  {
+    name: 'Taylor',
+    location: 'Bay Area',
+    date: '2018-06-09',
+    percent: 40,
+    paid: 3456,
+  },
+  {
+    name: 'Mike',
+    location: 'Boise',
+    date: '2018-06-11',
+    percent: 50,
+    paid: 1234,
+  },
+  {
+    name: 'Ian',
+    location: 'Houston',
+    date: '2018-06-10',
+    percent: 10,
+    paid: 2345,
+  },
+];
+
+export const OnSelectDataTable = () => {
+  const [select, setSelect] = useState<ReactText[]>([]);
+
+  return (
+    <Grommet theme={grommet}>
+      <Box align="center" pad="large">
+        <DataTable
+          columns={columns}
+          data={DATA}
+          step={10}
+          select={select}
+          onSelect={setSelect}
+        />
+      </Box>
+    </Grommet>
+  );
+};
+
+OnSelectDataTable.story = {
+  name: '[TS] OnSelect',
+};


### PR DESCRIPTION
#### What does this PR do?

Fixes DataTable onSelect types by excluding the onSelect inferred from table

#### Where should the reviewer start?

src/js/components/DataTable/index.d.ts

#### What testing has been done on this PR?

Storybook stories

#### How should this be manually tested?

See added storybook story or by linking the package and using DataTables onSelect -function

#### What are the relevant issues?

#4784 

#### Do the grommet docs need to be updated?

No


