### PR TITLE
Update Select `multiple` docs

### DIFF
--- a/src/js/components/Select/README.md
+++ b/src/js/components/Select/README.md
@@ -288,7 +288,9 @@ Custom messages.
 
 **multiple**
 
-Whether to allow multiple options to be selected.
+Whether to allow multiple options to be selected. When multiple is true, 
+      'value' should be an array of selected options and 'options' should be 
+      an array of possible options
 
 ```
 boolean

--- a/src/js/components/Select/doc.js
+++ b/src/js/components/Select/doc.js
@@ -117,7 +117,9 @@ export const doc = Select => {
       multiple: PropTypes.string,
     }).description('Custom messages.'),
     multiple: PropTypes.bool.description(
-      'Whether to allow multiple options to be selected.',
+      `Whether to allow multiple options to be selected. When multiple is true, 
+      'value' should be an array of selected options and 'options' should be 
+      an array of possible options`
     ),
     name: PropTypes.string.description(
       `The name of the attribute when in a Form or FormField.`,

--- a/src/js/components/Select/doc.js
+++ b/src/js/components/Select/doc.js
@@ -119,7 +119,7 @@ export const doc = Select => {
     multiple: PropTypes.bool.description(
       `Whether to allow multiple options to be selected. When multiple is true, 
       'value' should be an array of selected options and 'options' should be 
-      an array of possible options`
+      an array of possible options`,
     ),
     name: PropTypes.string.description(
       `The name of the attribute when in a Form or FormField.`,

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -13836,7 +13836,9 @@ Custom messages.
 
 **multiple**
 
-Whether to allow multiple options to be selected.
+Whether to allow multiple options to be selected. When multiple is true, 
+      'value' should be an array of selected options and 'options' should be 
+      an array of possible options
 
 \`\`\`
 boolean

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -6553,7 +6553,9 @@ function",
         "name": "messages",
       },
       Object {
-        "description": "Whether to allow multiple options to be selected.",
+        "description": "Whether to allow multiple options to be selected. When multiple is true, 
+      'value' should be an array of selected options and 'options' should be 
+      an array of possible options",
         "format": "boolean",
         "name": "multiple",
       },


### PR DESCRIPTION
#### What does this PR do?
Added the following information to the Select `multiple` docs 
When multiple is true, 'value' should be an array of selected options and 'options' should be an array of possible options

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?
Related Slack thread https://grommet.slack.com/archives/C09QQEG69/p1607119885347000?thread_ts=1607087274.344700&cid=C09QQEG69

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Done

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible