### PR TITLE
Changed Meter to accept a single value property

### DIFF
--- a/src/js/components/Meter/Meter.js
+++ b/src/js/components/Meter/Meter.js
@@ -18,15 +18,25 @@ const Meter = forwardRef(
   (
     {
       background = { color: 'light-2', opacity: 'medium' },
+      color,
       size = 'medium',
       thickness = 'medium',
       type = 'bar',
-      values,
+      value,
+      values: valuesProp,
       ...rest
     },
     ref,
   ) => {
+    // normalize values to an array of objects
+    const values = useMemo(() => {
+      if (valuesProp) return valuesProp;
+      if (value) return [{ color, value }];
+      return [];
+    }, [color, value, valuesProp]);
+
     const memoizedMax = useMemo(() => deriveMax(values), [values]);
+
     let content;
     if (type === 'bar') {
       content = (

--- a/src/js/components/Meter/README.md
+++ b/src/js/components/Meter/README.md
@@ -144,6 +144,15 @@ string
 }
 ```
 
+**color**
+
+The color of the value region.
+      This is only valid when used with 'value'
+
+```
+string
+```
+
 **max**
 
 The maximum value for the Meter.
@@ -195,6 +204,16 @@ The visual type of meter. Defaults to `bar`.
 ```
 bar
 circle
+```
+
+**value**
+
+
+      The numeric value to represent. Ignored when 'values' is specified.
+    
+
+```
+number
 ```
 
 **values**

--- a/src/js/components/Meter/__tests__/Meter-test.js
+++ b/src/js/components/Meter/__tests__/Meter-test.js
@@ -18,6 +18,16 @@ describe('Meter', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  test('single', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Meter value={25} />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   test('basic', () => {
     const component = renderer.create(
       <Grommet>

--- a/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
+++ b/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
@@ -444,6 +444,56 @@ exports[`Meter round 1`] = `
 </div>
 `;
 
+exports[`Meter single 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.c1 path {
+  -webkit-transition: stroke 0.3s,stroke-width 0.3s;
+  transition: stroke 0.3s,stroke-width 0.3s;
+}
+
+<div
+  className="c0"
+>
+  <svg
+    className="c1"
+    height={24}
+    preserveAspectRatio="none"
+    viewBox="0 0 384 24"
+    width={384}
+  >
+    <path
+      d="M 0,12 L 384,12"
+      fill="none"
+      stroke="#F2F2F2"
+      strokeLinecap="square"
+      strokeOpacity="0.4"
+      strokeWidth={24}
+    />
+    <path
+      d="M 0,12 L 96,12"
+      fill="none"
+      stroke="#6FFFB0"
+      strokeLinecap="butt"
+      strokeWidth={24}
+    />
+  </svg>
+</div>
+`;
+
 exports[`Meter size 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/Meter/doc.js
+++ b/src/js/components/Meter/doc.js
@@ -32,6 +32,10 @@ export const doc = Meter => {
         color: 'light-2',
         opacity: 'medium',
       }),
+    color: PropTypes.string.description(
+      `The color of the value region.
+      This is only valid when used with 'value'`,
+    ),
     max: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).description(
       'The maximum value for the Meter.',
     ),
@@ -53,6 +57,9 @@ export const doc = Meter => {
     type: PropTypes.oneOf(['bar', 'circle'])
       .description('The visual type of meter.')
       .defaultValue('bar'),
+    value: PropTypes.number.description(`
+      The numeric value to represent. Ignored when 'values' is specified.
+    `),
     values: PropTypes.arrayOf(
       PropTypes.shape({
         color: PropTypes.string,

--- a/src/js/components/Meter/index.d.ts
+++ b/src/js/components/Meter/index.d.ts
@@ -11,6 +11,7 @@ export interface MeterProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
   background?: string | { color?: string; opacity?: OpacityType };
+  color?: string;
   gridArea?: GridAreaType;
   margin?: MarginType;
   max?: number;
@@ -18,6 +19,7 @@ export interface MeterProps {
   size?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'full' | string;
   thickness?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | string;
   type?: 'bar' | 'circle';
+  value?: number;
   values?: {
     color?: string;
     highlight?: boolean;

--- a/src/js/components/Meter/stories/Bar.js
+++ b/src/js/components/Meter/stories/Bar.js
@@ -9,7 +9,7 @@ export const Bar = () => {
   return (
     <Grommet theme={grommet}>
       <Box align="center" pad="large">
-        <Meter type="bar" background="light-2" values={[{ value }]} />
+        <Meter type="bar" value={value} />
       </Box>
     </Grommet>
   );

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -12291,6 +12291,15 @@ string
 }
 \`\`\`
 
+**color**
+
+The color of the value region.
+      This is only valid when used with 'value'
+
+\`\`\`
+string
+\`\`\`
+
 **max**
 
 The maximum value for the Meter.
@@ -12342,6 +12351,16 @@ The visual type of meter. Defaults to \`bar\`.
 \`\`\`
 bar
 circle
+\`\`\`
+
+**value**
+
+
+      The numeric value to represent. Ignored when 'values' is specified.
+    
+
+\`\`\`
+number
 \`\`\`
 
 **values**

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -5801,6 +5801,12 @@ string",
         "name": "background",
       },
       Object {
+        "description": "The color of the value region.
+      This is only valid when used with 'value'",
+        "format": "string",
+        "name": "color",
+      },
+      Object {
         "description": "The maximum value for the Meter.",
         "format": "number
 string",
@@ -5841,6 +5847,13 @@ string",
         "format": "bar
 circle",
         "name": "type",
+      },
+      Object {
+        "description": "
+      The numeric value to represent. Ignored when 'values' is specified.
+    ",
+        "format": "number",
+        "name": "value",
       },
       Object {
         "description": "Array of value objects describing the data.


### PR DESCRIPTION
#### What does this PR do?

Changed Meter to accept a single value property and a color property.
This makes it easier to use for the 80% case where there is only one value.

#### Where should the reviewer start?

index.d.ts

#### What testing has been done on this PR?

Revised the "Bar" storybook to use it.
Added a unit test.

#### How should this be manually tested?

Bar story

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
