### PR TITLE
[TS] Fix Sidebar, Stack, Tab and Tabs extended types

### DIFF
--- a/src/js/components/Sidebar/index.d.ts
+++ b/src/js/components/Sidebar/index.d.ts
@@ -6,9 +6,12 @@ export interface SidebarProps {
   header?: React.ReactNode;
 }
 
-export type SidebarExtendedProps = BoxProps &
-  SidebarProps &
-  JSX.IntrinsicElements['div'];
+type divProps = Omit<JSX.IntrinsicElements['div'], 'onClick'>;
+
+export interface SidebarExtendedProps
+  extends BoxProps,
+    SidebarProps,
+    divProps {}
 
 declare const Sidebar: React.FC<SidebarExtendedProps>;
 

--- a/src/js/components/Sidebar/index.d.ts
+++ b/src/js/components/Sidebar/index.d.ts
@@ -6,8 +6,10 @@ export interface SidebarProps {
   header?: React.ReactNode;
 }
 
-declare const Sidebar: React.FC<BoxProps &
+export type SidebarExtendedProps = BoxProps &
   SidebarProps &
-  JSX.IntrinsicElements['div']>;
+  JSX.IntrinsicElements['div'];
+
+declare const Sidebar: React.FC<SidebarExtendedProps>;
 
 export { Sidebar };

--- a/src/js/components/Stack/index.d.ts
+++ b/src/js/components/Stack/index.d.ts
@@ -27,6 +27,10 @@ export interface StackProps {
   margin?: MarginType;
 }
 
-declare const Stack: React.FC<StackProps & JSX.IntrinsicElements['div']>;
+type divProps = JSX.IntrinsicElements['div'];
+
+export interface StackExtendedProps extends StackProps, divProps {}
+
+declare const Stack: React.FC<StackExtendedProps>;
 
 export { Stack };

--- a/src/js/components/Tab/index.d.ts
+++ b/src/js/components/Tab/index.d.ts
@@ -9,7 +9,10 @@ export interface TabProps {
   title?: React.ReactNode;
 }
 
-declare const Tab: React.ComponentClass<TabProps &
-  Omit<JSX.IntrinsicElements['button'], 'title'>>;
+export interface TabExtendedProps
+  extends TabProps,
+    Omit<JSX.IntrinsicElements['button'], 'title'> {}
+
+declare const Tab: React.FC<TabExtendedProps>;
 
 export { Tab };

--- a/src/js/components/Tabs/index.d.ts
+++ b/src/js/components/Tabs/index.d.ts
@@ -20,7 +20,9 @@ export interface TabsProps {
   onActive?: (index: number) => void;
 }
 
-export type TabsExtendedProps = TabsProps & JSX.IntrinsicElements['div'];
+type divProps = Omit<JSX.IntrinsicElements['div'], 'children'>;
+
+export interface TabsExtendedProps extends TabsProps, divProps {}
 
 declare const Tabs: React.FC<TabsExtendedProps>;
 

--- a/src/js/components/Tabs/index.d.ts
+++ b/src/js/components/Tabs/index.d.ts
@@ -20,6 +20,8 @@ export interface TabsProps {
   onActive?: (index: number) => void;
 }
 
-declare const Tabs: React.FC<TabsProps & JSX.IntrinsicElements['div']>;
+export type TabsExtendedProps = TabsProps & JSX.IntrinsicElements['div'];
+
+declare const Tabs: React.FC<TabsExtendedProps>;
 
 export { Tabs };


### PR DESCRIPTION
#### What does this PR do?
Add ExtendedProps declarations for Sidebar, Stack, Tab and Tabs components, forming part of issue #4998.

#### Where should the reviewer start?
Reviewers can start from any of the files, there were independent changes only in TS declaration files

#### What testing has been done on this PR?
No additional tests were added

#### How should this be manually tested?
The import of any of the modified components in question will now have the respective _JSX.IntrinsicElements_ property 

#### Any background context you want to provide?
Discussed in the #4978

#### What are the relevant issues?
Progress track: #4998

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Yes
