### PR TITLE
Fix Chart to not modify passed in colors array property

### DIFF
--- a/src/js/components/Chart/Chart.js
+++ b/src/js/components/Chart/Chart.js
@@ -521,6 +521,7 @@ const Chart = React.forwardRef(
         <defs>
           <linearGradient id={gradientId} x1={0} y1={0} x2={0} y2={1}>
             {color
+              .slice(0)
               .sort((c1, c2) => c2.value - c1.value)
               .map(({ value, color: gradientColor }) => (
                 <stop

--- a/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
+++ b/src/js/components/Chart/__tests__/__snapshots__/Chart-test.js.snap
@@ -654,7 +654,7 @@ exports[`Chart color 1`] = `
   >
     <defs>
       <linearGradient
-        id="border-brand-undefined-gradient"
+        id="brand-border-undefined-gradient"
         x1={0}
         x2={0}
         y1={0}
@@ -670,7 +670,7 @@ exports[`Chart color 1`] = `
         />
       </linearGradient>
       <mask
-        id="border-brand-undefined-mask"
+        id="brand-border-undefined-mask"
       >
         <g
           fill="none"
@@ -703,9 +703,9 @@ exports[`Chart color 1`] = `
       </mask>
     </defs>
     <rect
-      fill="url(#border-brand-undefined-gradient)"
+      fill="url(#brand-border-undefined-gradient)"
       height={216}
-      mask="url(#border-brand-undefined-mask)"
+      mask="url(#brand-border-undefined-mask)"
       width={408}
       x={-12}
       y={-12}


### PR DESCRIPTION


#### What does this PR do?
Changes Chart.js to sort a copy of the colors array rather than sorting the original and accidentally modifying it.

#### Where should the reviewer start?
Chart.js

#### What testing has been done on this PR?
Storybook Chart examples and Jest test cases.

#### How should this be manually tested?
Look at the id and mask of the gradient in the storybook Chart gradients example.

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #4858 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible