### PR TITLE
Leave header checkbox unchecked if table data is not present.

### DIFF
--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -142,7 +142,11 @@ const Header = forwardRef(
             <TableCell background={background || cellProps.background}>
               {onSelect && (
                 <CheckBox
-                  checked={selected.length === data.length}
+                  checked={
+                    selected.length > 0 &&
+                    data.length > 0 &&
+                    selected.length === data.length
+                  }
                   indeterminate={
                     selected.length > 0 && selected.length < data.length
                   }


### PR DESCRIPTION
Signed-off-by: AkshayChoulwar <achoulwar901@gmail.com>

#### What does this PR do?
If the data is not present in the DataTable then header checkbox was enabled by default. In this PR we have disabled the header checkbox if the data is not present.

#### Where should the reviewer start?
/src/js/components/DataTable/Header.js

#### What testing has been done on this PR?
Creating the data table with empty data.

#### How should this be manually tested?
Creating the data table with empty data.

#### Any background context you want to provide?
https://github.com/grommet/grommet/issues/5072

#### What are the relevant issues?
NA

#### Screenshots (if appropriate)
No need.

#### Do the grommet docs need to be updated?
No need to update the docs.

#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
Yes