### PR TITLE
Update button docs to clarify what relies on button.default

### DIFF
--- a/src/js/components/Button/README.md
+++ b/src/js/components/Button/README.md
@@ -546,7 +546,9 @@ undefined
 
 **button.active.primary**
 
-Adjustments to the primary Button style when the Button is active. Expects `{}`.
+Adjustments to the primary Button style when the Button is 
+    active. Only relevant for themes that have defined a value for 
+    button.default. Expects `{}`.
 
 Defaults to
 
@@ -556,7 +558,9 @@ undefined
 
 **button.active.secondary**
 
-Adjustments to the secondary Button style when the Button is active. Expects `{}`.
+Adjustments to the secondary Button style when the Button is 
+    active. Only relevant for themes that have defined a value for 
+    button.default. Expects `{}`.
 
 Defaults to
 
@@ -746,7 +750,9 @@ undefined
 
 **button.disabled.primary**
 
-Adjustments to the primary Button style when the Button is disabled. Expects `{}`.
+Adjustments to the primary Button style when the Button is 
+    disabled. Only relevant for themes that have defined a value for 
+    button.default. Expects `{}`.
 
 Defaults to
 
@@ -756,7 +762,9 @@ undefined
 
 **button.disabled.secondary**
 
-Adjustments to the secondary Button style when the Button is disabled. Expects `{}`.
+Adjustments to the secondary Button style when the Button is 
+    disabled. Only relevant for themes that have defined a value for 
+    button.default. Expects `{}`.
 
 Defaults to
 
@@ -816,7 +824,9 @@ undefined
 
 **button.hover.primary**
 
-Adjustments to the primary Button style when the Button is hovered. Expects `{}`.
+Adjustments to the primary Button style when the Button is 
+    hovered. Only relevant for themes that have defined a value for 
+    button.default. Expects `{}`.
 
 Defaults to
 
@@ -826,7 +836,9 @@ undefined
 
 **button.hover.secondary**
 
-Adjustments to the secondary Button style when the Button is hovered. Expects `{}`.
+Adjustments to the secondary Button style when the Button is 
+    hovered. Only relevant for themes that have defined a value for 
+    button.default. Expects `{}`.
 
 Defaults to
 
@@ -856,7 +868,8 @@ Defaults to
 
 **button.primary.background.color**
 
-The color of the background for primary buttons. Expects `string | { dark: string, light: string }`.
+The color of the background for primary buttons. Only 
+    relevant for themes that have defined a value for button.default. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 
@@ -866,7 +879,8 @@ undefined
 
 **button.primary.background.opacity**
 
-The value used for primary button background opacity. Expects `number | string`.
+The value used for primary button background opacity.
+    Only relevant for themes that have defined a value for button.default. Expects `number | string`.
 
 Defaults to
 
@@ -876,7 +890,8 @@ undefined
 
 **button.primary.border.color**
 
-The color of the border for primary buttons. Expects `string | { dark: string, light: string }`.
+The color of the border for primary buttons. Only relevant 
+    for themes that have defined a value for button.default. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 
@@ -936,7 +951,8 @@ undefined
 
 **button.secondary.background.color**
 
-The color of the background for secondary buttons. Expects `string | { dark: string, light: string }`.
+The color of the background for secondary buttons. Only 
+    relevant for themes that have defined a value for button.default. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 
@@ -946,7 +962,8 @@ undefined
 
 **button.secondary.background.opacity**
 
-The value used for secondary button background opacity. Expects `number | string`.
+The value used for secondary button background opacity. 
+    Only relevant for themes that have defined a value for button.default. Expects `number | string`.
 
 Defaults to
 
@@ -956,7 +973,8 @@ undefined
 
 **button.secondary.border.color**
 
-The color of the border for secondary buttons. Expects `string | { dark: string, light: string }`.
+The color of the border for secondary buttons. Only 
+    relevant for themes that have defined a value for button.default. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 
@@ -966,7 +984,8 @@ undefined
 
 **button.secondary.color**
 
-The color of the label for secondary buttons. Expects `string | { dark: string, light: string }`.
+The color of the label for secondary buttons. Only 
+    relevant for themes that have defined a value for button.default. Expects `string | { dark: string, light: string }`.
 
 Defaults to
 
@@ -976,7 +995,8 @@ undefined
 
 **button.secondary.font.weight**
 
-The weight of the text label for secondary buttons. Expects `string | number`.
+The weight of the text label for secondary buttons. Only 
+    relevant for themes that have defined a value for button.default. Expects `string | number`.
 
 Defaults to
 
@@ -986,7 +1006,8 @@ undefined
 
 **button.secondary.padding.horizontal**
 
-The horizontal padding for a secondary button. Expects `string`.
+The horizontal padding for a secondary button. Only 
+    relevant for themes that have defined a value for button.default. Expects `string`.
 
 Defaults to
 
@@ -996,7 +1017,8 @@ Defaults to
 
 **button.secondary.padding.vertical**
 
-The vertical padding for a secondary button. Expects `string`.
+The vertical padding for a secondary button. Only 
+    relevant for themes that have defined a value for button.default. Expects `string`.
 
 Defaults to
 
@@ -1006,7 +1028,8 @@ Defaults to
 
 **button.secondary.extend**
 
-Any additional style for a secondary button. Expects `string | (props) => {}`.
+Any additional style for a secondary button. Only 
+    relevant for themes that have defined a value for button.default. Expects `string | (props) => {}`.
 
 Defaults to
 

--- a/src/js/components/Button/doc.js
+++ b/src/js/components/Button/doc.js
@@ -196,7 +196,6 @@ export const themeDoc = {
     type: 'string | { dark: string, light: string }',
     defaultValue: "{ dark: '#f8f8f8', light: '#444444' }",
   },
-
   'text.medium.size': {
     description: 'The font size of the text label.',
     type: 'string',
@@ -207,7 +206,6 @@ export const themeDoc = {
     type: 'string',
     defaultValue: '24px',
   },
-
   'button.active.background.color': {
     description: `Background color when the button is active.`,
     type: 'string | { dark: string, light: string }',
@@ -235,18 +233,19 @@ export const themeDoc = {
     defaultValue: undefined,
   },
   'button.active.primary': {
-    description:
-      'Adjustments to the primary Button style when the Button is active.',
+    description: `Adjustments to the primary Button style when the Button is 
+    active. Only relevant for themes that have defined a value for 
+    button.default.`,
     type: '{}',
     defaultValue: undefined,
   },
   'button.active.secondary': {
-    description:
-      'Adjustments to the secondary Button style when the Button is active.',
+    description: `Adjustments to the secondary Button style when the Button is 
+    active. Only relevant for themes that have defined a value for 
+    button.default.`,
     type: '{}',
     defaultValue: undefined,
   },
-
   'button.border.color': {
     description: `The color of the border.`,
     type: 'string | { dark: string, light: string }',
@@ -261,12 +260,10 @@ export const themeDoc = {
     type: 'string',
     defaultValue: '2px',
   },
-
   'button.color': {
     description: `The color of the text label.`,
     type: 'string | { dark: string, light: string }',
   },
-
   'button.default.background.color': {
     description: `The color of the background for default buttons.`,
     type: 'string | { dark: string, light: string }',
@@ -332,18 +329,19 @@ export const themeDoc = {
     defaultValue: undefined,
   },
   'button.disabled.primary': {
-    description:
-      'Adjustments to the primary Button style when the Button is disabled.',
+    description: `Adjustments to the primary Button style when the Button is 
+    disabled. Only relevant for themes that have defined a value for 
+    button.default.`,
     type: '{}',
     defaultValue: undefined,
   },
   'button.disabled.secondary': {
-    description:
-      'Adjustments to the secondary Button style when the Button is disabled.',
+    description: `Adjustments to the secondary Button style when the Button is 
+    disabled. Only relevant for themes that have defined a value for 
+    button.default.`,
     type: '{}',
     defaultValue: undefined,
   },
-
   'button.hover.color': {
     description: `Label color when the button is hovered.`,
     type: 'string | { dark: string, light: string }',
@@ -367,18 +365,19 @@ export const themeDoc = {
     defaultValue: undefined,
   },
   'button.hover.primary': {
-    description:
-      'Adjustments to the primary Button style when the Button is hovered.',
+    description: `Adjustments to the primary Button style when the Button is 
+    hovered. Only relevant for themes that have defined a value for 
+    button.default.`,
     type: '{}',
     defaultValue: undefined,
   },
   'button.hover.secondary': {
-    description:
-      'Adjustments to the secondary Button style when the Button is hovered.',
+    description: `Adjustments to the secondary Button style when the Button is 
+    hovered. Only relevant for themes that have defined a value for 
+    button.default.`,
     type: '{}',
     defaultValue: undefined,
   },
-
   'button.padding.horizontal': {
     description: 'The horizontal padding.',
     type: 'string',
@@ -389,19 +388,21 @@ export const themeDoc = {
     type: 'string',
     defaultValue: '4px',
   },
-
   'button.primary.background.color': {
-    description: `The color of the background for primary buttons.`,
+    description: `The color of the background for primary buttons. Only 
+    relevant for themes that have defined a value for button.default.`,
     type: 'string | { dark: string, light: string }',
     defaultValue: undefined,
   },
   'button.primary.background.opacity': {
-    description: 'The value used for primary button background opacity.',
+    description: `The value used for primary button background opacity.
+    Only relevant for themes that have defined a value for button.default.`,
     type: 'number | string',
     defaultValue: undefined,
   },
   'button.primary.border.color': {
-    description: `The color of the border for primary buttons.`,
+    description: `The color of the border for primary buttons. Only relevant 
+    for themes that have defined a value for button.default.`,
     type: 'string | { dark: string, light: string }',
   },
   'button.primary.color': {
@@ -427,45 +428,51 @@ export const themeDoc = {
     type: 'string | (props) => {}',
     defaultValue: 'undefined',
   },
-
   'button.secondary.background.color': {
-    description: `The color of the background for secondary buttons.`,
+    description: `The color of the background for secondary buttons. Only 
+    relevant for themes that have defined a value for button.default.`,
     type: 'string | { dark: string, light: string }',
     defaultValue: undefined,
   },
   'button.secondary.background.opacity': {
-    description: 'The value used for secondary button background opacity.',
+    description: `The value used for secondary button background opacity. 
+    Only relevant for themes that have defined a value for button.default.`,
     type: 'number | string',
     defaultValue: undefined,
   },
   'button.secondary.border.color': {
-    description: `The color of the border for secondary buttons.`,
+    description: `The color of the border for secondary buttons. Only 
+    relevant for themes that have defined a value for button.default.`,
     type: 'string | { dark: string, light: string }',
   },
   'button.secondary.color': {
-    description: `The color of the label for secondary buttons.`,
+    description: `The color of the label for secondary buttons. Only 
+    relevant for themes that have defined a value for button.default.`,
     type: 'string | { dark: string, light: string }',
   },
   'button.secondary.font.weight': {
-    description: `The weight of the text label for secondary buttons.`,
+    description: `The weight of the text label for secondary buttons. Only 
+    relevant for themes that have defined a value for button.default.`,
     type: 'string | number',
   },
   'button.secondary.padding.horizontal': {
-    description: 'The horizontal padding for a secondary button.',
+    description: `The horizontal padding for a secondary button. Only 
+    relevant for themes that have defined a value for button.default.`,
     type: 'string',
     defaultValue: '22px',
   },
   'button.secondary.padding.vertical': {
-    description: 'The vertical padding for a secondary button.',
+    description: `The vertical padding for a secondary button. Only 
+    relevant for themes that have defined a value for button.default.`,
     type: 'string',
     defaultValue: '4px',
   },
   'button.secondary.extend': {
-    description: 'Any additional style for a secondary button.',
+    description: `Any additional style for a secondary button. Only 
+    relevant for themes that have defined a value for button.default.`,
     type: 'string | (props) => {}',
     defaultValue: 'undefined',
   },
-
   'button.size.small.border.radius': {
     description: 'The border corner radius.',
     type: 'string',
@@ -511,7 +518,6 @@ export const themeDoc = {
     type: 'string',
     defaultValue: '8px',
   },
-
   'button.transition.duration': {
     description: `The length of time it will take for the element to transition
 between two states.`,
@@ -529,7 +535,6 @@ duration and allowing it to change speed during its course.`,
     type: 'string',
     defaultValue: 'ease-in-out',
   },
-
   'button.extend': {
     description: 'Any additional style for the Button.',
     type: 'string | (props) => {}',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -2464,7 +2464,9 @@ undefined
 
 **button.active.primary**
 
-Adjustments to the primary Button style when the Button is active. Expects \`{}\`.
+Adjustments to the primary Button style when the Button is 
+    active. Only relevant for themes that have defined a value for 
+    button.default. Expects \`{}\`.
 
 Defaults to
 
@@ -2474,7 +2476,9 @@ undefined
 
 **button.active.secondary**
 
-Adjustments to the secondary Button style when the Button is active. Expects \`{}\`.
+Adjustments to the secondary Button style when the Button is 
+    active. Only relevant for themes that have defined a value for 
+    button.default. Expects \`{}\`.
 
 Defaults to
 
@@ -2664,7 +2668,9 @@ undefined
 
 **button.disabled.primary**
 
-Adjustments to the primary Button style when the Button is disabled. Expects \`{}\`.
+Adjustments to the primary Button style when the Button is 
+    disabled. Only relevant for themes that have defined a value for 
+    button.default. Expects \`{}\`.
 
 Defaults to
 
@@ -2674,7 +2680,9 @@ undefined
 
 **button.disabled.secondary**
 
-Adjustments to the secondary Button style when the Button is disabled. Expects \`{}\`.
+Adjustments to the secondary Button style when the Button is 
+    disabled. Only relevant for themes that have defined a value for 
+    button.default. Expects \`{}\`.
 
 Defaults to
 
@@ -2734,7 +2742,9 @@ undefined
 
 **button.hover.primary**
 
-Adjustments to the primary Button style when the Button is hovered. Expects \`{}\`.
+Adjustments to the primary Button style when the Button is 
+    hovered. Only relevant for themes that have defined a value for 
+    button.default. Expects \`{}\`.
 
 Defaults to
 
@@ -2744,7 +2754,9 @@ undefined
 
 **button.hover.secondary**
 
-Adjustments to the secondary Button style when the Button is hovered. Expects \`{}\`.
+Adjustments to the secondary Button style when the Button is 
+    hovered. Only relevant for themes that have defined a value for 
+    button.default. Expects \`{}\`.
 
 Defaults to
 
@@ -2774,7 +2786,8 @@ Defaults to
 
 **button.primary.background.color**
 
-The color of the background for primary buttons. Expects \`string | { dark: string, light: string }\`.
+The color of the background for primary buttons. Only 
+    relevant for themes that have defined a value for button.default. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 
@@ -2784,7 +2797,8 @@ undefined
 
 **button.primary.background.opacity**
 
-The value used for primary button background opacity. Expects \`number | string\`.
+The value used for primary button background opacity.
+    Only relevant for themes that have defined a value for button.default. Expects \`number | string\`.
 
 Defaults to
 
@@ -2794,7 +2808,8 @@ undefined
 
 **button.primary.border.color**
 
-The color of the border for primary buttons. Expects \`string | { dark: string, light: string }\`.
+The color of the border for primary buttons. Only relevant 
+    for themes that have defined a value for button.default. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 
@@ -2854,7 +2869,8 @@ undefined
 
 **button.secondary.background.color**
 
-The color of the background for secondary buttons. Expects \`string | { dark: string, light: string }\`.
+The color of the background for secondary buttons. Only 
+    relevant for themes that have defined a value for button.default. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 
@@ -2864,7 +2880,8 @@ undefined
 
 **button.secondary.background.opacity**
 
-The value used for secondary button background opacity. Expects \`number | string\`.
+The value used for secondary button background opacity. 
+    Only relevant for themes that have defined a value for button.default. Expects \`number | string\`.
 
 Defaults to
 
@@ -2874,7 +2891,8 @@ undefined
 
 **button.secondary.border.color**
 
-The color of the border for secondary buttons. Expects \`string | { dark: string, light: string }\`.
+The color of the border for secondary buttons. Only 
+    relevant for themes that have defined a value for button.default. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 
@@ -2884,7 +2902,8 @@ undefined
 
 **button.secondary.color**
 
-The color of the label for secondary buttons. Expects \`string | { dark: string, light: string }\`.
+The color of the label for secondary buttons. Only 
+    relevant for themes that have defined a value for button.default. Expects \`string | { dark: string, light: string }\`.
 
 Defaults to
 
@@ -2894,7 +2913,8 @@ undefined
 
 **button.secondary.font.weight**
 
-The weight of the text label for secondary buttons. Expects \`string | number\`.
+The weight of the text label for secondary buttons. Only 
+    relevant for themes that have defined a value for button.default. Expects \`string | number\`.
 
 Defaults to
 
@@ -2904,7 +2924,8 @@ undefined
 
 **button.secondary.padding.horizontal**
 
-The horizontal padding for a secondary button. Expects \`string\`.
+The horizontal padding for a secondary button. Only 
+    relevant for themes that have defined a value for button.default. Expects \`string\`.
 
 Defaults to
 
@@ -2914,7 +2935,8 @@ Defaults to
 
 **button.secondary.padding.vertical**
 
-The vertical padding for a secondary button. Expects \`string\`.
+The vertical padding for a secondary button. Only 
+    relevant for themes that have defined a value for button.default. Expects \`string\`.
 
 Defaults to
 
@@ -2924,7 +2946,8 @@ Defaults to
 
 **button.secondary.extend**
 
-Any additional style for a secondary button. Expects \`string | (props) => {}\`.
+Any additional style for a secondary button. Only 
+    relevant for themes that have defined a value for button.default. Expects \`string | (props) => {}\`.
 
 Defaults to
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Certain button theming is only available if the caller has defined `button.default` in their theme as well. This adds a note to the doc descriptions to clarify.

#### Where should the reviewer start?
src/js/components/Button/doc.js

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Updated here.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.