### PR TITLE
Changed Menu ItemWithIcon story to use 'children' prop

### DIFF
--- a/src/js/components/Menu/stories/ItemWithIcon.js
+++ b/src/js/components/Menu/stories/ItemWithIcon.js
@@ -32,12 +32,15 @@ const IconItemsMenu = () => (
             ),
           },
         ]}
-      >
-        <Box direction="row" gap="small" pad="large">
-          <FormDown />
-          <Text>Menu with Icon on the left</Text>
-        </Box>
-      </Menu>
+        /* eslint-disable react/no-children-prop */
+        children={() => (
+          <Box direction="row" gap="small" pad="large">
+            <FormDown />
+            <Text>Menu with Icon on the left</Text>
+          </Box>
+        )}
+        /* eslint-enable react/no-children-prop */
+      />
     </Box>
   </Grommet>
 );


### PR DESCRIPTION

#### What does this PR do?
Updated Menu/ItemWithIcon story to use `children` prop which fixes the following warning on storybook:
<img width="858" alt="Screen Shot 2020-12-09 at 1 37 30 PM" src="https://user-images.githubusercontent.com/54560994/101684471-b3382680-3a23-11eb-98a2-3c3e12d736d5.png">

Based on documentation children of menu should be passed in trough the children prop:
<img width="556" alt="Screen Shot 2020-12-09 at 1 39 45 PM" src="https://user-images.githubusercontent.com/54560994/101684668-03af8400-3a24-11eb-932e-5ad6099ef9a2.png">

#### Where should the reviewer start?

#### What testing has been done on this PR?
Storybook

#### How should this be manually tested?
Storybook

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #4811 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible