### PR TITLE
Made sure RangeSelector values are updated when bar is dragged quickly to ends

### DIFF
--- a/src/js/components/RangeSelector/RangeSelector.js
+++ b/src/js/components/RangeSelector/RangeSelector.js
@@ -81,9 +81,15 @@ const RangeSelector = forwardRef(
         ) {
           nextValues = [values[0], value];
         } else if (changing === 'selection' && value !== moveValue) {
-          const delta = value - moveValue;
-          if (values[0] + delta >= min && values[1] + delta <= max) {
-            nextValues = [values[0] + delta, values[1] + delta];
+          if (value === max) {
+            nextValues = [max - (values[1] - values[0]), max];
+          } else if (value === min) {
+            nextValues = [min, min + (values[1] - values[0])];
+          } else {
+            const delta = value - moveValue;
+            if (values[0] + delta >= min && values[1] + delta <= max) {
+              nextValues = [values[0] + delta, values[1] + delta];
+            }
           }
         }
         if (nextValues) {


### PR DESCRIPTION
#### What does this PR do?
This PR made sure values of RangeSelector are updated when its bar is dragged quickly to max or min end. If the drag is too fast, values may not be updated in time. The previous method using `delta` won't apply to the correct values. 
#### Where should the reviewer start?
The only file changed.
#### What testing has been done on this PR?
Manual testing using storybook. 
#### How should this be manually tested?
Test and compare the behavior of the Thin RangeSelector example in storybook. 
#### Any background context you want to provide?
NA
#### What are the relevant issues?
#4927
#### Screenshots (if appropriate)
NA
#### Do the grommet docs need to be updated?
No.
#### Should this PR be mentioned in the release notes?
Probably not. 
#### Is this change backwards compatible or is it a breaking change?
Should be backwards compatible