### PR TITLE
Enhance heading theme to accept color

### DIFF
--- a/src/js/components/Heading/README.md
+++ b/src/js/components/Heading/README.md
@@ -281,6 +281,16 @@ Defaults to
   }
 ```
 
+**heading.color**
+
+The color of the heading. Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+undefined
+```
+
 **heading.extend**
 
 Any additional style for Heading. Expects `string | (props) => {}`.

--- a/src/js/components/Heading/StyledHeading.js
+++ b/src/js/components/Heading/StyledHeading.js
@@ -74,7 +74,8 @@ const truncateStyle = `
 `;
 
 const colorStyle = css`
-  color: ${props => normalizeColor(props.colorProp, props.theme)};
+  color: ${props =>
+    normalizeColor(props.colorProp || props.theme.heading.color, props.theme)};
 `;
 
 const StyledHeading = styled.h1`
@@ -83,7 +84,7 @@ const StyledHeading = styled.h1`
   ${props => sizeStyle(props)}
   ${props => props.textAlign && textAlignStyle}
   ${props => props.truncate && truncateStyle}
-  ${props => props.colorProp && colorStyle}
+  ${props => (props.colorProp || props.theme.heading.color) && colorStyle}
   ${props => props.theme.heading && props.theme.heading.extend}
 `;
 

--- a/src/js/components/Heading/__tests__/Heading-test.js
+++ b/src/js/components/Heading/__tests__/Heading-test.js
@@ -206,6 +206,24 @@ test('Theme based font weight renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('Theme color renders', () => {
+  const customTheme = {
+    heading: {
+      color: 'text-strong',
+    },
+  };
+  const component = renderer.create(
+    <Grommet theme={customTheme}>
+      <Heading level={1} />
+      <Heading level={2} />
+      <Heading level={3} />
+      <Heading level={4} />
+    </Grommet>,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('Throws a warning when heading.level is undefined in the theme.', () => {
   global.console = {
     warn: jest.fn(),

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -1032,6 +1032,99 @@ exports[`Theme based font weight renders 1`] = `
 </div>
 `;
 
+exports[`Theme color renders 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  font-size: 50px;
+  line-height: 56px;
+  max-width: 1200px;
+  font-weight: 600;
+  color: #000000;
+}
+
+.c2 {
+  font-size: 34px;
+  line-height: 40px;
+  max-width: 816px;
+  font-weight: 600;
+  color: #000000;
+}
+
+.c3 {
+  font-size: 26px;
+  line-height: 32px;
+  max-width: 624px;
+  font-weight: 600;
+  color: #000000;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+  color: #000000;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    font-size: 34px;
+    line-height: 40px;
+    max-width: 816px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    font-size: 26px;
+    line-height: 32px;
+    max-width: 624px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <h1
+    className="c1"
+  />
+  <h2
+    className="c2"
+  />
+  <h3
+    className="c3"
+  />
+  <h4
+    className="c4"
+  />
+</div>
+`;
+
 exports[`responsive renders 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/Heading/doc.js
+++ b/src/js/components/Heading/doc.js
@@ -65,6 +65,11 @@ export const themeDoc = {
     'The possible breakpoints that could affect font-size and max-width',
   ),
   ...themeDocUtils.edgeStyle('The possible sizes for margin.'),
+  'heading.color': {
+    description: 'The color of the heading.',
+    type: 'string | { dark: string, light: string }',
+    defaultValue: undefined,
+  },
   'heading.extend': {
     description: 'Any additional style for Heading.',
     type: 'string | (props) => {}',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -10031,6 +10031,16 @@ Defaults to
   }
 \`\`\`
 
+**heading.color**
+
+The color of the heading. Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
 **heading.extend**
 
 Any additional style for Heading. Expects \`string | (props) => {}\`.

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -737,6 +737,7 @@ export interface ThemeType {
     extend?: ExtendType;
   };
   heading?: {
+    color?: ColorType;
     extend?: ExtendType;
     font?: {};
     level?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -828,6 +828,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // extend: undefined
     },
     heading: {
+      // color: undefined,
       font: {
         // family: undefined
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Enhance theme to allow for `heading.color`.

#### Where should the reviewer start?
src/js/components/Heading/StyledHeading.js

#### What testing has been done on this PR?
Tested in storybook custom heading and added a jest test

```
heading : {
   color: 'text-strong',
}
```

#### How should this be manually tested?
With the above in a custom theme.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, updated here.

#### Should this PR be mentioned in the release notes?
Theme now supports `theme.heading.color`

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.