### PR TITLE
Update DataTable groupBy/select/onSelect docs

### DIFF
--- a/src/js/components/DataTable/README.md
+++ b/src/js/components/DataTable/README.md
@@ -391,7 +391,8 @@ Property to group data by. If object is specified
       'property' is used to group data by, 'expand' accepts array of
        group keys that sets expanded groups and 'onExpand' is a function
        that will be called after expand button is clicked with
-       an array of keys of expanded groups.
+       an array of keys of expanded groups. Cannot be used at the same
+       time as select/onSelect.
 
 ```
 string
@@ -456,7 +457,8 @@ When supplied, causes checkboxes to be added to each row such that
       will be called with an array of primary key values, suitable to be
       passed to the 'select' property. If you are storing select state via
       a 'useState' hook, you can do something like:
-      '<DataTable select={select} onSelect={setSelect} />'.
+      '<DataTable select={select} onSelect={setSelect} />'. Cannot be used at 
+      the same time as groupBy.
 
 ```
 function
@@ -627,7 +629,8 @@ When supplied, causes checkboxes to be added to each row to indicate
       which rows are selected. The values in this array should match
       the 'primaryKey' or 'columns[].primary' keyed value for the row's data
       object. If 'onSelect' is provided, the CheckBoxes are enabled
-      and this function can be used to track select changes.
+      and this function can be used to track select changes. Cannot be used at 
+      the same time as groupBy.
 
 ```
 [

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -163,7 +163,8 @@ export const doc = DataTable => {
       'property' is used to group data by, 'expand' accepts array of
        group keys that sets expanded groups and 'onExpand' is a function
        that will be called after expand button is clicked with
-       an array of keys of expanded groups.`),
+       an array of keys of expanded groups. Cannot be used at the same
+       time as select/onSelect.`),
     onClickRow: PropTypes.func.description(
       `When supplied, this function will be called with an event object that
       include a 'datum' property containing the data value associated with
@@ -197,7 +198,8 @@ export const doc = DataTable => {
       will be called with an array of primary key values, suitable to be
       passed to the 'select' property. If you are storing select state via
       a 'useState' hook, you can do something like:
-      '<DataTable select={select} onSelect={setSelect} />'.`,
+      '<DataTable select={select} onSelect={setSelect} />'. Cannot be used at 
+      the same time as groupBy.`,
     ),
     onSort: PropTypes.func.description(
       `When supplied, this function will be called with an object
@@ -268,7 +270,8 @@ export const doc = DataTable => {
       which rows are selected. The values in this array should match
       the 'primaryKey' or 'columns[].primary' keyed value for the row's data
       object. If 'onSelect' is provided, the CheckBoxes are enabled
-      and this function can be used to track select changes.`,
+      and this function can be used to track select changes. Cannot be used at 
+      the same time as groupBy.`,
     ),
     show: PropTypes.oneOfType([
       PropTypes.number,

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -6760,7 +6760,8 @@ Property to group data by. If object is specified
       'property' is used to group data by, 'expand' accepts array of
        group keys that sets expanded groups and 'onExpand' is a function
        that will be called after expand button is clicked with
-       an array of keys of expanded groups.
+       an array of keys of expanded groups. Cannot be used at the same
+       time as select/onSelect.
 
 \`\`\`
 string
@@ -6825,7 +6826,8 @@ When supplied, causes checkboxes to be added to each row such that
       will be called with an array of primary key values, suitable to be
       passed to the 'select' property. If you are storing select state via
       a 'useState' hook, you can do something like:
-      '<DataTable select={select} onSelect={setSelect} />'.
+      '<DataTable select={select} onSelect={setSelect} />'. Cannot be used at 
+      the same time as groupBy.
 
 \`\`\`
 function
@@ -6996,7 +6998,8 @@ When supplied, causes checkboxes to be added to each row to indicate
       which rows are selected. The values in this array should match
       the 'primaryKey' or 'columns[].primary' keyed value for the row's data
       object. If 'onSelect' is provided, the CheckBoxes are enabled
-      and this function can be used to track select changes.
+      and this function can be used to track select changes. Cannot be used at 
+      the same time as groupBy.
 
 \`\`\`
 [


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
groupBy cannot be used at the same time as select/onSelect and vice versa. Updating docs to add clarity.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.