### PR TITLE
Allow required formfield asterisk to be enabled in the theme

### DIFF
--- a/src/js/components/Form/stories/RequiredLabel.js
+++ b/src/js/components/Form/stories/RequiredLabel.js
@@ -1,14 +1,6 @@
 import React from 'react';
 
-import {
-  Box,
-  Button,
-  Form,
-  FormField,
-  Grommet,
-  Text,
-  TextInput,
-} from 'grommet';
+import { Box, Button, Form, FormField, Grommet, Text } from 'grommet';
 import { grommet } from 'grommet/themes';
 import { deepMerge } from 'grommet/utils';
 

--- a/src/js/components/Form/stories/RequiredLabel.js
+++ b/src/js/components/Form/stories/RequiredLabel.js
@@ -1,35 +1,48 @@
 import React from 'react';
 
-import { Box, Button, Form, FormField, Grommet, Text } from 'grommet';
+import {
+  Box,
+  Button,
+  Form,
+  FormField,
+  Grommet,
+  Text,
+  TextInput,
+} from 'grommet';
 import { grommet } from 'grommet/themes';
+import { deepMerge } from 'grommet/utils';
 
-const FormFieldLabel = props => {
-  const { required, label, ...rest } = props;
-  return (
-    <FormField
-      label={
-        required ? (
-          <Box direction="row">
-            <Text>{label}</Text>
-            <Text color="status-critical">*</Text>
-          </Box>
-        ) : (
-          label
-        )
-      }
-      required={required}
-      {...rest}
-    />
-  );
-};
+const myTheme = deepMerge(grommet, {
+  formField: {
+    label: {
+      requiredAsterisk: true,
+    },
+  },
+});
 
 export const RequiredLabel = () => (
-  <Grommet theme={grommet}>
+  <Grommet theme={myTheme}>
     <Box align="center" pad="large">
       <Form>
-        <FormFieldLabel name="firstName" label="FirstName" required />
-        <FormFieldLabel name="LastName" label="LastName" required />
-        <FormFieldLabel name="email" label="Email" />
+        <FormField
+          name="firstName"
+          label="First Name"
+          htmlFor="firstName"
+          required
+        >
+          <TextInput id="firstName" name="firstName" />
+        </FormField>
+        <FormField
+          name="lastName"
+          label="Last Name"
+          htmlFor="lastName"
+          required
+        >
+          <TextInput id="lastName" name="lastName" />
+        </FormField>
+        <FormField name="email" label="Email" htmlFor="email" required>
+          <TextInput id="email" name="email" type="email" />
+        </FormField>
         <Button type="submit" label="Submit" primary />
         <Text margin={{ left: 'small' }} size="small" color="status-critical">
           * Required Field

--- a/src/js/components/Form/stories/RequiredLabel.js
+++ b/src/js/components/Form/stories/RequiredLabel.js
@@ -1,13 +1,21 @@
 import React from 'react';
 
-import { Box, Button, Form, FormField, Grommet, Text } from 'grommet';
+import {
+  Box,
+  Button,
+  Form,
+  FormField,
+  Grommet,
+  Text,
+  TextInput,
+} from 'grommet';
 import { grommet } from 'grommet/themes';
 import { deepMerge } from 'grommet/utils';
 
 const customTheme = deepMerge(grommet, {
   formField: {
     label: {
-      requiredAsterisk: true,
+      requiredIndicator: true,
     },
   },
 });
@@ -16,9 +24,25 @@ export const RequiredLabel = () => (
   <Grommet theme={customTheme}>
     <Box align="center" pad="large">
       <Form>
-        <FormField name="firstName" label="First Name" required />
-        <FormField name="lastName" label="Last Name" required />
-        <FormField name="email" label="Email" required />
+        <FormField
+          name="firstName"
+          htmlFor="firstName"
+          label="First Name"
+          required
+        >
+          <TextInput id="firstName" name="firstName" />
+        </FormField>
+        <FormField
+          name="lastName"
+          htmlFor="lastName"
+          label="Last Name"
+          required
+        >
+          <TextInput id="lastName" name="lastName" />
+        </FormField>
+        <FormField name="email" htmlFor="email" label="Email" required>
+          <TextInput id="email" name="email" type="email" />
+        </FormField>
         <Button type="submit" label="Submit" primary />
         <Text margin={{ left: 'small' }} size="small" color="status-critical">
           * Required Field

--- a/src/js/components/Form/stories/RequiredLabel.js
+++ b/src/js/components/Form/stories/RequiredLabel.js
@@ -24,25 +24,9 @@ export const RequiredLabel = () => (
   <Grommet theme={customTheme}>
     <Box align="center" pad="large">
       <Form>
-        <FormField
-          name="firstName"
-          label="First Name"
-          htmlFor="firstName"
-          required
-        >
-          <TextInput id="firstName" name="firstName" />
-        </FormField>
-        <FormField
-          name="lastName"
-          label="Last Name"
-          htmlFor="lastName"
-          required
-        >
-          <TextInput id="lastName" name="lastName" />
-        </FormField>
-        <FormField name="email" label="Email" htmlFor="email" required>
-          <TextInput id="email" name="email" type="email" />
-        </FormField>
+        <FormField name="firstName" label="First Name" required />
+        <FormField name="lastName" label="Last Name" required />
+        <FormField name="email" label="Email" required />
         <Button type="submit" label="Submit" primary />
         <Text margin={{ left: 'small' }} size="small" color="status-critical">
           * Required Field

--- a/src/js/components/Form/stories/RequiredLabel.js
+++ b/src/js/components/Form/stories/RequiredLabel.js
@@ -12,7 +12,7 @@ import {
 import { grommet } from 'grommet/themes';
 import { deepMerge } from 'grommet/utils';
 
-const myTheme = deepMerge(grommet, {
+const customTheme = deepMerge(grommet, {
   formField: {
     label: {
       requiredAsterisk: true,
@@ -21,7 +21,7 @@ const myTheme = deepMerge(grommet, {
 });
 
 export const RequiredLabel = () => (
-  <Grommet theme={myTheme}>
+  <Grommet theme={customTheme}>
     <Box align="center" pad="large">
       <Form>
         <FormField

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -356,6 +356,12 @@ const FormField = forwardRef(
           }
         : {};
 
+    let { requiredAsterisk } = theme.formField.label;
+    if (requiredAsterisk === true)
+      // a11yTitle necessary so screenreader announces as "required"
+      // as opposed to "star"
+      requiredAsterisk = <Text a11yTitle="required">*</Text>;
+
     return (
       <FormFieldBox
         ref={ref}
@@ -380,6 +386,7 @@ const FormField = forwardRef(
             {label && component !== CheckBox && (
               <Text as="label" htmlFor={htmlFor} {...labelStyle}>
                 {label}
+                {required && requiredAsterisk ? requiredAsterisk : undefined}
               </Text>
             )}
             <Message message={help} {...formFieldTheme.help} />

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -356,11 +356,12 @@ const FormField = forwardRef(
           }
         : {};
 
-    let { requiredAsterisk } = theme.formField.label;
-    if (requiredAsterisk === true)
+    let { requiredIndicator } = theme.formField.label;
+    if (requiredIndicator === true)
       // a11yTitle necessary so screenreader announces as "required"
       // as opposed to "star"
-      requiredAsterisk = <Text a11yTitle="required">*</Text>;
+      // accessibility resource: https://www.deque.com/blog/anatomy-of-accessible-forms-required-form-fields/
+      requiredIndicator = <Text a11yTitle="required">*</Text>;
 
     return (
       <FormFieldBox
@@ -386,7 +387,7 @@ const FormField = forwardRef(
             {label && component !== CheckBox && (
               <Text as="label" htmlFor={htmlFor} {...labelStyle}>
                 {label}
-                {required && requiredAsterisk ? requiredAsterisk : undefined}
+                {required && requiredIndicator ? requiredIndicator : undefined}
               </Text>
             )}
             <Message message={help} {...formFieldTheme.help} />

--- a/src/js/components/FormField/README.md
+++ b/src/js/components/FormField/README.md
@@ -522,6 +522,19 @@ Defaults to
 { vertical: 'xsmall', horizontal: 'small' }
 ```
 
+**formField.label.requiredAsterisk**
+
+Whether an asterisk should be shown next to the label of a 
+    required FormField. If providing a custom element, it is recommended that 
+    you apply an a11yTitle of "required" to be accessible for screen readers.
+    If using "true", this a11yTitle is automatically applied. Expects `boolean | element`.
+
+Defaults to
+
+```
+undefined
+```
+
 **formField.margin**
 
 The margin of FormField. Expects `string | object`.

--- a/src/js/components/FormField/README.md
+++ b/src/js/components/FormField/README.md
@@ -522,12 +522,13 @@ Defaults to
 { vertical: 'xsmall', horizontal: 'small' }
 ```
 
-**formField.label.requiredAsterisk**
+**formField.label.requiredIndicator**
 
-Whether an asterisk should be shown next to the label of a 
-    required FormField. If providing a custom element, it is recommended that 
-    you apply an a11yTitle of "required" to be accessible for screen readers.
-    If using "true", this a11yTitle is automatically applied. Expects `boolean | element | string`.
+Whether an asterisk (*) indicating that an input is required 
+    should be displayed adjacent to the FormField's label. If providing a 
+    custom element, for accessibility it is recommended that you include 
+    an a11yTitle of "required" to assist screen readers. If using "true", the 
+    a11yTitle is automatically applied. Expects `boolean | element | string`.
 
 Defaults to
 

--- a/src/js/components/FormField/README.md
+++ b/src/js/components/FormField/README.md
@@ -527,7 +527,7 @@ Defaults to
 Whether an asterisk should be shown next to the label of a 
     required FormField. If providing a custom element, it is recommended that 
     you apply an a11yTitle of "required" to be accessible for screen readers.
-    If using "true", this a11yTitle is automatically applied. Expects `boolean | element`.
+    If using "true", this a11yTitle is automatically applied. Expects `boolean | element | string`.
 
 Defaults to
 

--- a/src/js/components/FormField/__tests__/FormField-test.js
+++ b/src/js/components/FormField/__tests__/FormField-test.js
@@ -7,7 +7,7 @@ import 'regenerator-runtime/runtime';
 
 import { axe } from 'jest-axe';
 import { cleanup, render } from '@testing-library/react';
-import { Alert, StatusInfo } from 'grommet-icons';
+import { Alert, New, StatusInfo } from 'grommet-icons';
 import { Grommet } from '../../Grommet';
 import { Form } from '../../Form';
 import { FormField } from '..';
@@ -356,6 +356,46 @@ describe('FormField', () => {
               border: false,
             }}
           />
+        </Form>
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('should render asterisk when requiredAsterisk === true', () => {
+    const component = renderer.create(
+      <Grommet
+        theme={{
+          formField: {
+            label: {
+              requiredAsterisk: true,
+            },
+          },
+        }}
+      >
+        <Form>
+          <FormField label="label" required />
+        </Form>
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('should render custom asterisk when requiredAsterisk is element', () => {
+    const component = renderer.create(
+      <Grommet
+        theme={{
+          formField: {
+            label: {
+              requiredAsterisk: <New size="small" />,
+            },
+          },
+        }}
+      >
+        <Form>
+          <FormField label="label" required />
         </Form>
       </Grommet>,
     );

--- a/src/js/components/FormField/__tests__/FormField-test.js
+++ b/src/js/components/FormField/__tests__/FormField-test.js
@@ -363,13 +363,13 @@ describe('FormField', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  test('should render asterisk when requiredAsterisk === true', () => {
+  test('should render asterisk when requiredIndicator === true', () => {
     const component = renderer.create(
       <Grommet
         theme={{
           formField: {
             label: {
-              requiredAsterisk: true,
+              requiredIndicator: true,
             },
           },
         }}
@@ -383,13 +383,14 @@ describe('FormField', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  test('should render custom asterisk when requiredAsterisk is element', () => {
+  test(`should render custom indicator when requiredIndicator is 
+  element`, () => {
     const component = renderer.create(
       <Grommet
         theme={{
           formField: {
             label: {
-              requiredAsterisk: <New size="small" />,
+              requiredIndicator: <New size="small" />,
             },
           },
         }}

--- a/src/js/components/FormField/__tests__/FormField-test.js
+++ b/src/js/components/FormField/__tests__/FormField-test.js
@@ -364,7 +364,7 @@ describe('FormField', () => {
   });
 
   test('should render asterisk when requiredIndicator === true', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet
         theme={{
           formField: {
@@ -379,13 +379,13 @@ describe('FormField', () => {
         </Form>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test(`should render custom indicator when requiredIndicator is 
   element`, () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet
         theme={{
           formField: {
@@ -400,7 +400,7 @@ describe('FormField', () => {
         </Form>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -2485,41 +2485,33 @@ exports[`FormField should render asterisk when requiredIndicator === true 1`] = 
 }
 
 <div
-  className="c0"
+  class="c0"
 >
-  <form
-    onReset={[Function]}
-    onSubmit={[Function]}
-  >
+  <form>
     <div
-      className="c1 "
-      onBlur={[Function]}
-      onFocus={[Function]}
+      class="c1 "
     >
       <label
-        className="c2"
+        class="c2"
       >
         label
         <span
           aria-label="required"
-          className="c3"
+          class="c3"
         >
           *
         </span>
       </label>
       <div
-        className="c4 FormField__FormFieldContentBox-m9hood-1"
+        class="c4 FormField__FormFieldContentBox-m9hood-1"
       >
         <div
-          className="c5"
+          class="c5"
         >
           <input
-            autoComplete="off"
-            className="c6"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            autocomplete="off"
+            class="c6"
+            value=""
           />
         </div>
       </div>
@@ -2675,47 +2667,39 @@ exports[`FormField should render custom indicator when requiredIndicator is
 }
 
 <div
-  className="c0"
+  class="c0"
 >
-  <form
-    onReset={[Function]}
-    onSubmit={[Function]}
-  >
+  <form>
     <div
-      className="c1 "
-      onBlur={[Function]}
-      onFocus={[Function]}
+      class="c1 "
     >
       <label
-        className="c2"
+        class="c2"
       >
         label
         <svg
           aria-label="New"
-          className="c3"
+          class="c3"
           viewBox="0 0 24 24"
         >
           <path
             d="M12,1 L12,23 M2,6 L22,18 M22.0000001,6 L2.00000008,18"
             fill="none"
             stroke="#000"
-            strokeWidth="2"
+            stroke-width="2"
           />
         </svg>
       </label>
       <div
-        className="c4 FormField__FormFieldContentBox-m9hood-1"
+        class="c4 FormField__FormFieldContentBox-m9hood-1"
       >
         <div
-          className="c5"
+          class="c5"
         >
           <input
-            autoComplete="off"
-            className="c6"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            autocomplete="off"
+            class="c6"
+            value=""
           />
         </div>
       </div>

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -2367,3 +2367,358 @@ exports[`FormField should have no accessibility violations 1`] = `
   </div>
 </div>
 `;
+
+exports[`FormField should render asterisk when requiredAsterisk === true 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c6 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  outline: none;
+  border: none;
+}
+
+.c6::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c6:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c6::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c6:-moz-placeholder,
+.c6::-moz-placeholder {
+  opacity: 1;
+}
+
+.c5 {
+  position: relative;
+  width: 100%;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+<div
+  className="c0"
+>
+  <form
+    onReset={[Function]}
+    onSubmit={[Function]}
+  >
+    <div
+      className="c1 "
+      onBlur={[Function]}
+      onFocus={[Function]}
+    >
+      <label
+        className="c2"
+      >
+        label
+        <span
+          aria-label="required"
+          className="c3"
+        >
+          *
+        </span>
+      </label>
+      <div
+        className="c4 FormField__FormFieldContentBox-m9hood-1"
+      >
+        <div
+          className="c5"
+        >
+          <input
+            autoComplete="off"
+            className="c6"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+          />
+        </div>
+      </div>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`FormField should render custom asterisk when requiredAsterisk is element 1`] = `
+.c3 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 12px;
+  height: 12px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c3 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c3 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c3 *[stroke*="#"],
+.c3 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c3 *[fill-rule],
+.c3 *[FILL-RULE],
+.c3 *[fill*="#"],
+.c3 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c6 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  outline: none;
+  border: none;
+}
+
+.c6::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c6:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c6::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c6:-moz-placeholder,
+.c6::-moz-placeholder {
+  opacity: 1;
+}
+
+.c5 {
+  position: relative;
+  width: 100%;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+<div
+  className="c0"
+>
+  <form
+    onReset={[Function]}
+    onSubmit={[Function]}
+  >
+    <div
+      className="c1 "
+      onBlur={[Function]}
+      onFocus={[Function]}
+    >
+      <label
+        className="c2"
+      >
+        label
+        <svg
+          aria-label="New"
+          className="c3"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12,1 L12,23 M2,6 L22,18 M22.0000001,6 L2.00000008,18"
+            fill="none"
+            stroke="#000"
+            strokeWidth="2"
+          />
+        </svg>
+      </label>
+      <div
+        className="c4 FormField__FormFieldContentBox-m9hood-1"
+      >
+        <div
+          className="c5"
+        >
+          <input
+            autoComplete="off"
+            className="c6"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+          />
+        </div>
+      </div>
+    </div>
+  </form>
+</div>
+`;

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -2368,7 +2368,7 @@ exports[`FormField should have no accessibility violations 1`] = `
 </div>
 `;
 
-exports[`FormField should render asterisk when requiredAsterisk === true 1`] = `
+exports[`FormField should render asterisk when requiredIndicator === true 1`] = `
 .c0 {
   font-size: 18px;
   line-height: 24px;
@@ -2528,7 +2528,8 @@ exports[`FormField should render asterisk when requiredAsterisk === true 1`] = `
 </div>
 `;
 
-exports[`FormField should render custom asterisk when requiredAsterisk is element 1`] = `
+exports[`FormField should render custom indicator when requiredIndicator is 
+  element 1`] = `
 .c3 {
   display: inline-block;
   -webkit-flex: 0 0 auto;

--- a/src/js/components/FormField/doc.js
+++ b/src/js/components/FormField/doc.js
@@ -238,10 +238,11 @@ export const themeDoc = {
     defaultValue: "{ vertical: 'xsmall', horizontal: 'small' }",
   },
   'formField.label.requiredAsterisk': {
-    description: `Whether an asterisk should be shown next to the label of a 
-    required FormField. If providing a custom element, it is recommended that 
-    you apply an a11yTitle of "required" to be accessible for screen readers.
-    If using "true", this a11yTitle is automatically applied.`,
+    description: `Whether an asterisk (*) indicating that an input is required 
+    should be displayed adjacent to the FormField's label. If providing a 
+    custom element, for accessibility it is recommended that you include 
+    an a11yTitle of "required" to assist screen readers. If using "true", the 
+    a11yTitle is automatically applied.`,
     type: 'boolean | element | string',
     defaultValue: 'undefined',
   },

--- a/src/js/components/FormField/doc.js
+++ b/src/js/components/FormField/doc.js
@@ -237,6 +237,14 @@ export const themeDoc = {
     type: 'string | object',
     defaultValue: "{ vertical: 'xsmall', horizontal: 'small' }",
   },
+  'formField.label.requiredAsterisk': {
+    description: `Whether an asterisk should be shown next to the label of a 
+    required FormField. If providing a custom element, it is recommended that 
+    you apply an a11yTitle of "required" to be accessible for screen readers.
+    If using "true", this a11yTitle is automatically applied.`,
+    type: 'boolean | element',
+    defaultValue: 'undefined',
+  },
   'formField.margin': {
     description: 'The margin of FormField.',
     type: 'string | object',

--- a/src/js/components/FormField/doc.js
+++ b/src/js/components/FormField/doc.js
@@ -242,7 +242,7 @@ export const themeDoc = {
     required FormField. If providing a custom element, it is recommended that 
     you apply an a11yTitle of "required" to be accessible for screen readers.
     If using "true", this a11yTitle is automatically applied.`,
-    type: 'boolean | element',
+    type: 'boolean | element | string',
     defaultValue: 'undefined',
   },
   'formField.margin': {

--- a/src/js/components/FormField/doc.js
+++ b/src/js/components/FormField/doc.js
@@ -237,7 +237,7 @@ export const themeDoc = {
     type: 'string | object',
     defaultValue: "{ vertical: 'xsmall', horizontal: 'small' }",
   },
-  'formField.label.requiredAsterisk': {
+  'formField.label.requiredIndicator': {
     description: `Whether an asterisk (*) indicating that an input is required 
     should be displayed adjacent to the FormField's label. If providing a 
     custom element, for accessibility it is recommended that you include 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -8923,7 +8923,7 @@ Defaults to
 Whether an asterisk should be shown next to the label of a 
     required FormField. If providing a custom element, it is recommended that 
     you apply an a11yTitle of \\"required\\" to be accessible for screen readers.
-    If using \\"true\\", this a11yTitle is automatically applied. Expects \`boolean | element\`.
+    If using \\"true\\", this a11yTitle is automatically applied. Expects \`boolean | element | string\`.
 
 Defaults to
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -8918,6 +8918,19 @@ Defaults to
 { vertical: 'xsmall', horizontal: 'small' }
 \`\`\`
 
+**formField.label.requiredAsterisk**
+
+Whether an asterisk should be shown next to the label of a 
+    required FormField. If providing a custom element, it is recommended that 
+    you apply an a11yTitle of \\"required\\" to be accessible for screen readers.
+    If using \\"true\\", this a11yTitle is automatically applied. Expects \`boolean | element\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
 **formField.margin**
 
 The margin of FormField. Expects \`string | object\`.

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -8918,12 +8918,13 @@ Defaults to
 { vertical: 'xsmall', horizontal: 'small' }
 \`\`\`
 
-**formField.label.requiredAsterisk**
+**formField.label.requiredIndicator**
 
-Whether an asterisk should be shown next to the label of a 
-    required FormField. If providing a custom element, it is recommended that 
-    you apply an a11yTitle of \\"required\\" to be accessible for screen readers.
-    If using \\"true\\", this a11yTitle is automatically applied. Expects \`boolean | element | string\`.
+Whether an asterisk (*) indicating that an input is required 
+    should be displayed adjacent to the FormField's label. If providing a 
+    custom element, for accessibility it is recommended that you include 
+    an a11yTitle of \\"required\\" to assist screen readers. If using \\"true\\", the 
+    a11yTitle is automatically applied. Expects \`boolean | element | string\`.
 
 Defaults to
 

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -142,6 +142,10 @@ interface ButtonKindType {
   extend?: ExtendType;
 }
 
+interface FormFieldLabelType extends TextProps {
+  requiredIndicator?: boolean | JSX.Element | string;
+}
+
 export interface ThemeType {
   global?: {
     active?: {
@@ -729,10 +733,7 @@ export interface ThemeType {
       container?: BoxProps;
       icon?: any;
     };
-    label?: {
-      margin?: MarginType;
-      requiredIndicator?: boolean | JSX.Element | string;
-    };
+    label?: FormFieldLabelType;
     margin?: MarginType;
     round?: RoundType;
   };

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -729,7 +729,10 @@ export interface ThemeType {
       container?: BoxProps;
       icon?: any;
     };
-    label?: TextProps;
+    label?: {
+      margin?: MarginType;
+      requiredAsterisk?: boolean | JSX.Element;
+    };
     margin?: MarginType;
     round?: RoundType;
   };

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -731,7 +731,7 @@ export interface ThemeType {
     };
     label?: {
       margin?: MarginType;
-      requiredAsterisk?: boolean | JSX.Element | string;
+      requiredIndicator?: boolean | JSX.Element | string;
     };
     margin?: MarginType;
     round?: RoundType;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -731,7 +731,7 @@ export interface ThemeType {
     };
     label?: {
       margin?: MarginType;
-      requiredAsterisk?: boolean | JSX.Element;
+      requiredAsterisk?: boolean | JSX.Element | string;
     };
     margin?: MarginType;
     round?: RoundType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -820,7 +820,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
       label: {
         margin: { vertical: 'xsmall', horizontal: 'small' },
-        // requiredAsterisk: undefined,
+        // requiredIndicator: undefined,
       },
       margin: { bottom: 'small' },
       // round: undefined,

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -820,6 +820,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
       label: {
         margin: { vertical: 'xsmall', horizontal: 'small' },
+        // requiredAsterisk: undefined,
       },
       margin: { bottom: 'small' },
       // round: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Enhances the theme to allow users to enable an asterisk * to appear next to required form field labels. Alternately, they can provide a string or a custom JSX element (if they want their own symbol for example). Currently, grommet users have to create a custom label render component any time they want to have this functionality. Having a place in the theme to control this would remove the need for users to use a custom component on every instance of a required formfield.

If the user flags this theme item as "true", then grommet will automatically apply an a11yTitle of "required". This a11yTitle is necessary so that screen readers read out the symbol as "required" as opposed to "star". If a user provides a custom element, such as a custom icon, then it will render this.

#### Where should the reviewer start?
src/js/components/FormField/FormField.js

#### What testing has been done on this PR?
Tested/updated Required Label Form storybook and added jest tests.

#### How should this be manually tested?
Look at Required Label Form storybook example.

#### Any background context you want to provide?

#### What are the relevant issues?
Related to https://github.com/grommet/hpe-design-system/issues/1378

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, updated here.

#### Should this PR be mentioned in the release notes?
Yes. Use `theme.formField.label.requiredAsterisk` to have a * or custom element appear next to the label on required FormFields.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.