### PR TITLE
Fix Drop content text color behavior when plain

### DIFF
--- a/src/js/components/Drop/StyledDrop.js
+++ b/src/js/components/Drop/StyledDrop.js
@@ -1,7 +1,10 @@
 import styled, { keyframes } from 'styled-components';
 
 import { baseStyle } from '../../utils';
-import { backgroundStyle } from '../../utils/background';
+import {
+  backgroundStyle,
+  backgroundAndTextColors,
+} from '../../utils/background';
 import { defaultProps } from '../../default-props';
 
 function getTransformOriginStyle(align) {
@@ -36,8 +39,18 @@ const StyledDrop = styled.div`
   outline: none;
 
   ${props =>
-    !props.plain &&
-    backgroundStyle(props.theme.global.drop.background, props.theme)}
+    !props.plain
+      ? backgroundStyle(props.theme.global.drop.background, props.theme)
+      : () => {
+          const [, textColor] = backgroundAndTextColors(
+            props.theme.global.drop.background,
+            undefined,
+            props.theme,
+          );
+          return `${textColor ? `color: ${textColor};` : ''}`;
+        }}
+
+
 
   opacity: 0;
   transform-origin: ${props => getTransformOriginStyle(props.alignProp)};

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -1329,6 +1329,7 @@ exports[`Drop plain renders 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
+  color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
   -ms-transform-origin: top left;

--- a/src/js/components/Tip/__tests__/__snapshots__/Tip-test.js.snap
+++ b/src/js/components/Tip/__tests__/__snapshots__/Tip-test.js.snap
@@ -285,6 +285,7 @@ exports[`Tip mouseOver and mouseOut events on the Tip's child 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
+  color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
   -ms-transform-origin: top left;
@@ -382,6 +383,7 @@ exports[`Tip plain 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
+  color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
   -ms-transform-origin: top left;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes #4950 , where components such <Tip /> wouldn't follow `theme.global.colors.text`.

Even though being related as a <Tip /> issue, after some debugging, this happens because of <Drop /> component.

Tip forces a `plain` state on Drop, which removes some styling related to background and elevation, but it also includes text-color styling. 

This PR fixes the issue by providing text color styling when `plain` is set to true on <Drop /> component.

Note that manual content styling such as `<Text color="red">Text in red</Text>` worked just fine prior to this.

#### Where should the reviewer start?

`./src/js/components/Drop/StyledDrop.js`

#### What testing has been done on this PR?

Manual testing, and update snapshots that already cover Drop `plain` usage.

#### How should this be manually tested?

```js
const theme = {
  global: {
    colors: {
      // text: 'blue',
      text: {
        light: 'blue',
        dark: 'blue',
      },
    },
  },
};

const override = deepMerge(grommet, theme);

export const Simple = () => (
  <Grommet theme={override}>
    <Text>Grommet &gt; Text</Text>
    <Box pad="small" gap="xlarge">
      <Text>Global text color theme is set to blue</Text>

      <Tip content="Tip with regular text">
        <Button label="Hover" />
      </Tip>

      <Button label="Hover" tip="Tip as Button prop" />

      <Tip content={<Text>Tip using Text component as content</Text>}>
        <Button label="Hover" />
      </Tip>

      <Button
        label="Hover"
        tip={{
          content: (
            <Text>Tip as button prop using Text component as content</Text>
          ),
        }}
      />
    </Box>
  </Grommet>
);
```

#### Any background context you want to provide?

#### What are the relevant issues?

#4950 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible considering general behavior. Breaking change if you consider global styling usage.
