### PR TITLE
Fix: add onMouseLeave prop to button to fix bug with tip

### DIFF
--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -109,6 +109,7 @@ const Button = forwardRef(
       onBlur,
       onClick,
       onFocus,
+      onMouseLeave,
       onMouseOut,
       onMouseOver,
       plain,
@@ -202,8 +203,9 @@ const Button = forwardRef(
 
     const onMouseOutButton = event => {
       setHover(false);
-      if (onMouseOut) {
-        onMouseOut(event);
+      const outEvent = onMouseLeave || onMouseOut;
+      if (outEvent) {
+        outEvent(event);
       }
     };
 

--- a/src/js/components/Button/__tests__/Button-test.js
+++ b/src/js/components/Button/__tests__/Button-test.js
@@ -159,6 +159,21 @@ describe('Button', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('tip with label using mouseLeave', () => {
+    const { container, queryByText } = render(
+      <Grommet>
+        <Button label={<Text> Label </Text>} onClick={() => {}} tip="tooltip" />
+      </Grommet>,
+    );
+
+    fireEvent.mouseOver(queryByText('Label'));
+    expect(queryByText('tooltip')).toBeTruthy();
+    fireEvent.mouseLeave(queryByText('Label'));
+    expect(queryByText('tooltip')).toBeFalsy();
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('disabled', () => {
     const component = renderer.create(
       <Grommet>

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -3149,6 +3149,107 @@ exports[`Button tip 1`] = `
 </div>
 `;
 
+exports[`Button tip with label using mouseLeave 1`] = `
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c1:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus > circle,
+.c1:focus > ellipse,
+.c1:focus > line,
+.c1:focus > path,
+.c1:focus > polygon,
+.c1:focus > polyline,
+.c1:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
+<div
+  class="c0"
+>
+  <button
+    class="c1"
+    type="button"
+  >
+    <span
+      class="c2"
+    >
+       Label 
+    </span>
+  </button>
+</div>
+`;
+
 exports[`Button warns about invalid icon 1`] = `
 .c1 {
   display: inline-block;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix bug with tip on button using a element as label.
#### Where should the reviewer start?
`src/js/components/Button/Button.js`
#### What testing has been done on this PR?
Unit and manually tests.
#### How should this be manually tested?
With storybook
#### Any background context you want to provide?
No
#### What are the relevant issues?
#4865
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes

#### Is this change backwards compatible or is it a breaking change?
backwards compatible