### PR TITLE
Added search value to Select

### DIFF
--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -73,6 +73,7 @@ const Select = forwardRef(
       onMore,
       onOpen,
       onSearch,
+      searchValue,
       open: propOpen,
       options: optionsProp,
       placeholder,
@@ -115,7 +116,8 @@ const Select = forwardRef(
     // to be referenced when filtered by search.
     useEffect(() => {
       if (!search) setAllOptions(optionsProp);
-    }, [optionsProp, search]);
+      if (searchValue) setSearch(searchValue);
+    }, [optionsProp, search, searchValue]);
 
     // the option indexes present in the value
     const optionIndexesInValue = useMemo(() => {

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -342,6 +342,13 @@ const SelectContainer = forwardRef(
                 type="search"
                 value={search || ''}
                 placeholder={searchPlaceholder}
+                onFocus={() => {
+                  if (search) {
+                    setSearch(search);
+                    setActiveIndex(-1);
+                    onSearch(search);
+                  }
+                }}
                 onChange={event => {
                   const nextSearch = event.target.value;
                   setSearch(nextSearch);

--- a/src/js/components/Select/__tests__/Select-test.js
+++ b/src/js/components/Select/__tests__/Select-test.js
@@ -201,6 +201,27 @@ describe('Select', () => {
     expect(window.scrollTo).toBeCalled();
   });
 
+  test('search with search value prop', () => {
+    jest.useFakeTimers();
+    const onSearch = jest.fn();
+    const { container } = render(
+      <Select
+        id="test-select"
+        options={['one', 'two']}
+        onSearch={onSearch}
+        searchValue="two"
+      />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+
+    // advance timers so select can open
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    expect(document.activeElement).toMatchSnapshot();
+  });
+
   test('size', () => {
     const component = renderer.create(
       <Select

--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -40,6 +40,7 @@ export interface SelectProps {
   onMore?: (...args: any[]) => any;
   onOpen?: (...args: any[]) => any;
   onSearch?: (search: string) => void;
+  searchValue?: string | JSX.Element | number | object;
   options: (string | boolean | number | JSX.Element | object)[];
   open?: boolean;
   placeholder?: PlaceHolderType;

--- a/src/js/components/Select/stories/Search.js
+++ b/src/js/components/Select/stories/Search.js
@@ -11,6 +11,7 @@ for (let i = 1; i <= 200; i += 1) {
 export const Search = () => {
   const [options, setOptions] = useState(defaultOptions);
   const [value, setValue] = useState('');
+  const [searchValue, setSearchValue] = useState('');
   const [valueMultiple, setValueMultiple] = useState([]);
 
   return (
@@ -20,10 +21,12 @@ export const Search = () => {
           size="medium"
           placeholder="Select single option"
           value={value}
+          searchValue={searchValue}
           options={options}
           onChange={({ option }) => setValue(option)}
           onClose={() => setOptions(defaultOptions)}
           onSearch={text => {
+            setSearchValue(text);
             // The line below escapes regular expression special characters:
             // [ \ ^ $ . | ? * + ( )
             const escapedText = text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
@@ -40,10 +43,12 @@ export const Search = () => {
           size="medium"
           placeholder="Select multiple options"
           value={valueMultiple}
+          searchValue={searchValue}
           options={options}
           onChange={({ value: nextValue }) => setValueMultiple(nextValue)}
           onClose={() => setOptions(defaultOptions)}
           onSearch={text => {
+            setSearchValue(text);
             // The line below escapes regular expression special characters:
             // [ \ ^ $ . | ? * + ( )
             const escapedText = text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Added a search value prop for the Select component so ensure that the search term is controlled (controlled as in a "controlled input") and always in sync with some external state that is tracking the search term.

#### Where should the reviewer start?

First of all, access the storybook and see the new feature.

#### What testing has been done on this PR?

The test wrote is called `search with search value prop`. I think it need some improvement. I am open to suggestions, cause I have few familiarity with grommet's test cases

#### How should this be manually tested?

Test the Select component inform some value to prop `searchValue`. Something like this:

![image](https://user-images.githubusercontent.com/23138717/106811154-ae22dc80-664c-11eb-9e6f-eadffa704c8d.png)

So, You will see that search input will filled with prop informed.

#### Any background context you want to provide?

I think not

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

I think so.

#### Should this PR be mentioned in the release notes?

Issue #4870

#### Is this change backwards compatible or is it a breaking change?

I think not

Waiting your feedback.


