### PR TITLE
[TS] Add Layer and Menu extended props interfaces, use React.FC for Chart and Select types

### DIFF
--- a/src/js/components/Chart/index.d.ts
+++ b/src/js/components/Chart/index.d.ts
@@ -96,6 +96,6 @@ export interface ChartProps {
   )[];
 }
 
-declare const Chart: React.ComponentClass<ChartProps>;
+declare const Chart: React.FC<ChartProps>;
 
 export { Chart };

--- a/src/js/components/Layer/index.d.ts
+++ b/src/js/components/Layer/index.d.ts
@@ -34,7 +34,10 @@ export interface LayerProps {
   target?: object;
 }
 
-declare const Layer: React.ComponentClass<LayerProps &
-  JSX.IntrinsicElements['div']>;
+type divProps = JSX.IntrinsicElements['div'];
+
+export interface LayerExtendedProps extends LayerProps, divProps {}
+
+declare const Layer: React.FC<LayerExtendedProps>;
 
 export { Layer };

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -39,6 +39,10 @@ export interface MenuProps {
   size?: 'small' | 'medium' | 'large' | 'xlarge' | string;
 }
 
-declare const Menu: React.FC<MenuProps & Omit<ButtonType, 'icon'>>;
+export interface MenuExtendedProps
+  extends MenuProps,
+    Omit<ButtonType, 'icon' | 'size'> {}
+
+declare const Menu: React.FC<MenuExtendedProps>;
 
 export { Menu };

--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -57,6 +57,6 @@ export interface SelectProps {
   emptySearchMessage?: string;
 }
 
-declare const Select: React.ComponentClass<SelectProps>;
+declare const Select: React.FC<SelectProps>;
 
 export { Select };


### PR DESCRIPTION
#### What does this PR do?

This PR adds and exports `<component>ExtendedProps` declarations for the Layer and Menu components, forming part of issue #4998. It also changes the type of the `Chart` and `Select` components to `React.FC<component>` instead of `React.ComponentClass<component>`, for consistency with the component implementation.

#### Where should the reviewer start?

The only files changed are the TS declaration files for each of the four mentioned components. All components are eaqually good places to start.

#### What testing has been done on this PR?

No new tests were added, all tests passed locally on each commit's pre-commit hook.

#### How should this be manually tested?

Importing the extended prop interfaces from a separate project should allow `JSX.IntrinsicElements` keys to be passed through to the imported interface, e.g. importing `LayerExtendedProps` should make `div` keys available, as well as general HTML keys like `children`. Also double check any keys included in `Omit<..., ...>` types for consistency with original intersected types.

#### Any background context you want to provide?

All background context is available in this discussion/design issue: #4978

#### What are the relevant issues?

Progress tracking: #4998
Design/discussion: #4978

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Not this PR specifically, but users should be made aware of the new extended prop type declarations.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.