### PR TITLE
[TS] Add Avatar, CheckBoxGroup, Chart and Clock extended props interfaces

### DIFF
--- a/src/js/components/Avatar/index.d.ts
+++ b/src/js/components/Avatar/index.d.ts
@@ -6,8 +6,11 @@ export interface AvatarProps {
   src?: string;
 }
 
-declare const Avatar: React.FC<BoxProps &
-  AvatarProps &
-  JSX.IntrinsicElements['div']>;
+export interface AvatarExtendedProps
+  extends BoxProps,
+    AvatarProps,
+    Omit<JSX.IntrinsicElements['div'], 'onClick'> {}
+
+declare const Avatar: React.FC<AvatarExtendedProps>;
 
 export { Avatar };

--- a/src/js/components/Chart/index.d.ts
+++ b/src/js/components/Chart/index.d.ts
@@ -96,6 +96,6 @@ export interface ChartProps {
   )[];
 }
 
-declare const Chart: React.ComponentClass<ChartProps>;
+declare const Chart: React.FC<ChartProps>;
 
 export { Chart };

--- a/src/js/components/CheckBoxGroup/index.d.ts
+++ b/src/js/components/CheckBoxGroup/index.d.ts
@@ -22,8 +22,11 @@ export interface CheckBoxGroupProps {
   valueKey?: string;
 }
 
-declare const CheckBoxGroup: React.ComponentClass<CheckBoxGroupProps &
-  BoxProps &
-  JSX.IntrinsicElements['div']>;
+export interface CheckBoxGroupExtendedProps
+  extends CheckBoxGroupProps,
+    BoxProps,
+    Omit<JSX.IntrinsicElements['div'], 'onClick' | 'onChange'> {}
+
+declare const CheckBoxGroup: React.FC<CheckBoxGroupExtendedProps>;
 
 export { CheckBoxGroup };

--- a/src/js/components/Clock/index.d.ts
+++ b/src/js/components/Clock/index.d.ts
@@ -28,7 +28,17 @@ export interface ClockProps {
   type?: 'analog' | 'digital';
 }
 
-declare const Clock: React.ComponentClass<ClockProps &
-  (JSX.IntrinsicElements['div'] | JSX.IntrinsicElements['svg'])>;
+/**
+ * Ideally this would be an interface, however since the Clock component can be
+ * either analog (svg) or digital (div), we cannot know at compile time whether
+ * ClockExtendedProps should contain svg or div props.
+ */
+export type ClockExtendedProps = ClockProps &
+  (
+    | Omit<JSX.IntrinsicElements['svg'], 'onChange' | 'type'>
+    | Omit<JSX.IntrinsicElements['div'], 'onChange'>
+  );
+
+declare const Clock: React.FC<ClockExtendedProps>;
 
 export { Clock };


### PR DESCRIPTION
#### What does this PR do?

This PR adds and exports `<component>ExtendedProps` declarations for the Avatar, CheckBoxGroup, Chart and Clock components, forming part of issue #4998.

#### Where should the reviewer start?

The only files changed are the TS declaration files for each of the four components. The `Clock` component required some discussion, so should be reviewed last.

#### What testing has been done on this PR?

No new tests were added, all tests passed locally on each commit's pre-commit hook.

#### How should this be manually tested?

Importing the extended prop interfaces from a separate project should allow `JSX.IntrinsicElements` keys to be passed through to the imported interface, e.g. importing `AvatarExtendedProps` should make `div` keys available, as well as general HTML keys like `children`. Also double check any keys included in `Omit<..., ...>` types for consistency with original intersected types.

#### Any background context you want to provide?

All background context is available in this discussion/design issue: #4978

#### What are the relevant issues?

Progress tracking: #4998
Design/discussion: #4978

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Not this PR specifically, but users should be made aware of the new extended prop type declarations.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.