### PR TITLE
Add extend to drop on Tip

### DIFF
--- a/src/js/components/Tip/README.md
+++ b/src/js/components/Tip/README.md
@@ -62,3 +62,13 @@ Defaults to
 ```
 {align: { top: 'bottom' }}
 ```
+
+**tip.drop.extend**
+
+Any additional style for Drop within tooltip. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```

--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -5,11 +5,15 @@ import React, {
   useContext,
   useState,
 } from 'react';
-import { ThemeContext } from 'styled-components';
+import styled, { ThemeContext } from 'styled-components';
 
 import { Box } from '../Box';
 import { Drop } from '../Drop';
 import { useForwardedRef } from '../../utils/refs';
+
+const StyledDrop = styled(Drop)`
+  ${props => props.theme.tip.drop && props.theme.tip.drop.extend}}
+`;
 
 const Tip = forwardRef(({ children, content, dropProps, plain }, tipRef) => {
   const theme = useContext(ThemeContext);
@@ -59,7 +63,7 @@ const Tip = forwardRef(({ children, content, dropProps, plain }, tipRef) => {
   return [
     clonedChild,
     over && (
-      <Drop
+      <StyledDrop
         target={componentRef.current}
         trapFocus={false}
         key="tip-drop"
@@ -68,7 +72,7 @@ const Tip = forwardRef(({ children, content, dropProps, plain }, tipRef) => {
         {...dropProps}
       >
         {plain ? content : <Box {...theme.tip.content}>{content}</Box>}
-      </Drop>
+      </StyledDrop>
     ),
   ];
 });

--- a/src/js/components/Tip/__tests__/__snapshots__/Tip-test.js.snap
+++ b/src/js/components/Tip/__tests__/__snapshots__/Tip-test.js.snap
@@ -106,7 +106,7 @@ exports[`Tip dropProps should pass props to Drop 1`] = `
   aria-hidden="false"
 >
   <div
-    class="c0 c1"
+    class="c0 c1 "
     data-g-portal-id="0"
     style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
     tabindex="-1"
@@ -335,7 +335,7 @@ exports[`Tip mouseOver and mouseOut events on the Tip's child 1`] = `
 }
 
 <div
-  class="c0 c1"
+  class="c0 c1 "
   data-g-portal-id="0"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
   tabindex="-1"
@@ -410,7 +410,7 @@ exports[`Tip plain 1`] = `
     aria-hidden="false"
   >
     <div
-      class="c0 c1"
+      class="c0 c1 "
       data-g-portal-id="0"
       style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
       tabindex="-1"

--- a/src/js/components/Tip/doc.js
+++ b/src/js/components/Tip/doc.js
@@ -43,4 +43,9 @@ export const themeDoc = {
     type: 'object',
     defaultValue: "{align: { top: 'bottom' }}",
   },
+  'tip.drop.extend': {
+    description: 'Any additional style for Drop within tooltip.',
+    type: 'string | (props) => {}',
+    defaultValue: undefined,
+  },
 };

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -17332,6 +17332,16 @@ Defaults to
 \`\`\`
 {align: { top: 'bottom' }}
 \`\`\`
+
+**tip.drop.extend**
+
+Any additional style for Drop within tooltip. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
 ",
   "Video": "## Video
 A video player.

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1255,6 +1255,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       drop: {
         // any props for the drop
         align: { top: 'bottom' }, // most common use case is Header with Buttons
+        // extend: undefined,
       },
     },
     video: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds the extend option for `tooltip.drop` in the theme.
#### Where should the reviewer start?
tip.js
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?

#### Any background context you want to provide?
Currently, in hpe-design-system we have a alignment issue with the tooltip. We had to add `margin-top` and `margin-bottom` to the theme for `select` that can be found here.
https://github.com/grommet/grommet-theme-hpe/blob/master/src/js/index.js#L226

One idea was to add this for tooltip so that we can set the  
```
margin-top: 0;
margin-bottom: 0;

```

that way the alignment will not be off.
#### What are the relevant issues?

https://github.com/grommet/hpe-design-system/issues/1449
#### Screenshots (if appropriate)
This is the problem

<img width="389" alt="Screen Shot 2021-02-25 at 9 47 43 AM" src="https://user-images.githubusercontent.com/42451602/109186783-83f5a380-774e-11eb-86bb-257bb47d0f83.png">

If the margin is set to 0 then it will be centered aligned

<img width="215" alt="Screen Shot 2021-02-25 at 9 50 14 AM" src="https://user-images.githubusercontent.com/42451602/109187164-de8eff80-774e-11eb-9f40-12278d0eb3dc.png">


#### Do the grommet docs need to be updated?
auto
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backward compatible