### PR TITLE
[TS] Fix Anchor, FormField, Image and TextArea extended types definition

### DIFF
--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -32,7 +32,9 @@ export interface AnchorProps {
   weight?: 'normal' | 'bold' | number;
 }
 
-declare const Anchor: React.FC<AnchorProps &
-  Omit<JSX.IntrinsicElements['a'], 'color'>>;
+export type AnchorExtendedProps = AnchorProps &
+  Omit<JSX.IntrinsicElements['a'], 'color'>;
+
+declare const Anchor: React.FC<AnchorExtendedProps>;
 
 export { Anchor };

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -32,8 +32,9 @@ export interface AnchorProps {
   weight?: 'normal' | 'bold' | number;
 }
 
-export type AnchorExtendedProps = AnchorProps &
-  Omit<JSX.IntrinsicElements['a'], 'color'>;
+type aProps = Omit<JSX.IntrinsicElements['a'], 'color'>;
+
+export interface AnchorExtendedProps extends AnchorProps, aProps {}
 
 declare const Anchor: React.FC<AnchorExtendedProps>;
 

--- a/src/js/components/FormField/index.d.ts
+++ b/src/js/components/FormField/index.d.ts
@@ -35,7 +35,9 @@ export interface FormFieldProps {
       )[];
 }
 
-declare const FormField: React.ComponentClass<FormFieldProps &
-  Omit<JSX.IntrinsicElements['input'], 'placeholder'>>;
+export type FormFieldExtendedProps = FormFieldProps &
+  Omit<JSX.IntrinsicElements['input'], 'placeholder'>;
+
+declare const FormField: React.FC<FormFieldExtendedProps>;
 
 export { FormField };

--- a/src/js/components/FormField/index.d.ts
+++ b/src/js/components/FormField/index.d.ts
@@ -35,8 +35,9 @@ export interface FormFieldProps {
       )[];
 }
 
-export type FormFieldExtendedProps = FormFieldProps &
-  Omit<JSX.IntrinsicElements['input'], 'placeholder'>;
+type inputProps = Omit<JSX.IntrinsicElements['input'], 'placeholder'>;
+
+export interface FormFieldExtendedProps extends FormFieldProps, inputProps {}
 
 declare const FormField: React.FC<FormFieldExtendedProps>;
 

--- a/src/js/components/Image/index.d.ts
+++ b/src/js/components/Image/index.d.ts
@@ -18,6 +18,8 @@ export interface ImageProps {
   opacity?: 'weak' | 'medium' | 'strong' | string | boolean;
 }
 
-declare const Image: React.FC<ImageProps & JSX.IntrinsicElements['img']>;
+export type ImageExtendedProps = ImageProps & JSX.IntrinsicElements['img'];
+
+declare const Image: React.FC<ImageExtendedProps>;
 
 export { Image };

--- a/src/js/components/Image/index.d.ts
+++ b/src/js/components/Image/index.d.ts
@@ -18,7 +18,9 @@ export interface ImageProps {
   opacity?: 'weak' | 'medium' | 'strong' | string | boolean;
 }
 
-export type ImageExtendedProps = ImageProps & JSX.IntrinsicElements['img'];
+type imgProps = JSX.IntrinsicElements['img'];
+
+export interface ImageExtendedProps extends ImageProps, imgProps {}
 
 declare const Image: React.FC<ImageExtendedProps>;
 

--- a/src/js/components/TextArea/index.d.ts
+++ b/src/js/components/TextArea/index.d.ts
@@ -14,8 +14,9 @@ export interface TextAreaProps {
   value?: string;
 }
 
-export type TextAreaExtendedProps = TextAreaProps &
-  JSX.IntrinsicElements['textarea'];
+type textareaProps = Omit<JSX.IntrinsicElements['textarea'], 'value'>;
+
+export interface TextAreaExtendedProps extends TextAreaProps, textareaProps {}
 
 declare const TextArea: React.FC<TextAreaExtendedProps>;
 

--- a/src/js/components/TextArea/index.d.ts
+++ b/src/js/components/TextArea/index.d.ts
@@ -14,7 +14,9 @@ export interface TextAreaProps {
   value?: string;
 }
 
-declare const TextArea: React.FC<TextAreaProps &
-  JSX.IntrinsicElements['textarea']>;
+export type TextAreaExtendedProps = TextAreaProps &
+  JSX.IntrinsicElements['textarea'];
+
+declare const TextArea: React.FC<TextAreaExtendedProps>;
 
 export { TextArea };


### PR DESCRIPTION
#### What does this PR do?

This PR adds and exports ExtendedProps declarations for the Anchor, FormField, Image and TextArea components, forming part of issue #4998.

#### Where should the reviewer start?

Any of the type definition files, the changes should be simple to understand, it's just a new export using the intrinsic elements properties. Component Class has also being replaced by Functional Component.

#### What testing has been done on this PR?

No new tests has been written, the changes passed in all the current ones and it seem to be enough.

#### How should this be manually tested?

Now the type definition must contain the intrinsic elements properties. 

#### Any background context you want to provide?

These changes were discussed in the #4978 issue.

#### What are the relevant issues?

#4998 and #4978

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
