### PR TITLE
Fix ResponsiveGrid story occured on size argument with small

### DIFF
--- a/src/js/components/Grid/stories/Responsive.js
+++ b/src/js/components/Grid/stories/Responsive.js
@@ -114,14 +114,14 @@ const Responsive = ({
       // Take into consideration if not array is sent but a simple string
       let columnsVal = columns;
       if (columns) {
-        if (columns[size]) {
+        if (columns[size] && typeof columns !== "string") {
           columnsVal = columns[size];
         }
       }
 
       let rowsVal = rows;
       if (rows) {
-        if (rows[size]) {
+        if (rows[size] && typeof columns !== "string") {
           rowsVal = rows[size];
         }
       }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix storybook code in an example of ResponsiveGrid.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
```javascript
let a = "arbitary string"
let b = "small" // This is problem
// We don't expect below is true, but it is
typeof a[b] === "function"
```

#### Any background context you want to provide?
I'm not professional on javascript.
What I've figured out on this problem is that javascript string object has a method called `small`. So if we try `string["small"]`, it returns a `small` function that is method of string object in javascript.

This cause an error to someone who follows storybook example code of `ResponsiveGrid`.
This error only happens when the responsive size is small.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No. It is not a problem of grommet. It's just example.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
No effect on main code stream I guess.
