### PR TITLE
Button padding should use size "medium" by default

### DIFF
--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -116,7 +116,7 @@ const Button = forwardRef(
       reverse,
       secondary,
       selected,
-      size = 'medium',
+      size,
       tip,
       type = 'button',
       as,

--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -116,7 +116,7 @@ const Button = forwardRef(
       reverse,
       secondary,
       selected,
-      size,
+      size = 'medium',
       tip,
       type = 'button',
       as,

--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -32,7 +32,7 @@ const fontStyle = props => {
   `;
 };
 
-const padFromTheme = (size, theme) => {
+const padFromTheme = (size = 'medium', theme) => {
   if (
     size &&
     theme.button.size &&

--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -32,7 +32,8 @@ const fontStyle = props => {
   `;
 };
 
-const padFromTheme = (size, theme) => {
+const padFromTheme = (sizeProp, theme) => {
+  const size = sizeProp || 'medium';
   if (
     size &&
     theme.button.size &&

--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -32,8 +32,7 @@ const fontStyle = props => {
   `;
 };
 
-const padFromTheme = (sizeProp, theme) => {
-  const size = sizeProp || 'medium';
+const padFromTheme = (size, theme) => {
   if (
     size &&
     theme.button.size &&

--- a/src/js/components/Button/__tests__/Button-kind-test.js
+++ b/src/js/components/Button/__tests__/Button-kind-test.js
@@ -381,4 +381,53 @@ describe('Button kind', () => {
     fireEvent.mouseOver(getByText('Button'));
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test(`should apply size styling correctly`, () => {
+    const { container } = render(
+      <Grommet
+        theme={{
+          button: {
+            default: {},
+            size: {
+              small: {
+                border: {
+                  radius: '4px',
+                },
+                pad: {
+                  vertical: '4px',
+                  horizontal: '8px',
+                },
+              },
+              medium: {
+                border: {
+                  radius: '4px',
+                },
+                pad: {
+                  vertical: '6px',
+                  horizontal: '12px',
+                },
+              },
+              large: {
+                border: {
+                  radius: '6px',
+                },
+                pad: {
+                  vertical: '6px',
+                  horizontal: '16px',
+                },
+              },
+            },
+          },
+        }}
+      >
+        <Button label="Button" size="small" />
+        {/* button with no size specified should have medium styling applied 
+        by default */}
+        <Button label="Button" />
+        <Button label="Button" size="medium" />
+        <Button label="Button" size="large" />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/js/components/Button/__tests__/Button-kind-test.js
+++ b/src/js/components/Button/__tests__/Button-kind-test.js
@@ -382,7 +382,7 @@ describe('Button kind', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test(`should apply size styling correctly`, () => {
+  test(`should apply styling according to theme size definitions`, () => {
     const { container } = render(
       <Grommet
         theme={{

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -1663,7 +1663,7 @@ exports[`Button kind secondary button 1`] = `
 </div>
 `;
 
-exports[`Button kind should apply size styling correctly 1`] = `
+exports[`Button kind should apply styling according to theme size definitions 1`] = `
 .c1 {
   display: inline-block;
   box-sizing: border-box;
@@ -1725,7 +1725,7 @@ exports[`Button kind should apply size styling correctly 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 18px;
+  border-radius: 4px;
   padding: 6px 12px;
   font-size: 18px;
   line-height: 24px;
@@ -1774,10 +1774,10 @@ exports[`Button kind should apply size styling correctly 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 4px;
-  padding: 6px 12px;
-  font-size: 18px;
-  line-height: 24px;
+  border-radius: 6px;
+  padding: 6px 16px;
+  font-size: 22px;
+  line-height: 28px;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -1811,55 +1811,6 @@ exports[`Button kind should apply size styling correctly 1`] = `
   border: 0;
 }
 
-.c4 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 6px;
-  padding: 6px 16px;
-  font-size: 22px;
-  line-height: 28px;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-}
-
-.c4 > svg {
-  vertical-align: bottom;
-}
-
-.c4:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c0 {
   font-size: 18px;
   line-height: 24px;
@@ -1886,13 +1837,13 @@ exports[`Button kind should apply size styling correctly 1`] = `
     Button
   </button>
   <button
-    class="c3"
+    class="c2"
     type="button"
   >
     Button
   </button>
   <button
-    class="c4"
+    class="c3"
     type="button"
   >
     Button

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -1663,6 +1663,243 @@ exports[`Button kind secondary button 1`] = `
 </div>
 `;
 
+exports[`Button kind should apply size styling correctly 1`] = `
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 14px;
+  line-height: 20px;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c1 > svg {
+  vertical-align: bottom;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus > circle,
+.c1:focus > ellipse,
+.c1:focus > line,
+.c1:focus > path,
+.c1:focus > polygon,
+.c1:focus > polyline,
+.c1:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c2 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 18px;
+  padding: 6px 12px;
+  font-size: 18px;
+  line-height: 24px;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c2 > svg {
+  vertical-align: bottom;
+}
+
+.c2:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus > circle,
+.c2:focus > ellipse,
+.c2:focus > line,
+.c2:focus > path,
+.c2:focus > polygon,
+.c2:focus > polyline,
+.c2:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-size: 18px;
+  line-height: 24px;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c3 > svg {
+  vertical-align: bottom;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 16px;
+  font-size: 22px;
+  line-height: 28px;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c4 > svg {
+  vertical-align: bottom;
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+  class="c0"
+>
+  <button
+    class="c1"
+    type="button"
+  >
+    Button
+  </button>
+  <button
+    class="c2"
+    type="button"
+  >
+    Button
+  </button>
+  <button
+    class="c3"
+    type="button"
+  >
+    Button
+  </button>
+  <button
+    class="c4"
+    type="button"
+  >
+    Button
+  </button>
+</div>
+`;
+
 exports[`Button kind size of default button 1`] = `
 .c1 {
   display: inline-block;

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -1725,7 +1725,7 @@ exports[`Button kind should apply styling according to theme size definitions 1`
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 4px;
+  border-radius: 18px;
   padding: 6px 12px;
   font-size: 18px;
   line-height: 24px;
@@ -1774,10 +1774,10 @@ exports[`Button kind should apply styling according to theme size definitions 1`
   overflow: visible;
   text-transform: none;
   border: none;
-  border-radius: 6px;
-  padding: 6px 16px;
-  font-size: 22px;
-  line-height: 28px;
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-size: 18px;
+  line-height: 24px;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -1811,6 +1811,55 @@ exports[`Button kind should apply styling according to theme size definitions 1`
   border: 0;
 }
 
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 16px;
+  font-size: 22px;
+  line-height: 28px;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c4 > svg {
+  vertical-align: bottom;
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus::-moz-focus-inner {
+  border: 0;
+}
+
 .c0 {
   font-size: 18px;
   line-height: 24px;
@@ -1837,13 +1886,13 @@ exports[`Button kind should apply styling according to theme size definitions 1`
     Button
   </button>
   <button
-    class="c2"
+    class="c3"
     type="button"
   >
     Button
   </button>
   <button
-    class="c3"
+    class="c4"
     type="button"
   >
     Button


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR ensures that StyledButtonKind uses size "medium" by default. Currently, it wasn't falling back to any size and this was causing discrepancies between buttons implemented as `<Button />` vs `<Button size="medium" />` but they should be identical.

#### Where should the reviewer start?
src/js/components/Button/StyledButtonKind.js

#### What testing has been done on this PR?
Tested local in storybook, created custom theme with size definitions. Default (no size prop specified) and medium should be the same always.

Before (notice padding difference between default and medium):
<img width="161" alt="Screen Shot 2021-02-17 at 3 52 14 PM" src="https://user-images.githubusercontent.com/12522275/108284631-7468d000-713a-11eb-94bd-91badb861294.png">

After:
<img width="169" alt="Screen Shot 2021-02-17 at 3 52 23 PM" src="https://user-images.githubusercontent.com/12522275/108284639-79c61a80-713a-11eb-890e-9b68cebea500.png">

#### How should this be manually tested?

#### Any background context you want to provide?
Noticed the HPE button dimensions had shifted after we removed padding values in this PR but when I looked into it further I also noticed that buttons implemented as `<Button label="Label" />` were not receiving styling for "medium" size like they should.

#### What are the relevant issues?
Noticed issue after https://github.com/grommet/grommet-theme-hpe/pull/163 merged in HPE theme and a subsequent PR on design system site noted snapshot changes.

#### Screenshots (if appropriate)
See above.

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.