### PR TITLE
Allow new Text sizes to be optional props

### DIFF
--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1192,27 +1192,27 @@ export interface ThemeType {
       height?: string;
       maxWidth?: string;
     };
-    '2xl?': {
+    '2xl'?: {
       size?: string;
       height?: string;
       maxWidth?: string;
     };
-    '3xl?': {
+    '3xl'?: {
       size?: string;
       height?: string;
       maxWidth?: string;
     };
-    '4xl?': {
+    '4xl'?: {
       size?: string;
       height?: string;
       maxWidth?: string;
     };
-    '5xl?': {
+    '5xl'?: {
       size?: string;
       height?: string;
       maxWidth?: string;
     };
-    '6xl?': {
+    '6xl'?: {
       size?: string;
       height?: string;
       maxWidth?: string;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Bug Fix: updates the typings in `src/theme/base.d.ts`. The typings for the newly added text sizes `2xl, 3xl, 4xl, 5xl, 6xl` were incorrectly typed and non-optional. This updates the typings so the optional property is correctly outside of the string used for the key.

#### Where should the reviewer start?
 
NA

#### What testing has been done on this PR?

NA

#### What are the relevant issues?

[4928](https://github.com/grommet/grommet/issues/4928)

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

Backwards
