### PR TITLE
Allow Menu drop to be themed, any Drop props accepted

### DIFF
--- a/src/js/components/Grommet/Grommet.js
+++ b/src/js/components/Grommet/Grommet.js
@@ -60,6 +60,18 @@ const Grommet = forwardRef((props, ref) => {
   const theme = useMemo(() => {
     const nextTheme = deepMerge(baseTheme, themeProp || {});
 
+    // if user provides specific menu alignment, we don't want
+    // the defaults to be included at all (can cause issues with controlMirror)
+    // override merged value with themeProp value
+    if (
+      themeProp &&
+      themeProp.menu &&
+      themeProp.menu.drop &&
+      themeProp.menu.drop.align
+    ) {
+      delete nextTheme.menu.drop.align;
+      nextTheme.menu.drop.align = themeProp.menu.drop.align;
+    }
     const {
       colors: { background: themeBackground },
     } = nextTheme.global;

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -72,9 +72,9 @@ const Menu = forwardRef((props, ref) => {
   const iconColor = normalizeColor(theme.menu.icons.color || 'control', theme);
   // need to destructure the align otherwise it will get passed through
   // to DropButton and override prop values
-  const { align: menuAlign, ...themeDropProps } = theme.menu.drop;
+  const { align: themeDropAlign, ...themeDropProps } = theme.menu.drop;
 
-  const align = (dropProps && dropProps.align) || dropAlign || menuAlign;
+  const align = (dropProps && dropProps.align) || dropAlign || themeDropAlign;
   const controlButtonIndex = useMemo(() => {
     if (align.top === 'top') return -1;
     if (align.bottom === 'bottom') return items.length;

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -70,7 +70,7 @@ const Menu = forwardRef((props, ref) => {
   } = props;
   const theme = useContext(ThemeContext) || defaultProps.theme;
   const iconColor = normalizeColor(theme.menu.icons.color || 'control', theme);
-  const align = dropProps.align || dropAlign;
+  const align = dropProps.align || dropAlign || theme.menu.drop.align;
   const controlButtonIndex = useMemo(() => {
     if (align.top === 'top') return -1;
     if (align.bottom === 'bottom') return items.length;
@@ -357,10 +357,6 @@ const Menu = forwardRef((props, ref) => {
 });
 
 Menu.defaultProps = {
-  dropAlign: {
-    top: 'top',
-    left: 'left',
-  },
   dropProps: {},
   items: [],
   messages: {

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -70,7 +70,11 @@ const Menu = forwardRef((props, ref) => {
   } = props;
   const theme = useContext(ThemeContext) || defaultProps.theme;
   const iconColor = normalizeColor(theme.menu.icons.color || 'control', theme);
-  const align = dropProps.align || dropAlign || theme.menu.drop.align;
+  // need to destructure the align otherwise it will get passed through
+  // to DropButton and override prop values
+  const { align: menuAlign, ...themeDropProps } = theme.menu.drop;
+
+  const align = (dropProps && dropProps.align) || dropAlign || menuAlign;
   const controlButtonIndex = useMemo(() => {
     if (align.top === 'top') return -1;
     if (align.bottom === 'bottom') return items.length;
@@ -270,7 +274,7 @@ const Menu = forwardRef((props, ref) => {
         disabled={disabled}
         dropAlign={align}
         dropTarget={dropTarget}
-        dropProps={dropProps}
+        dropProps={dropProps || themeDropProps}
         open={isOpen}
         onOpen={onDropOpen}
         onClose={onDropClose}
@@ -357,7 +361,6 @@ const Menu = forwardRef((props, ref) => {
 });
 
 Menu.defaultProps = {
-  dropProps: {},
   items: [],
   messages: {
     openMenu: 'Open Menu',

--- a/src/js/components/Menu/README.md
+++ b/src/js/components/Menu/README.md
@@ -339,6 +339,19 @@ Defaults to
 undefined
 ```
 
+**menu.drop.align**
+
+The alignment of the drop with respect to the menu button. Expects `string`.
+
+Defaults to
+
+```
+{
+      top: 'top',
+      left: 'left',
+    },
+```
+
 **menu.extend**
 
 Any additional style for the Menu. Expects `string | (props) => {}`.

--- a/src/js/components/Menu/README.md
+++ b/src/js/components/Menu/README.md
@@ -341,7 +341,7 @@ undefined
 
 **menu.drop.align**
 
-The alignment of the drop with respect to the menu button. Expects `string`.
+The alignment of the drop with respect to the menu button. Expects `string | object`.
 
 Defaults to
 

--- a/src/js/components/Menu/README.md
+++ b/src/js/components/Menu/README.md
@@ -220,7 +220,7 @@ object
 
 **dropProps**
 
-Any valid Drop prop. Defaults to `{}`.
+Any valid Drop prop.
 
 ```
 object
@@ -339,14 +339,14 @@ Defaults to
 undefined
 ```
 
-**menu.drop.align**
+**menu.drop**
 
-The alignment of the drop with respect to the menu button. Expects `string | object`.
+Any valid Drop props for the Menu drop. Expects `object`.
 
 Defaults to
 
 ```
-{
+align: {
       top: 'top',
       left: 'left',
     },

--- a/src/js/components/Menu/__tests__/Menu-test.js
+++ b/src/js/components/Menu/__tests__/Menu-test.js
@@ -14,6 +14,12 @@ import { Grommet, Menu } from '../..';
 
 const customTheme = {
   menu: {
+    drop: {
+      align: {
+        top: 'bottom',
+        left: 'right',
+      },
+    },
     icons: {
       color: '#F08080',
     },
@@ -557,5 +563,18 @@ describe('Menu', () => {
       </Grommet>,
     );
     expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  test('should apply custom drop alignment', () => {
+    const { container } = render(
+      <Grommet theme={customTheme}>
+        <Menu
+          label="Test Menu"
+          items={[{ label: 'Item 1' }, { label: 'Item 2' }]}
+          open
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/components/Menu/__tests__/Menu-test.js
+++ b/src/js/components/Menu/__tests__/Menu-test.js
@@ -19,6 +19,7 @@ const customTheme = {
         top: 'bottom',
         left: 'right',
       },
+      elevation: 'xlarge',
     },
     icons: {
       color: '#F08080',
@@ -565,7 +566,7 @@ describe('Menu', () => {
     expect(component.toJSON()).toMatchSnapshot();
   });
 
-  test('should apply custom drop alignment', () => {
+  test('should apply themed drop props', () => {
     const { container } = render(
       <Grommet theme={customTheme}>
         <Menu

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -4343,7 +4343,7 @@ exports[`Menu shift + tab through menu until it closes 1`] = `
 </div>
 `;
 
-exports[`Menu should apply custom drop alignment 1`] = `
+exports[`Menu should apply themed drop props 1`] = `
 .c5 {
   display: inline-block;
   -webkit-flex: 0 0 auto;

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -4343,6 +4343,187 @@ exports[`Menu shift + tab through menu until it closes 1`] = `
 </div>
 `;
 
+exports[`Menu should apply custom drop alignment 1`] = `
+.c5 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #F08080;
+  stroke: #F08080;
+}
+
+.c5 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c5 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c5 *[stroke*="#"],
+.c5 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c5 *[fill-rule],
+.c5 *[FILL-RULE],
+.c5 *[fill*="#"],
+.c5 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  padding: 12px;
+}
+
+.c4 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 12px;
+}
+
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus > circle,
+.c1:focus > ellipse,
+.c1:focus > line,
+.c1:focus > path,
+.c1:focus > polygon,
+.c1:focus > polyline,
+.c1:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    width: 6px;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
+<div
+  class="c0"
+>
+  <button
+    aria-label="Open Menu"
+    class="c1"
+    type="button"
+  >
+    <div
+      class="c2"
+    >
+      <span
+        class="c3"
+      >
+        Test Menu
+      </span>
+      <div
+        class="c4"
+      />
+      <svg
+        aria-label="FormDown"
+        class="c5"
+        viewBox="0 0 24 24"
+      >
+        <polyline
+          fill="none"
+          points="18 9 12 15 6 9"
+          stroke="#000"
+          stroke-width="2"
+        />
+      </svg>
+    </div>
+  </button>
+</div>
+`;
+
 exports[`Menu should have no accessibility violations 1`] = `
 .c4 {
   display: inline-block;

--- a/src/js/components/Menu/doc.js
+++ b/src/js/components/Menu/doc.js
@@ -139,6 +139,14 @@ export const themeDoc = {
     type: 'string',
     defaultValue: undefined,
   },
+  'menu.drop.align': {
+    description: 'The alignment of the drop with respect to the menu button.',
+    type: 'string',
+    defaultValue: `{
+      top: 'top',
+      left: 'left',
+    },`,
+  },
   'menu.extend': {
     description: 'Any additional style for the Menu.',
     type: 'string | (props) => {}',

--- a/src/js/components/Menu/doc.js
+++ b/src/js/components/Menu/doc.js
@@ -141,7 +141,7 @@ export const themeDoc = {
   },
   'menu.drop.align': {
     description: 'The alignment of the drop with respect to the menu button.',
-    type: 'string',
+    type: 'string | object',
     defaultValue: `{
       top: 'top',
       left: 'left',

--- a/src/js/components/Menu/doc.js
+++ b/src/js/components/Menu/doc.js
@@ -77,7 +77,9 @@ one of top or bottom should be specified.`,
       a React reference. Typically, this is not required as the drop will be
       aligned to the Menu itself by default.`,
     ),
-    dropProps: PropTypes.object.description('Any valid Drop prop.'),
+    dropProps: PropTypes.object
+      .description('Any valid Drop prop.')
+      .defaultValue(undefined),
     justifyContent: PropTypes.oneOf([
       'start',
       'center',
@@ -139,10 +141,10 @@ export const themeDoc = {
     type: 'string',
     defaultValue: undefined,
   },
-  'menu.drop.align': {
-    description: 'The alignment of the drop with respect to the menu button.',
-    type: 'string | object',
-    defaultValue: `{
+  'menu.drop': {
+    description: 'Any valid Drop props for the Menu drop.',
+    type: 'object',
+    defaultValue: `align: {
       top: 'top',
       left: 'left',
     },`,

--- a/src/js/components/Menu/stories/Simple.js
+++ b/src/js/components/Menu/stories/Simple.js
@@ -2,30 +2,19 @@ import React from 'react';
 
 import { Grommet, Box, Menu } from 'grommet';
 import { grommet } from 'grommet/themes';
-import { deepMerge } from 'grommet/utils';
 
-const myTheme = deepMerge(grommet, {
-  menu: {
-    drop: {
-      align: {
-        top: 'top',
-        left: 'right',
-      },
-    },
-  },
-});
 const SimpleMenu = () => (
-  <Grommet theme={myTheme}>
+  <Grommet theme={grommet}>
     <Box align="center" pad="large">
       <Menu
-        // dropProps={{
-        //   align: { top: 'bottom', left: 'left' },
-        //   elevation: 'xlarge',
-        // }}
+        dropProps={{
+          align: { top: 'bottom', left: 'left' },
+          elevation: 'xlarge',
+        }}
         label="actions"
         items={[
-          { label: 'Launch Something', onClick: () => {} },
-          { label: 'Abort Something', onClick: () => {} },
+          { label: 'Launch', onClick: () => {} },
+          { label: 'Abort', onClick: () => {} },
           { label: 'Disabled', disabled: true },
         ]}
       />

--- a/src/js/components/Menu/stories/Simple.js
+++ b/src/js/components/Menu/stories/Simple.js
@@ -2,19 +2,30 @@ import React from 'react';
 
 import { Grommet, Box, Menu } from 'grommet';
 import { grommet } from 'grommet/themes';
+import { deepMerge } from 'grommet/utils';
 
+const myTheme = deepMerge(grommet, {
+  menu: {
+    drop: {
+      align: {
+        top: 'top',
+        left: 'right',
+      },
+    },
+  },
+});
 const SimpleMenu = () => (
-  <Grommet theme={grommet}>
+  <Grommet theme={myTheme}>
     <Box align="center" pad="large">
       <Menu
-        dropProps={{
-          align: { top: 'bottom', left: 'left' },
-          elevation: 'xlarge',
-        }}
+        // dropProps={{
+        //   align: { top: 'bottom', left: 'left' },
+        //   elevation: 'xlarge',
+        // }}
         label="actions"
         items={[
-          { label: 'Launch', onClick: () => {} },
-          { label: 'Abort', onClick: () => {} },
+          { label: 'Launch Something', onClick: () => {} },
+          { label: 'Abort Something', onClick: () => {} },
           { label: 'Disabled', disabled: true },
         ]}
       />

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -12539,7 +12539,7 @@ undefined
 
 **menu.drop.align**
 
-The alignment of the drop with respect to the menu button. Expects \`string\`.
+The alignment of the drop with respect to the menu button. Expects \`string | object\`.
 
 Defaults to
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -12537,6 +12537,19 @@ Defaults to
 undefined
 \`\`\`
 
+**menu.drop.align**
+
+The alignment of the drop with respect to the menu button. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+{
+      top: 'top',
+      left: 'left',
+    },
+\`\`\`
+
 **menu.extend**
 
 Any additional style for the Menu. Expects \`string | (props) => {}\`.

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -12426,7 +12426,7 @@ object
 
 **dropProps**
 
-Any valid Drop prop. Defaults to \`{}\`.
+Any valid Drop prop.
 
 \`\`\`
 object
@@ -12545,14 +12545,14 @@ Defaults to
 undefined
 \`\`\`
 
-**menu.drop.align**
+**menu.drop**
 
-The alignment of the drop with respect to the menu button. Expects \`string | object\`.
+Any valid Drop props for the Menu drop. Expects \`object\`.
 
 Defaults to
 
 \`\`\`
-{
+align: {
       top: 'top',
       left: 'left',
     },

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -5823,7 +5823,7 @@ one of top or bottom should be specified.",
         "name": "dropTarget",
       },
       Object {
-        "defaultValue": Object {},
+        "defaultValue": undefined,
         "description": "Any valid Drop prop.",
         "format": "object",
         "name": "dropProps",

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -970,9 +970,7 @@ export interface ThemeType {
   };
   menu?: {
     background?: BackgroundType;
-    drop?: {
-      align?: AlignContentType;
-    };
+    drop?: DropProps;
     extend?: ExtendType;
     icons?: {
       down?: any;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -970,6 +970,9 @@ export interface ThemeType {
   };
   menu?: {
     background?: BackgroundType;
+    drop?: {
+      align?: AlignContentType;
+    };
     extend?: ExtendType;
     icons?: {
       down?: any;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -987,6 +987,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           top: 'top',
           left: 'left',
         },
+        // any drop props
       },
       icons: {
         down: FormDown,

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -982,6 +982,12 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     menu: {
       // background: undefined,
       // extend: undefined,
+      drop: {
+        align: {
+          top: 'top',
+          left: 'left',
+        },
+      },
       icons: {
         down: FormDown,
         // up: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds `theme.menu.drop` to theme to allow users to style their Menu drop from the theme rather than having to repeat the styling every time via props. This is beneficial for apps that always want a Menu to have drop alignment of, for example, `{ top: 'bottom', left: 'left' }`.

#### Where should the reviewer start?
src/js/components/Menu/Menu.js

#### What testing has been done on this PR?
Tested in storybook example by creating custom theme and added jest test.

#### How should this be manually tested?
Create custom theme.

#### Any background context you want to provide?
HPE Design System calls for Menu that is always aligned `{ top: 'bottom', left: 'left' }`. Instead of having teams implement on every Menu instance, it should come automatically from theme.

<img width="191" alt="Screen Shot 2021-02-25 at 2 51 03 PM" src="https://user-images.githubusercontent.com/12522275/109230648-09db1400-777a-11eb-9f34-b42c4d14ac0c.png">


#### What are the relevant issues?
Related to https://github.com/grommet/hpe-design-system/issues/1416

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, updated here.

#### Should this PR be mentioned in the release notes?
Added `theme.menu.drop` to allow theming of Menu's drop alignment.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.