### PR TITLE
Fixed RadioButtonGroup and CheckBoxGroup to update with mutated array

### DIFF
--- a/src/js/components/CheckBoxGroup/CheckBoxGroup.js
+++ b/src/js/components/CheckBoxGroup/CheckBoxGroup.js
@@ -1,4 +1,4 @@
-import React, { forwardRef, useContext, useMemo } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 
 import { CheckBox } from '../CheckBox';
@@ -24,18 +24,14 @@ export const CheckBoxGroup = forwardRef(
     const theme = useContext(ThemeContext) || defaultProps.theme;
 
     // In case option is a string, normalize it to be an object
-    const options = useMemo(
-      () =>
-        optionsProp.map(option =>
-          typeof option === 'string'
-            ? {
-                disabled: disabledProp,
-                value: option,
-                label: option,
-              }
-            : option,
-        ),
-      [optionsProp, disabledProp],
+    const options = optionsProp.map(option =>
+      typeof option === 'string'
+        ? {
+            disabled: disabledProp,
+            value: option,
+            label: option,
+          }
+        : option,
     );
 
     // 'value' is an array of checked valueKeys

--- a/src/js/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/js/components/RadioButtonGroup/RadioButtonGroup.js
@@ -2,7 +2,6 @@ import React, {
   forwardRef,
   useContext,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -32,19 +31,15 @@ const RadioButtonGroup = forwardRef(
     const theme = useContext(ThemeContext) || defaultProps.theme;
 
     // normalize options to always use an object
-    const options = useMemo(
-      () =>
-        optionsProp.map(o =>
-          typeof o !== 'object'
-            ? {
-                disabled,
-                id: rest.id ? `${rest.id}-${o}` : `${o}`, // force string
-                label: typeof o !== 'string' ? JSON.stringify(o) : o,
-                value: o,
-              }
-            : { disabled, ...o },
-        ),
-      [disabled, optionsProp, rest.id],
+    const options = optionsProp.map(o =>
+      typeof o !== 'object'
+        ? {
+            disabled,
+            id: rest.id ? `${rest.id}-${o}` : `${o}`, // force string
+            label: typeof o !== 'string' ? JSON.stringify(o) : o,
+            value: o,
+          }
+        : { disabled, ...o },
     );
 
     const [value, setValue] = formContext.useFormInput(name, valueProp, '');


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Previously when the options array was updated using map or other methods that create a new array, the useMemo function wouldn't trigger. This PR removes useMemo from the options function so that when the options array is changed this function will be called.

This codesandbox shows RadioButtonGroup not updating
https://codesandbox.io/s/small-lake-uyt2p

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with the following storybook stories
CheckBoxGroup:
```javascript
import React, { useState } from "react";
import { Grommet, Button, CheckBoxGroup } from "grommet";

const GrommetComponent = (props) => {
  const { options } = props;
  const [value, setValue] = useState();
  console.log(options);
  return (
    <CheckBoxGroup
      labelKey="label"
      valueKey="key"
      value={value}
      onChange={event => {
        setValue(event.value);
        console.log('Group2: ', event.value);
      }}
      options={options}
    />
  );
}

const OPTIONS = [
    { label: 'Option 1', key: 1 },
];

export const TEST = () => {
  const [count, setCount] = useState(2);

  return (
    <Grommet>
      <GrommetComponent options={OPTIONS} />
      <Button
        onClick={() => {
          OPTIONS.push({ label: `Option ${count}`, key: count });
          setUselessState(uselessState + 1);
        }}
      >
        Click me to add an option
      </Button>
    </Grommet>
  );
}

export default {
    title: 'Input/CheckBoxGroup/TEST',
};
```
RadioButtonGroup:
```javascript
import React, { useState } from "react";
import { Button, Grommet, RadioButtonGroup } from "grommet";

const GrommetComponent = (props) => {
  const { options } = props;
  const [value, setValue] = useState("option1");
  console.log(options);
  return (
    <RadioButtonGroup
      options={options}
      id={"RBG"}
      name={"RBG"}
      value={value}
      onChange={event => setValue(event.target.value)}
      readOnly
    />
  );
}

const OPTIONS = [
  {
    "disabled": false,
    "id": "option1",
    "name": "option1",
    "value": "option1",
    "label": "option 1",
  }
];

export const TEST = () => {
  const [count, setCount] = useState(2);

  return (
    <Grommet>
      <GrommetComponent options={OPTIONS} />
      <Button
        onClick={() => {
          OPTIONS.push({
            "disabled": false,
            "id": `option ${count}`,
            "name": `option ${count}`,
            "value": `option ${count}`,
            "label": `option ${count}`,
          });
          setCount(count + 1);
        }}
      >
        Click me to add an option
      </Button>
    </Grommet>
  );
}

export default {
    title: 'Input/RadioButtonGroup/TEST',
  };
```
#### How should this be manually tested?
^ see above

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #4415 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards Compatible