### PR TITLE
[Bug] right calendar border not visible 

### DIFF
--- a/src/js/components/Calendar/StyledCalendar.js
+++ b/src/js/components/Calendar/StyledCalendar.js
@@ -100,7 +100,7 @@ Object.setPrototypeOf(StyledWeek.defaultProps, defaultProps);
 // The width of 14.3% is derived from dividing 100/7. We want the
 // widths of 7 days to equally fill 100% of the row.
 const StyledDayContainer = styled.div`
-  flex: 0 0 auto;
+  flex: 0 1 auto;
   ${props => props.fillContainer && 'width: 14.3%;'}
 `;
 

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -224,9 +224,9 @@ exports[`Calendar change months 1`] = `
 }
 
 .c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c15 {
@@ -1143,7 +1143,7 @@ exports[`Calendar change months 2`] = `
             class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sun Dec 29 2019"
@@ -1159,7 +1159,7 @@ exports[`Calendar change months 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Mon Dec 30 2019"
@@ -1175,7 +1175,7 @@ exports[`Calendar change months 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Tue Dec 31 2019"
@@ -1191,7 +1191,7 @@ exports[`Calendar change months 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Wed Jan 01 2020"
@@ -1207,7 +1207,7 @@ exports[`Calendar change months 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Thu Jan 02 2020"
@@ -1223,7 +1223,7 @@ exports[`Calendar change months 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Fri Jan 03 2020"
@@ -1239,7 +1239,7 @@ exports[`Calendar change months 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sat Jan 04 2020"
@@ -1259,7 +1259,7 @@ exports[`Calendar change months 2`] = `
             class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sun Jan 05 2020"
@@ -1275,7 +1275,7 @@ exports[`Calendar change months 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Mon Jan 06 2020"
@@ -1291,7 +1291,7 @@ exports[`Calendar change months 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Tue Jan 07 2020"
@@ -1307,7 +1307,7 @@ exports[`Calendar change months 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Wed Jan 08 2020"
@@ -1323,7 +1323,7 @@ exports[`Calendar change months 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Thu Jan 09 2020"
@@ -1339,7 +1339,7 @@ exports[`Calendar change months 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Fri Jan 10 2020"
@@ -1355,7 +1355,7 @@ exports[`Calendar change months 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sat Jan 11 2020"
@@ -1421,9 +1421,9 @@ exports[`Calendar change months 2`] = `
 }
 
 .c1 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c3 {
@@ -1641,9 +1641,9 @@ exports[`Calendar change months 2`] = `
 }
 
 .c1 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c3 {
@@ -1841,9 +1841,9 @@ exports[`Calendar change months 2`] = `
 }
 
 .c1 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c4 {
@@ -2059,9 +2059,9 @@ exports[`Calendar change months 2`] = `
 }
 
 .c1 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c3 {
@@ -2431,9 +2431,9 @@ exports[`Calendar children 1`] = `
 }
 
 .c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
   width: 14.3%;
 }
 
@@ -3187,9 +3187,9 @@ exports[`Calendar date 1`] = `
 }
 
 .c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c14 {
@@ -4501,9 +4501,9 @@ exports[`Calendar dates 1`] = `
 }
 
 .c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c14 {
@@ -5833,9 +5833,9 @@ exports[`Calendar daysOfWeek 1`] = `
 }
 
 .c10 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c11 {
@@ -7272,9 +7272,9 @@ exports[`Calendar disabled 1`] = `
 }
 
 .c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c14 {
@@ -8607,9 +8607,9 @@ exports[`Calendar fill 1`] = `
 }
 
 .c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
   width: 14.3%;
 }
 
@@ -9922,9 +9922,9 @@ exports[`Calendar first day sunday week monday 1`] = `
 }
 
 .c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c14 {
@@ -11010,9 +11010,9 @@ exports[`Calendar firstDayOfWeek 1`] = `
 }
 
 .c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c14 {
@@ -13274,9 +13274,9 @@ exports[`Calendar header 1`] = `
 }
 
 .c10 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c12 {
@@ -14604,9 +14604,9 @@ exports[`Calendar reference 1`] = `
 }
 
 .c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c14 {
@@ -15898,9 +15898,9 @@ exports[`Calendar select date 1`] = `
 }
 
 .c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c14 {
@@ -16837,7 +16837,7 @@ exports[`Calendar select date 2`] = `
             class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sun Dec 29 2019"
@@ -16853,7 +16853,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Mon Dec 30 2019"
@@ -16869,7 +16869,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Tue Dec 31 2019"
@@ -16885,7 +16885,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Wed Jan 01 2020"
@@ -16901,7 +16901,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Thu Jan 02 2020"
@@ -16917,7 +16917,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Fri Jan 03 2020"
@@ -16933,7 +16933,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sat Jan 04 2020"
@@ -16953,7 +16953,7 @@ exports[`Calendar select date 2`] = `
             class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sun Jan 05 2020"
@@ -16969,7 +16969,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Mon Jan 06 2020"
@@ -16985,7 +16985,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Tue Jan 07 2020"
@@ -17001,7 +17001,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Wed Jan 08 2020"
@@ -17017,7 +17017,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Thu Jan 09 2020"
@@ -17033,7 +17033,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Fri Jan 10 2020"
@@ -17049,7 +17049,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sat Jan 11 2020"
@@ -17069,7 +17069,7 @@ exports[`Calendar select date 2`] = `
             class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sun Jan 12 2020"
@@ -17085,7 +17085,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Mon Jan 13 2020"
@@ -17101,7 +17101,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Tue Jan 14 2020"
@@ -17117,7 +17117,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Wed Jan 15 2020"
@@ -17133,7 +17133,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Thu Jan 16 2020"
@@ -17149,7 +17149,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Fri Jan 17 2020"
@@ -17165,7 +17165,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sat Jan 18 2020"
@@ -17185,7 +17185,7 @@ exports[`Calendar select date 2`] = `
             class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sun Jan 19 2020"
@@ -17201,7 +17201,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Mon Jan 20 2020"
@@ -17217,7 +17217,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Tue Jan 21 2020"
@@ -17233,7 +17233,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Wed Jan 22 2020"
@@ -17249,7 +17249,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Thu Jan 23 2020"
@@ -17265,7 +17265,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Fri Jan 24 2020"
@@ -17281,7 +17281,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sat Jan 25 2020"
@@ -17301,7 +17301,7 @@ exports[`Calendar select date 2`] = `
             class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sun Jan 26 2020"
@@ -17317,7 +17317,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Mon Jan 27 2020"
@@ -17333,7 +17333,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Tue Jan 28 2020"
@@ -17349,7 +17349,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Wed Jan 29 2020"
@@ -17365,7 +17365,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Thu Jan 30 2020"
@@ -17381,7 +17381,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Fri Jan 31 2020"
@@ -17397,7 +17397,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sat Feb 01 2020"
@@ -17417,7 +17417,7 @@ exports[`Calendar select date 2`] = `
             class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sun Feb 02 2020"
@@ -17433,7 +17433,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Mon Feb 03 2020"
@@ -17449,7 +17449,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Tue Feb 04 2020"
@@ -17465,7 +17465,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Wed Feb 05 2020"
@@ -17481,7 +17481,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Thu Feb 06 2020"
@@ -17497,7 +17497,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Fri Feb 07 2020"
@@ -17513,7 +17513,7 @@ exports[`Calendar select date 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sat Feb 08 2020"
@@ -17760,9 +17760,9 @@ exports[`Calendar select dates 1`] = `
 }
 
 .c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c14 {
@@ -18717,7 +18717,7 @@ exports[`Calendar select dates 2`] = `
             class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sun Dec 29 2019"
@@ -18733,7 +18733,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Mon Dec 30 2019"
@@ -18749,7 +18749,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Tue Dec 31 2019"
@@ -18765,7 +18765,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Wed Jan 01 2020"
@@ -18781,7 +18781,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Thu Jan 02 2020"
@@ -18797,7 +18797,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Fri Jan 03 2020"
@@ -18813,7 +18813,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sat Jan 04 2020"
@@ -18833,7 +18833,7 @@ exports[`Calendar select dates 2`] = `
             class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sun Jan 05 2020"
@@ -18849,7 +18849,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Mon Jan 06 2020"
@@ -18865,7 +18865,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Tue Jan 07 2020"
@@ -18881,7 +18881,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Wed Jan 08 2020"
@@ -18897,7 +18897,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Thu Jan 09 2020"
@@ -18913,7 +18913,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Fri Jan 10 2020"
@@ -18929,7 +18929,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sat Jan 11 2020"
@@ -18949,7 +18949,7 @@ exports[`Calendar select dates 2`] = `
             class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sun Jan 12 2020"
@@ -18965,7 +18965,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Mon Jan 13 2020"
@@ -18981,7 +18981,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Tue Jan 14 2020"
@@ -18997,7 +18997,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Wed Jan 15 2020"
@@ -19013,7 +19013,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Thu Jan 16 2020"
@@ -19029,7 +19029,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Fri Jan 17 2020"
@@ -19045,7 +19045,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sat Jan 18 2020"
@@ -19065,7 +19065,7 @@ exports[`Calendar select dates 2`] = `
             class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sun Jan 19 2020"
@@ -19081,7 +19081,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Mon Jan 20 2020"
@@ -19097,7 +19097,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Tue Jan 21 2020"
@@ -19113,7 +19113,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Wed Jan 22 2020"
@@ -19129,7 +19129,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Thu Jan 23 2020"
@@ -19145,7 +19145,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Fri Jan 24 2020"
@@ -19161,7 +19161,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sat Jan 25 2020"
@@ -19181,7 +19181,7 @@ exports[`Calendar select dates 2`] = `
             class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sun Jan 26 2020"
@@ -19197,7 +19197,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Mon Jan 27 2020"
@@ -19213,7 +19213,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Tue Jan 28 2020"
@@ -19229,7 +19229,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Wed Jan 29 2020"
@@ -19245,7 +19245,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Thu Jan 30 2020"
@@ -19261,7 +19261,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Fri Jan 31 2020"
@@ -19277,7 +19277,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sat Feb 01 2020"
@@ -19297,7 +19297,7 @@ exports[`Calendar select dates 2`] = `
             class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
           >
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sun Feb 02 2020"
@@ -19313,7 +19313,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Mon Feb 03 2020"
@@ -19329,7 +19329,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Tue Feb 04 2020"
@@ -19345,7 +19345,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Wed Feb 05 2020"
@@ -19361,7 +19361,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Thu Feb 06 2020"
@@ -19377,7 +19377,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Fri Feb 07 2020"
@@ -19393,7 +19393,7 @@ exports[`Calendar select dates 2`] = `
               </button>
             </div>
             <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
                 aria-label="Sat Feb 08 2020"
@@ -19640,9 +19640,9 @@ exports[`Calendar showAdjacentDays 1`] = `
 }
 
 .c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c14 {
@@ -22798,9 +22798,9 @@ exports[`Calendar size 1`] = `
 }
 
 .c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c14 {

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
@@ -842,9 +842,9 @@ exports[`DateInput focus 2`] = `
 }
 
 .c13 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c15 {
@@ -2290,9 +2290,9 @@ exports[`DateInput format inline 1`] = `
 }
 
 .c15 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c17 {
@@ -3726,9 +3726,9 @@ exports[`DateInput inline 1`] = `
 }
 
 .c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c14 {
@@ -5325,9 +5325,9 @@ exports[`DateInput range format inline 1`] = `
 }
 
 .c15 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c17 {
@@ -6779,9 +6779,9 @@ exports[`DateInput range inline 1`] = `
 }
 
 .c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c14 {
@@ -8342,9 +8342,9 @@ exports[`DateInput select format 3`] = `
 }
 
 .c13 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c15 {
@@ -9449,9 +9449,9 @@ exports[`DateInput select format inline 1`] = `
 }
 
 .c15 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c17 {
@@ -10527,7 +10527,7 @@ exports[`DateInput select format inline 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Jun 28 2020"
@@ -10543,7 +10543,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Jun 29 2020"
@@ -10559,7 +10559,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Jun 30 2020"
@@ -10575,7 +10575,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Jul 01 2020"
@@ -10591,7 +10591,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Jul 02 2020"
@@ -10607,7 +10607,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Jul 03 2020"
@@ -10623,7 +10623,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Jul 04 2020"
@@ -10643,7 +10643,7 @@ exports[`DateInput select format inline 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Jul 05 2020"
@@ -10659,7 +10659,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Jul 06 2020"
@@ -10675,7 +10675,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Jul 07 2020"
@@ -10691,7 +10691,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Jul 08 2020"
@@ -10707,7 +10707,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Jul 09 2020"
@@ -10723,7 +10723,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Jul 10 2020"
@@ -10739,7 +10739,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Jul 11 2020"
@@ -10759,7 +10759,7 @@ exports[`DateInput select format inline 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Jul 12 2020"
@@ -10775,7 +10775,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Jul 13 2020"
@@ -10791,7 +10791,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Jul 14 2020"
@@ -10807,7 +10807,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Jul 15 2020"
@@ -10823,7 +10823,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Jul 16 2020"
@@ -10839,7 +10839,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Jul 17 2020"
@@ -10855,7 +10855,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Jul 18 2020"
@@ -10875,7 +10875,7 @@ exports[`DateInput select format inline 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Jul 19 2020"
@@ -10891,7 +10891,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Jul 20 2020"
@@ -10907,7 +10907,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Jul 21 2020"
@@ -10923,7 +10923,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Jul 22 2020"
@@ -10939,7 +10939,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Jul 23 2020"
@@ -10955,7 +10955,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Jul 24 2020"
@@ -10971,7 +10971,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Jul 25 2020"
@@ -10991,7 +10991,7 @@ exports[`DateInput select format inline 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Jul 26 2020"
@@ -11007,7 +11007,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Jul 27 2020"
@@ -11023,7 +11023,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Jul 28 2020"
@@ -11039,7 +11039,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Jul 29 2020"
@@ -11055,7 +11055,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Jul 30 2020"
@@ -11071,7 +11071,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Jul 31 2020"
@@ -11087,7 +11087,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Aug 01 2020"
@@ -11107,7 +11107,7 @@ exports[`DateInput select format inline 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Aug 02 2020"
@@ -11123,7 +11123,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Aug 03 2020"
@@ -11139,7 +11139,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Aug 04 2020"
@@ -11155,7 +11155,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Aug 05 2020"
@@ -11171,7 +11171,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Aug 06 2020"
@@ -11187,7 +11187,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Aug 07 2020"
@@ -11203,7 +11203,7 @@ exports[`DateInput select format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Aug 08 2020"
@@ -11461,9 +11461,9 @@ exports[`DateInput select format inline range 1`] = `
 }
 
 .c15 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c17 {
@@ -12557,7 +12557,7 @@ exports[`DateInput select format inline range 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Jun 28 2020"
@@ -12573,7 +12573,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Jun 29 2020"
@@ -12589,7 +12589,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Jun 30 2020"
@@ -12605,7 +12605,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Jul 01 2020"
@@ -12621,7 +12621,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Jul 02 2020"
@@ -12637,7 +12637,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Jul 03 2020"
@@ -12653,7 +12653,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Jul 04 2020"
@@ -12673,7 +12673,7 @@ exports[`DateInput select format inline range 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Jul 05 2020"
@@ -12689,7 +12689,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Jul 06 2020"
@@ -12705,7 +12705,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Jul 07 2020"
@@ -12721,7 +12721,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Jul 08 2020"
@@ -12737,7 +12737,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Jul 09 2020"
@@ -12753,7 +12753,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Jul 10 2020"
@@ -12769,7 +12769,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Jul 11 2020"
@@ -12789,7 +12789,7 @@ exports[`DateInput select format inline range 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Jul 12 2020"
@@ -12805,7 +12805,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Jul 13 2020"
@@ -12821,7 +12821,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Jul 14 2020"
@@ -12837,7 +12837,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Jul 15 2020"
@@ -12853,7 +12853,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Jul 16 2020"
@@ -12869,7 +12869,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Jul 17 2020"
@@ -12885,7 +12885,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Jul 18 2020"
@@ -12905,7 +12905,7 @@ exports[`DateInput select format inline range 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Jul 19 2020"
@@ -12921,7 +12921,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Jul 20 2020"
@@ -12937,7 +12937,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Jul 21 2020"
@@ -12953,7 +12953,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Jul 22 2020"
@@ -12969,7 +12969,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Jul 23 2020"
@@ -12985,7 +12985,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Jul 24 2020"
@@ -13001,7 +13001,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Jul 25 2020"
@@ -13021,7 +13021,7 @@ exports[`DateInput select format inline range 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Jul 26 2020"
@@ -13037,7 +13037,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Jul 27 2020"
@@ -13053,7 +13053,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Jul 28 2020"
@@ -13069,7 +13069,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Jul 29 2020"
@@ -13085,7 +13085,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Jul 30 2020"
@@ -13101,7 +13101,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Jul 31 2020"
@@ -13117,7 +13117,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Aug 01 2020"
@@ -13137,7 +13137,7 @@ exports[`DateInput select format inline range 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Aug 02 2020"
@@ -13153,7 +13153,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Aug 03 2020"
@@ -13169,7 +13169,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Aug 04 2020"
@@ -13185,7 +13185,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Aug 05 2020"
@@ -13201,7 +13201,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Aug 06 2020"
@@ -13217,7 +13217,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Aug 07 2020"
@@ -13233,7 +13233,7 @@ exports[`DateInput select format inline range 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Aug 08 2020"
@@ -13491,9 +13491,9 @@ exports[`DateInput select inline 1`] = `
 }
 
 .c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c14 {
@@ -14580,9 +14580,9 @@ exports[`DateInput type format inline 1`] = `
 }
 
 .c15 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c17 {
@@ -15658,7 +15658,7 @@ exports[`DateInput type format inline 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Jun 28 2020"
@@ -15674,7 +15674,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Jun 29 2020"
@@ -15690,7 +15690,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Jun 30 2020"
@@ -15706,7 +15706,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Jul 01 2020"
@@ -15722,7 +15722,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Jul 02 2020"
@@ -15738,7 +15738,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Jul 03 2020"
@@ -15754,7 +15754,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Jul 04 2020"
@@ -15774,7 +15774,7 @@ exports[`DateInput type format inline 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Jul 05 2020"
@@ -15790,7 +15790,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Jul 06 2020"
@@ -15806,7 +15806,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Jul 07 2020"
@@ -15822,7 +15822,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Jul 08 2020"
@@ -15838,7 +15838,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Jul 09 2020"
@@ -15854,7 +15854,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Jul 10 2020"
@@ -15870,7 +15870,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Jul 11 2020"
@@ -15890,7 +15890,7 @@ exports[`DateInput type format inline 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Jul 12 2020"
@@ -15906,7 +15906,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Jul 13 2020"
@@ -15922,7 +15922,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Jul 14 2020"
@@ -15938,7 +15938,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Jul 15 2020"
@@ -15954,7 +15954,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Jul 16 2020"
@@ -15970,7 +15970,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Jul 17 2020"
@@ -15986,7 +15986,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Jul 18 2020"
@@ -16006,7 +16006,7 @@ exports[`DateInput type format inline 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Jul 19 2020"
@@ -16022,7 +16022,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Jul 20 2020"
@@ -16038,7 +16038,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Jul 21 2020"
@@ -16054,7 +16054,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Jul 22 2020"
@@ -16070,7 +16070,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Jul 23 2020"
@@ -16086,7 +16086,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Jul 24 2020"
@@ -16102,7 +16102,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Jul 25 2020"
@@ -16122,7 +16122,7 @@ exports[`DateInput type format inline 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Jul 26 2020"
@@ -16138,7 +16138,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Jul 27 2020"
@@ -16154,7 +16154,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Jul 28 2020"
@@ -16170,7 +16170,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Jul 29 2020"
@@ -16186,7 +16186,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Jul 30 2020"
@@ -16202,7 +16202,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Jul 31 2020"
@@ -16218,7 +16218,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Aug 01 2020"
@@ -16238,7 +16238,7 @@ exports[`DateInput type format inline 2`] = `
               class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
             >
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sun Aug 02 2020"
@@ -16254,7 +16254,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Mon Aug 03 2020"
@@ -16270,7 +16270,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Tue Aug 04 2020"
@@ -16286,7 +16286,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Wed Aug 05 2020"
@@ -16302,7 +16302,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Thu Aug 06 2020"
@@ -16318,7 +16318,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Fri Aug 07 2020"
@@ -16334,7 +16334,7 @@ exports[`DateInput type format inline 2`] = `
                 </button>
               </div>
               <div
-                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 DjmJE"
+                class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
               >
                 <button
                   aria-label="Sat Aug 08 2020"


### PR DESCRIPTION
Currently, when given the `fill` prop, the calendar is rendered larger than the available space, causing part of it to be cut off to the right side of the screen. This is easily visible in the [CustomDay story](https://storybook.grommet.io/?path=/story/visualizations-calendar-custom-day--custom-day-calendar) of the storybook:
![image](https://user-images.githubusercontent.com/8217788/111334000-7a879900-8673-11eb-8a56-d07f15cb0491.png)



#### What does this PR do?
I set the `DayContainer` wrapper to shrink down if there is not enough space available:
![image](https://user-images.githubusercontent.com/8217788/111334718-174a3680-8674-11eb-9640-1a9da5bea24d.png)


#### What testing has been done on this PR?
None. Should be covered by chromatic.
