### PR TITLE
Feature label toggle alignment

### DIFF
--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -43,6 +43,7 @@ const CheckBox = forwardRef(
       reverse,
       toggle,
       indeterminate,
+      containerWidth,
       ...rest
     },
     ref,
@@ -197,6 +198,7 @@ const CheckBox = forwardRef(
         {...removeUndefined({ htmlFor: id, disabled })}
         checked={checked}
         onClick={stopLabelClick}
+        width={containerWidth}
         {...themeableProps}
       >
         {first}

--- a/src/js/components/CheckBox/README.md
+++ b/src/js/components/CheckBox/README.md
@@ -97,6 +97,15 @@ NOTE: This can only be used with non-toggle components
 ```
 boolean
 ```
+
+**containerWidth**
+
+Define a value for the container width and 
+        set value for justify content to space between.
+
+```
+string
+```
   
 ## Intrinsic element
 

--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -37,6 +37,8 @@ const StyledCheckBoxContainer = styled.label`
   align-items: center;
   user-select: none;
   width: fit-content;
+  ${props =>
+    props.width && `width: ${props.width}; justify-content: space-between;`}
   ${props => props.disabled && disabledStyle}
   ${props => !props.disabled && 'cursor: pointer;'}
   ${props => props.theme.checkBox.hover.border.color && hoverStyle}

--- a/src/js/components/CheckBox/__tests__/CheckBox-test.js
+++ b/src/js/components/CheckBox/__tests__/CheckBox-test.js
@@ -7,6 +7,7 @@ import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
 import { Grommet } from '../../Grommet';
+import { Box } from '../../Box';
 import { CheckBox } from '..';
 
 describe('CheckBox', () => {
@@ -163,5 +164,18 @@ describe('CheckBox', () => {
     expect(container.firstChild).toMatchSnapshot();
     fireEvent.click(getByText('test-label'));
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('different container widths', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Box pad="small" width="20%">
+          <CheckBox width="50%" />
+          <CheckBox width="48px" />
+        </Box>
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
   });
 });

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -329,7 +329,7 @@ exports[`CheckBox controlled 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <label
-    class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+    class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -519,6 +519,198 @@ exports[`CheckBox defaultChecked 1`] = `
       </div>
     </div>
   </label>
+</div>
+`;
+
+exports[`CheckBox different container widths 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 20%;
+  padding: 12px;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px rgba(0,0,0,0.15);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: pointer;
+}
+
+.c2:hover input:not([disabled]) + div,
+.c2:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c5 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.c5:checked + span > span {
+  left: calc( 48px - 24px );
+  background: #7D4CDB;
+}
+
+.c4 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    border: solid 2px rgba(0,0,0,0.15);
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <label
+      checked={false}
+      className="c2"
+      onClick={[Function]}
+    >
+      <div
+        checked={false}
+        className="c3 c4"
+      >
+        <input
+          checked={false}
+          className="c5"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          type="checkbox"
+          width="50%"
+        />
+        <div
+          checked={false}
+          className="c6 "
+        />
+      </div>
+    </label>
+    <label
+      checked={false}
+      className="c2"
+      onClick={[Function]}
+    >
+      <div
+        checked={false}
+        className="c3 c4"
+      >
+        <input
+          checked={false}
+          className="c5"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          type="checkbox"
+          width="48px"
+        />
+        <div
+          checked={false}
+          className="c6 "
+        />
+      </div>
+    </label>
+  </div>
 </div>
 `;
 

--- a/src/js/components/CheckBox/doc.js
+++ b/src/js/components/CheckBox/doc.js
@@ -54,6 +54,12 @@ export const doc = CheckBox => {
 NOTE: This can only be used with non-toggle components`,
       )
       .defaultValue(false),
+    containerWidth: PropTypes.string
+      .description(
+        `Define a value for the container width and 
+        set value for justify content to space between.`,
+      )
+      .defaultValue(false),
   };
 
   return DocumentedCheckBox;

--- a/src/js/components/CheckBox/index.d.ts
+++ b/src/js/components/CheckBox/index.d.ts
@@ -11,6 +11,7 @@ export interface CheckBoxProps {
   reverse?: boolean;
   toggle?: boolean;
   indeterminate?: boolean;
+  containerWidth?: string;
 }
 
 declare const CheckBox: React.FC<CheckBoxProps &

--- a/src/js/components/CheckBox/stories/CustomWidth.js
+++ b/src/js/components/CheckBox/stories/CustomWidth.js
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { grommet, Box, Grommet, FormField, CheckBox } from 'grommet';
+
+export const CustomWidth = () => (
+  <Grommet theme={grommet}>
+    <Box pad="small" width="20%">
+      <FormField name="required-field" label="Label" required>
+        <CheckBox
+          name="checkbox"
+          id="required-field"
+          label="Validation"
+          toggle
+          reverse
+          containerWidth="50%"
+        />
+
+        <CheckBox
+          name="checkbox"
+          id="required-field"
+          label="Validation"
+          toggle
+          reverse
+          containerWidth="40%"
+        />
+      </FormField>
+    </Box>
+  </Grommet>
+);
+
+export default {
+  title: 'Input/CheckBox/Custom Width',
+};

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
@@ -8,7 +8,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
     class="StyledBox-sc-13pk1d4-0 ftUyAh StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -29,7 +29,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 dLcqZl"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -59,7 +59,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 llTcBl"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 blBbHc"
       disabled={true}
       onClick={[Function]}
     >
@@ -92,7 +92,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     />
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 llTcBl"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 blBbHc"
       disabled={true}
       onClick={[Function]}
     >
@@ -126,7 +126,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 llTcBl"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 blBbHc"
       disabled={true}
       onClick={[Function]}
     >
@@ -160,7 +160,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 llTcBl"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 blBbHc"
       disabled={true}
       onClick={[Function]}
     >
@@ -201,7 +201,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
       onClick={[Function]}
     >
       <div
@@ -230,7 +230,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
     />
     <label
       checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
       onClick={[Function]}
     >
       <div
@@ -271,7 +271,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
     />
     <label
       checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
       onClick={[Function]}
     >
       <div
@@ -319,7 +319,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
     class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -340,7 +340,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -369,7 +369,7 @@ exports[`CheckBoxGroup onChange 1`] = `
     class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -401,7 +401,7 @@ exports[`CheckBoxGroup onChange 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -431,7 +431,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
     tabindex="0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -463,7 +463,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -493,7 +493,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
     tabindex="0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -514,7 +514,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -544,7 +544,7 @@ exports[`CheckBoxGroup options renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
       onClick={[Function]}
     >
       <div
@@ -573,7 +573,7 @@ exports[`CheckBoxGroup options renders 1`] = `
     />
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
       onClick={[Function]}
     >
       <div
@@ -610,7 +610,7 @@ exports[`CheckBoxGroup value renders 1`] = `
   >
     <label
       checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
       onClick={[Function]}
     >
       <div
@@ -651,7 +651,7 @@ exports[`CheckBoxGroup value renders 1`] = `
     />
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
       onClick={[Function]}
     >
       <div
@@ -687,7 +687,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
     class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -708,7 +708,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -3409,7 +3409,7 @@ exports[`DataTable custom theme 2`] = `
         >
           <label
             aria-label="unselect alpha"
-            class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 llTcBl"
+            class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 blBbHc"
             disabled=""
           >
             <div
@@ -3468,7 +3468,7 @@ exports[`DataTable custom theme 2`] = `
         >
           <label
             aria-label="select beta"
-            class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 llTcBl"
+            class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 blBbHc"
             disabled=""
           >
             <div
@@ -12550,7 +12550,7 @@ exports[`DataTable select 2`] = `
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 gAxdWq"
         >
           <label
-            class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+            class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
           >
             <div
               class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -12623,7 +12623,7 @@ exports[`DataTable select 2`] = `
         >
           <label
             aria-label="unselect alpha"
-            class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+            class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
           >
             <div
               class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -12673,7 +12673,7 @@ exports[`DataTable select 2`] = `
         >
           <label
             aria-label="unselect beta"
-            class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+            class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
           >
             <div
               class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -2612,7 +2612,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -2851,7 +2851,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1 iUyYoX"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -1273,7 +1273,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -1512,7 +1512,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1 iUyYoX"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -2901,7 +2901,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 htOOow"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
           for="test-checkbox"
         >
           <div

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4790,6 +4790,15 @@ NOTE: This can only be used with non-toggle components
 \`\`\`
 boolean
 \`\`\`
+
+**containerWidth**
+
+Define a value for the container width and 
+        set value for justify content to space between.
+
+\`\`\`
+string
+\`\`\`
   
 ## Intrinsic element
 

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2243,6 +2243,13 @@ NOTE: This can only be used with non-toggle components",
         "format": "boolean",
         "name": "indeterminate",
       },
+      Object {
+        "defaultValue": false,
+        "description": "Define a value for the container width and 
+        set value for justify content to space between.",
+        "format": "string",
+        "name": "containerWidth",
+      },
     ],
     "usage": "import { CheckBox } from 'grommet';
 <CheckBox />",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR aims to implement the improvement mentioned in issue #5001 . The idea here is to pass a props called `containerWidth` so that each `Checkbox` can have a variable size inside a `Container`.

#### Where should the reviewer start?
`./src/js/components/Checkbox/CheckBox.js`

#### What testing has been done on this PR?
Manual testing, storybook testing (including a brand new example) and update snapshots that already cover Checkbox plain usage.

#### How should this be manually tested?
```js
import React from 'react';

import { grommet, Box, Grommet, FormField, CheckBox } from 'grommet';

export const CustomWidth = () => (
  <Grommet theme={grommet}>
    <Box pad="small" width="20%">
      <FormField name="required-field" label="Label" required>
        <CheckBox
          name="checkbox"
          id="required-field"
          label="Validation"
          toggle
          reverse
          containerWidth="50%"
        />

        <CheckBox
          name="checkbox"
          id="required-field"
          label="Validation"
          toggle
          reverse
          containerWidth="40%"
        />
      </FormField>
    </Box>
  </Grommet>
);
```
#### Any background context you want to provide?

#### What are the relevant issues?
#5001 

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/24996268/109431884-6ee77180-79e7-11eb-9259-559717a5265b.png)

#### Do the grommet docs need to be updated?
Yes

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
I believe it's backwards compatible, since it's only a new prop.