### PR TITLE
Disable animation on layer tests

### DIFF
--- a/src/js/components/Layer/__tests__/Layer-test.js
+++ b/src/js/components/Layer/__tests__/Layer-test.js
@@ -333,7 +333,11 @@ describe('Layer', () => {
     const onClickOutside = jest.fn();
     render(
       <Grommet>
-        <FakeLayer id="layer-node" onClickOutside={onClickOutside}>
+        <FakeLayer
+          id="layer-node"
+          onClickOutside={onClickOutside}
+          animation={false}
+        >
           <div data-testid="test-body-node" />
         </FakeLayer>
       </Grommet>,
@@ -355,6 +359,7 @@ describe('Layer', () => {
           id="layer-node"
           onClickOutside={onClickOutside}
           modal={false}
+          animation={false}
         >
           <div data-testid="test-body-node" />
         </FakeLayer>
@@ -376,6 +381,7 @@ describe('Layer', () => {
         id="target-test"
         onClickOutside={onClickOutside}
         modal={false}
+        animation={false}
       />,
     );
     expectPortal('target-test').toMatchSnapshot();
@@ -389,7 +395,13 @@ describe('Layer', () => {
 
   test('invoke onClickOutside when modal={true} and layer has target', () => {
     const onClickOutside = jest.fn();
-    render(<TargetLayer id="target-test" onClickOutside={onClickOutside} />);
+    render(
+      <TargetLayer
+        id="target-test"
+        onClickOutside={onClickOutside}
+        animation={false}
+      />,
+    );
     expectPortal('target-test').toMatchSnapshot();
 
     fireEvent(
@@ -410,7 +422,9 @@ describe('Layer', () => {
 
     render(
       <Grommet theme={theme}>
-        <Layer id="custom-theme-test">This is a layer</Layer>
+        <Layer id="custom-theme-test" animation={false}>
+          This is a layer
+        </Layer>
       </Grommet>,
     );
     expectPortal('custom-theme-test').toMatchSnapshot();
@@ -422,7 +436,7 @@ describe('Layer', () => {
     const onEsc = jest.fn();
     const { getByText, queryByText } = render(
       <Grommet>
-        <Layer id="esc-test" onEsc={onEsc} modal={false}>
+        <Layer id="esc-test" onEsc={onEsc} modal={false} animation={false}>
           <Select options={['one', 'two', 'three']} data-testid="test-select" />
         </Layer>
       </Grommet>,

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -944,8 +944,6 @@ exports[`Layer custom theme 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: hWAzxx 0.2s ease-in-out forwards;
-  animation: hWAzxx 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -1507,8 +1505,6 @@ exports[`Layer invoke onClickOutside when modal={false} 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: hWAzxx 0.2s ease-in-out forwards;
-  animation: hWAzxx 0.2s ease-in-out forwards;
 }
 
 .c1 {
@@ -1623,8 +1619,6 @@ exports[`Layer invoke onClickOutside when modal={false} and layer has target 1`]
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: hWAzxx 0.2s ease-in-out forwards;
-  animation: hWAzxx 0.2s ease-in-out forwards;
 }
 
 .c1 {
@@ -1762,8 +1756,6 @@ exports[`Layer invoke onClickOutside when modal={true} 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: hWAzxx 0.2s ease-in-out forwards;
-  animation: hWAzxx 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -1945,8 +1937,6 @@ exports[`Layer invoke onClickOutside when modal={true} and layer has target 1`] 
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: hWAzxx 0.2s ease-in-out forwards;
-  animation: hWAzxx 0.2s ease-in-out forwards;
 }
 
 .c3 {
@@ -2265,8 +2255,6 @@ exports[`Layer invokes onEsc when modal={false} 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  -webkit-animation: hWAzxx 0.2s ease-in-out forwards;
-  animation: hWAzxx 0.2s ease-in-out forwards;
 }
 
 .c1 {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Disables animation for Layer tests that involved onClickOutside/onEsc. There have been occasional test failures, and I am wondering if the layer animation in the jest environment was causing timing issues. Disabling animation to see if that removes test failures consistently. If we see Layer test failures again in the future, then more investigation will be needed.

#### Where should the reviewer start?
src/js/components/Layer/__tests__/Layer-test.js

#### What testing has been done on this PR?
Updated snapshots.

#### How should this be manually tested?

#### Any background context you want to provide?

Occasional Layer test failures. They would pass sometimes, and fail on others. Animation was potentially causing that unreliability.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.