### PR TITLE
Clickable DataTable performance improvement

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -1,4 +1,4 @@
-import React, { forwardRef, Fragment } from 'react';
+import React, { forwardRef, Fragment, memo } from 'react';
 
 import { CheckBox } from '../CheckBox';
 import { InfiniteScroll } from '../InfiniteScroll';
@@ -10,6 +10,116 @@ import { ExpanderCell } from './ExpanderCell';
 import { Cell } from './Cell';
 import { StyledDataTableBody, StyledDataTableRow } from './StyledDataTable';
 import { datumValue } from './buildState';
+
+const Row = memo(
+  ({
+    primaryValue,
+    index,
+    rowRef,
+    size,
+    active,
+    onClickRow,
+    datum,
+    setActive,
+    selected,
+    onSelect,
+    background,
+    isSelected,
+    rowDetails,
+    isRowExpanded,
+    setRowExpand,
+    rowExpand,
+    columns,
+    pinnedBackground,
+    border,
+    pad,
+    primaryProperty,
+    rowProps,
+    data,
+  }) => (
+    <>
+      <StyledDataTableRow
+        ref={rowRef}
+        size={size}
+        active={active}
+        onClick={
+          onClickRow
+            ? event => {
+                // extract from React's synthetic event pool
+                event.persist();
+                const adjustedEvent = event;
+                adjustedEvent.datum = datum;
+                adjustedEvent.index = index;
+                onClickRow(adjustedEvent);
+              }
+            : undefined
+        }
+        onMouseEnter={onClickRow ? () => setActive(index) : undefined}
+        onMouseLeave={onClickRow ? () => setActive(undefined) : undefined}
+        onFocus={onClickRow ? () => setActive(index) : undefined}
+        onBlur={onClickRow ? () => setActive(undefined) : undefined}
+      >
+        {(selected || onSelect) && (
+          <TableCell background={background}>
+            <CheckBox
+              a11yTitle={`${
+                isSelected ? 'unselect' : 'select'
+              } ${primaryValue}`}
+              checked={isSelected}
+              disabled={!onSelect}
+              onChange={() => {
+                if (isSelected) {
+                  onSelect(selected.filter(s => s !== primaryValue));
+                } else onSelect([...selected, primaryValue]);
+              }}
+            />
+          </TableCell>
+        )}
+
+        {rowDetails && (
+          <ExpanderCell
+            context={isRowExpanded ? 'groupHeader' : 'body'}
+            expanded={isRowExpanded}
+            onToggle={() => {
+              if (isRowExpanded) {
+                setRowExpand(rowExpand.filter(s => s !== index));
+              } else {
+                setRowExpand([...rowExpand, index]);
+              }
+            }}
+          />
+        )}
+        {columns.map(column => (
+          <Cell
+            key={column.property}
+            background={column.pin ? pinnedBackground : background}
+            border={border}
+            context="body"
+            column={column}
+            datum={datum}
+            index={index}
+            pad={pad}
+            primaryProperty={primaryProperty}
+            rowProp={rowProps && rowProps[primaryValue]}
+            scope={
+              column.primary || column.property === primaryProperty
+                ? 'row'
+                : undefined
+            }
+          />
+        ))}
+      </StyledDataTableRow>
+      {rowDetails && isRowExpanded && (
+        <StyledDataTableRow key={`${index.toString()}_expand`}>
+          {(selected || onSelect) && <TableCell />}
+          <TableCell colSpan={columns.length + 1}>
+            {rowDetails(data[index])}
+          </TableCell>
+        </StyledDataTableRow>
+      )}
+    </>
+  ),
+);
 
 const Body = forwardRef(
   (
@@ -93,93 +203,32 @@ const Body = forwardRef(
               const isSelected = selected && selected.includes(primaryValue);
               const isRowExpanded = rowExpand && rowExpand.includes(index);
               return (
-                <Fragment key={primaryValue || index}>
-                  <StyledDataTableRow
-                    ref={rowRef}
-                    size={size}
-                    active={active >= 0 ? active === index : undefined}
-                    onClick={
-                      onClickRow
-                        ? event => {
-                            // extract from React's synthetic event pool
-                            event.persist();
-                            const adjustedEvent = event;
-                            adjustedEvent.datum = datum;
-                            adjustedEvent.index = index;
-                            onClickRow(adjustedEvent);
-                          }
-                        : undefined
-                    }
-                    onMouseEnter={
-                      onClickRow ? () => setActive(index) : undefined
-                    }
-                    onMouseLeave={
-                      onClickRow ? () => setActive(undefined) : undefined
-                    }
-                    onFocus={onClickRow ? () => setActive(index) : undefined}
-                    onBlur={onClickRow ? () => setActive(undefined) : undefined}
-                  >
-                    {(selected || onSelect) && (
-                      <TableCell background={background}>
-                        <CheckBox
-                          a11yTitle={`${
-                            isSelected ? 'unselect' : 'select'
-                          } ${primaryValue}`}
-                          checked={isSelected}
-                          disabled={!onSelect}
-                          onChange={() => {
-                            if (isSelected) {
-                              onSelect(
-                                selected.filter(s => s !== primaryValue),
-                              );
-                            } else onSelect([...selected, primaryValue]);
-                          }}
-                        />
-                      </TableCell>
-                    )}
-
-                    {rowDetails && (
-                      <ExpanderCell
-                        context={isRowExpanded ? 'groupHeader' : 'body'}
-                        expanded={isRowExpanded}
-                        onToggle={() => {
-                          if (isRowExpanded) {
-                            setRowExpand(rowExpand.filter(s => s !== index));
-                          } else {
-                            setRowExpand([...rowExpand, index]);
-                          }
-                        }}
-                      />
-                    )}
-                    {columns.map(column => (
-                      <Cell
-                        key={column.property}
-                        background={column.pin ? pinnedBackground : background}
-                        border={border}
-                        context="body"
-                        column={column}
-                        datum={datum}
-                        index={index}
-                        pad={pad}
-                        primaryProperty={primaryProperty}
-                        rowProp={rowProps && rowProps[primaryValue]}
-                        scope={
-                          column.primary || column.property === primaryProperty
-                            ? 'row'
-                            : undefined
-                        }
-                      />
-                    ))}
-                  </StyledDataTableRow>
-                  {rowDetails && isRowExpanded && (
-                    <StyledDataTableRow key={`${index.toString()}_expand`}>
-                      {(selected || onSelect) && <TableCell />}
-                      <TableCell colSpan={columns.length + 1}>
-                        {rowDetails(data[index])}
-                      </TableCell>
-                    </StyledDataTableRow>
-                  )}
-                </Fragment>
+                <Row
+                  key={primaryValue || index}
+                  rowRef={rowRef}
+                  primaryValue={primaryValue}
+                  isSelected={isSelected}
+                  isRowExpanded={isRowExpanded}
+                  index={index}
+                  size={size}
+                  active={active >= 0 ? active === index : undefined}
+                  onClickRow={onClickRow}
+                  datum={datum}
+                  setActive={setActive}
+                  selected={selected}
+                  onSelect={onSelect}
+                  background={background}
+                  rowDetails={rowDetails}
+                  setRowExpand={setRowExpand}
+                  rowExpand={rowExpand}
+                  columns={columns}
+                  pinnedBackground={pinnedBackground}
+                  border={border}
+                  pad={pad}
+                  primaryProperty={primaryProperty}
+                  rowProps={rowProps}
+                  data={data}
+                />
               );
             }}
           </InfiniteScroll>

--- a/src/js/components/DataTable/Cell.js
+++ b/src/js/components/DataTable/Cell.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { memo, useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 
 import { defaultProps } from '../../default-props';
@@ -13,88 +13,91 @@ const normalizeProp = (name, rowProp, prop) => {
   return prop;
 };
 
-const Cell = ({
-  background: backgroundProp,
-  border,
-  column: {
-    align,
-    pin: columnPin,
-    footer,
-    property,
-    render,
-    verticalAlign,
-    size,
-  },
-  datum,
-  index,
-  pad,
-  pin: cellPin,
-  primaryProperty,
-  rowProp,
-  scope,
-}) => {
-  const theme = useContext(ThemeContext) || defaultProps.theme;
-  const value = datumValue(datum, property);
-  const context = useContext(TableContext);
-  const renderContexts =
-    context === 'body' || (context === 'footer' && footer && footer.aggregate);
+const Cell = memo(
+  ({
+    background: backgroundProp,
+    border,
+    column: {
+      align,
+      pin: columnPin,
+      footer,
+      property,
+      render,
+      verticalAlign,
+      size,
+    },
+    datum,
+    index,
+    pad,
+    pin: cellPin,
+    primaryProperty,
+    rowProp,
+    scope,
+  }) => {
+    const theme = useContext(ThemeContext) || defaultProps.theme;
+    const value = datumValue(datum, property);
+    const context = useContext(TableContext);
+    const renderContexts =
+      context === 'body' ||
+      (context === 'footer' && footer && footer.aggregate);
 
-  let content;
-  if (render && renderContexts) {
-    content = render(datum);
-  } else if (value !== undefined) {
-    content = value;
-  }
-
-  if (typeof content === 'string' || typeof content === 'number') {
-    const textProps =
-      property === primaryProperty ? theme.dataTable.primary : {};
-    content = <Text {...textProps}>{content}</Text>;
-  }
-
-  let pin;
-  if (cellPin) pin = cellPin;
-  else if (columnPin) pin = ['left'];
-
-  let background;
-  if (pin && theme.dataTable.pinned && theme.dataTable.pinned[context]) {
-    background = theme.dataTable.pinned[context].background;
-    if (!background.color && theme.background) {
-      // theme context has an active background color but the
-      // theme doesn't set an explicit color, repeat the context
-      // background explicitly
-      background = {
-        ...background,
-        color: normalizeBackgroundColor(theme),
-      };
+    let content;
+    if (render && renderContexts) {
+      content = render(datum);
+    } else if (value !== undefined) {
+      content = value;
     }
-  } else background = undefined;
 
-  return (
-    <StyledDataTableCell
-      scope={scope}
-      {...theme.dataTable[context]}
-      align={align}
-      context={context}
-      verticalAlign={verticalAlign}
-      size={size}
-      background={
-        normalizeProp(
-          'background',
-          rowProp,
-          Array.isArray(backgroundProp)
-            ? backgroundProp[index % backgroundProp.length]
-            : backgroundProp,
-        ) || background
+    if (typeof content === 'string' || typeof content === 'number') {
+      const textProps =
+        property === primaryProperty ? theme.dataTable.primary : {};
+      content = <Text {...textProps}>{content}</Text>;
+    }
+
+    let pin;
+    if (cellPin) pin = cellPin;
+    else if (columnPin) pin = ['left'];
+
+    let background;
+    if (pin && theme.dataTable.pinned && theme.dataTable.pinned[context]) {
+      background = theme.dataTable.pinned[context].background;
+      if (!background.color && theme.background) {
+        // theme context has an active background color but the
+        // theme doesn't set an explicit color, repeat the context
+        // background explicitly
+        background = {
+          ...background,
+          color: normalizeBackgroundColor(theme),
+        };
       }
-      border={normalizeProp('border', rowProp, border)}
-      pad={normalizeProp('pad', rowProp, pad)}
-      pin={pin}
-    >
-      {content}
-    </StyledDataTableCell>
-  );
-};
+    } else background = undefined;
+
+    return (
+      <StyledDataTableCell
+        scope={scope}
+        {...theme.dataTable[context]}
+        align={align}
+        context={context}
+        verticalAlign={verticalAlign}
+        size={size}
+        background={
+          normalizeProp(
+            'background',
+            rowProp,
+            Array.isArray(backgroundProp)
+              ? backgroundProp[index % backgroundProp.length]
+              : backgroundProp,
+          ) || background
+        }
+        border={normalizeProp('border', rowProp, border)}
+        pad={normalizeProp('pad', rowProp, pad)}
+        pin={pin}
+      >
+        {content}
+      </StyledDataTableCell>
+    );
+  },
+);
 
 Cell.displayName = 'Cell';
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Extracted `DataTable` row to another component and wrapped with `React.memo` to improve performance. Also wrapped `Cell` to gain a bit more improvement (check JS activity in screenshots for more info).

#### Where should the reviewer start?
It should be simple - we need to confirm all the props are properly extracted.

#### What testing has been done on this PR?
Compared with all DataTable Storybook components - everything looks the same.

#### How should this be manually tested?
Just make sure everything works as before.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
##### before
![screenshot-initial](https://user-images.githubusercontent.com/1783133/111567836-fa962780-8775-11eb-9fa5-cd3fdf617e96.png)

##### Cell memoed
![screenshot-cell-memoed](https://user-images.githubusercontent.com/1783133/111567864-0b469d80-8776-11eb-90a7-723aee69178f.png)

##### Row extracted (and Cell memoed)
![screenshot-cell-memoed-row-extracted](https://user-images.githubusercontent.com/1783133/111567906-21ecf480-8776-11eb-99f5-d1cd15ba0907.png)


##### Before

https://user-images.githubusercontent.com/1783133/111567926-2b765c80-8776-11eb-9595-4a4be85f37a1.mp4

##### After

https://user-images.githubusercontent.com/1783133/111568070-72fce880-8776-11eb-995d-3b339901489c.mp4




#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Maybe as a performance improvement, or bug fix.

#### Is this change backwards compatible or is it a breaking change?
No breaking changes, and no API changes.
