### PR TITLE
Don't let kind attribute leak to DOM

### DIFF
--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -152,7 +152,10 @@ const plainStyle = () => css`
   }
 `;
 
-const StyledButtonKind = styled.button`
+const StyledButtonKind = styled.button.attrs(() => ({
+  // don't let kind attribute leak to DOM
+  kind: undefined,
+}))`
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -68,7 +68,6 @@ exports[`Button kind border on default button 1`] = `
 >
   <button
     class="c1"
-    kind="default"
     type="button"
   >
     Test
@@ -177,7 +176,6 @@ exports[`Button kind button icon colors 1`] = `
 >
   <button
     class="c1"
-    kind="default"
     type="button"
   >
     <svg
@@ -295,7 +293,6 @@ exports[`Button kind button with icon and align 1`] = `
 >
   <button
     class="c1"
-    kind="default"
     type="button"
   >
     <svg
@@ -386,7 +383,6 @@ exports[`Button kind default button 1`] = `
 >
   <button
     class="c1"
-    kind="default"
     type="button"
   />
 </div>
@@ -461,7 +457,6 @@ exports[`Button kind disabled with hoverIndicator should not hover 1`] = `
   <button
     class="c1"
     disabled=""
-    kind="default"
     type="button"
   >
     Button
@@ -476,7 +471,6 @@ exports[`Button kind disabled with hoverIndicator should not hover 2`] = `
   <button
     class="StyledButtonKind-sc-1vhfpnt-0 hMrilV"
     disabled=""
-    kind="default"
     type="button"
   >
     Button
@@ -550,7 +544,6 @@ exports[`Button kind extend on default button 1`] = `
 >
   <button
     class="c1"
-    kind="default"
     type="button"
   >
     Test
@@ -729,21 +722,18 @@ exports[`Button kind fill 1`] = `
 >
   <button
     class="c1"
-    kind="default"
     type="button"
   >
     Test
   </button>
   <button
     class="c2"
-    kind="default"
     type="button"
   >
     Test
   </button>
   <button
     class="c3"
-    kind="default"
     type="button"
   >
     Test
@@ -818,7 +808,6 @@ exports[`Button kind font on button default 1`] = `
 >
   <button
     class="c1"
-    kind="default"
     type="button"
   >
     Test
@@ -891,7 +880,6 @@ exports[`Button kind font undefined 1`] = `
 >
   <button
     class="c1"
-    kind="default"
     type="button"
   >
     Test
@@ -962,7 +950,6 @@ exports[`Button kind hover on default button 1`] = `
 >
   <button
     class="c1"
-    kind="default"
     type="button"
   >
     Test
@@ -1103,7 +1090,6 @@ exports[`Button kind mouseOver and mouseOut events 1`] = `
 >
   <button
     class="c1"
-    kind="default"
     type="button"
   >
     <div
@@ -1136,7 +1122,6 @@ exports[`Button kind mouseOver and mouseOut events 2`] = `
 >
   <button
     class="StyledButtonKind-sc-1vhfpnt-0 jcRPDY"
-    kind="default"
     type="button"
   >
     <div
@@ -1229,7 +1214,6 @@ exports[`Button kind no border on default button 1`] = `
 >
   <button
     class="c1"
-    kind="default"
     type="button"
   >
     Test
@@ -1304,7 +1288,6 @@ exports[`Button kind no padding on default button 1`] = `
 >
   <button
     class="c1"
-    kind="default"
     type="button"
   >
     Test
@@ -1378,7 +1361,6 @@ exports[`Button kind opacity on default button 1`] = `
 >
   <button
     class="c1"
-    kind="default"
     type="button"
   >
     Test
@@ -1454,7 +1436,6 @@ exports[`Button kind padding on default button 1`] = `
 >
   <button
     class="c1"
-    kind="default"
     type="button"
   >
     Test
@@ -1530,7 +1511,6 @@ exports[`Button kind primary button 1`] = `
 >
   <button
     class="c1"
-    kind="primary"
     type="button"
   />
 </div>
@@ -1594,7 +1574,6 @@ exports[`Button kind render of children 1`] = `
 >
   <button
     class="c1"
-    kind="default"
     type="button"
   >
     Test
@@ -1678,7 +1657,6 @@ exports[`Button kind secondary button 1`] = `
 >
   <button
     class="c1"
-    kind="secondary"
     type="button"
   />
 </div>
@@ -1749,7 +1727,6 @@ exports[`Button kind size of default button 1`] = `
 >
   <button
     class="c1"
-    kind="default"
     type="button"
   >
     Test

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -1457,7 +1457,6 @@ exports[`Menu custom theme with default button 1`] = `
   <button
     aria-label="Open Menu"
     className="c1"
-    kind="default"
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -2414,7 +2413,6 @@ exports[`Menu menu with children when custom theme has default button 1`] = `
   <button
     aria-label="Open Menu"
     className="c1"
-    kind="default"
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.js.snap
@@ -2650,7 +2650,6 @@ exports[`Tabs should apply custom theme disabled style when theme.button.default
         aria-expanded="true"
         aria-selected="true"
         class="c3"
-        kind="default"
         role="tab"
         type="button"
       >
@@ -2669,7 +2668,6 @@ exports[`Tabs should apply custom theme disabled style when theme.button.default
         aria-selected="false"
         class="c7"
         disabled=""
-        kind="default"
         role="tab"
         type="button"
       >


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
`kind` prop was leaking to the DOM. This change makes sure that it does not. In React 16, unknown attributes passed onto elements are no longer sifted out. See documentation here (https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html). Therefore, this change makes sure that no kind value is passed onto the DOM element.

#### Where should the reviewer start?
src/js/components/Button/StyledButtonKind.js

#### What testing has been done on this PR?
Snapshot updates, only the `kind` attribute is being removed. no styling changes.

#### How should this be manually tested?

#### Any background context you want to provide?
kind prop was leaking to the DOM, this removes it.

#### What are the relevant issues?

#### Screenshots (if appropriate)
before:
<img width="384" alt="Screen Shot 2021-01-13 at 10 05 42 AM" src="https://user-images.githubusercontent.com/12522275/104491326-ecb20380-5586-11eb-91e6-55f4bed26026.png">

after:
<img width="372" alt="Screen Shot 2021-01-13 at 10 06 13 AM" src="https://user-images.githubusercontent.com/12522275/104491859-ac06ba00-5587-11eb-8d12-67f54249d0a0.png">

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.