### PR TITLE
Dont show styledplaceholder if placeholder is string

### DIFF
--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -451,7 +451,11 @@ const TextInput = forwardRef(
                     // will come from this onChange and remove the placeholder
                     // so we need to update state to ensure the styled
                     // placeholder only appears when there is no value
-                    setShowStyledPlaceholder(!event.target.value);
+                    setShowStyledPlaceholder(
+                      placeholder &&
+                        typeof placeholder !== 'string' &&
+                        !event.target.value,
+                    );
                     setValue(event.target.value);
                     setActiveSuggestionIndex(-1);
                     if (onChange) onChange(event);

--- a/src/js/components/TextInput/__tests__/TextInput-test.js
+++ b/src/js/components/TextInput/__tests__/TextInput-test.js
@@ -575,6 +575,33 @@ describe('TextInput', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test(`should only should default placeholder when placeholder is a 
+  string`, () => {
+    const { container, getByTestId } = render(
+      <Grommet>
+        <TextInput
+          data-testid="placeholder"
+          id="placeholder"
+          name="placeholder"
+          placeholder="placeholder text"
+        />
+      </Grommet>,
+    );
+
+    const placeholder = screen.queryByText('placeholder text');
+    fireEvent.change(getByTestId('placeholder'), {
+      target: { value: 'something' },
+    });
+    expect(placeholder).toBeNull();
+    expect(container.firstChild).toMatchSnapshot();
+
+    // after value is removed, only one placeholder should be present
+    // nothing from styled placeholder should appear since placeholder
+    // is a string
+    fireEvent.change(getByTestId('placeholder'), { target: { value: '' } });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('textAlign end', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -2836,6 +2836,105 @@ exports[`TextInput should not have padding when plain="full" 1`] = `
 </div>
 `;
 
+exports[`TextInput should only should default placeholder when placeholder is a 
+  string 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+}
+
+.c2::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c2::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c2:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c2::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c2::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c2:-moz-placeholder,
+.c2::-moz-placeholder {
+  opacity: 1;
+}
+
+.c1 {
+  position: relative;
+  width: 100%;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <input
+      autocomplete="off"
+      class="c2"
+      data-testid="placeholder"
+      id="placeholder"
+      name="placeholder"
+      placeholder="placeholder text"
+      value=""
+    />
+  </div>
+</div>
+`;
+
+exports[`TextInput should only should default placeholder when placeholder is a 
+  string 2`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
+>
+  <div
+    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 dpaJQp"
+  >
+    <input
+      autocomplete="off"
+      class="StyledTextInput-sc-1x30a0s-0 jKshUE"
+      data-testid="placeholder"
+      id="placeholder"
+      name="placeholder"
+      placeholder="placeholder text"
+      value=""
+    />
+  </div>
+</div>
+`;
+
 exports[`TextInput should show non-string placeholder 1`] = `
 .c0 {
   font-size: 18px;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes condition that determines if styledplaceholder should show. We only want to show it if the placeholder is not a string (custom placeholder)

#### Where should the reviewer start?
src/js/components/TextInput/TextInput.js

#### What testing has been done on this PR?
Tested in TextInput Icon story and styled placeholder. Added jest test.

#### How should this be manually tested?
In TextInput Icon story, type a value (placeholder should be removed). Then delete value, placeholder should appear.

Same in Styled Placeholder story.

In both, only one placeholder should be there.

#### Any background context you want to provide?
showStyledPlaceholder was being set to true regardless of if placeholder was custom or not.

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/4922

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.