### PR TITLE
[TS] Fix Table, TableHeader, TableFooter and TableBody Prop Types

### DIFF
--- a/src/js/components/Table/index.d.ts
+++ b/src/js/components/Table/index.d.ts
@@ -14,6 +14,10 @@ export interface TableProps {
   margin?: MarginType;
 }
 
-declare const Table: React.FC<TableProps & JSX.IntrinsicElements['table']>;
+type htmlTableProps = JSX.IntrinsicElements['table'];
+
+export interface TableExtendedProps extends TableProps, htmlTableProps {}
+
+declare const Table: React.FC<TableExtendedProps>;
 
 export { Table };

--- a/src/js/components/TableBody/index.d.ts
+++ b/src/js/components/TableBody/index.d.ts
@@ -2,7 +2,12 @@ import * as React from 'react';
 
 export interface TableBodyProps {}
 
-declare const TableBody: React.FC<TableBodyProps &
-  JSX.IntrinsicElements['tbody']>;
+type htmlTableBodyProps = JSX.IntrinsicElements['tbody'];
+
+export interface TableBodyExtendedProps
+  extends TableBodyProps,
+    htmlTableBodyProps {}
+
+declare const TableBody: React.FC<TableBodyExtendedProps>;
 
 export { TableBody };

--- a/src/js/components/TableFooter/index.d.ts
+++ b/src/js/components/TableFooter/index.d.ts
@@ -2,7 +2,12 @@ import * as React from 'react';
 
 export interface TableFooterProps {}
 
-declare const TableFooter: React.FC<TableFooterProps &
-  JSX.IntrinsicElements['tfoot']>;
+type htmlTableFooterProps = JSX.IntrinsicElements['tfoot'];
+
+export interface TableFooterExtendedProps
+  extends TableFooterProps,
+    htmlTableFooterProps {}
+
+declare const TableFooter: React.FC<TableFooterExtendedProps>;
 
 export { TableFooter };

--- a/src/js/components/TableHeader/index.d.ts
+++ b/src/js/components/TableHeader/index.d.ts
@@ -2,7 +2,12 @@ import * as React from 'react';
 
 export interface TableHeaderProps {}
 
-declare const TableHeader: React.FC<TableHeaderProps &
-  JSX.IntrinsicElements['thead']>;
+type htmlTableHeaderProps = JSX.IntrinsicElements['thead'];
+
+export interface TableHeaderExtendedProps
+  extends TableHeaderProps,
+    htmlTableHeaderProps {}
+
+declare const TableHeader: React.FC<TableHeaderExtendedProps>;
 
 export { TableHeader };


### PR DESCRIPTION
#### What does this PR do?

This PR adds and exports `<component>ExtendedProps` declarations for the Table, TableHeader, TableFooter and TableBody components, forming part of issue #4998.

#### Where should the reviewer start?

The only files changed are the TS declaration files for each of the four components. Any of these files are good places to start

#### What testing has been done on this PR?

No new tests were added, all tests passed locally on each commit's pre-commit hook.

#### How should this be manually tested?

Importing the extended prop interfaces from a separate project should allow `JSX.IntrinsicElements` keys to be passed through to the imported interface, e.g. importing `TableExtendedProps` should make `table` keys available, as well as general HTML keys like `children`.

#### Any background context you want to provide?

All background context is available in this discussion/design issue: #4978

#### What are the relevant issues?

Progress tracking: #4998
Design/discussion: #4978

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Not this PR specifically, but users should be made aware of the new extended prop type declarations.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.