### PR TITLE
Changed DataTable to use onMouseEnter for hover detection

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -103,8 +103,8 @@ const Body = forwardRef(
                         }
                       : undefined
                   }
-                  onMouseOver={onClickRow ? () => setActive(index) : undefined}
-                  onMouseOut={
+                  onMouseEnter={onClickRow ? () => setActive(index) : undefined}
+                  onMouseLeave={
                     onClickRow ? () => setActive(undefined) : undefined
                   }
                   onFocus={onClickRow ? () => setActive(index) : undefined}


### PR DESCRIPTION
#### What does this PR do?

Changed DataTable to use onMouseEnter for hover detection. This reduces the amount of re-rendering needed. There might be even more aggressive ways to tackle this down the road. But, this seems a good quick win.

#### What testing has been done on this PR?

whitebox 400 rows and onClickRow

#### How should this be manually tested?

same

#### What are the relevant issues?

#4881

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
