### PR TITLE
Fix warning on Accordion custom story

### DIFF
--- a/src/js/components/Accordion/stories/Custom.js
+++ b/src/js/components/Accordion/stories/Custom.js
@@ -19,7 +19,9 @@ const customAccordionTheme = {
       margin: { vertical: '6px', horizontal: '24px' },
     },
     hover: {
-      color: 'accent-2',
+      heading: {
+        color: 'accent-2',
+      },
     },
     icons: {
       collapse: SubtractCircle,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Change the custom story in Accordion to use `hover.heading.color` instead of the deprecated `hover.color`. This gets rid of the console warning on this story.

#### Where should the reviewer start?
Custom.js

#### What testing has been done on this PR?
Storybook

#### How should this be manually tested?
Storybook

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible