### PR TITLE
Changed keyboard handling of TextInput suggestions

### DIFF
--- a/src/js/components/Form/stories/Controlled.js
+++ b/src/js/components/Form/stories/Controlled.js
@@ -26,6 +26,8 @@ const defaultValue = {
   age: '',
 };
 
+const suggestions = ['Shimi', 'Eric'];
+
 export const Controlled = () => {
   const [value, setValue] = useState(defaultValue);
   return (
@@ -44,7 +46,7 @@ export const Controlled = () => {
             }
           >
             <FormField label="Name" name="name">
-              <TextInput name="name" suggestions={['shimi', 'eric']} />
+              <TextInput name="name" suggestions={suggestions} />
             </FormField>
             <FormField label="Email" name="email" required>
               <MaskedInput

--- a/src/js/components/Form/stories/Controlled.js
+++ b/src/js/components/Form/stories/Controlled.js
@@ -44,7 +44,7 @@ export const Controlled = () => {
             }
           >
             <FormField label="Name" name="name">
-              <TextInput name="name" />
+              <TextInput name="name" suggestions={['shimi', 'eric']} />
             </FormField>
             <FormField label="Email" name="email" required>
               <MaskedInput

--- a/src/js/components/Form/stories/Uncontrolled.js
+++ b/src/js/components/Form/stories/Uncontrolled.js
@@ -16,6 +16,8 @@ import {
 } from 'grommet';
 import { grommet } from 'grommet/themes';
 
+const suggestions = ['Shimi', 'Eric'];
+
 export const Uncontrolled = () => (
   <Grommet full theme={grommet}>
     <Box fill align="center" justify="center">
@@ -25,7 +27,7 @@ export const Uncontrolled = () => (
           onSubmit={event => console.log('Submit', event.value, event.touched)}
         >
           <FormField label="Name" name="name">
-            <TextInput name="name" />
+            <TextInput name="name" suggestions={suggestions} />
           </FormField>
           <FormField label="Email" name="email" required>
             <MaskedInput

--- a/src/js/components/Layer/stories/Form.js
+++ b/src/js/components/Layer/stories/Form.js
@@ -15,6 +15,8 @@ import {
 } from 'grommet';
 import { grommet } from 'grommet/themes';
 
+const suggestions = ['alpha', 'beta'];
+
 export const FormLayer = () => {
   const [open, setOpen] = React.useState(false);
   const [select, setSelect] = React.useState('');
@@ -51,7 +53,7 @@ export const FormLayer = () => {
               </Box>
               <Box flex="grow" overflow="auto" pad={{ vertical: 'medium' }}>
                 <FormField label="First">
-                  <TextInput />
+                  <TextInput suggestions={suggestions} />
                 </FormField>
                 <FormField label="Second">
                   <Select

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -177,7 +177,7 @@ const TextInput = forwardRef(
 
     // Only update active suggestion index when the mouse actually moves,
     // not when suggestions are moving under the mouse.
-    const [mouseArmed, setMouseArmed] = useState();
+    const [mouseMovedSinceLastKey, setMouseMovedSinceLastKey] = useState();
 
     // reset activeSuggestionIndex when the drop is closed
     useEffect(() => {
@@ -262,7 +262,7 @@ const TextInput = forwardRef(
           suggestions.length - 1,
         );
         setActiveSuggestionIndex(nextActiveIndex);
-        setMouseArmed(false);
+        setMouseMovedSinceLastKey(false);
       },
       [activeSuggestionIndex, suggestions],
     );
@@ -272,7 +272,7 @@ const TextInput = forwardRef(
         event.preventDefault();
         const nextActiveIndex = Math.max(activeSuggestionIndex - 1, 0);
         setActiveSuggestionIndex(nextActiveIndex);
-        setMouseArmed(false);
+        setMouseMovedSinceLastKey(false);
       },
       [activeSuggestionIndex],
     );
@@ -305,7 +305,7 @@ const TextInput = forwardRef(
             ref={suggestionsRef}
             overflow="auto"
             dropHeight={dropHeight}
-            onMouseMove={() => setMouseArmed(true)}
+            onMouseMove={() => setMouseMovedSinceLastKey(true)}
           >
             <StyledSuggestions>
               <InfiniteScroll items={suggestions} step={theme.select.step}>
@@ -345,7 +345,8 @@ const TextInput = forwardRef(
                           setValueFromSuggestion(event, suggestion)
                         }
                         onMouseMove={
-                          mouseArmed && activeSuggestionIndex !== index
+                          mouseMovedSinceLastKey &&
+                          activeSuggestionIndex !== index
                             ? () => setActiveSuggestionIndex(index)
                             : undefined
                         }

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -233,7 +233,7 @@ const TextInput = forwardRef(
       if (onSuggestionsClose) onSuggestionsClose();
     }, [messages.onSuggestionsClose, onSuggestionsClose]);
 
-    const setFromSuggestion = (event, suggestion) => {
+    const setValueFromSuggestion = (event, suggestion) => {
       // if we stole the focus in the drop, perhaps by interacting with
       // a suggestion button or the scrollbar, give it back
       inputRef.current.focus();
@@ -242,7 +242,6 @@ const TextInput = forwardRef(
         if (event.persist) event.persist();
         const adjustedEvent = event;
         adjustedEvent.suggestion = suggestion;
-        // adjustedEvent.target = inputRef.current;
         handleSuggestionSelect(adjustedEvent);
       }
       inputRef.current.value = suggestion; // needed for uncontrolled cases
@@ -328,7 +327,9 @@ const TextInput = forwardRef(
                         kind={!child ? 'option' : undefined}
                         hoverIndicator={!child ? undefined : 'background'}
                         label={!child ? renderedLabel : undefined}
-                        onClick={event => setFromSuggestion(event, suggestion)}
+                        onClick={event =>
+                          setValueFromSuggestion(event, suggestion)
+                        }
                         onMouseOver={() => setActiveSuggestionIndex(index)}
                         onFocus={() => setActiveSuggestionIndex(index)}
                       >
@@ -344,16 +345,13 @@ const TextInput = forwardRef(
       );
     }
 
-    // If we have focus, then we set the target to the document, otherwise
-    // we only listen to onDown on the input element itself, primarily for
-    // tests.
     const keyboardProps = { onKeyDown };
     if (showDrop) {
       keyboardProps.onEnter = event => {
         // prevent submitting forms via Enter when the drop is open
         event.preventDefault();
         if (activeSuggestionIndex >= 0)
-          setFromSuggestion(event, suggestions[activeSuggestionIndex]);
+          setValueFromSuggestion(event, suggestions[activeSuggestionIndex]);
       };
       if (activeSuggestionIndex > 0) keyboardProps.onUp = onPreviousSuggestion;
       if (activeSuggestionIndex < suggestions.length - 1)
@@ -362,6 +360,12 @@ const TextInput = forwardRef(
     } else if (suggestions && suggestions.length > 0) {
       keyboardProps.onDown = openDrop;
     }
+
+    // For the Keyboard target below, if we have focus,
+    // either on the input element or within the drop,
+    // then we set the target to the document,
+    // otherwise we only listen to onDown on the input element itself,
+    // primarily for tests.
 
     return (
       <StyledTextInputContainer plain={plain}>

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -452,6 +452,7 @@ const TextInput = forwardRef(
                     // placeholder only appears when there is no value
                     setShowStyledPlaceholder(!event.target.value);
                     setValue(event.target.value);
+                    setActiveSuggestionIndex(-1);
                     if (onChange) onChange(event);
                   }
             }

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -169,6 +169,8 @@ const TextInput = forwardRef(
       return -1;
     }, [defaultSuggestion, suggestions, value]);
 
+    // activeSuggestionIndex unifies mouse and keyboard interaction of
+    // the suggestions
     const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(
       bestSuggestion(),
     );
@@ -309,7 +311,7 @@ const TextInput = forwardRef(
                         {renderedLabel}
                       </Box>
                     );
-                  // if we have a child, turn on plain, and hoverIndicator
+                  // if we have a child, turn on plain
 
                   return (
                     <li
@@ -325,7 +327,6 @@ const TextInput = forwardRef(
                         plain={!child ? undefined : true}
                         align="start"
                         kind={!child ? 'option' : undefined}
-                        hoverIndicator={!child ? undefined : 'background'}
                         label={!child ? renderedLabel : undefined}
                         onClick={event =>
                           setValueFromSuggestion(event, suggestion)

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -371,6 +371,7 @@ const TextInput = forwardRef(
         event.preventDefault();
         if (activeSuggestionIndex >= 0)
           setValueFromSuggestion(event, suggestions[activeSuggestionIndex]);
+        else closeDrop();
       };
       if (activeSuggestionIndex > 0) keyboardProps.onUp = onPreviousSuggestion;
       if (activeSuggestionIndex < suggestions.length - 1)

--- a/src/js/components/TextInput/__tests__/TextInput-test.js
+++ b/src/js/components/TextInput/__tests__/TextInput-test.js
@@ -340,11 +340,9 @@ describe('TextInput', () => {
     fireEvent.keyDown(input, { keyCode: 40 }); // down
     // pressing enter here closes drop but doesn't select
     fireEvent.keyDown(input, { keyCode: 13 }); // enter
-    expect(onSelect).toBeCalledWith(
-      expect.objectContaining({
-        suggestion: undefined,
-      }),
-    );
+    // if no suggestion had been selected, don't call onSelect
+    expect(onSelect).not.toBeCalled();
+
     // open drop
     fireEvent.keyDown(input, { keyCode: 40 }); // down
     // highlight first

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -296,11 +296,6 @@ exports[`TextInput calls onSuggestionsClose 2`] = `
   flex: 1 0 auto;
 }
 
-.c5:hover {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
 .c5:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
@@ -518,11 +513,6 @@ exports[`TextInput calls onSuggestionsOpen 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
-}
-
-.c5:hover {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 .c5:focus {
@@ -799,11 +789,6 @@ exports[`TextInput close suggestion drop 2`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
-}
-
-.c5:hover {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 .c5:focus {
@@ -1099,11 +1084,6 @@ exports[`TextInput complex suggestions 2`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
-}
-
-.c5:hover {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 .c5:focus {
@@ -1722,11 +1702,6 @@ exports[`TextInput large drop height 1`] = `
   flex: 1 0 auto;
 }
 
-.c5:hover {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
 .c5:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
@@ -1925,11 +1900,6 @@ exports[`TextInput medium drop height 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
-}
-
-.c5:hover {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 .c5:focus {
@@ -2362,11 +2332,6 @@ exports[`TextInput select suggestion 2`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
-}
-
-.c5:hover {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 .c5:focus {
@@ -3078,11 +3043,6 @@ exports[`TextInput small drop height 1`] = `
   flex: 1 0 auto;
 }
 
-.c5:hover {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
 .c5:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
@@ -3343,11 +3303,6 @@ exports[`TextInput suggestions 2`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
-}
-
-.c5:hover {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 .c5:focus {

--- a/src/js/components/TextInput/index.d.ts
+++ b/src/js/components/TextInput/index.d.ts
@@ -42,7 +42,7 @@ export interface TextInputProps {
   value?: string | number;
 }
 
-declare const TextInput: React.ComponentClass<TextInputProps &
+declare const TextInput: React.FC<TextInputProps &
   Omit<JSX.IntrinsicElements['input'], 'onSelect' | 'size' | 'placeholder'>>;
 
 export { TextInput };

--- a/src/js/components/TextInput/stories/WithTags.js
+++ b/src/js/components/TextInput/stories/WithTags.js
@@ -85,10 +85,7 @@ const TagInput = ({ value = [], onAdd, onChange, onRemove, ...rest }) => {
             {...rest}
             onChange={updateCurrentTag}
             value={currentTag}
-            onSelect={event => {
-              event.stopPropagation();
-              onAddTag(event.suggestion);
-            }}
+            onSuggestionSelect={event => onAddTag(event.suggestion)}
           />
         </Box>
       </Box>

--- a/src/js/components/TextInput/stories/typescript/CustomSuggestions.tsx
+++ b/src/js/components/TextInput/stories/typescript/CustomSuggestions.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import { Search } from 'grommet-icons';
 import { Box, Grommet, Image, Text, TextInput } from 'grommet';
@@ -78,17 +78,9 @@ export const CustomSuggestions = () => {
   const [value, setValue] = useState('');
   const [suggestionOpen, setSuggestionOpen] = useState(false);
   const [suggestedFolks, setSuggestedFolks] = useState([]);
-
-  const [, updateState] = useState();
-  const forceUpdate = useCallback(() => updateState({}), []);
-
   const boxRef = useRef();
 
-  useEffect(() => {
-    forceUpdate();
-  }, [forceUpdate]);
-
-  const onChange = event => {
+  const onChange = useCallback(event => {
     const { value: newValue } = event.target;
     setValue(newValue);
 
@@ -98,37 +90,45 @@ export const CustomSuggestions = () => {
       // simulate an async call to the backend
       setTimeout(() => setSuggestedFolks(folks), 300);
     }
-  };
+  }, []);
 
-  const onSelect = event => setValue(event.suggestion.value);
+  const onSuggestionSelect = useCallback(
+    event => setValue(event.suggestion.value),
+    [],
+  );
 
-  const renderSuggestions = () => {
-    return suggestedFolks
-      .filter(
-        ({ name }) => name.toLowerCase().indexOf(value.toLowerCase()) >= 0,
-      )
-      .map(({ name, imageUrl }, index, list) => ({
-        label: (
-          <Box
-            direction="row"
-            align="center"
-            gap="small"
-            border={index < list.length - 1 ? 'bottom' : undefined}
-            pad="small"
-          >
-            <Image
-              width="48px"
-              src={imageUrl}
-              style={{ borderRadius: '100%' }}
-            />
-            <Text>
-              <strong>{name}</strong>
-            </Text>
-          </Box>
-        ),
-        value: name,
-      }));
-  };
+  const onSuggestionsOpen = useCallback(() => setSuggestionOpen(true), []);
+  const onSuggestionsClose = useCallback(() => setSuggestionOpen(false), []);
+
+  const suggestions = useMemo(
+    () =>
+      suggestedFolks
+        .filter(
+          ({ name }) => name.toLowerCase().indexOf(value.toLowerCase()) >= 0,
+        )
+        .map(({ name, imageUrl }, index, list) => ({
+          label: (
+            <Box
+              direction="row"
+              align="center"
+              gap="small"
+              border={index < list.length - 1 ? 'bottom' : undefined}
+              pad="small"
+            >
+              <Image
+                width="48px"
+                src={imageUrl}
+                style={{ borderRadius: '100%' }}
+              />
+              <Text>
+                <strong>{name}</strong>
+              </Text>
+            </Box>
+          ),
+          value: name,
+        })),
+    [suggestedFolks, value],
+  );
 
   return (
     <Grommet full theme={myCustomTheme}>
@@ -156,16 +156,15 @@ export const CustomSuggestions = () => {
         >
           <Search color="brand" />
           <TextInput
-            type="search"
             dropTarget={boxRef.current}
+            placeholder="Enter your name..."
             plain
+            suggestions={suggestions}
             value={value}
             onChange={onChange}
-            onSelect={onSelect}
-            suggestions={renderSuggestions()}
-            placeholder="Enter your name..."
-            onSuggestionsOpen={() => setSuggestionOpen(true)}
-            onSuggestionsClose={() => setSuggestionOpen(false)}
+            onSuggestionsOpen={onSuggestionsOpen}
+            onSuggestionsClose={onSuggestionsClose}
+            onSuggestionSelect={onSuggestionSelect}
           />
         </Box>
       </Box>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Handling the double trigger of keypress up/down of TextInput suggestion.
The issue only reproduces on stable and not on an official release, the issue was introduced ~2 weeks ago with the new `capture` prop addition for the Keyboard component.
https://github.com/grommet/grommet/pull/4864

TextInput is currently using two instances of the Keyboard component and each one fired the onDown/onUp event, since `capture` was added, none of the events got waved, and each single keyboard arrow action was triggered twice.

Along with fixing the issue, this PR is attempting to clean-up some of the `onEnter` code duplications, and as a result of making `onEnter` as generic as possible for both keyboard instances the test file had to be changed since `onSelect` would no longer be called in case there is no active index -- let me know what you think about this change.

I was also contemplating removing completely one of the Keyboard instances, but each one serves a separate scenario according to the code's comments that I found to be merit during testing -- let me know if you have any thoughts on consolidating the component to a single instance.

#### Where should the reviewer start?
TextInput.js
#### What testing has been done on this PR?
jest, storybook
#### How should this be manually tested?
story/input-textinput--suggestions
story/input-textinput--default-suggestion

Try to hover, move scroll, click up/down, enter, and all the other keyboard Shabang.

#### Any background context you want to provide?
https://github.com/grommet/grommet/pull/4864

#### What are the relevant issues?
#4875 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No - the issue was never introduced on an official release.
#### Is this change backwards compatible or is it a breaking change?
b/c - unless we think that the fact `onSelect` isn't being called with the empty suggestion object, is not b/c.