### PR TITLE
[TS] Add DataTable, Grid and Grommet extended props interfaces, use React.FC for InfiniteScroll type

### DIFF
--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -105,8 +105,12 @@ export interface DataTableProps<TRowType = any> {
   onSort?: (sort: { property: string; direction: 'asc' | 'desc' }) => void;
 }
 
+export interface DataTableExtendedProps<TRowType = any>
+  extends DataTableProps<TRowType>,
+    Omit<JSX.IntrinsicElements['table'], 'onSelect' | 'placeholder'> {}
+
 declare class DataTable<TRowType = any> extends React.Component<
-  DataTableProps<TRowType> & Omit<JSX.IntrinsicElements['table'], 'onSelect'>
+  DataTableExtendedProps<TRowType>
 > {}
 
 export { DataTable };

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -102,6 +102,10 @@ export interface GridProps {
   tag?: PolymorphicType;
 }
 
-declare const Grid: React.FC<GridProps & JSX.IntrinsicElements['div']>;
+type divProps = JSX.IntrinsicElements['div'];
+
+export interface GridExtendedProps extends GridProps, divProps {}
+
+declare const Grid: React.FC<GridExtendedProps>;
 
 export { Grid };

--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -14,7 +14,10 @@ export interface GrommetProps {
   userAgent?: string;
 }
 
-declare const Grommet: React.ComponentClass<GrommetProps &
-  JSX.IntrinsicElements['div']>;
+export interface GrommetExtendedProps
+  extends GrommetProps,
+    Omit<JSX.IntrinsicElements['div'], 'dir'> {}
+
+declare const Grommet: React.FC<GrommetExtendedProps>;
 
 export { Grommet };

--- a/src/js/components/InfiniteScroll/index.d.ts
+++ b/src/js/components/InfiniteScroll/index.d.ts
@@ -10,6 +10,6 @@ export interface InfiniteScrollProps {
   step?: number;
 }
 
-declare const InfiniteScroll: React.ComponentClass<InfiniteScrollProps>;
+declare const InfiniteScroll: React.FC<InfiniteScrollProps>;
 
 export { InfiniteScroll };


### PR DESCRIPTION
#### What does this PR do?

This PR adds and exports `<component>ExtendedProps` declarations for the DataTable, Grid and Grommet components, forming part of issue #4998. It also changes the type of the `InfiniteScroll` component to `React.FC<InfiniteScrollProps>` instead of `React.ComponentClass<InfiniteScrollProps>`, for consistency with other components.

#### Where should the reviewer start?

The only files changed are the TS declaration files for each of the three components, with the `InfiniteScroll` component having a different change. Any of those TS files are a good place to start.

#### What testing has been done on this PR?

No new tests were added, all tests passed locally on each commit's pre-commit hook.

#### How should this be manually tested?

Importing the extended prop interfaces from a separate project should allow `JSX.IntrinsicElements` keys to be passed through to the imported interface, e.g. importing `GrommetExtendedProps` should make `div` keys available, as well as general HTML keys like `children`. Also double check any keys included in `Omit<..., ...>` types for consistency with original intersected types.

#### Any background context you want to provide?

All background context is available in this discussion/design issue: #4978

#### What are the relevant issues?

Progress tracking: #4998
Design/discussion: #4978

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Not this PR specifically, but users should be made aware of the new extended prop type declarations.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.