### PR TITLE
Added Drop props and theme support for 'margin', 'round' & 'background'

### DIFF
--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -145,7 +145,7 @@ const wrapStyle = css`
   flex-wrap: ${props => WRAP_MAP[props.wrapProp]};
 `;
 
-const ROUND_MAP = {
+export const ROUND_MAP = {
   full: '100%',
 };
 

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -6,6 +6,7 @@ import {
   getBorderPropType,
   hoverIndicatorPropType,
   padPropType,
+  roundPropType,
 } from '../../utils/prop-types';
 import { getAvailableAtBadge } from '../../utils/mixins';
 import { themeDocUtils } from '../../utils/themeDocUtils';
@@ -247,29 +248,7 @@ export const doc = Box => {
       sizes should be scaled for mobile environments.`,
       )
       .defaultValue(true),
-    round: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.oneOf(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full']),
-      PropTypes.string,
-      PropTypes.shape({
-        corner: PropTypes.oneOf([
-          'top',
-          'left',
-          'bottom',
-          'right',
-          'top-left',
-          'top-right',
-          'bottom-left',
-          'bottom-right',
-        ]),
-        size: PropTypes.oneOfType([
-          PropTypes.oneOf(['xsmall', 'small', 'medium', 'large', 'xlarge']),
-          PropTypes.string,
-        ]),
-      }),
-    ])
-      .description('How much to round the corners.')
-      .defaultValue(false),
+    round: roundPropType,
     tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).description(
       `The DOM tag to use for the element. NOTE: This is deprecated in favor
 of indicating the DOM tag via the 'as' property.`,

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -37,6 +37,7 @@ const DropContainer = forwardRef(
   (
     {
       align = defaultAlign,
+      background,
       onAlign,
       children,
       dropTarget,
@@ -314,6 +315,7 @@ const DropContainer = forwardRef(
       <StyledDrop
         ref={ref || dropRef}
         as={Box}
+        background={background}
         plain={plain}
         elevation={
           !plain
@@ -330,8 +332,11 @@ const DropContainer = forwardRef(
       </StyledDrop>
     );
 
-    if (theme.global.drop.background) {
-      const dark = backgroundIsDark(theme.global.drop.background, theme);
+    if (background || theme.global.drop.background) {
+      const dark = backgroundIsDark(
+        background || theme.global.drop.background,
+        theme,
+      );
       if (dark !== undefined && dark !== theme.dark) {
         content = (
           <ThemeContext.Provider value={{ ...theme, dark }}>

--- a/src/js/components/Drop/README.md
+++ b/src/js/components/Drop/README.md
@@ -169,6 +169,89 @@ xlarge
 string
 ```
 
+**margin**
+
+The amount of margin around the component. An object can
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  end: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  start: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
 **plain**
 
 Whether the drop element should have no background nor elevation.
@@ -242,7 +325,10 @@ The background color of Drop. Expects `string | { dark: string, light: string }`
 Defaults to
 
 ```
-#ffffff
+{
+      dark: 'black',
+      light: 'white',
+    }
 ```
 
 **global.drop.border.radius**
@@ -283,4 +369,26 @@ Defaults to
 
 ```
 20
+```
+
+**global.edgeSize**
+
+The possible sizes for the Drop margin. Expects `object`.
+
+Defaults to
+
+```
+{
+    edgeSize: {
+      none: '0px',
+      hair: '1px',
+      xxsmall: '3px',
+      xsmall: '6px',
+      small: '12px',
+      medium: '24px',
+      large: '48px',
+      xlarge: '96px',
+      responsiveBreakpoint: 'small',
+    },
+  }
 ```

--- a/src/js/components/Drop/README.md
+++ b/src/js/components/Drop/README.md
@@ -37,6 +37,45 @@ How to align the drop with respect to the target element. Not
 }
 ```
 
+**background**
+
+Either a color 
+identifier to use for the background color. For example: 'neutral-1'. Or, a 
+'url()' for an image. Dark is not needed if color is provided.
+
+```
+string
+{
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
+  dark: 
+    boolean
+    string,
+  image: string,
+  position: string,
+  opacity: 
+    string
+    boolean
+    number
+    weak
+    medium
+    strong,
+  repeat: 
+    no-repeat
+    repeat
+    string,
+  size: 
+    cover
+    contain
+    string,
+  light: string
+}
+```
+
 **onClickOutside**
 
 Function that will be invoked when the user clicks outside the drop.
@@ -136,6 +175,39 @@ Whether the drop element should have no background nor elevation.
 
 ```
 boolean
+```
+
+**round**
+
+How much to round the corners.
+
+```
+boolean
+xsmall
+small
+medium
+large
+xlarge
+full
+string
+{
+  corner: 
+    top
+    left
+    bottom
+    right
+    top-left
+    top-right
+    bottom-left
+    bottom-right,
+  size: 
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
 ```
 
 **trapFocus**

--- a/src/js/components/Drop/StyledDrop.js
+++ b/src/js/components/Drop/StyledDrop.js
@@ -49,11 +49,11 @@ const StyledDrop = styled.div`
     )}
 
   ${props =>
-    props.margin &&
+    (props.margin || props.theme.global.drop.margin) &&
     props.theme.global &&
     edgeStyle(
       'margin',
-      props.margin,
+      props.margin || props.theme.global.drop.margin,
       props.responsive,
       props.theme.global.edgeSize.responsiveBreakpoint,
       props.theme,

--- a/src/js/components/Drop/StyledDrop.js
+++ b/src/js/components/Drop/StyledDrop.js
@@ -1,6 +1,7 @@
 import styled, { keyframes } from 'styled-components';
 
-import { baseStyle } from '../../utils';
+import { ROUND_MAP } from '../Box/StyledBox';
+import { baseStyle, edgeStyle } from '../../utils';
 import { backgroundStyle } from '../../utils/background';
 import { defaultProps } from '../../default-props';
 
@@ -30,14 +31,33 @@ const dropKeyFrames = keyframes`
 const StyledDrop = styled.div`
   ${baseStyle}
 
-  border-radius: ${props => props.theme.global.drop.border.radius};
+  border-radius: ${props =>
+    ROUND_MAP[props.round] ||
+    props.theme.global.edgeSize[props.round] ||
+    props.round ||
+    props.theme.global.drop.border.radius};
+    
   position: fixed;
   z-index: ${props => props.theme.global.drop.zIndex};
   outline: none;
 
   ${props =>
     !props.plain &&
-    backgroundStyle(props.theme.global.drop.background, props.theme)}
+    backgroundStyle(
+      props.background || props.theme.global.drop.background,
+      props.theme,
+    )}
+
+  ${props =>
+    props.margin &&
+    props.theme.global &&
+    edgeStyle(
+      'margin',
+      props.margin,
+      props.responsive,
+      props.theme.global.edgeSize.responsiveBreakpoint,
+      props.theme,
+    )}
 
   opacity: 0;
   transform-origin: ${props => getTransformOriginStyle(props.alignProp)};

--- a/src/js/components/Drop/__tests__/Drop-test.js
+++ b/src/js/components/Drop/__tests__/Drop-test.js
@@ -15,6 +15,10 @@ const customTheme = {
   global: {
     drop: {
       shadowSize: 'large',
+      background: { dark: 'neutral-2', light: 'background-contrast' },
+      border: { radius: '10px' },
+      zIndex: '15',
+      margin: 'xsmall',
     },
   },
 };
@@ -171,13 +175,28 @@ describe('Drop', () => {
     expectPortal('drop-node').toMatchSnapshot();
   });
 
-  test('props elevation renders', () => {
+  test('elevation prop renders', () => {
     render(<TestInput theme={customTheme} elevation="medium" />);
     expectPortal('drop-node').toMatchSnapshot();
   });
 
   test('plain renders', () => {
     render(<TestInput plain />);
+    expectPortal('drop-node').toMatchSnapshot();
+  });
+
+  test('round prop renders', () => {
+    render(<TestInput round="full" />);
+    expectPortal('drop-node').toMatchSnapshot();
+  });
+
+  test('margin prop renders', () => {
+    render(<TestInput margin="small" />);
+    expectPortal('drop-node').toMatchSnapshot();
+  });
+
+  test('background prop renders', () => {
+    render(<TestInput background="background-contrast" />);
     expectPortal('drop-node').toMatchSnapshot();
   });
 

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -593,6 +593,86 @@ exports[`Drop align right right bottom top 4`] = `
 }"
 `;
 
+exports[`Drop background prop renders 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background: #33333310;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: auto;
+  box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
+}
+
+.c1 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  border-radius: 0px;
+  position: fixed;
+  z-index: 20;
+  outline: none;
+  background: #33333310;
+  opacity: 0;
+  -webkit-transform-origin: top left;
+  -ms-transform-origin: top left;
+  transform-origin: top left;
+  -webkit-animation: kPQHBD 0.1s forwards;
+  animation: kPQHBD 0.1s forwards;
+  -webkit-animation-delay: 0.01s;
+  animation-delay: 0.01s;
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+<div
+  class="c0 c1"
+  data-g-portal-id="0"
+  id="drop-node"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
+  tabindex="-1"
+>
+  this is a test
+</div>
+`;
+
+exports[`Drop background prop renders 2`] = `
+"@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+  .jpgUDo {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}"
+`;
+
 exports[`Drop basic 1`] = `
 .c0 {
   display: -webkit-box;
@@ -947,6 +1027,86 @@ exports[`Drop default elevation renders 2`] = `
 }"
 `;
 
+exports[`Drop elevation prop renders 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: auto;
+  box-shadow: 0px 4px 8px rgba(0,0,0,0.20);
+}
+
+.c1 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  border-radius: 10px;
+  position: fixed;
+  z-index: 15;
+  outline: none;
+  background: #33333310;
+  margin: 6px;
+  opacity: 0;
+  -webkit-transform-origin: top left;
+  -ms-transform-origin: top left;
+  transform-origin: top left;
+  -webkit-animation: kPQHBD 0.1s forwards;
+  animation: kPQHBD 0.1s forwards;
+  -webkit-animation-delay: 0.01s;
+  animation-delay: 0.01s;
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+<div
+  class="c0 c1"
+  data-g-portal-id="0"
+  id="drop-node"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
+  tabindex="-1"
+>
+  this is a test
+</div>
+`;
+
+exports[`Drop elevation prop renders 2`] = `
+"@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+  .jpgUDo {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}"
+`;
+
 exports[`Drop invalid align 1`] = `
 .c0 {
   display: -webkit-box;
@@ -1183,6 +1343,94 @@ exports[`Drop invoke onClickOutside 2`] = `
 }"
 `;
 
+exports[`Drop margin prop renders 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: auto;
+  box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
+}
+
+.c1 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  border-radius: 0px;
+  position: fixed;
+  z-index: 20;
+  outline: none;
+  background-color: #FFFFFF;
+  color: #444444;
+  margin: 12px;
+  opacity: 0;
+  -webkit-transform-origin: top left;
+  -ms-transform-origin: top left;
+  transform-origin: top left;
+  -webkit-animation: kPQHBD 0.1s forwards;
+  animation: kPQHBD 0.1s forwards;
+  -webkit-animation-delay: 0.01s;
+  animation-delay: 0.01s;
+}
+
+@media only screen and (max-width:768px) {
+  .c0 {
+    margin: 6px;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+<div
+  class="c0 c1"
+  data-g-portal-id="0"
+  id="drop-node"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
+  tabindex="-1"
+>
+  this is a test
+</div>
+`;
+
+exports[`Drop margin prop renders 2`] = `
+"@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+  .jpgUDo {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}"
+`;
+
 exports[`Drop no stretch 1`] = `
 .c0 {
   display: -webkit-box;
@@ -1365,109 +1613,6 @@ exports[`Drop plain renders 1`] = `
 
 exports[`Drop plain renders 2`] = `
 "@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .jpgUDo {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}"
-`;
-
-exports[`Drop props elevation renders 1`] = `
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  overflow: auto;
-  box-shadow: 0px 4px 8px rgba(0,0,0,0.20);
-}
-
-.c1 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  border-radius: 0px;
-  position: fixed;
-  z-index: 20;
-  outline: none;
-  background-color: #FFFFFF;
-  color: #444444;
-  opacity: 0;
-  -webkit-transform-origin: top left;
-  -ms-transform-origin: top left;
-  transform-origin: top left;
-  -webkit-animation: kPQHBD 0.1s forwards;
-  animation: kPQHBD 0.1s forwards;
-  -webkit-animation-delay: 0.01s;
-  animation-delay: 0.01s;
-}
-
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c1 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-<div
-  class="c0 c1"
-  data-g-portal-id="0"
-  id="drop-node"
-  style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
-  tabindex="-1"
->
-  this is a test
-</div>
-`;
-
-exports[`Drop props elevation renders 2`] = `
-".jpgUDo {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  border-radius: 0px;
-  position: fixed;
-  z-index: 20;
-  outline: none;
-  background-color: #ffffff;
-  color: #444444;
-  opacity: 0;
-  -webkit-transform-origin: top left;
-  -ms-transform-origin: top left;
-  transform-origin: top left;
-  -webkit-animation: kPQHBD 0.1s forwards;
-  animation: kPQHBD 0.1s forwards;
-  -webkit-animation-delay: 0.01s;
-  animation-delay: 0.01s;
-}
-@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
   .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
@@ -1737,6 +1882,87 @@ exports[`Drop restrict focus 4`] = `
 <body />
 `;
 
+exports[`Drop round prop renders 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-radius: 100%;
+  overflow: auto;
+  box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
+}
+
+.c1 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  border-radius: 100%;
+  position: fixed;
+  z-index: 20;
+  outline: none;
+  background-color: #FFFFFF;
+  color: #444444;
+  opacity: 0;
+  -webkit-transform-origin: top left;
+  -ms-transform-origin: top left;
+  transform-origin: top left;
+  -webkit-animation: kPQHBD 0.1s forwards;
+  animation: kPQHBD 0.1s forwards;
+  -webkit-animation-delay: 0.01s;
+  animation-delay: 0.01s;
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+<div
+  class="c0 c1"
+  data-g-portal-id="0"
+  id="drop-node"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
+  tabindex="-1"
+>
+  this is a test
+</div>
+`;
+
+exports[`Drop round prop renders 2`] = `
+"@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+  .jpgUDo {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}"
+`;
+
 exports[`Drop should have no accessibility violations 1`] = `
 .c0 {
   font-size: 18px;
@@ -1909,12 +2135,12 @@ exports[`Drop theme elevation renders 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-  border-radius: 0px;
+  border-radius: 10px;
   position: fixed;
-  z-index: 20;
+  z-index: 15;
   outline: none;
-  background-color: #FFFFFF;
-  color: #444444;
+  background: #33333310;
+  margin: 6px;
   opacity: 0;
   -webkit-transform-origin: top left;
   -ms-transform-origin: top left;
@@ -1950,30 +2176,7 @@ exports[`Drop theme elevation renders 1`] = `
 `;
 
 exports[`Drop theme elevation renders 2`] = `
-".jpgUDo {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  border-radius: 0px;
-  position: fixed;
-  z-index: 20;
-  outline: none;
-  background-color: #ffffff;
-  color: #444444;
-  opacity: 0;
-  -webkit-transform-origin: top left;
-  -ms-transform-origin: top left;
-  transform-origin: top left;
-  -webkit-animation: kPQHBD 0.1s forwards;
-  animation: kPQHBD 0.1s forwards;
-  -webkit-animation-delay: 0.01s;
-  animation-delay: 0.01s;
-}
-@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+"@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
   .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.js.snap
@@ -82,7 +82,7 @@ exports[`Drop align left left 2`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -176,7 +176,7 @@ exports[`Drop align left right top bottom 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.dRXDSv {
+.jpgUDo {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -200,7 +200,7 @@ exports[`Drop align left right top bottom 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -295,7 +295,7 @@ exports[`Drop align right left top top 2`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -390,7 +390,7 @@ exports[`Drop align right right 2`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -485,7 +485,7 @@ exports[`Drop align right right bottom top 2`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -580,7 +580,7 @@ exports[`Drop align right right bottom top 4`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -674,7 +674,7 @@ exports[`Drop basic 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.dRXDSv {
+.jpgUDo {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -698,7 +698,7 @@ exports[`Drop basic 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -792,7 +792,7 @@ exports[`Drop close 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.dRXDSv {
+.jpgUDo {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -816,7 +816,7 @@ exports[`Drop close 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -910,7 +910,7 @@ exports[`Drop default elevation renders 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.dRXDSv {
+.jpgUDo {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -934,7 +934,7 @@ exports[`Drop default elevation renders 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1028,7 +1028,7 @@ exports[`Drop invalid align 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.dRXDSv {
+.jpgUDo {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1052,7 +1052,7 @@ exports[`Drop invalid align 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1146,7 +1146,7 @@ exports[`Drop invoke onClickOutside 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.dRXDSv {
+.jpgUDo {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1170,7 +1170,7 @@ exports[`Drop invoke onClickOutside 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1264,7 +1264,7 @@ exports[`Drop no stretch 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.dRXDSv {
+.jpgUDo {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1288,7 +1288,7 @@ exports[`Drop no stretch 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1365,7 +1365,7 @@ exports[`Drop plain renders 1`] = `
 
 exports[`Drop plain renders 2`] = `
 "@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1444,7 +1444,7 @@ exports[`Drop props elevation renders 1`] = `
 `;
 
 exports[`Drop props elevation renders 2`] = `
-".dRXDSv {
+".jpgUDo {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1468,7 +1468,7 @@ exports[`Drop props elevation renders 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1562,7 +1562,7 @@ exports[`Drop resize 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.dRXDSv {
+.jpgUDo {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1586,7 +1586,7 @@ exports[`Drop resize 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1666,7 +1666,7 @@ exports[`Drop restrict focus 1`] = `
 
 exports[`Drop restrict focus 2`] = `
 <div
-  class="StyledBox-sc-13pk1d4-0 diBiFz StyledDrop-sc-16s5rx8-0 dRXDSv"
+  class="StyledBox-sc-13pk1d4-0 diBiFz StyledDrop-sc-16s5rx8-0 jpgUDo"
   data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -1692,7 +1692,7 @@ exports[`Drop restrict focus 3`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.dRXDSv {
+.jpgUDo {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1716,7 +1716,7 @@ exports[`Drop restrict focus 3`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1847,7 +1847,7 @@ exports[`Drop stretch = align 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.dRXDSv {
+.jpgUDo {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1871,7 +1871,7 @@ exports[`Drop stretch = align 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1950,7 +1950,7 @@ exports[`Drop theme elevation renders 1`] = `
 `;
 
 exports[`Drop theme elevation renders 2`] = `
-".dRXDSv {
+".jpgUDo {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1974,7 +1974,7 @@ exports[`Drop theme elevation renders 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .dRXDSv {
+  .jpgUDo {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;

--- a/src/js/components/Drop/doc.js
+++ b/src/js/components/Drop/doc.js
@@ -1,7 +1,14 @@
 import { describe, PropTypes } from 'react-desc';
 
 import { OVERFLOW_VALUES } from '../Box/doc';
+
 import { getAvailableAtBadge } from '../../utils/mixins';
+import { themeDocUtils } from '../../utils/themeDocUtils';
+import {
+  backgroundDoc,
+  roundPropType,
+  marginProp,
+} from '../../utils/prop-types';
 
 // if you update values here, make sure to update in Box/doc too.
 const dropOverflowPropTypes = PropTypes.oneOfType([
@@ -38,6 +45,7 @@ export const doc = Drop => {
         top: 'top',
         left: 'left',
       }),
+    background: backgroundDoc,
     onClickOutside: PropTypes.func.description(
       'Function that will be invoked when the user clicks outside the drop.',
     ),
@@ -73,11 +81,13 @@ export const doc = Drop => {
       `Elevated height of the target, indicated via a drop shadow. 
       Only applicable if the Drop isn't plain.`,
     ),
+    margin: marginProp,
     plain: PropTypes.bool
       .description(
         `Whether the drop element should have no background nor elevation.`,
       )
       .defaultValue(false),
+    round: roundPropType,
     trapFocus: PropTypes.bool
       .description(`Traps keyboard focus inside of drop.`)
       .defaultValue(true),
@@ -95,7 +105,10 @@ export const themeDoc = {
   'global.drop.background': {
     description: 'The background color of Drop.',
     type: 'string | { dark: string, light: string }',
-    defaultValue: '#ffffff',
+    defaultValue: `{
+      dark: 'black',
+      light: 'white',
+    }`,
   },
   'global.drop.border.radius': {
     description: 'The border radius of the Drop container.',
@@ -117,4 +130,5 @@ export const themeDoc = {
     type: 'number',
     defaultValue: 20,
   },
+  ...themeDocUtils.edgeStyle('The possible sizes for the Drop margin.'),
 };

--- a/src/js/components/Drop/stories/Styled.js
+++ b/src/js/components/Drop/stories/Styled.js
@@ -1,0 +1,56 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import { Box, Drop, Grommet } from 'grommet';
+import { grommet } from 'grommet/themes';
+
+export const Styled = () => {
+  const targetRef = useRef();
+
+  const [, setShowDrop] = useState(false);
+  useEffect(() => {
+    setShowDrop(true);
+  }, []);
+
+  return (
+    <Grommet theme={grommet} full>
+      <Box fill align="center" justify="center">
+        <Box
+          background="dark-3"
+          pad="medium"
+          align="center"
+          justify="start"
+          ref={targetRef}
+        >
+          Target
+        </Box>
+        {targetRef.current && (
+          <>
+            <Drop
+              align={{ top: 'bottom', left: 'left' }}
+              target={targetRef.current}
+              elevation="large"
+              margin={{ top: 'medium' }}
+            >
+              <Box pad="large">Drop Contents with elevation and margin</Box>
+            </Drop>
+            <Drop
+              align={{ bottom: 'top', left: 'left' }}
+              target={targetRef.current}
+              round="large"
+              background="background-contrast"
+              margin={{ bottom: 'small' }}
+            >
+              <Box pad="large">
+                Drop Contents with round, background and margin
+              </Box>
+            </Drop>
+          </>
+        )}
+      </Box>
+    </Grommet>
+  );
+};
+
+export default {
+  title: 'Controls/Drop/Styled',
+};

--- a/src/js/components/Drop/stories/Themed.js
+++ b/src/js/components/Drop/stories/Themed.js
@@ -7,14 +7,16 @@ import { deepMerge } from 'grommet/utils';
 const customTheme = deepMerge(grommet, {
   global: {
     drop: {
-      background: { dark: 'neutral-2', light: 'neutral-2' },
-      border: { radius: '10px' },
+      background: { dark: 'neutral-2', light: 'background-contrast' },
+      border: { radius: '10px' }, // impacting 'round' behavior
       zIndex: '13',
+      shadowSize: 'large', // impacting the elevation
+      margin: 'xsmall',
     },
   },
 });
 
-const CustomDrop = () => {
+export const Themed = () => {
   const [, setShowDrop] = useState(false);
   const targetRef = useRef();
 
@@ -44,8 +46,6 @@ const CustomDrop = () => {
   );
 };
 
-export const Custom = () => <CustomDrop />;
-
 export default {
-  title: 'Controls/Drop/Custom',
+  title: 'Controls/Drop/Themed',
 };

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -2567,7 +2567,7 @@ exports[`Select Controlled multiple onChange without valueKey 3`] = `
 
 exports[`Select Controlled multiple onChange without valueKey 4`] = `
 <div
-  class="StyledBox-sc-13pk1d4-0 diBiFz StyledDrop-sc-16s5rx8-0 dRXDSv"
+  class="StyledBox-sc-13pk1d4-0 diBiFz StyledDrop-sc-16s5rx8-0 jpgUDo"
   data-g-portal-id="0"
   id="test-select__drop"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -8051,6 +8051,89 @@ xlarge
 string
 \`\`\`
 
+**margin**
+
+The amount of margin around the component. An object can
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  end: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  start: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
 **plain**
 
 Whether the drop element should have no background nor elevation.
@@ -8124,7 +8207,10 @@ The background color of Drop. Expects \`string | { dark: string, light: string }
 Defaults to
 
 \`\`\`
-#ffffff
+{
+      dark: 'black',
+      light: 'white',
+    }
 \`\`\`
 
 **global.drop.border.radius**
@@ -8165,6 +8251,28 @@ Defaults to
 
 \`\`\`
 20
+\`\`\`
+
+**global.edgeSize**
+
+The possible sizes for the Drop margin. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+    edgeSize: {
+      none: '0px',
+      hair: '1px',
+      xxsmall: '3px',
+      xsmall: '6px',
+      small: '12px',
+      medium: '24px',
+      large: '48px',
+      xlarge: '96px',
+      responsiveBreakpoint: 'small',
+    },
+  }
 \`\`\`
 ",
   "DropButton": "## DropButton

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -7919,6 +7919,45 @@ How to align the drop with respect to the target element. Not
 }
 \`\`\`
 
+**background**
+
+Either a color 
+identifier to use for the background color. For example: 'neutral-1'. Or, a 
+'url()' for an image. Dark is not needed if color is provided.
+
+\`\`\`
+string
+{
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
+  dark: 
+    boolean
+    string,
+  image: string,
+  position: string,
+  opacity: 
+    string
+    boolean
+    number
+    weak
+    medium
+    strong,
+  repeat: 
+    no-repeat
+    repeat
+    string,
+  size: 
+    cover
+    contain
+    string,
+  light: string
+}
+\`\`\`
+
 **onClickOutside**
 
 Function that will be invoked when the user clicks outside the drop.
@@ -8018,6 +8057,39 @@ Whether the drop element should have no background nor elevation.
 
 \`\`\`
 boolean
+\`\`\`
+
+**round**
+
+How much to round the corners.
+
+\`\`\`
+boolean
+xsmall
+small
+medium
+large
+xlarge
+full
+string
+{
+  corner: 
+    top
+    left
+    bottom
+    right
+    top-left
+    top-right
+    bottom-left
+    bottom-right,
+  size: 
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
 \`\`\`
 
 **trapFocus**

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1001,7 +1001,7 @@ string",
         "name": "responsive",
       },
       Object {
-        "defaultValue": false,
+        "defaultValue": undefined,
         "description": "How much to round the corners.",
         "format": "boolean
 xsmall
@@ -3368,13 +3368,93 @@ string",
         "name": "elevation",
       },
       Object {
+        "description": "The amount of margin around the component. An object can
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.",
+        "format": "none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  end: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  start: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string",
+        "name": "margin",
+      },
+      Object {
         "defaultValue": false,
         "description": "Whether the drop element should have no background nor elevation.",
         "format": "boolean",
         "name": "plain",
       },
       Object {
-        "defaultValue": false,
+        "defaultValue": undefined,
         "description": "How much to round the corners.",
         "format": "boolean
 xsmall

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -3258,6 +3258,42 @@ string",
         "name": "align",
       },
       Object {
+        "description": "Either a color 
+identifier to use for the background color. For example: 'neutral-1'. Or, a 
+'url()' for an image. Dark is not needed if color is provided.",
+        "format": "string
+{
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
+  dark: 
+    boolean
+    string,
+  image: string,
+  position: string,
+  opacity: 
+    string
+    boolean
+    number
+    weak
+    medium
+    strong,
+  repeat: 
+    no-repeat
+    repeat
+    string,
+  size: 
+    cover
+    contain
+    string,
+  light: string
+}",
+        "name": "background",
+      },
+      Object {
         "description": "Function that will be invoked when the user clicks outside the drop.",
         "format": "function",
         "name": "onClickOutside",
@@ -3336,6 +3372,37 @@ string",
         "description": "Whether the drop element should have no background nor elevation.",
         "format": "boolean",
         "name": "plain",
+      },
+      Object {
+        "defaultValue": false,
+        "description": "How much to round the corners.",
+        "format": "boolean
+xsmall
+small
+medium
+large
+xlarge
+full
+string
+{
+  corner: 
+    top
+    left
+    bottom
+    right
+    top-left
+    top-right
+    bottom-left
+    bottom-right,
+  size: 
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}",
+        "name": "round",
       },
       Object {
         "defaultValue": true,

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -225,6 +225,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         border: {
           radius: '0px',
         },
+        // round: undefined
         shadowSize: 'small',
         zIndex: '20',
       },

--- a/src/js/utils/prop-types.js
+++ b/src/js/utils/prop-types.js
@@ -225,4 +225,4 @@ export const roundPropType = PropTypes.oneOfType([
   }),
 ])
   .description('How much to round the corners.')
-  .defaultValue(false);
+  .defaultValue(undefined);

--- a/src/js/utils/prop-types.js
+++ b/src/js/utils/prop-types.js
@@ -202,3 +202,27 @@ export const patternPropType = PropTypes.oneOf([
   'stripesDiagonalDown',
   'stripesDiagonalUp',
 ]);
+
+export const roundPropType = PropTypes.oneOfType([
+  PropTypes.bool,
+  PropTypes.oneOf(['xsmall', 'small', 'medium', 'large', 'xlarge', 'full']),
+  PropTypes.string,
+  PropTypes.shape({
+    corner: PropTypes.oneOf([
+      'top',
+      'left',
+      'bottom',
+      'right',
+      'top-left',
+      'top-right',
+      'bottom-left',
+      'bottom-right',
+    ]),
+    size: PropTypes.oneOfType([
+      PropTypes.oneOf(['xsmall', 'small', 'medium', 'large', 'xlarge']),
+      PropTypes.string,
+    ]),
+  }),
+])
+  .description('How much to round the corners.')
+  .defaultValue(false);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Added Drop props and theme support for 'margin', 'round', 'background' & 'elevation' 
Priority is given to props over theme props.

`elevation` is translated to `shadowSize` on the theme.
`border.radius` was already supported on the theme.
`background` was only supported by the theme.
`margin` was added from scratch for both props & theme.

#### Where should the reviewer start?
doc.js
#### What testing has been done on this PR?
jest + storybook. Added and refined stories.

#### How should this be manually tested?
jest + storybook.
#### Any background context you want to provide?
This PR is the groundwork for #4950 

#### Do the grommet docs need to be updated?
Yes, done.
#### Should this PR be mentioned in the release notes?
YES
#### Is this change backwards compatible or is it a breaking change?
b/c