### PR TITLE
Changed DataChart to be more resilient to empty properties

### DIFF
--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -56,7 +56,8 @@ const DataChart = forwardRef(
           typeof s === 'string' ? { property: s } : s,
         );
       if (typeof seriesProp === 'string') return [{ property: seriesProp }];
-      return [seriesProp];
+      if (seriesProp) return [seriesProp];
+      return [];
     }, [seriesProp]);
 
     const getPropertySeries = prop =>
@@ -70,7 +71,9 @@ const DataChart = forwardRef(
     const charts = useMemo(() => {
       if (!chart) {
         if (series.length === 1)
-          return series.map(s => ({ property: s.property }));
+          return series
+            .filter(s => s.property)
+            .map(s => ({ property: s.property }));
         // if we have more than one property, we'll use the first for
         // the x-axis and we'll plot the rest
         return series.slice(1).map(s => ({ property: s.property }));
@@ -79,7 +82,9 @@ const DataChart = forwardRef(
         return chart
           .map(c => (typeof c === 'string' ? { property: c } : c))
           .filter(({ property }) => property);
-      return typeof chart === 'string' ? [{ property: chart }] : [chart];
+      if (typeof chart === 'string') return [{ property: chart }];
+      if (chart) return [chart];
+      return [];
     }, [chart, series]);
 
     // map the series property values into their own arrays
@@ -267,7 +272,7 @@ const DataChart = forwardRef(
         });
       });
 
-      if (boundsProp === 'align') {
+      if (boundsProp === 'align' && chartBounds.length) {
         const alignedBounds = [...chartBounds[0]];
         chartBounds.forEach(bounds => {
           alignedBounds[0][0] = Math.min(alignedBounds[0][0], bounds[0][0]);
@@ -426,7 +431,7 @@ const DataChart = forwardRef(
     // TODO: revisit how x/y axis are hooked up to charts and series
 
     const xAxisElement =
-      axis && axis.x ? (
+      axis && axis.x && chartProps.length ? (
         <XAxis
           ref={xRef}
           axis={axis}
@@ -438,7 +443,7 @@ const DataChart = forwardRef(
       ) : null;
 
     const yAxisElement =
-      axis && axis.y ? (
+      axis && axis.y && chartProps.length ? (
         <YAxis
           axis={axis}
           chartProps={chartProps}

--- a/src/js/components/DataChart/__tests__/DataChart-test.js
+++ b/src/js/components/DataChart/__tests__/DataChart-test.js
@@ -23,6 +23,22 @@ describe('DataChart', () => {
     warnSpy.mockRestore();
   });
 
+  test('nothing', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const component = renderer.create(
+      <Grommet>
+        <DataChart data={data} />
+        <DataChart data={data} series={[]} />
+        <DataChart data={data} series={[{}]} />
+        <DataChart data={data} chart={[]} />
+        <DataChart data={data} chart={[{}]} />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+    warnSpy.mockRestore();
+  });
+
   test('gap', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const component = renderer.create(

--- a/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
+++ b/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
@@ -6204,6 +6204,43 @@ exports[`DataChart legend 1`] = `
 </div>
 `;
 
+exports[`DataChart nothing 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  position: relative;
+  grid-area: charts;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  />
+  <div
+    className="c1"
+  />
+  <div
+    className="c1"
+  />
+  <div
+    className="c1"
+  />
+  <div
+    className="c1"
+  />
+</div>
+`;
+
 exports[`DataChart pad 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/DataChart/stories/Simple.js
+++ b/src/js/components/DataChart/stories/Simple.js
@@ -14,7 +14,7 @@ for (let i = 1; i < 8; i += 1) {
 export const Simple = () => (
   <Grommet theme={grommet}>
     <Box align="center" justify="start" pad="large">
-      <DataChart data={data} series={[{}]} />
+      <DataChart data={data} series="percent" />
     </Box>
   </Grommet>
 );

--- a/src/js/components/DataChart/stories/Simple.js
+++ b/src/js/components/DataChart/stories/Simple.js
@@ -14,7 +14,7 @@ for (let i = 1; i < 8; i += 1) {
 export const Simple = () => (
   <Grommet theme={grommet}>
     <Box align="center" justify="start" pad="large">
-      <DataChart data={data} series="percent" />
+      <DataChart data={data} series={[{}]} />
     </Box>
   </Grommet>
 );


### PR DESCRIPTION
#### What does this PR do?

Changed DataChart to be more resilient to empty properties.

This helps makes DataChart more resilient when used in designer.grommet.io.

#### What testing has been done on this PR?

Added unit tests.
Tested with grommet-designer locally

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible, without these changes, the browser crashes
