### PR TITLE
Fix1396 add elevation prop

### DIFF
--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -30,6 +30,7 @@ const defaultPortalContext = [];
 const LayerContainer = forwardRef(
   (
     {
+      elevation,
       background,
       children,
       full = false,
@@ -169,7 +170,8 @@ const LayerContainer = forwardRef(
       <StyledContainer
         ref={ref || containerRef}
         background={background}
-        elevation={theme.layer.container.elevation}
+        // elevation munged to avoid styled-components putting it in the DOM
+        elevationProp={elevation}
         id={id}
         full={full}
         margin={margin}

--- a/src/js/components/Layer/README.md
+++ b/src/js/components/Layer/README.md
@@ -73,6 +73,21 @@ string
 }
 ```
 
+**elevation**
+
+Elevated height above the underlying context, indicated
+        via a drop shadow. Defaults to `none`.
+
+```
+none
+xsmall
+small
+medium
+large
+xlarge
+string
+```
+
 **full**
 
 Whether the width and/or height should fill the current viewport

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -766,7 +766,7 @@ const responsiveContainerStyle = css`
 const elevationStyle = css`
   box-shadow: ${props =>
     props.theme.global.elevation[props.theme.dark ? 'dark' : 'light'][
-      props.theme.layer.container.elevation
+      props.elevationProp
     ]};
 `;
 
@@ -784,7 +784,7 @@ const StyledContainer = styled.div`
     )} outline: none;
   pointer-events: all;
   z-index: ${props => props.theme.layer.container.zIndex};
-  ${props => props.theme.layer.container.elevation && elevationStyle}
+  ${props => props.elevationProp && elevationStyle}
   ${desktopContainerStyle}
   ${props => {
     if (props.responsive && props.theme.layer.responsiveBreakpoint) {

--- a/src/js/components/Layer/__tests__/Layer-test.js
+++ b/src/js/components/Layer/__tests__/Layer-test.js
@@ -129,6 +129,15 @@ describe('Layer', () => {
     }),
   );
 
+  test('elevation', () => {
+    render(
+      <Grommet>
+        <Layer id="elevation-test" elevation="large" />
+      </Grommet>,
+    );
+    expectPortal('elevation-test').toMatchSnapshot();
+  });
+
   test(`should apply background`, () => {
     render(
       <Grommet>

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -940,7 +940,6 @@ exports[`Layer custom theme 1`] = `
   outline: none;
   pointer-events: all;
   z-index: 20;
-  box-shadow: 0px 8px 16px rgba(0,0,0,0.20);
   position: absolute;
   max-height: calc(100% - 0px - 0px);
   max-width: calc(100% - 0px - 0px);
@@ -1005,7 +1004,6 @@ exports[`Layer custom theme 1`] = `
   <div
     class="c2"
     data-g-portal-id="0"
-    elevation="large"
     id="custom-theme-test"
   >
     <a
@@ -1150,6 +1148,185 @@ exports[`Layer dark context 1`] = `
 
 exports[`Layer dark context 2`] = `
 "@media only screen and (max-width: 768px) {
+  .ijyCbN {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    min-height: 100vh;
+  }
+}
+@media only screen and (max-width: 768px) {
+  .dfssdJ {
+    position: relative;
+  }
+}
+@media only screen and (max-width: 768px) {
+  .xWjcQ {
+    position: relative;
+    max-height: none;
+    max-width: none;
+    border-radius: 0;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    -webkit-transform: none;
+    -ms-transform: none;
+    transform: none;
+    -webkit-animation: none;
+    animation: none;
+    height: 100vh;
+    width: 100vw;
+  }
+}"
+`;
+
+exports[`Layer elevation 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  background: transparent;
+  position: relative;
+  z-index: 20;
+  pointer-events: none;
+  outline: none;
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  background-color: rgba(0,0,0,0.5);
+  color: #f8f8f8;
+  pointer-events: all;
+  will-change: transform;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-height: 48px;
+  background-color: #FFFFFF;
+  color: #444444;
+  outline: none;
+  pointer-events: all;
+  z-index: 20;
+  box-shadow: 0px 8px 16px rgba(0,0,0,0.20);
+  position: absolute;
+  max-height: calc(100% - 0px - 0px);
+  max-width: calc(100% - 0px - 0px);
+  border-radius: 4px;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+  -webkit-animation: hWAzxx 0.2s ease-in-out forwards;
+  animation: hWAzxx 0.2s ease-in-out forwards;
+}
+
+.c3 {
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+@media only screen and (max-width:768px) {
+  .c0 {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    min-height: 100vh;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    position: relative;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    position: relative;
+    max-height: none;
+    max-width: none;
+    border-radius: 0;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    -webkit-transform: none;
+    -ms-transform: none;
+    transform: none;
+    -webkit-animation: none;
+    animation: none;
+    height: 100vh;
+    width: 100vw;
+  }
+}
+
+<div
+  class="c0"
+  id="elevation-test"
+  tabindex="-1"
+>
+  <div
+    class="c1"
+  />
+  <div
+    class="c2"
+    data-g-portal-id="0"
+    id="elevation-test"
+  >
+    <a
+      aria-hidden="true"
+      class="c3"
+      tabindex="-1"
+    />
+  </div>
+</div>
+`;
+
+exports[`Layer elevation 2`] = `
+".ijyCbN {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  background: transparent;
+  position: relative;
+  z-index: 20;
+  pointer-events: none;
+  outline: none;
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+}
+@media only screen and (max-width: 768px) {
   .ijyCbN {
     position: absolute;
     width: 100%;

--- a/src/js/components/Layer/doc.js
+++ b/src/js/components/Layer/doc.js
@@ -37,6 +37,15 @@ export const doc = Layer => {
       )
       .defaultValue('slide'),
     background: backgroundDoc,
+    elevation: PropTypes.oneOfType([
+      PropTypes.oneOf(['none', 'xsmall', 'small', 'medium', 'large', 'xlarge']),
+      PropTypes.string,
+    ])
+      .description(
+        `Elevated height above the underlying context, indicated
+        via a drop shadow.`,
+      )
+      .defaultValue('none'),
     full: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.oneOf(['vertical', 'horizontal']),

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -10613,6 +10613,21 @@ string
 }
 \`\`\`
 
+**elevation**
+
+Elevated height above the underlying context, indicated
+        via a drop shadow. Defaults to \`none\`.
+
+\`\`\`
+none
+xsmall
+small
+medium
+large
+xlarge
+string
+\`\`\`
+
 **full**
 
 Whether the width and/or height should fill the current viewport

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -4926,6 +4926,19 @@ identifier to use for the background color. For example: 'neutral-1'. Or, a
         "name": "background",
       },
       Object {
+        "defaultValue": "none",
+        "description": "Elevated height above the underlying context, indicated
+        via a drop shadow.",
+        "format": "none
+xsmall
+small
+medium
+large
+xlarge
+string",
+        "name": "elevation",
+      },
+      Object {
         "defaultValue": false,
         "description": "Whether the width and/or height should fill the current viewport
         size.",

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -904,7 +904,6 @@ export interface ThemeType {
       intelligentRounding?: boolean;
     };
     container?: {
-      elevation?: ElevationType;
       zIndex?: string;
     };
     extend?: ExtendType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -908,7 +908,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // intelligentRounding: undefined,
       },
       container: {
-        // elevation: undefined,
         zIndex: '20',
       },
       // extend: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
I have 2 suggestions for the current bug in the design-system
1. The first suggestion is taking elevation out of the theme and making it a prop for grommet, that can be used in the design system. This would prevent the bug that is happening now with the elevation. See below. If this is a prop then we can prevent this from happening.  
<img width="802" alt="Screen Shot 2021-02-17 at 9 54 29 AM" src="https://user-images.githubusercontent.com/42451602/108238373-233ee900-7106-11eb-91d0-cf101a45ab3c.png">

2. The other  approach would be to change the design. We can use `flex` within the`box` in the `layer` to take up the space. The `border-radius` is different from the outside box.
<img width="410" alt="Screen Shot 2021-02-17 at 9 55 34 AM" src="https://user-images.githubusercontent.com/42451602/108238818-8c266100-7106-11eb-9285-24c73eec0dc8.png">

This would have to be changed in figma to make the `border-radius` match. 
<img width="410" alt="Screen Shot 2021-02-17 at 10 02 02 AM" src="https://user-images.githubusercontent.com/42451602/108239521-3acaa180-7107-11eb-9cfc-cfb0c2b9f30e.png">

#### What does this PR do?
This PR takes the first suggestion by adding an elevation prop
#### Where should the reviewer start?
layer.js
#### What testing has been done on this PR?
StoryBook 

```
       <Layer
          position="bottom"
          modal={false}
          margin={{ vertical: 'medium', horizontal: 'small' }}
          onEsc={onClose}
          responsive={false}
          plain
          elevation="large"
        >
          <Box
            align="center"
            direction="row"
            gap="small"
            justify="between"
            round="medium"
            elevation="medium"
            pad={{ vertical: 'xsmall', horizontal: 'small' }}
            background="status-ok"
          >
            <Box align="center" direction="row" gap="xsmall">
              <StatusGood />
              <Text>
                A new virtual machine has been successfully added (this Layer
                will close after 3 seconds)
              </Text>
            </Box>
            <Button icon={<FormClose />} onClick={onClose} plain />
          </Box>
        </Layer>

```
#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
issue
https://github.com/grommet/hpe-design-system/issues/1396
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
already  updated
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
yes