### PR TITLE
Provide Checkbox with FormField context

### DIFF
--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -5,6 +5,7 @@ import { removeUndefined } from '../../utils/object';
 import { defaultProps } from '../../default-props';
 import { Box } from '../Box';
 import { FormContext } from '../Form/FormContext';
+import { FormFieldContext } from '../FormField/FormFieldContext';
 
 import {
   StyledCheckBox,
@@ -48,12 +49,15 @@ const CheckBox = forwardRef(
   ) => {
     const theme = useContext(ThemeContext) || defaultProps.theme;
     const formContext = useContext(FormContext);
+    const formFieldContext = useContext(FormFieldContext);
 
     const [checked, setChecked] = formContext.useFormInput(
       name,
       checkedProp,
       false,
     );
+
+    const { inFormField } = formFieldContext;
 
     const [focus, setFocus] = useState(focusProp);
     useEffect(() => setFocus(focusProp), [focusProp]);
@@ -79,6 +83,7 @@ const CheckBox = forwardRef(
       reverse,
       toggle,
       indeterminate,
+      inFormField,
     };
 
     let hidden;

--- a/src/js/components/CheckBox/stories/CheckBox.stories.js
+++ b/src/js/components/CheckBox/stories/CheckBox.stories.js
@@ -9,6 +9,7 @@ export { Reverse } from './Basics';
 export { Simple } from './Basics';
 export { Toggle } from './Basics';
 export { WithStickyDiv } from './WithStickyDiv';
+export { Temp } from './Temp';
 
 export default {
   title: 'Input/CheckBox',

--- a/src/js/components/CheckBox/stories/Temp.js
+++ b/src/js/components/CheckBox/stories/Temp.js
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+
+import { Box, Grommet, CheckBox, FormField, DataTable } from 'grommet';
+// import { grommet } from 'grommet/themes';
+import { deepMerge } from 'grommet/utils';
+import { hpe } from 'grommet-theme-hpe';
+
+// Source code for the data can be found here
+// https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
+import { columns, DATA } from '../../DataTable/stories/data';
+
+const controlledColumns = columns.map(col => ({ ...col }));
+delete controlledColumns[0].footer;
+delete controlledColumns[3].footer;
+delete controlledColumns[4].footer;
+delete controlledColumns[4].aggregate;
+
+const myTheme = deepMerge(hpe, {
+  checkBox: {
+    check: {
+      extend: props => {
+        return `
+          ${props.inFormField ? `box-shadow: none` : `box-shadow: undefined`};
+        `;
+      },
+    },
+  },
+});
+
+export const Temp = () => {
+  const [checked1, setChecked1] = useState(false);
+  const [checked2, setChecked2] = useState(false);
+  const [checked, setChecked] = React.useState([]);
+
+  const onCheck = (event, value) => {
+    if (event.target.checked) {
+      setChecked([...checked, value]);
+    } else {
+      setChecked(checked.filter(item => item !== value));
+    }
+  };
+
+  const onCheckAll = event =>
+    setChecked(event.target.checked ? DATA.map(datum => datum.name) : []);
+
+  return (
+    <Grommet theme={myTheme}>
+      <Box align="start" pad="large" gap="large">
+        <CheckBox
+          checked={checked1}
+          onChange={event => setChecked1(event.target.checked)}
+          label="I agree"
+        />
+        <FormField>
+          <CheckBox
+            checked={checked2}
+            onChange={event => setChecked2(event.target.checked)}
+            label="I understand and approve"
+          />
+        </FormField>
+        <DataTable
+          columns={[
+            {
+              property: 'checkbox',
+              render: datum => (
+                <CheckBox
+                  key={datum.name}
+                  checked={checked.indexOf(datum.name) !== -1}
+                  onChange={e => onCheck(e, datum.name)}
+                />
+              ),
+              header: (
+                <CheckBox
+                  checked={checked.length === DATA.length}
+                  indeterminate={
+                    checked.length > 0 && checked.length < DATA.length
+                  }
+                  onChange={onCheckAll}
+                />
+              ),
+              sortable: false,
+            },
+            ...controlledColumns,
+          ].map(col => ({ ...col }))}
+          data={DATA}
+          sortable
+          size="medium"
+        />
+      </Box>
+    </Grommet>
+  );
+};

--- a/src/js/components/CheckBox/stories/Temp.js
+++ b/src/js/components/CheckBox/stories/Temp.js
@@ -30,7 +30,7 @@ const myTheme = deepMerge(hpe, {
 export const Temp = () => {
   const [checked1, setChecked1] = useState(false);
   const [checked2, setChecked2] = useState(false);
-  const [checked, setChecked] = React.useState([]);
+  const [checked, setChecked] = useState([]);
 
   const onCheck = (event, value) => {
     if (event.target.checked) {

--- a/src/js/components/CheckBox/stories/Temp.js
+++ b/src/js/components/CheckBox/stories/Temp.js
@@ -18,11 +18,8 @@ delete controlledColumns[4].aggregate;
 const myTheme = deepMerge(hpe, {
   checkBox: {
     check: {
-      extend: props => {
-        return `
-          ${props.inFormField ? `box-shadow: none` : `box-shadow: undefined`};
-        `;
-      },
+      extend: props =>
+        props.inFormField ? `box-shadow: none` : `box-shadow: undefined`,
     },
   },
 });

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -16,6 +16,7 @@ import { RadioButtonGroup } from '../RadioButtonGroup';
 import { Text } from '../Text';
 import { TextInput } from '../TextInput';
 import { FormContext } from '../Form/FormContext';
+import { FormFieldContext } from './FormFieldContext';
 
 const grommetInputNames = [
   'TextInput',
@@ -375,19 +376,21 @@ const FormField = forwardRef(
         }}
         {...containerRest}
       >
-        {(label && component !== CheckBox) || help ? (
-          <>
-            {label && component !== CheckBox && (
-              <Text as="label" htmlFor={htmlFor} {...labelStyle}>
-                {label}
-              </Text>
-            )}
-            <Message message={help} {...formFieldTheme.help} />
-          </>
-        ) : (
-          undefined
-        )}
-        {contents}
+        <FormFieldContext.Provider value={{ inFormField: true }}>
+          {(label && component !== CheckBox) || help ? (
+            <>
+              {label && component !== CheckBox && (
+                <Text as="label" htmlFor={htmlFor} {...labelStyle}>
+                  {label}
+                </Text>
+              )}
+              <Message message={help} {...formFieldTheme.help} />
+            </>
+          ) : (
+            undefined
+          )}
+          {contents}
+        </FormFieldContext.Provider>
         <Message type="error" message={error} {...formFieldTheme.error} />
         <Message type="info" message={info} {...formFieldTheme.info} />
       </FormFieldBox>

--- a/src/js/components/FormField/FormFieldContext.js
+++ b/src/js/components/FormField/FormFieldContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const inFormField = false;
+
+export const FormFieldContext = React.createContext({ inFormField });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This is a draft for which to solicit reaction. Alternate approach provided here https://github.com/grommet/grommet/pull/4911

Fixes https://github.com/grommet/grommet-theme-hpe/issues/151 which restores focus to Checkboxes when not contained in a FormField.

More specifically, it allows a Checkbox to alter its styling (e.g. focus) based on whether or not it is contained within a FormField.

**Background**
The HPE Design System provides direction to place focus around the FormField (as opposed to the checkbox itself). However, that did not account for Checkboxes used in other contexts such as a standalone instance or when contained in a DataTable.

The desired design is:
- When a Checkbox is contained in a FormField, the [FormField receives the focus](https://www.figma.com/file/7Mm1xDBTOtPHqggEVpaD2N/HPE-Checkbox-Component?node-id=1388%3A77).
- When a Checkbox is not in a FormField, the [Checkbox receives focus](https://www.figma.com/file/7Mm1xDBTOtPHqggEVpaD2N/HPE-Checkbox-Component?node-id=2120%3A252).

**Approach**
This approach creates a FormFieldContext which allows components to know whether they are contained in a FormField or not.

Pros - Solves issue, allowing for contextual Checkbox styling.
Cons - Feels a bit off and is particular to inputs such as Checkbox, Checkbox toggle, RangeInput, and RangeSelector. Concept is limited to FormField - is there benefit to a more generic, adaptable solution?

#### Where should the reviewer start?

Checkbox.js and FormField.js

#### What testing has been done on this PR?

Storybook using the story "input-checkbox--temp" which will be removed from the PR,  but is useful for testing.

#### How should this be manually tested?

Storybook - Checkbox/stories/Temp.js

#### Any background context you want to provide?

From above: "The HPE Design System provides direction to place focus around the FormField (as opposed to the checkbox itself). However, that did not account for Checkboxes used in other contexts such as a standalone instance or when contained in a DataTable.

The desired design is:
- When a Checkbox is contained in a FormField, the FormField receives the focus.
- When a Checkbox is not in a FormField, the Checkbox receives focus."

#### What are the relevant issues?

https://github.com/grommet/grommet-theme-hpe/issues/151 

#### Screenshots (if appropriate)

**Different focus treatment in different contexts**
![Screen Shot 2021-01-29 at 11 36 49 AM](https://user-images.githubusercontent.com/1756948/106314345-d95d9400-6226-11eb-9e8b-14508ff5f7fb.png)
![Screen Shot 2021-01-29 at 11 37 03 AM](https://user-images.githubusercontent.com/1756948/106314348-db275780-6226-11eb-8645-001e8d80cbad.png)
![Screen Shot 2021-01-29 at 11 37 17 AM](https://user-images.githubusercontent.com/1756948/106314356-dcf11b00-6226-11eb-87a8-52a07fbb0b60.png)


#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
