### PR TITLE
[TS] Add Spinner and MaskedInput extended props interfaces

### DIFF
--- a/src/js/components/MaskedInput/index.d.ts
+++ b/src/js/components/MaskedInput/index.d.ts
@@ -21,9 +21,13 @@ export interface MaskedInputProps {
   value?: string | number;
 }
 
-declare const MaskedInput: React.ComponentClass<MaskedInputProps &
-  Omit<JSX.IntrinsicElements['input'], keyof MaskedInputProps>>;
-export type MaskedInputType = MaskedInputProps &
-  Omit<JSX.IntrinsicElements['input'], keyof MaskedInputProps>;
+export interface MaskedInputExtendedProps
+  extends MaskedInputProps,
+    Omit<JSX.IntrinsicElements['input'], keyof MaskedInputProps> {}
+
+// Keep type alias for backwards compatibility.
+export type MaskedInputType = MaskedInputExtendedProps;
+
+declare const MaskedInput: React.FC<MaskedInputExtendedProps>;
 
 export { MaskedInput };

--- a/src/js/components/Spinner/index.d.ts
+++ b/src/js/components/Spinner/index.d.ts
@@ -8,6 +8,8 @@ export interface SpinnerProps {
   message?: string | { start?: string; end?: string };
 }
 
-declare const Spinner: React.FC<BoxProps & SpinnerProps>;
+export interface SpinnerExtendedProps extends BoxProps, SpinnerProps {}
+
+declare const Spinner: React.FC<SpinnerExtendedProps>;
 
 export { Spinner };


### PR DESCRIPTION
#### What does this PR do?

This PR adds and exports `<component>ExtendedProps` declarations for the Spinner and MaskedInput components, forming part of issue #4998

#### Where should the reviewer start?

The only files changed are the TS declaration files for each of the two mentioned components. The spinner component is more straightforward, since it is more similar to the majority of the components changed as part of issue #4998.

The `MaskedInput` component previously defined a `MaskedInputType`, which has been kept with the addition of the `MaskedInputExtendedProps` interface for backwards compatibility. The reviewer should double check that the changes are backwards compatible.

#### What testing has been done on this PR?

No new tests were added, all tests passed locally on each commit's pre-commit hook.

#### How should this be manually tested?

Importing the extended prop interfaces from a separate project should allow `JSX.IntrinsicElements` keys to be passed through to the imported interface, e.g. importing `LayerExtendedProps` should make `div` keys available, as well as general HTML keys like `children`. Also double check any keys included in `Omit<..., ...>` types for consistency with original intersected types.

#### Any background context you want to provide?

All background context is available in this discussion/design issue: #4978

#### What are the relevant issues?

Progress tracking: #4998
Design/discussion: #4978

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Not this PR specifically, but users should be made aware of the new extended prop type declarations.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.