### PR TITLE
[TS] Fix Collapsible, List, Video and World Map extended type definitions

### DIFF
--- a/src/js/components/Collapsible/index.d.ts
+++ b/src/js/components/Collapsible/index.d.ts
@@ -5,7 +5,10 @@ export interface CollapsibleProps {
   direction?: 'horizontal' | 'vertical';
 }
 
-declare const Collapsible: React.ComponentClass<CollapsibleProps &
-  JSX.IntrinsicElements['div']>;
+type divProps = JSX.IntrinsicElements['div'];
+
+export interface CollapsibleExtendedProps extends CollapsibleProps, divProps {}
+
+declare const Collapsible: React.FC<CollapsibleExtendedProps>;
 
 export { Collapsible };

--- a/src/js/components/List/index.d.ts
+++ b/src/js/components/List/index.d.ts
@@ -61,7 +61,10 @@ export interface ListProps {
   action?: (item: any, index: number) => void;
 }
 
-declare const List: React.ComponentClass<ListProps &
-  JSX.IntrinsicElements['ul']>;
+type ulProps = JSX.IntrinsicElements['ul'];
+
+export interface ListExtendedProps extends ListProps, ulProps {}
+
+declare const List: React.FC<ListExtendedProps>;
 
 export { List };

--- a/src/js/components/Video/index.d.ts
+++ b/src/js/components/Video/index.d.ts
@@ -31,7 +31,10 @@ export interface VideoProps {
   mute?: boolean;
 }
 
-declare const Video: React.ComponentClass<VideoProps &
-  Omit<JSX.IntrinsicElements['video'], 'controls'>>;
+export interface VideoExtendedProps
+  extends VideoProps,
+    Omit<JSX.IntrinsicElements['video'], 'controls'> {}
+
+declare const Video: React.FC<VideoExtendedProps>;
 
 export { Video };

--- a/src/js/components/WorldMap/index.d.ts
+++ b/src/js/components/WorldMap/index.d.ts
@@ -38,7 +38,10 @@ export interface WorldMapProps {
   }[];
 }
 
-declare const WorldMap: React.ComponentClass<WorldMapProps &
-  Omit<JSX.IntrinsicElements['svg'], 'color'>>;
+export interface WorldMapExtendedProps
+  extends WorldMapProps,
+    Omit<JSX.IntrinsicElements['svg'], 'color' | 'fill'> {}
+
+declare const WorldMap: React.FC<WorldMapExtendedProps>;
 
 export { WorldMap };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Create and export extended type declarations with component and JSX.IntrinsicElements props for the following components:
- Collapsible
- List
- Video
- World Map

#### Where should the reviewer start?
any of these declaration files:
`src/js/components/Collapsible/index.d.ts`
`src/js/components/List/index.d.ts`
`src/js/components/Video/index.d.ts`
`src/js/components/WorldMap/index.d.ts`

#### What testing has been done on this PR?
`yarn storybook` (typescript stories) and `yarn test`

#### How should this be manually tested?
On a local typescript project, you can import the extended types and you should be able to reference both `<component>Props` and `JSX.IntrinsicElements` keys 

#### Any background context you want to provide?

#### What are the relevant issues?
Relevant to #4998 and #4978

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backwards compatible
