### PR TITLE
Added support for the box row-reverse with column reverse.

### DIFF
--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -396,6 +396,11 @@ column
 row-responsive
 row-reverse
 column-reverse
+{
+  direction: string,
+  responsive: boolean,
+  reverse: boolean
+}
 ```
 
 **elevation**
@@ -971,7 +976,7 @@ undefined
 
 **box.responsiveBreakpoint**
 
-The actual breakpoint to trigger changes in the border, 
+The actual breakpoint to trigger changes in the border,
     direction, gap, margin, pad, and round. Expects `string`.
 
 Defaults to
@@ -1004,7 +1009,7 @@ Defaults to
 
 **global.breakpoints**
 
-The possible breakpoints that could affect border, direction, gap, margin, 
+The possible breakpoints that could affect border, direction, gap, margin,
     pad, and round. Expects `object`.
 
 Defaults to

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -68,20 +68,14 @@ const basisStyle = css`
 // we assume we are in the context of a Box going the other direction
 // TODO: revisit this
 const directionStyle = (directionWrapper, theme) => {
-  let direction;
-  let isResponsive;
-  let isReverse;
+  let { direction } = directionWrapper;
+  const { responsive, reverse } = directionWrapper;
 
   if (
     typeof directionWrapper === 'string' ||
     directionWrapper instanceof String
   ) {
     direction = directionWrapper;
-  } else {
-    // DirectionWrapper is object now.
-    direction = directionWrapper.direction;
-    isResponsive = directionWrapper.responsive;
-    isReverse = directionWrapper.reverse;
   }
 
   const styles = [
@@ -92,43 +86,46 @@ const directionStyle = (directionWrapper, theme) => {
     `,
   ];
 
-  const breakpoint = getBreakpointStyle(theme, theme.box.responsiveBreakpoint);
-
-  if (
-    direction === 'row-responsive' &&
-    theme.box.responsiveBreakpoint &&
-    breakpoint
-  ) {
-    styles.push(
-      breakpointStyle(
-        breakpoint,
-        `
-        flex-direction: column;
-        flex-basis: auto;
-        justify-content: flex-start;
-        align-items: stretch;
-      `,
-      ),
+  if (direction === 'row-responsive' && theme.box.responsiveBreakpoint) {
+    const breakpoint = getBreakpointStyle(
+      theme,
+      theme.box.responsiveBreakpoint,
     );
+
+    if (breakpoint) {
+      styles.push(
+        breakpointStyle(
+          breakpoint,
+          `
+          flex-direction: column;
+          flex-basis: auto;
+          justify-content: flex-start;
+          align-items: stretch;
+        `,
+        ),
+      );
+    }
   }
 
-  if (
-    direction === 'row' &&
-    isResponsive === true &&
-    isReverse === true &&
-    breakpoint
-  ) {
-    styles.push(
-      breakpointStyle(
-        breakpoint,
-        `
-         flex-direction: column-reverse;
-         flex-basis: auto;
-         justify-content: flex-start;
-         align-items: stretch;
-      `,
-      ),
+  if (direction === 'row' && responsive && reverse) {
+    const breakpoint = getBreakpointStyle(
+      theme,
+      theme.box.responsiveBreakpoint,
     );
+
+    if (breakpoint) {
+      styles.push(
+        breakpointStyle(
+          breakpoint,
+          `
+           flex-direction: column-reverse;
+           flex-basis: auto;
+           justify-content: flex-start;
+           align-items: stretch;
+        `,
+        ),
+      );
+    }
   }
   return styles;
 };
@@ -495,7 +492,7 @@ const gapStyle = (directionProp, gap, responsive, border, theme) => {
         styles.push(breakpointStyle(breakpoint, `width: ${responsiveMetric};`));
       } else if (
         directionProp === 'row-responsive' ||
-        (directionProp.direction === 'row' && directionProp.responsive === true)
+        (directionProp.direction === 'row' && directionProp.responsive)
       ) {
         styles.push(
           breakpointStyle(
@@ -580,8 +577,7 @@ const gapStyle = (directionProp, gap, responsive, border, theme) => {
           );
         } else if (
           directionProp === 'row-responsive' ||
-          (directionProp.direction === 'row' &&
-            directionProp.responsive === true)
+          (directionProp.direction === 'row' && directionProp.responsive)
         ) {
           const adjustedBorder2 =
             typeof border === 'string' ? 'top' : { ...border, side: 'top' };

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -67,7 +67,23 @@ const basisStyle = css`
 // https://stackoverflow.com/questions/36247140/why-doesnt-flex-item-shrink-past-content-size
 // we assume we are in the context of a Box going the other direction
 // TODO: revisit this
-const directionStyle = (direction, theme) => {
+const directionStyle = (directionWrapper, theme) => {
+  let direction;
+  let isResponsive;
+  let isReverse;
+
+  if (
+    typeof directionWrapper === 'string' ||
+    directionWrapper instanceof String
+  ) {
+    direction = directionWrapper;
+  } else {
+    // DirectionWrapper is object now.
+    direction = directionWrapper.direction;
+    isResponsive = directionWrapper.responsive;
+    isReverse = directionWrapper.reverse;
+  }
+
   const styles = [
     css`
       min-width: 0;
@@ -75,24 +91,44 @@ const directionStyle = (direction, theme) => {
       flex-direction: ${direction === 'row-responsive' ? 'row' : direction};
     `,
   ];
-  if (direction === 'row-responsive' && theme.box.responsiveBreakpoint) {
-    const breakpoint = getBreakpointStyle(
-      theme,
-      theme.box.responsiveBreakpoint,
-    );
-    if (breakpoint) {
-      styles.push(
-        breakpointStyle(
-          breakpoint,
-          `
+
+  const breakpoint = getBreakpointStyle(theme, theme.box.responsiveBreakpoint);
+
+  if (
+    direction === 'row-responsive' &&
+    theme.box.responsiveBreakpoint &&
+    breakpoint
+  ) {
+    styles.push(
+      breakpointStyle(
+        breakpoint,
+        `
         flex-direction: column;
         flex-basis: auto;
         justify-content: flex-start;
         align-items: stretch;
       `,
-        ),
-      );
-    }
+      ),
+    );
+  }
+
+  if (
+    direction === 'row' &&
+    isResponsive === true &&
+    isReverse === true &&
+    breakpoint
+  ) {
+    styles.push(
+      breakpointStyle(
+        breakpoint,
+        `
+         flex-direction: column-reverse;
+         flex-basis: auto;
+         justify-content: flex-start;
+         align-items: stretch;
+      `,
+      ),
+    );
   }
   return styles;
 };
@@ -457,7 +493,10 @@ const gapStyle = (directionProp, gap, responsive, border, theme) => {
     if (responsiveMetric) {
       if (directionProp === 'row' || directionProp === 'row-reverse') {
         styles.push(breakpointStyle(breakpoint, `width: ${responsiveMetric};`));
-      } else if (directionProp === 'row-responsive') {
+      } else if (
+        directionProp === 'row-responsive' ||
+        (directionProp.direction === 'row' && directionProp.responsive === true)
+      ) {
         styles.push(
           breakpointStyle(
             breakpoint,
@@ -539,7 +578,11 @@ const gapStyle = (directionProp, gap, responsive, border, theme) => {
               }`,
             ),
           );
-        } else if (directionProp === 'row-responsive') {
+        } else if (
+          directionProp === 'row-responsive' ||
+          (directionProp.direction === 'row' &&
+            directionProp.responsive === true)
+        ) {
           const adjustedBorder2 =
             typeof border === 'string' ? 'top' : { ...border, side: 'top' };
           styles.push(

--- a/src/js/components/Box/__tests__/Box-test.js
+++ b/src/js/components/Box/__tests__/Box-test.js
@@ -27,6 +27,13 @@ describe('Box', () => {
         <Box direction="column" />
         <Box direction="column-reverse" />
         <Box direction="row-reverse" />
+        <Box
+          direction={{
+            direction: 'row',
+            responsive: true,
+            reverse: true,
+          }}
+        />
       </Grommet>,
     );
     const tree = component.toJSON();

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -2074,11 +2074,44 @@ exports[`Box direction 1`] = `
   flex-direction: row-reverse;
 }
 
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
 @media only screen and (max-width:768px) {
   .c2 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
+    -webkit-flex-basis: auto;
+    -ms-flex-preferred-size: auto;
+    flex-basis: auto;
+    -webkit-box-pack: start;
+    -webkit-justify-content: flex-start;
+    -ms-flex-pack: start;
+    justify-content: flex-start;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    -webkit-flex-direction: column-reverse;
+    -ms-flex-direction: column-reverse;
+    flex-direction: column-reverse;
     -webkit-flex-basis: auto;
     -ms-flex-preferred-size: auto;
     flex-basis: auto;
@@ -2110,6 +2143,9 @@ exports[`Box direction 1`] = `
   />
   <div
     className="c5"
+  />
+  <div
+    className="c6"
   />
 </div>
 `;

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -127,12 +127,19 @@ export const doc = Box => {
       `Include a border. 'between' will place a border in the gap between
       child elements. You must have a 'gap' to use 'between'.`,
     ),
-    direction: PropTypes.oneOf([
-      'row',
-      'column',
-      'row-responsive',
-      'row-reverse',
-      'column-reverse',
+    direction: PropTypes.oneOfType([
+      PropTypes.oneOf([
+        'row',
+        'column',
+        'row-responsive',
+        'row-reverse',
+        'column-reverse',
+      ]),
+      PropTypes.shape({
+        direction: PropTypes.string,
+        responsive: PropTypes.bool,
+        reverse: PropTypes.bool,
+      }),
     ])
       .description('The orientation to layout the child components in.')
       .defaultValue('column'),
@@ -401,7 +408,7 @@ export const themeDoc = {
     defaultValue: undefined,
   },
   'box.responsiveBreakpoint': {
-    description: `The actual breakpoint to trigger changes in the border, 
+    description: `The actual breakpoint to trigger changes in the border,
     direction, gap, margin, pad, and round.`,
     type: 'string',
     defaultValue: 'small',
@@ -410,7 +417,7 @@ export const themeDoc = {
     'The possible sizes for any of gap, margin, and pad.',
   ),
   ...themeDocUtils.breakpointStyle(
-    `The possible breakpoints that could affect border, direction, gap, margin, 
+    `The possible breakpoints that could affect border, direction, gap, margin,
     pad, and round.`,
   ),
 };

--- a/src/js/components/Box/stories/RowResponsiveBox.js
+++ b/src/js/components/Box/stories/RowResponsiveBox.js
@@ -38,6 +38,37 @@ export const SimpleRowReverseBox = () => (
         <Button label="Button" onClick={() => {}} />
       </Box>
     </Box>
+
+    <Box
+      direction={{
+        direction: 'row',
+      }}
+      justify="center"
+      align="center"
+      pad="xlarge"
+      background="dark-2"
+      gap="medium"
+    >
+      <Box
+        pad="large"
+        align="center"
+        background={{ color: 'light-2', opacity: 'strong' }}
+        round
+        gap="small"
+      >
+        <Attraction size="large" />
+        <Text>Party</Text>
+        <Anchor href="" label="Link" />
+        <Button label="Button" onClick={() => {}} />
+      </Box>
+
+      <Box pad="large" align="center" background="dark-3" round gap="small">
+        <Car size="large" color="light-2" />
+        <Text>Travel</Text>
+        <Anchor href="" label="Link" />
+        <Button label="Button" onClick={() => {}} />
+      </Box>
+    </Box>
   </Grommet>
 );
 

--- a/src/js/components/Box/stories/RowResponsiveBox.js
+++ b/src/js/components/Box/stories/RowResponsiveBox.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Attraction, Car } from 'grommet-icons';
+
+import { Grommet, Anchor, Box, Button, Text } from 'grommet';
+import { grommet } from '../../../themes';
+
+export const SimpleRowReverseBox = () => (
+  <Grommet theme={grommet}>
+    <Box
+      direction={{
+        direction: 'row',
+        responsive: true,
+        reverse: true,
+      }}
+      justify="center"
+      align="center"
+      pad="xlarge"
+      background="dark-2"
+      gap="medium"
+    >
+      <Box
+        pad="large"
+        align="center"
+        background={{ color: 'light-2', opacity: 'strong' }}
+        round
+        gap="small"
+      >
+        <Attraction size="large" />
+        <Text>Party</Text>
+        <Anchor href="" label="Link" />
+        <Button label="Button" onClick={() => {}} />
+      </Box>
+
+      <Box pad="large" align="center" background="dark-3" round gap="small">
+        <Car size="large" color="light-2" />
+        <Text>Travel</Text>
+        <Anchor href="" label="Link" />
+        <Button label="Button" onClick={() => {}} />
+      </Box>
+    </Box>
+  </Grommet>
+);
+
+SimpleRowReverseBox.storyName = 'RowResponsive';
+
+export default {
+  title: 'Layout/Box/RowResponsive',
+};

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1312,6 +1312,11 @@ column
 row-responsive
 row-reverse
 column-reverse
+{
+  direction: string,
+  responsive: boolean,
+  reverse: boolean
+}
 \`\`\`
 
 **elevation**
@@ -1887,7 +1892,7 @@ undefined
 
 **box.responsiveBreakpoint**
 
-The actual breakpoint to trigger changes in the border, 
+The actual breakpoint to trigger changes in the border,
     direction, gap, margin, pad, and round. Expects \`string\`.
 
 Defaults to
@@ -1920,7 +1925,7 @@ Defaults to
 
 **global.breakpoints**
 
-The possible breakpoints that could affect border, direction, gap, margin, 
+The possible breakpoints that could affect border, direction, gap, margin,
     pad, and round. Expects \`object\`.
 
 Defaults to

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -751,7 +751,12 @@ between
 column
 row-responsive
 row-reverse
-column-reverse",
+column-reverse
+{
+  direction: string,
+  responsive: boolean,
+  reverse: boolean
+}",
         "name": "direction",
       },
       Object {

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -160,12 +160,18 @@ export type BorderType =
       style?: BoxStyleType;
     }[];
 export type ColorType = string | { dark?: string; light?: string } | undefined;
+type DirectionObjectType = {
+  direction: string;
+  reverse?: boolean;
+  responsive?: boolean;
+};
 export type DirectionType =
   | 'row'
   | 'column'
   | 'row-responsive'
   | 'row-reverse'
-  | 'column-reverse';
+  | 'column-reverse'
+  | DirectionObjectType;
 export type ElevationType =
   | 'none'
   | 'xsmall'


### PR DESCRIPTION
Added support for the box row-reverse with column reverse.

Currently, we don't have a straight forward way to provide a solution.
A nice enhancement that will allow this functionality in a more straight forward way will be to extend the direction prop:
direction={{ direction: 'row', responsive: true, reverse: true }}

#### What does this PR do?
We can use column reverse functionality for the Box.

#### Where should the reviewer start?
- src/js/components/Box/StyledBox.js
- src/js/components/Box/stories/RowResponsiveBox.js
- src/js/utils/index.d.ts

#### What testing has been done on this PR?
Added RowResponsiveBox story and tested with npm run storybook.

#### How should this be manually tested?
Use Box with relevant props.

#### Any background context you want to provide?
https://github.com/grommet/grommet/issues/3551

#### What are the relevant issues?
NA

#### Screenshots (if appropriate)

Before Reducing Viewport Width: 
![image](https://user-images.githubusercontent.com/17611765/111062947-19748f80-84d2-11eb-87f2-3f79cd87cb37.png)

After Reducing Viewport Width:
![image](https://user-images.githubusercontent.com/17611765/111063164-20e86880-84d3-11eb-9337-c65f5c9f8fd4.png)


#### Do the grommet docs need to be updated?
Yes

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
This PR is backward compatible.