### PR TITLE
Handle DataTable data reset with InfiniteScroll

### DIFF
--- a/src/js/components/InfiniteScroll/InfiniteScroll.js
+++ b/src/js/components/InfiniteScroll/InfiniteScroll.js
@@ -13,6 +13,9 @@ import {
 } from '../../utils';
 import { Box } from '../Box';
 
+const calculateLastPageBound = (show, step) =>
+  show ? Math.floor((show + step) / step) - 1 : 0;
+
 const InfiniteScroll = ({
   children,
   items = [],
@@ -34,7 +37,7 @@ const InfiniteScroll = ({
   // the pages we are rendering
   const [renderPageBounds, setRenderPageBounds] = useState([
     0,
-    show ? Math.floor((show + step) / step) - 1 : 0,
+    calculateLastPageBound(show, step),
   ]);
 
   // the heights of the pages, approximated after we render the first page
@@ -98,7 +101,7 @@ const InfiniteScroll = ({
 
       if (show) {
         // ensure we try to render any show page
-        const showPage = Math.floor((show + step) / step) - 1;
+        const showPage = calculateLastPageBound(show, step);
         nextBeginPage = Math.min(showPage, nextBeginPage);
         nextEndPage = Math.max(showPage, nextEndPage);
       }
@@ -151,7 +154,7 @@ const InfiniteScroll = ({
     if (lastPage === 0 && pendingLength !== 0) {
       setPageHeights([]);
       setPendingLength(0);
-      setRenderPageBounds([0, show ? Math.floor((show + step) / step) - 1 : 0]);
+      setRenderPageBounds([0, calculateLastPageBound(show, step)]);
     }
   }, [lastPage, pendingLength, show, step]);
 

--- a/src/js/components/InfiniteScroll/InfiniteScroll.js
+++ b/src/js/components/InfiniteScroll/InfiniteScroll.js
@@ -147,6 +147,14 @@ const InfiniteScroll = ({
     }
   }, [items.length, lastPage, onMore, pendingLength, renderPageBounds, step]);
 
+  useEffect(() => {
+    if (items.length === 0 && lastPage === 0 && pendingLength !== 0) {
+      setPageHeights([]);
+      setPendingLength(0);
+      setRenderPageBounds([0, 0]);
+    }
+  }, [items.length, lastPage, pendingLength]);
+
   // scroll to any 'show'
   useLayoutEffect(() => {
     // ride out any animation delays, 100ms empirically measured

--- a/src/js/components/InfiniteScroll/InfiniteScroll.js
+++ b/src/js/components/InfiniteScroll/InfiniteScroll.js
@@ -148,12 +148,12 @@ const InfiniteScroll = ({
   }, [items.length, lastPage, onMore, pendingLength, renderPageBounds, step]);
 
   useEffect(() => {
-    if (items.length === 0 && lastPage === 0 && pendingLength !== 0) {
+    if (lastPage === 0 && pendingLength !== 0) {
       setPageHeights([]);
       setPendingLength(0);
-      setRenderPageBounds([0, 0]);
+      setRenderPageBounds([0, show ? Math.floor((show + step) / step) - 1 : 0]);
     }
-  }, [items.length, lastPage, pendingLength]);
+  }, [lastPage, pendingLength, show, step]);
 
   // scroll to any 'show'
   useLayoutEffect(() => {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Provides a fix for #4934, allowing `onMore` to be triggered when manually resetting `DataTable` data.
Even though it's related to `DataTable`, the fix was made on `InfiniteScroll`, as it's the one handling `onMore` calls.

This issue has a use case that updates data dynamically, but when a manual reset is made, some internal states are kept. This fix verifies a condition that indicates a manual data reset (data length = 0, last page = 0, and pending length != 0). If the condition is valid, it resets pageHeights, pendingLength and renderPageBounds, which will make the DataTable behave just as how it works when it first renders.

Note that the given example starts with `currentData = [ ]`, and this should be consistently followed in order for this to work, meaning that the reset should set `currentData = [ ]`.

#### Where should the reviewer start?

`src/js/components/InfiniteScroll/InfiniteScroll.js`

#### What testing has been done on this PR?

Manual testing using storybook, as this issue involves updates to `BoundingCliendRect`, and I do believe those can't be easily tested using RTL/JSDom.

#### How should this be manually tested?

An updated version of the example provided by the issue reporter. Based on storybook/DataTable/Infinite Scroll

https://gist.github.com/leossantiago/cfcbd3de1e88d28c2d96df98b199c4b9


#### Any background context you want to provide?

#### What are the relevant issues?

#4934 

#### Screenshots (if appropriate)

![Peek 2021-02-08 02-41](https://user-images.githubusercontent.com/47114840/107180268-2411a580-69b7-11eb-8b65-18390815ae1c.gif)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible. 