### PR TITLE
Type render functions of calendar component

### DIFF
--- a/src/js/components/Calendar/index.d.ts
+++ b/src/js/components/Calendar/index.d.ts
@@ -7,6 +7,22 @@ import {
   MarginType,
 } from '../../utils';
 
+export interface RenderProps {
+  date: Date;
+  day: number;
+  isInRange: boolean;
+  isSelected: boolean;
+}
+
+export interface HeaderProps {
+  date: Date;
+  locale?: string;
+  onPreviousMonth: () => void;
+  onNextMonth: () => void;
+  previousInBound: 1 | 2 | undefined;
+  nextInBound: 1 | 2 | undefined;
+}
+
 export interface CalendarProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
@@ -15,14 +31,14 @@ export interface CalendarProps {
   activeDate?: 'start' | 'end';
   animate?: AnimateType;
   bounds?: string[];
-  children?: (...args: any[]) => any;
+  children?: (args: RenderProps) => React.ReactNode;
   date?: string;
   dates?: (string | string[])[];
   daysOfWeek?: boolean;
   disabled?: (string | string[])[];
   fill?: boolean;
   firstDayOfWeek?: 0 | 1;
-  header?: (...args: any[]) => any;
+  header?: (args: HeaderProps) => React.ReactNode;
   locale?: string;
   onReference?: (reference: string) => void;
   onSelect?: (select: string | string[]) => any;


### PR DESCRIPTION
The render functions of the `Calendar` component were `any` typed. This PR replaces those typings with correct ones.