### PR TITLE
fix: added missing types for textInput

### DIFF
--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1196,6 +1196,15 @@ export interface ThemeType {
   textInput?: {
     extend?: ExtendType;
     disabled?: OpacityType;
+    container?: {
+      extend?: ExtendType;
+    };
+    placeholder?: {
+      extend?: ExtendType;
+    };
+    suggestions?: {
+      extend?: ExtendType;
+    };
   };
   tip?: {
     content?: BoxProps;


### PR DESCRIPTION
fix: added missing types for textInput > placeholder, placeholder, suggestions

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
add typescript types
#### Where should the reviewer start?

#### What testing has been done on this PR?
typescript should still compile
#### How should this be manually tested?
no
#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
no