### PR TITLE
Updated prop type for pad in List

### DIFF
--- a/src/js/components/List/README.md
+++ b/src/js/components/List/README.md
@@ -263,66 +263,25 @@ function
 
 **pad**
 
-Item padding.
+Item padding. Defaults to `none`.
 
 ```
+none
 xxsmall
 xsmall
 small
 medium
 large
 xlarge
-string
 {
-  horizontal: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
-  vertical: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
-  top: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
   bottom: 
     xxsmall
     xsmall
     small
     medium
     large
-    xlarge,
-  left: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
-  right: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
-  start: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
+    xlarge
+    string,
   end: 
     xxsmall
     xsmall
@@ -330,7 +289,57 @@ string
     medium
     large
     xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  start: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
 }
+string
 ```
 
 **primaryKey**

--- a/src/js/components/List/README.md
+++ b/src/js/components/List/README.md
@@ -263,7 +263,7 @@ function
 
 **pad**
 
-Item padding. Defaults to `none`.
+Item padding.
 
 ```
 none

--- a/src/js/components/List/doc.js
+++ b/src/js/components/List/doc.js
@@ -1,6 +1,6 @@
 import { describe, PropTypes } from 'react-desc';
 
-import { genericProps } from '../../utils/prop-types';
+import { genericProps, padPropType } from '../../utils/prop-types';
 import { getAvailableAtBadge } from '../../utils/mixins';
 
 const sizes = ['xxsmall', 'xsmall', 'small', 'medium', 'large', 'xlarge'];
@@ -100,11 +100,7 @@ export const doc = List => {
       Anchor or Button inside 'primaryKey' or 'secondaryKey' as that can
       cause confusion with overlapping interactive elements.`,
     ),
-    pad: PropTypes.oneOfType([
-      PropTypes.oneOf(sizes),
-      PropTypes.string,
-      PropTypes.shape(padShapeSides),
-    ]).description(`Item padding.`),
+    pad: padPropType.description(`Item padding.`),
     primaryKey: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.func,

--- a/src/js/components/List/doc.js
+++ b/src/js/components/List/doc.js
@@ -100,7 +100,7 @@ export const doc = List => {
       Anchor or Button inside 'primaryKey' or 'secondaryKey' as that can
       cause confusion with overlapping interactive elements.`,
     ),
-    pad: padPropType.description(`Item padding.`),
+    pad: PropTypes.oneOfType([padPropType]).description(`Item padding.`),
     primaryKey: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.func,

--- a/src/js/components/List/index.d.ts
+++ b/src/js/components/List/index.d.ts
@@ -4,6 +4,7 @@ import {
   AlignSelfType,
   GridAreaType,
   MarginType,
+  PadType,
 } from '../../utils';
 
 type SizeType =
@@ -22,25 +23,6 @@ type SideType =
   | 'horizontal'
   | 'vertical'
   | 'all';
-type PadSizeType =
-  | 'none'
-  | 'xxsmall'
-  | 'xsmall'
-  | 'small'
-  | 'medium'
-  | 'large'
-  | 'xlarge'
-  | string;
-type PadType =
-  | PadSizeType
-  | {
-      bottom?: PadSizeType;
-      horizontal?: PadSizeType;
-      left?: PadSizeType;
-      right?: PadSizeType;
-      top?: PadSizeType;
-      vertical?: PadSizeType;
-    };
 type BorderType =
   | boolean
   | SideType

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11187,66 +11187,25 @@ function
 
 **pad**
 
-Item padding.
+Item padding. Defaults to \`none\`.
 
 \`\`\`
+none
 xxsmall
 xsmall
 small
 medium
 large
 xlarge
-string
 {
-  horizontal: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
-  vertical: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
-  top: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
   bottom: 
     xxsmall
     xsmall
     small
     medium
     large
-    xlarge,
-  left: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
-  right: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
-  start: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
+    xlarge
+    string,
   end: 
     xxsmall
     xsmall
@@ -11254,7 +11213,57 @@ string
     medium
     large
     xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  start: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
 }
+string
 \`\`\`
 
 **primaryKey**

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11187,7 +11187,7 @@ function
 
 **pad**
 
-Item padding. Defaults to \`none\`.
+Item padding.
 
 \`\`\`
 none

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -915,7 +915,8 @@ string",
       },
       Object {
         "defaultValue": "none",
-        "description": "Item padding.",
+        "description": "Spacing around the outer edge of
+    the drawing coordinate area for the graphic elements to overflow into.",
         "format": "none
 xxsmall
 xsmall
@@ -1946,7 +1947,8 @@ boolean",
       },
       Object {
         "defaultValue": "none",
-        "description": "Item padding.",
+        "description": "Spacing around the outer edge of
+    the drawing coordinate area for the graphic elements to overflow into.",
         "format": "none
 xxsmall
 xsmall
@@ -2902,7 +2904,8 @@ string",
       },
       Object {
         "defaultValue": "none",
-        "description": "Item padding.",
+        "description": "Spacing around the outer edge of
+    the drawing coordinate area for the graphic elements to overflow into.",
         "format": "none
 xxsmall
 xsmall
@@ -4243,7 +4246,8 @@ stretch",
       },
       Object {
         "defaultValue": "none",
-        "description": "Item padding.",
+        "description": "Spacing around the outer edge of
+    the drawing coordinate area for the graphic elements to overflow into.",
         "format": "none
 xxsmall
 xsmall
@@ -5183,7 +5187,6 @@ end
         "name": "onClickItem",
       },
       Object {
-        "defaultValue": "none",
         "description": "Item padding.",
         "format": "none
 xxsmall

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -915,8 +915,7 @@ string",
       },
       Object {
         "defaultValue": "none",
-        "description": "Spacing around the outer edge of
-    the drawing coordinate area for the graphic elements to overflow into.",
+        "description": "Item padding.",
         "format": "none
 xxsmall
 xsmall
@@ -1947,8 +1946,7 @@ boolean",
       },
       Object {
         "defaultValue": "none",
-        "description": "Spacing around the outer edge of
-    the drawing coordinate area for the graphic elements to overflow into.",
+        "description": "Item padding.",
         "format": "none
 xxsmall
 xsmall
@@ -2904,8 +2902,7 @@ string",
       },
       Object {
         "defaultValue": "none",
-        "description": "Spacing around the outer edge of
-    the drawing coordinate area for the graphic elements to overflow into.",
+        "description": "Item padding.",
         "format": "none
 xxsmall
 xsmall
@@ -4246,8 +4243,7 @@ stretch",
       },
       Object {
         "defaultValue": "none",
-        "description": "Spacing around the outer edge of
-    the drawing coordinate area for the graphic elements to overflow into.",
+        "description": "Item padding.",
         "format": "none
 xxsmall
 xsmall
@@ -5187,64 +5183,24 @@ end
         "name": "onClickItem",
       },
       Object {
+        "defaultValue": "none",
         "description": "Item padding.",
-        "format": "xxsmall
+        "format": "none
+xxsmall
 xsmall
 small
 medium
 large
 xlarge
-string
 {
-  horizontal: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
-  vertical: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
-  top: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
   bottom: 
     xxsmall
     xsmall
     small
     medium
     large
-    xlarge,
-  left: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
-  right: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
-  start: 
-    xxsmall
-    xsmall
-    small
-    medium
-    large
-    xlarge,
+    xlarge
+    string,
   end: 
     xxsmall
     xsmall
@@ -5252,7 +5208,57 @@ string
     medium
     large
     xlarge
-}",
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  start: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string",
         "name": "pad",
       },
       Object {


### PR DESCRIPTION
#### What does this PR do?
Updates the prop type of `pad` in List to `padPropType`. This allows an object to be used to define pixel size `pad={{ vertical: '0' }}`

#### Where should the reviewer start?

#### What testing has been done on this PR?
Storybook
added `pad={{ vertical: '0' }}` to List story

#### How should this be manually tested?
Storybook

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #4912 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Done

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible