### PR TITLE
Fix 4908 - InfiniteScroll test timing and call to scrollIntoView

### DIFF
--- a/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
+++ b/src/js/components/InfiniteScroll/__tests__/InfiniteScroll-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Grommet, Image, Box } from '../..';
@@ -229,6 +229,10 @@ describe('Number of Items Rendered', () => {
 
 describe('show scenarios', () => {
   test(`When show, show item should be visible in window`, () => {
+    jest.useFakeTimers();
+    // Mock scrollIntoView since JSDOM doesn't do layout.
+    // https://github.com/jsdom/jsdom/issues/1695#issuecomment-449931788
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
     const { container } = render(
       <Grommet>
         <InfiniteScroll items={simpleItems(300)} show={105}>
@@ -236,6 +240,8 @@ describe('show scenarios', () => {
         </InfiniteScroll>
       </Grommet>,
     );
+    // advance timers so InfiniteScroll can scroll to show index
+    act(() => jest.advanceTimersByTime(200));
     // item(104) = 'item 105' because indexing starts at 0.
     // Need to modify this next selection to only be concerned with the
     // visible window.


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Closes https://github.com/grommet/grommet/issues/4908 by adding timers to Jest test, plus mocking `scrollIntoView` function which is called in some InfiniteScroll + show scenarios, but is not supported by JSDOM.

#### Where should the reviewer start?

InfiniteScroll-test.js

#### What testing has been done on this PR?

Jest tests. 

Re: reliably reproducing issue - The issue was intermittent because the timer calling `scrollIntoView` could be longer than the duration of the test. Reducing the timeout duration allowed consistent reproduction, followed by use of Jest timers.

#### How should this be manually tested?

#### Any background context you want to provide?

There is quite a bit of discussion on the JSDOM project about how to test components relying on the scroll APIs https://github.com/jsdom/jsdom/issues/1695#issuecomment-449931788.

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/4908

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
