### PR TITLE
RadioButtonGroup CustomTheme story showing custom text color

### DIFF
--- a/src/js/components/RadioButtonGroup/stories/CustomTheme.js
+++ b/src/js/components/RadioButtonGroup/stories/CustomTheme.js
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Box, Grommet, RadioButtonGroup, ThemeContext } from 'grommet';
 import { grommet } from 'grommet/themes';
 import { deepMerge } from 'grommet/utils';
+import { css } from 'styled-components';
 
 const customTheme = deepMerge(grommet, {
   radioButtonGroup: {
@@ -14,6 +15,11 @@ const customTheme = deepMerge(grommet, {
     border: {
       color: 'red',
       width: '10px',
+    },
+    container: {
+      extend: css`
+        color: red;
+      `,
     },
     hover: {
       border: {


### PR DESCRIPTION
#### What does this PR do?
This PR adds an example of changing the text color for RadioButtonGroup into the already existing CustomTheme story. This is a common question people ask on Github and Slack so it will useful to have in a storybook example.

#### Where should the reviewer start?

#### What testing has been done on this PR?
storybook

#### How should this be manually tested?
storybook

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #4935

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible