### PR TITLE
Type object added on row property for Grid

### DIFF
--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -75,6 +75,26 @@ export interface GridProps {
   pad?: PadType;
   responsive?: boolean;
   rows?:
+    | {
+        count?: 'fit' | 'fill' | number;
+        size?:
+          | 'xsmall'
+          | 'small'
+          | 'medium'
+          | 'large'
+          | 'xlarge'
+          | 'full'
+          | '1/2'
+          | '1/3'
+          | '2/3'
+          | '1/4'
+          | '2/4'
+          | '3/4'
+          | 'flex'
+          | 'auto'
+          | string
+          | string[];
+      }
     | (
         | 'xsmall'
         | 'small'

--- a/src/js/components/TextInput/index.d.ts
+++ b/src/js/components/TextInput/index.d.ts
@@ -44,6 +44,7 @@ export interface TextInputProps
   suggestions?: ({ label?: React.ReactNode; value?: any } | string)[];
   textAlign?: TextAlignType;
   value?: string | number;
+  ref?: React.Ref<HTMLInputElement>;
 }
 
 declare const TextInput: React.FC<TextInputProps>;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds an additional type on the row property.
#### Where should the reviewer start?
By comparing the Grid Documentation (scroll down to row and check the recommended types) vs the Grid/stories/Responsive.js and checking the "const rows" what is passed as a value.
#### What testing has been done on this PR?
The default ones
#### How should this be manually tested?
N/A
#### Any background context you want to provide?
We have built a custom Responsive Grid component on top of the Grommet one but using TypeScript when we are passing an object on the row property, the compiler will give us "Object not assignable to type...etc". Because the one in Grommet is built in Javascript, it won't check for the type and the tests are not failing.
#### What are the relevant issues?
Need an extra type on the row property to avoid TypeScript error when building a reusable component and passing an object on the Grid row property.
#### Screenshots (if appropriate)
[Screenshot](https://ibb.co/McYGH5y)
#### Do the grommet docs need to be updated?
Yes
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backward compatible or is it a breaking change?
Backward compatible
