### PR TITLE
[TS] Fix TableRow and TableCell Prop Types

### DIFF
--- a/src/js/components/TableCell/index.d.ts
+++ b/src/js/components/TableCell/index.d.ts
@@ -21,8 +21,13 @@ export interface TableCellProps {
   verticalAlign?: 'top' | 'middle' | 'bottom';
 }
 
-declare const TableCell: React.FC<TableCellProps &
-  BoxTypes &
-  JSX.IntrinsicElements['td']>;
+// We combine BoxTypes & JSX.IntrinsicElements['td'] inline here since BoxTypes
+// is a combination of BoxProps & JSX.IntrinsicElements['div'], and there is a
+// large overlap between td and div attributes.
+export interface TableCellExtendedProps
+  extends TableCellProps,
+    Omit<BoxTypes & JSX.IntrinsicElements['td'], 'scope'> {}
+
+declare const TableCell: React.FC<TableCellExtendedProps>;
 
 export { TableCell };

--- a/src/js/components/TableRow/index.d.ts
+++ b/src/js/components/TableRow/index.d.ts
@@ -2,6 +2,12 @@ import * as React from 'react';
 
 export interface TableRowProps {}
 
-declare const TableRow: React.FC<TableRowProps & JSX.IntrinsicElements['tr']>;
+type htmlTableRowProps = JSX.IntrinsicElements['tr'];
+
+export interface TableRowExtendedProps
+  extends TableRowProps,
+    htmlTableRowProps {}
+
+declare const TableRow: React.FC<TableRowExtendedProps>;
 
 export { TableRow };


### PR DESCRIPTION
#### What does this PR do?

This PR adds and exports `<component>ExtendedProps` declarations for the TableRow and TableCell components, forming part of issue #4998.

#### Where should the reviewer start?

The only files changed are the TS declaration files for each of the components. The simplest is the TableRow component, so it's a good place to start.

#### What testing has been done on this PR?

No new tests were added, all tests passed locally on each commit's pre-commit hook.

#### How should this be manually tested?

Importing the extended prop interfaces from a separate project should allow `JSX.IntrinsicElements` keys to be passed through to the imported interface, e.g. importing `TableRowExtendedProps` should make `tr` keys available, as well as general HTML keys like `children`.

#### Any background context you want to provide?

All background context is available in this discussion/design issue: #4978

#### What are the relevant issues?

Progress tracking: #4998
Design/discussion: #4978

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Not this PR specifically, but users should be made aware of the new extended prop type declarations.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.