### PR TITLE
Fix Layer container custom theming

### DIFF
--- a/src/js/components/Layer/README.md
+++ b/src/js/components/Layer/README.md
@@ -36,7 +36,7 @@ boolean
 
 **full**
 
-Whether the width and/or height should fill the current viewport 
+Whether the width and/or height should fill the current viewport
         size.
 
 ```
@@ -121,7 +121,7 @@ string
 
 **modal**
 
-Whether there should be an overlay preventing interaction underneath 
+Whether there should be an overlay preventing interaction underneath
         the layer. Defaults to `true`.
 
 ```
@@ -130,7 +130,7 @@ boolean
 
 **onClickOutside**
 
-Function that will be invoked on modal layers when the user clicks 
+Function that will be invoked on modal layers when the user clicks
       outside the layer.
 
 ```
@@ -183,7 +183,7 @@ boolean
 
 **target**
 
-Target where the layer will be aligned to. This should be a React 
+Target where the layer will be aligned to. This should be a React
       reference.
 
 ```
@@ -237,6 +237,16 @@ Defaults to
 undefined
 ```
 
+**layer.container.extend**
+
+Any additional style for Layer inner Container. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```
+
 **layer.overlay.background**
 
 The background of the Layer overlay. Expects `string`.
@@ -249,7 +259,7 @@ rgba(0, 0, 0, 0.5)
 
 **layer.responsiveBreakpoint**
 
-The actual breakpoint to trigger changes in the border, 
+The actual breakpoint to trigger changes in the border,
 direction, gap, margin, pad, and round. Expects `string`.
 
 Defaults to
@@ -270,7 +280,7 @@ Defaults to
 
 **global.breakpoints**
 
-The possible breakpoints that could affect border, direction, gap, margin, 
+The possible breakpoints that could affect border, direction, gap, margin,
     pad, and round. Expects `object`.
 
 Defaults to

--- a/src/js/components/Layer/README.md
+++ b/src/js/components/Layer/README.md
@@ -239,7 +239,7 @@ undefined
 
 **layer.container.extend**
 
-Any additional style for Layer inner Container. Expects `string | (props) => {}`.
+Any additional style for Layer Container. Expects `string | (props) => {}`.
 
 Defaults to
 

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -61,7 +61,8 @@ const StyledLayer = styled.div`
       styles.push(breakpointStyle(breakpoint, responsiveLayerStyle));
     }
     return styles;
-  }} ${props => props.theme.layer && props.theme.layer.extend};
+  }}
+  ${props => props.theme.layer && props.theme.layer.extend};
 `;
 
 StyledLayer.defaultProps = {};
@@ -699,6 +700,7 @@ const StyledContainer = styled.div`
     }
     return '';
   }};
+  ${props => props.theme.layer.container && props.theme.layer.container.extend};
 `;
 
 StyledContainer.defaultProps = {};

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -158,7 +158,7 @@ exports[`Layer animation fadeIn 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -334,7 +334,7 @@ exports[`Layer animation false 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -512,7 +512,7 @@ exports[`Layer animation slide 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -690,7 +690,7 @@ exports[`Layer animation true 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -868,7 +868,7 @@ exports[`Layer custom margin 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -979,7 +979,7 @@ exports[`Layer dark context 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1198,7 +1198,7 @@ exports[`Layer hidden 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1228,7 +1228,7 @@ exports[`Layer hidden 3`] = `
     class="StyledLayer__StyledOverlay-rmtehz-1 iconax"
   />
   <div
-    class="StyledLayer__StyledContainer-rmtehz-2 cOGSGt"
+    class="StyledLayer__StyledContainer-rmtehz-2 hcrNod"
     data-g-portal-id="0"
     id="hidden-test"
   >
@@ -1276,7 +1276,7 @@ exports[`Layer hidden 4`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1392,7 +1392,7 @@ exports[`Layer invoke onClickOutside when modal={false} 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1507,7 +1507,7 @@ exports[`Layer invoke onClickOutside when modal={false} and layer has target 2`]
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1690,7 +1690,7 @@ exports[`Layer invoke onClickOutside when modal={true} 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -1853,7 +1853,7 @@ exports[`Layer invoke onClickOutside when modal={true} and layer has target 2`] 
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2088,7 +2088,7 @@ exports[`Layer margin large 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2266,7 +2266,7 @@ exports[`Layer margin medium 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2444,7 +2444,7 @@ exports[`Layer margin none 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2622,7 +2622,7 @@ exports[`Layer margin small 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2800,7 +2800,7 @@ exports[`Layer margin xsmall 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -2911,7 +2911,7 @@ exports[`Layer non-modal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3169,7 +3169,7 @@ exports[`Layer plain 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3347,7 +3347,7 @@ exports[`Layer position: bottom - full: false 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3526,7 +3526,7 @@ exports[`Layer position: bottom - full: horizontal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3706,7 +3706,7 @@ exports[`Layer position: bottom - full: true 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -3885,7 +3885,7 @@ exports[`Layer position: bottom - full: vertical 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4063,7 +4063,7 @@ exports[`Layer position: bottom-left - full: false 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4242,7 +4242,7 @@ exports[`Layer position: bottom-left - full: horizontal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4422,7 +4422,7 @@ exports[`Layer position: bottom-left - full: true 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4601,7 +4601,7 @@ exports[`Layer position: bottom-left - full: vertical 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4779,7 +4779,7 @@ exports[`Layer position: bottom-right - full: false 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -4958,7 +4958,7 @@ exports[`Layer position: bottom-right - full: horizontal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -5138,7 +5138,7 @@ exports[`Layer position: bottom-right - full: true 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -5317,7 +5317,7 @@ exports[`Layer position: bottom-right - full: vertical 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -5495,7 +5495,7 @@ exports[`Layer position: center - full: false 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -5674,7 +5674,7 @@ exports[`Layer position: center - full: horizontal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -5851,7 +5851,7 @@ exports[`Layer position: center - full: true 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -6030,7 +6030,7 @@ exports[`Layer position: center - full: vertical 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -6208,7 +6208,7 @@ exports[`Layer position: end - full: false 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -6387,7 +6387,7 @@ exports[`Layer position: end - full: horizontal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -6567,7 +6567,7 @@ exports[`Layer position: end - full: true 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -6746,7 +6746,7 @@ exports[`Layer position: end - full: vertical 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -6924,7 +6924,7 @@ exports[`Layer position: left - full: false 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -7103,7 +7103,7 @@ exports[`Layer position: left - full: horizontal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -7283,7 +7283,7 @@ exports[`Layer position: left - full: true 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -7462,7 +7462,7 @@ exports[`Layer position: left - full: vertical 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -7640,7 +7640,7 @@ exports[`Layer position: right - full: false 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -7819,7 +7819,7 @@ exports[`Layer position: right - full: horizontal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -7999,7 +7999,7 @@ exports[`Layer position: right - full: true 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -8178,7 +8178,7 @@ exports[`Layer position: right - full: vertical 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -8356,7 +8356,7 @@ exports[`Layer position: start - full: false 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -8535,7 +8535,7 @@ exports[`Layer position: start - full: horizontal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -8715,7 +8715,7 @@ exports[`Layer position: start - full: true 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -8894,7 +8894,7 @@ exports[`Layer position: start - full: vertical 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -9072,7 +9072,7 @@ exports[`Layer position: top - full: false 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -9251,7 +9251,7 @@ exports[`Layer position: top - full: horizontal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -9431,7 +9431,7 @@ exports[`Layer position: top - full: true 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -9610,7 +9610,7 @@ exports[`Layer position: top - full: vertical 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -9788,7 +9788,7 @@ exports[`Layer position: top-left - full: false 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -9967,7 +9967,7 @@ exports[`Layer position: top-left - full: horizontal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -10147,7 +10147,7 @@ exports[`Layer position: top-left - full: true 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -10326,7 +10326,7 @@ exports[`Layer position: top-left - full: vertical 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -10504,7 +10504,7 @@ exports[`Layer position: top-right - full: false 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -10683,7 +10683,7 @@ exports[`Layer position: top-right - full: horizontal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -10863,7 +10863,7 @@ exports[`Layer position: top-right - full: true 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -11042,7 +11042,7 @@ exports[`Layer position: top-right - full: vertical 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -11205,7 +11205,7 @@ exports[`Layer target 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;
@@ -11320,7 +11320,7 @@ exports[`Layer target not modal 2`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .buMBTw {
+  .kNxNMQ {
     position: relative;
     max-height: none;
     max-width: none;

--- a/src/js/components/Layer/doc.js
+++ b/src/js/components/Layer/doc.js
@@ -157,7 +157,7 @@ export const themeDoc = {
     defaultValue: undefined,
   },
   'layer.container.extend': {
-    description: 'Any additional style for Layer inner Container.',
+    description: 'Any additional style for Layer Container.',
     type: 'string | (props) => {}',
     defaultValue: undefined,
   },

--- a/src/js/components/Layer/doc.js
+++ b/src/js/components/Layer/doc.js
@@ -40,7 +40,7 @@ export const doc = Layer => {
       PropTypes.oneOf(['vertical', 'horizontal']),
     ])
       .description(
-        `Whether the width and/or height should fill the current viewport 
+        `Whether the width and/or height should fill the current viewport
         size.`,
       )
       .defaultValue(false),
@@ -88,12 +88,12 @@ particular side of the layer`,
     ),
     modal: PropTypes.bool
       .description(
-        `Whether there should be an overlay preventing interaction underneath 
+        `Whether there should be an overlay preventing interaction underneath
         the layer.`,
       )
       .defaultValue(true),
     onClickOutside: PropTypes.func.description(
-      `Function that will be invoked on modal layers when the user clicks 
+      `Function that will be invoked on modal layers when the user clicks
       outside the layer.`,
     ),
     onEsc: PropTypes.func.description(
@@ -127,7 +127,7 @@ particular side of the layer`,
       )
       .defaultValue(true),
     target: PropTypes.object.description(
-      `Target where the layer will be aligned to. This should be a React 
+      `Target where the layer will be aligned to. This should be a React
       reference.`,
     ),
   };
@@ -156,13 +156,18 @@ export const themeDoc = {
     type: 'string | (props) => {}',
     defaultValue: undefined,
   },
+  'layer.container.extend': {
+    description: 'Any additional style for Layer inner Container.',
+    type: 'string | (props) => {}',
+    defaultValue: undefined,
+  },
   'layer.overlay.background': {
     description: 'The background of the Layer overlay.',
     type: 'string',
     defaultValue: 'rgba(0, 0, 0, 0.5)',
   },
   'layer.responsiveBreakpoint': {
-    description: `The actual breakpoint to trigger changes in the border, 
+    description: `The actual breakpoint to trigger changes in the border,
 direction, gap, margin, pad, and round.`,
     type: 'string',
     defaultValue: 'small',
@@ -173,7 +178,7 @@ direction, gap, margin, pad, and round.`,
     defaultValue: '20',
   },
   ...themeDocUtils.breakpointStyle(
-    `The possible breakpoints that could affect border, direction, gap, margin, 
+    `The possible breakpoints that could affect border, direction, gap, margin,
     pad, and round.`,
   ),
 };

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -10529,7 +10529,7 @@ boolean
 
 **full**
 
-Whether the width and/or height should fill the current viewport 
+Whether the width and/or height should fill the current viewport
         size.
 
 \`\`\`
@@ -10614,7 +10614,7 @@ string
 
 **modal**
 
-Whether there should be an overlay preventing interaction underneath 
+Whether there should be an overlay preventing interaction underneath
         the layer. Defaults to \`true\`.
 
 \`\`\`
@@ -10623,7 +10623,7 @@ boolean
 
 **onClickOutside**
 
-Function that will be invoked on modal layers when the user clicks 
+Function that will be invoked on modal layers when the user clicks
       outside the layer.
 
 \`\`\`
@@ -10676,7 +10676,7 @@ boolean
 
 **target**
 
-Target where the layer will be aligned to. This should be a React 
+Target where the layer will be aligned to. This should be a React
       reference.
 
 \`\`\`
@@ -10730,6 +10730,16 @@ Defaults to
 undefined
 \`\`\`
 
+**layer.container.extend**
+
+Any additional style for Layer Container. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
 **layer.overlay.background**
 
 The background of the Layer overlay. Expects \`string\`.
@@ -10742,7 +10752,7 @@ rgba(0, 0, 0, 0.5)
 
 **layer.responsiveBreakpoint**
 
-The actual breakpoint to trigger changes in the border, 
+The actual breakpoint to trigger changes in the border,
 direction, gap, margin, pad, and round. Expects \`string\`.
 
 Defaults to
@@ -10763,7 +10773,7 @@ Defaults to
 
 **global.breakpoints**
 
-The possible breakpoints that could affect border, direction, gap, margin, 
+The possible breakpoints that could affect border, direction, gap, margin,
     pad, and round. Expects \`object\`.
 
 Defaults to

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -4775,7 +4775,7 @@ boolean",
       },
       Object {
         "defaultValue": false,
-        "description": "Whether the width and/or height should fill the current viewport 
+        "description": "Whether the width and/or height should fill the current viewport
         size.",
         "format": "boolean
 vertical
@@ -4855,13 +4855,13 @@ string",
       },
       Object {
         "defaultValue": true,
-        "description": "Whether there should be an overlay preventing interaction underneath 
+        "description": "Whether there should be an overlay preventing interaction underneath
         the layer.",
         "format": "boolean",
         "name": "modal",
       },
       Object {
-        "description": "Function that will be invoked on modal layers when the user clicks 
+        "description": "Function that will be invoked on modal layers when the user clicks
       outside the layer.",
         "format": "function",
         "name": "onClickOutside",
@@ -4902,7 +4902,7 @@ top-right",
         "name": "responsive",
       },
       Object {
-        "description": "Target where the layer will be aligned to. This should be a React 
+        "description": "Target where the layer will be aligned to. This should be a React
       reference.",
         "format": "object",
         "name": "target",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update StyledContainer to allow custom styling through extend prop
So in your theme you can do as such:

```js
const customTheme = {
    ...grommet,
    layer: {
      container: {
        extend: 'border-radius: 40px',
      },
    },
  };
```

#### Where should the reviewer start?
`src/js/components/Layer/StyledLayer.js `

#### What testing has been done on this PR?
`yarn test -u src/js/components/Layer`

#### How should this be manually tested?
`yarn storybook`

#### Any background context you want to provide?

#### What are the relevant issues?

#4805 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
backwards compatible
