### PR TITLE
[TS] Fix RadioButton, RadioButtonGroup, RangeInput and RangeSelector type interfaces

### DIFF
--- a/src/js/components/RadioButton/index.d.ts
+++ b/src/js/components/RadioButton/index.d.ts
@@ -14,6 +14,6 @@ export interface RadioButtonExtendedProps
   extends RadioButtonProps,
     Omit<JSX.IntrinsicElements['input'], 'name'> {}
 
-declare const RadioButton: React.ComponentClass<RadioButtonExtendedProps>;
+declare const RadioButton: React.FC<RadioButtonExtendedProps>;
 
 export { RadioButton };

--- a/src/js/components/RadioButton/index.d.ts
+++ b/src/js/components/RadioButton/index.d.ts
@@ -10,7 +10,10 @@ export interface RadioButtonProps {
   name: string;
 }
 
-declare const RadioButton: React.ComponentClass<RadioButtonProps &
-  JSX.IntrinsicElements['input']>;
+export interface RadioButtonExtendedProps
+  extends RadioButtonProps,
+    Omit<JSX.IntrinsicElements['input'], 'name'> {}
+
+declare const RadioButton: React.ComponentClass<RadioButtonExtendedProps>;
 
 export { RadioButton };

--- a/src/js/components/RadioButtonGroup/index.d.ts
+++ b/src/js/components/RadioButtonGroup/index.d.ts
@@ -18,11 +18,12 @@ export interface RadioButtonGroupProps {
   )[];
   value?: string | number | boolean | object;
 }
+
 export interface RadioButtonGroupExtendedProps
   extends RadioButtonGroupProps,
     BoxProps,
     Omit<JSX.IntrinsicElements['div'], 'onClick' | 'onChange'> {}
 
-declare const RadioButtonGroup: React.ComponentClass<RadioButtonGroupExtendedProps>;
+declare const RadioButtonGroup: React.FC<RadioButtonGroupExtendedProps>;
 
 export { RadioButtonGroup };

--- a/src/js/components/RadioButtonGroup/index.d.ts
+++ b/src/js/components/RadioButtonGroup/index.d.ts
@@ -18,9 +18,11 @@ export interface RadioButtonGroupProps {
   )[];
   value?: string | number | boolean | object;
 }
+export interface RadioButtonGroupExtendedProps
+  extends RadioButtonGroupProps,
+    BoxProps,
+    Omit<JSX.IntrinsicElements['div'], 'onClick' | 'onChange'> {}
 
-declare const RadioButtonGroup: React.ComponentClass<RadioButtonGroupProps &
-  BoxProps &
-  JSX.IntrinsicElements['div']>;
+declare const RadioButtonGroup: React.ComponentClass<RadioButtonGroupExtendedProps>;
 
 export { RadioButtonGroup };

--- a/src/js/components/RangeInput/index.d.ts
+++ b/src/js/components/RangeInput/index.d.ts
@@ -11,7 +11,10 @@ export interface RangeInputProps {
   value?: number | string;
 }
 
-declare const RangeInput: React.FC<RangeInputProps &
-  JSX.IntrinsicElements['input']>;
+export interface RangeInputExtendedProps
+  extends RangeInputProps,
+    Omit<JSX.IntrinsicElements['input'], 'step' | 'value'> {}
+
+declare const RangeInput: React.FC<RangeInputExtendedProps>;
 
 export { RangeInput };

--- a/src/js/components/RangeSelector/index.d.ts
+++ b/src/js/components/RangeSelector/index.d.ts
@@ -28,7 +28,7 @@ export interface RangeSelectorExtendedProps
   extends RangeSelectorProps,
     Omit<JSX.IntrinsicElements['div'], 'color' | 'onChange'> {}
 
-declare const RangeSelector: React.ComponentClass<RangeSelectorProps &
+declare const RangeSelector: React.FC<RangeSelectorProps &
   Omit<JSX.IntrinsicElements['div'], 'color'>>;
 
 export { RangeSelector };

--- a/src/js/components/RangeSelector/index.d.ts
+++ b/src/js/components/RangeSelector/index.d.ts
@@ -24,6 +24,10 @@ export interface RangeSelectorProps {
   values: number[];
 }
 
+export interface RangeSelectorExtendedProps
+  extends RangeSelectorProps,
+    Omit<JSX.IntrinsicElements['div'], 'color' | 'onChange'> {}
+
 declare const RangeSelector: React.ComponentClass<RangeSelectorProps &
   Omit<JSX.IntrinsicElements['div'], 'color'>>;
 


### PR DESCRIPTION
#### What does this PR do?

This PR adds and exports `<component>ExtendedProps` declarations for the RadioButton, RadioButtonGroup, RangeInput and RangeSelector components, forming part of issue #4998.

#### Where should the reviewer start?

The only files changed are the TS declaration files for each of the four components. Any of these files are good places to start.

#### What testing has been done on this PR?

No new tests were added, all tests passed locally on each commit's pre-commit hook.

#### How should this be manually tested?

Importing the extended prop interfaces from a separate project should allow `JSX.IntrinsicElements` keys to be passed through to the imported interface, e.g. importing `RadioButtonExtendedProps` should make `input` keys available, as well as general HTML keys like `children`. Also double check any keys included in `Omit<..., ...>` types for consistency with original intersected types.

#### Any background context you want to provide?

All background context is available in this discussion/design issue: #4978

#### What are the relevant issues?

Progress tracking: #4998
Design/discussion: #4978

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Not this PR specifically, but users should be made aware of the new extended prop type declarations.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.