### PR TITLE
Add docs for TextInput defaultSuggestion prop

### DIFF
--- a/src/js/components/TextInput/README.md
+++ b/src/js/components/TextInput/README.md
@@ -19,6 +19,18 @@ Custom title to be used by screen readers.
 string
 ```
 
+**defaultSuggestion**
+
+Default suggestion to highlight, as an index into the suggestions array.
+
+      If set, the suggestion at the specified index in the suggestions array
+      will be highlighted by default when the suggestions drop opens.
+      
+
+```
+number
+```
+
 **dropAlign**
 
 How to align the drop. Defaults to `{

--- a/src/js/components/TextInput/doc.js
+++ b/src/js/components/TextInput/doc.js
@@ -19,6 +19,13 @@ export const doc = TextInput => {
     a11yTitle: PropTypes.string.description(
       'Custom title to be used by screen readers.',
     ),
+    defaultSuggestion: PropTypes.number.description(
+      `Default suggestion to highlight, as an index into the suggestions array.
+
+      If set, the suggestion at the specified index in the suggestions array
+      will be highlighted by default when the suggestions drop opens.
+      `,
+    ),
     dropAlign: PropTypes.shape({
       top: PropTypes.oneOf(['top', 'bottom']),
       bottom: PropTypes.oneOf(['top', 'bottom']),

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -16276,6 +16276,18 @@ Custom title to be used by screen readers.
 string
 \`\`\`
 
+**defaultSuggestion**
+
+Default suggestion to highlight, as an index into the suggestions array.
+
+      If set, the suggestion at the specified index in the suggestions array
+      will be highlighted by default when the suggestions drop opens.
+      
+
+\`\`\`
+number
+\`\`\`
+
 **dropAlign**
 
 How to align the drop. Defaults to \`{

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -7316,6 +7316,15 @@ string",
         "name": "a11yTitle",
       },
       Object {
+        "description": "Default suggestion to highlight, as an index into the suggestions array.
+
+      If set, the suggestion at the specified index in the suggestions array
+      will be highlighted by default when the suggestions drop opens.
+      ",
+        "format": "number",
+        "name": "defaultSuggestion",
+      },
+      Object {
         "defaultValue": Object {
           "left": "left",
           "top": "bottom",


### PR DESCRIPTION
#### What does this PR do?

Follow-on to #4806 , this adds documentation for the newly added prop.

#### Where should the reviewer start?

`doc.js`

#### What testing has been done on this PR?

I've run tests, manually inspected the auto-generated README file, and run `test-update` to update the README snapshots.

#### How should this be manually tested?

Manual inspection of the generated README is probably the best route.

#### Any background context you want to provide?

See #4806 

#### What are the relevant issues?

#4781 

#### Screenshots (if appropriate)

N/A

#### Do the grommet docs need to be updated?

This does that.

#### Should this PR be mentioned in the release notes?

Not separately from #4806 , no.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible (documentation only).