### PR TITLE
Added textAlign to TextInput

### DIFF
--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -203,7 +203,7 @@ exports[`Form controlled controlled 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             name="test"
             placeholder="test input"
             value="v"
@@ -237,7 +237,7 @@ exports[`Form controlled controlled 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             name="test"
             placeholder="test input"
             value="v"
@@ -479,7 +479,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             id="test"
             name="test"
             value="v"
@@ -519,7 +519,7 @@ exports[`Form controlled controlled FormField deprecated 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             id="test"
             name="test"
             value="v"
@@ -740,7 +740,7 @@ exports[`Form controlled controlled input 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             name="test"
             placeholder="test input"
             value="v"
@@ -774,7 +774,7 @@ exports[`Form controlled controlled input 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             name="test"
             placeholder="test input"
             value="v"
@@ -995,7 +995,7 @@ exports[`Form controlled controlled input lazy 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             name="test"
             placeholder="test input"
             value="v"
@@ -1029,7 +1029,7 @@ exports[`Form controlled controlled input lazy 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             name="test"
             placeholder="test input"
             value="v"
@@ -1250,7 +1250,7 @@ exports[`Form controlled controlled lazy 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             name="test"
             placeholder="test input"
             value="v"
@@ -1284,7 +1284,7 @@ exports[`Form controlled controlled lazy 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             name="test"
             placeholder="test input"
             value="v"
@@ -1692,7 +1692,7 @@ exports[`Form controlled controlled onValidate 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             name="test"
             placeholder="test input"
             value=""
@@ -1940,7 +1940,7 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             name="test"
             placeholder="test input"
             value=""
@@ -2188,7 +2188,7 @@ exports[`Form controlled controlled onValidate custom info 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             name="test"
             placeholder="test input"
             value=""

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -1532,7 +1532,7 @@ exports[`Form uncontrolled uncontrolled 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             name="test"
             placeholder="test input"
             value=""
@@ -1566,7 +1566,7 @@ exports[`Form uncontrolled uncontrolled 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             name="test"
             placeholder="test input"
             value=""
@@ -1787,7 +1787,7 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             name="test"
             placeholder="test input"
             value=""
@@ -2035,7 +2035,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             name="test"
             placeholder="test input"
             value=""
@@ -2283,7 +2283,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ"
             name="test"
             placeholder="test input"
             value=""

--- a/src/js/components/Heading/StyledHeading.js
+++ b/src/js/components/Heading/StyledHeading.js
@@ -1,6 +1,11 @@
 import styled, { css } from 'styled-components';
 
-import { breakpointStyle, genericStyles, normalizeColor } from '../../utils';
+import {
+  breakpointStyle,
+  genericStyles,
+  normalizeColor,
+  textAlignStyle,
+} from '../../utils';
 import { defaultProps } from '../../default-props';
 
 const sizeStyle = props => {
@@ -61,16 +66,6 @@ const fontFamily = props => {
       `
     : '';
 };
-
-const TEXT_ALIGN_MAP = {
-  center: 'center',
-  end: 'right',
-  start: 'left',
-};
-
-const textAlignStyle = css`
-  text-align: ${props => TEXT_ALIGN_MAP[props.textAlign]};
-`;
 
 const truncateStyle = `
   white-space: nowrap;

--- a/src/js/components/Paragraph/StyledParagraph.js
+++ b/src/js/components/Paragraph/StyledParagraph.js
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { genericStyles, normalizeColor } from '../../utils';
+import { genericStyles, normalizeColor, textAlignStyle } from '../../utils';
 import { defaultProps } from '../../default-props';
 
 const colorStyle = css`
@@ -19,16 +19,6 @@ const sizeStyle = props => {
 
 const fontFamily = css`
   font-family: ${props => props.theme.paragraph.font.family};
-`;
-
-const TEXT_ALIGN_MAP = {
-  center: 'center',
-  end: 'right',
-  start: 'left',
-};
-
-const textAlignStyle = css`
-  text-align: ${props => TEXT_ALIGN_MAP[props.textAlign]};
 `;
 
 const StyledParagraph = styled.p`

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -2552,7 +2552,7 @@ exports[`Select complex options and children 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 kfWKkd Select__SelectTextInput-sc-17idtfo-0 bIurki"
+          class="StyledTextInput-sc-1x30a0s-0 nnMiQ Select__SelectTextInput-sc-17idtfo-0 bIurki"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -3062,7 +3062,7 @@ exports[`Select disabled 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 kfWKkd Select__SelectTextInput-sc-17idtfo-0 cANsmG"
+          class="StyledTextInput-sc-1x30a0s-0 nnMiQ Select__SelectTextInput-sc-17idtfo-0 cANsmG"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -6877,7 +6877,7 @@ exports[`Select prop: onOpen 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 kfWKkd Select__SelectTextInput-sc-17idtfo-0 bIurki"
+          class="StyledTextInput-sc-1x30a0s-0 nnMiQ Select__SelectTextInput-sc-17idtfo-0 bIurki"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -7742,7 +7742,7 @@ exports[`Select renders custom up and down icons 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kfWKkd Select__SelectTextInput-sc-17idtfo-0 bIurki"
+            class="StyledTextInput-sc-1x30a0s-0 nnMiQ Select__SelectTextInput-sc-17idtfo-0 bIurki"
             placeholder="Select..."
             readonly=""
             tabindex="-1"
@@ -9657,7 +9657,7 @@ exports[`Select search 3`] = `
 exports[`Select search 4`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 iQPXZo"
+  class="StyledTextInput-sc-1x30a0s-0 gyrSNV"
   type="search"
   value=""
 />
@@ -9666,7 +9666,7 @@ exports[`Select search 4`] = `
 exports[`Select search 5`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 iQPXZo"
+  class="StyledTextInput-sc-1x30a0s-0 gyrSNV"
   type="search"
   value="o"
 />

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -2895,7 +2895,7 @@ exports[`Select Controlled multiple values 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 kfWKkd Select__SelectTextInput-sc-17idtfo-0 bIurki"
+          class="StyledTextInput-sc-1x30a0s-0 nnMiQ Select__SelectTextInput-sc-17idtfo-0 bIurki"
           id="test-select__input"
           placeholder="test select"
           readonly=""

--- a/src/js/components/Text/StyledText.js
+++ b/src/js/components/Text/StyledText.js
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { genericStyles, normalizeColor } from '../../utils';
+import { genericStyles, normalizeColor, textAlignStyle } from '../../utils';
 import { defaultProps } from '../../default-props';
 
 const sizeStyle = props => {
@@ -17,16 +17,6 @@ const sizeStyle = props => {
     line-height: normal;
   `;
 };
-
-const TEXT_ALIGN_MAP = {
-  center: 'center',
-  end: 'right',
-  start: 'left',
-};
-
-const textAlignStyle = css`
-  text-align: ${props => TEXT_ALIGN_MAP[props.textAlign]};
-`;
 
 const truncateStyle = `
   white-space: nowrap;

--- a/src/js/components/TextInput/README.md
+++ b/src/js/components/TextInput/README.md
@@ -228,6 +228,16 @@ suggestions and instead rely on the user to type more.
 ]
 ```
 
+**textAlign**
+
+How to align the text inside the input. Defaults to `start`.
+
+```
+start
+center
+end
+```
+
 **value**
 
 What text to put in the input.

--- a/src/js/components/TextInput/StyledTextInput.js
+++ b/src/js/components/TextInput/StyledTextInput.js
@@ -6,6 +6,7 @@ import {
   inputStyle,
   parseMetricToNum,
   plainInputStyle,
+  textAlignStyle,
 } from '../../utils';
 import { defaultProps } from '../../default-props';
 
@@ -32,6 +33,7 @@ const StyledTextInput = styled.input`
       props.theme.textInput.disabled && props.theme.textInput.disabled.opacity,
     )}
   ${props => props.theme.textInput && props.theme.textInput.extend};
+  ${props => props.textAlign && textAlignStyle}
 `;
 
 StyledTextInput.defaultProps = {};

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -98,6 +98,7 @@ const TextInput = forwardRef(
       readOnly,
       reverse,
       suggestions,
+      textAlign,
       value: valueProp,
       ...rest
     },
@@ -420,6 +421,7 @@ const TextInput = forwardRef(
             icon={icon}
             reverse={reverse}
             focus={focus}
+            textAlign={textAlign}
             {...rest}
             {...extraProps}
             defaultValue={renderLabel(defaultValue)}

--- a/src/js/components/TextInput/__tests__/TextInput-test.js
+++ b/src/js/components/TextInput/__tests__/TextInput-test.js
@@ -508,4 +508,14 @@ describe('TextInput', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('textAlign end', () => {
+    const { container } = render(
+      <Grommet>
+        <TextInput value="1234" textAlign="end" />
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -411,7 +411,7 @@ exports[`TextInput calls onSuggestionsClose 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 DuCTw"
+      class="StyledTextInput-sc-1x30a0s-0 fEXQSl"
       data-testid="test-input"
       id="item"
       name="item"
@@ -916,7 +916,7 @@ exports[`TextInput close suggestion drop 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 DuCTw"
+      class="StyledTextInput-sc-1x30a0s-0 fEXQSl"
       data-testid="test-input"
       id="item"
       name="item"
@@ -1355,7 +1355,7 @@ exports[`TextInput handles next and previous without suggestion 2`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 fwbQtl"
+      class="StyledTextInput-sc-1x30a0s-0 jKshUE"
       data-testid="test-input"
       id="item"
       name="item"
@@ -2479,7 +2479,7 @@ exports[`TextInput select suggestion 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 jnTIjY"
+      class="StyledTextInput-sc-1x30a0s-0 dTQNsV"
       data-testid="test-input"
       id="item"
       name="item"
@@ -3450,3 +3450,77 @@ exports[`TextInput suggestions 2`] = `
 `;
 
 exports[`TextInput suggestions 3`] = `""`;
+
+exports[`TextInput textAlign end 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  text-align: right;
+}
+
+.c2::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c2::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c2:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c2::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c2::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c2:-moz-placeholder,
+.c2::-moz-placeholder {
+  opacity: 1;
+}
+
+.c1 {
+  position: relative;
+  width: 100%;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <input
+      autocomplete="off"
+      class="c2"
+      value="1234"
+    />
+  </div>
+</div>
+`;

--- a/src/js/components/TextInput/doc.js
+++ b/src/js/components/TextInput/doc.js
@@ -123,6 +123,9 @@ export const doc = TextInput => {
       `Suggestions to show. It is recommended to avoid showing too many
 suggestions and instead rely on the user to type more.`,
     ),
+    textAlign: PropTypes.oneOf(['start', 'center', 'end'])
+      .description('How to align the text inside the input.')
+      .defaultValue('start'),
     value: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,

--- a/src/js/components/TextInput/index.d.ts
+++ b/src/js/components/TextInput/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Omit, PlaceHolderType } from '../../utils';
+import { Omit, PlaceHolderType, TextAlignType } from '../../utils';
 import { DropProps } from '../Drop';
 
 export interface TextInputProps {
@@ -33,6 +33,7 @@ export interface TextInputProps {
   reverse?: boolean;
   size?: 'small' | 'medium' | 'large' | 'xlarge' | string;
   suggestions?: ({ label?: React.ReactNode; value?: any } | string)[];
+  textAlign?: TextAlignType;
   value?: string | number;
 }
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -16438,6 +16438,16 @@ suggestions and instead rely on the user to type more.
 ]
 \`\`\`
 
+**textAlign**
+
+How to align the text inside the input. Defaults to \`start\`.
+
+\`\`\`
+start
+center
+end
+\`\`\`
+
 **value**
 
 What text to put in the input.

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -7446,6 +7446,14 @@ suggestions and instead rely on the user to type more.",
         "name": "suggestions",
       },
       Object {
+        "defaultValue": "start",
+        "description": "How to align the text inside the input.",
+        "format": "start
+center
+end",
+        "name": "textAlign",
+      },
+      Object {
         "description": "What text to put in the input.",
         "format": "string
 number",

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -605,3 +605,13 @@ export const kindPartStyles = (obj, theme, colorValue) => {
   if (obj.extend) styles.push(obj.extend);
   return styles;
 };
+
+const TEXT_ALIGN_MAP = {
+  center: 'center',
+  end: 'right',
+  start: 'left',
+};
+
+export const textAlignStyle = css`
+  text-align: ${props => TEXT_ALIGN_MAP[props.textAlign]};
+`;


### PR DESCRIPTION
#### What does this PR do?
Add `textAlign` property to TextInput.
Refactor the conversion of `textAlign` to CSS into utils and changed other places that use `textAlign` to use this util rather than duplicating its implementation.

One main use-case of `textAlign` in an input is in DataTables when TextInput is used for numeric data. In this case it is helpful to align the numbers like you would for static numeric cell data. See #4736 .

Note: some of the existing TextInput-related snapshots changed, likely due to how styled-components names css classes due to the 'empty' style when textAlign isn't defined, although the resulting styles are the same.

#### Where should the reviewer start?
StyledTextInput.js and utils.js

#### What testing has been done on this PR?
Manual testing in storybook.
Added a Jest test case.

#### How should this be manually tested?
Manual testing in storybook.

#### Any background context you want to provide?

#### What are the relevant issues?
#4736 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
