### PR TITLE
AllComponents Story Loaded First

### DIFF
--- a/src/js/all/stories/AllComponents.js
+++ b/src/js/all/stories/AllComponents.js
@@ -387,5 +387,5 @@ const Components = () => {
 
 export const All = () => <Components />;
 export default {
-  title: 'Others/All',
+  title: 'All',
 };

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -3,6 +3,7 @@ export const parameters = {
   options: {
     storySort: {
       method: 'alphabetical',
+      order: ['All'],
     },
   },
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
In the new storybook format when storybook is opened, the AllComponents story is displayed. It is also listed first before every thing else. I moved the 'All' story outside of the 'Others' category so that the entire 'Others' category was not moved to the top.

#### Where should the reviewer start?

#### What testing has been done on this PR?
storybook

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
<img width="213" alt="Screen Shot 2021-02-08 at 5 15 52 PM" src="https://user-images.githubusercontent.com/54560994/107297795-4f38db00-6a31-11eb-9ac4-e081ca10fc39.png">

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible