### PR TITLE
[TS] Add Box, Button, Calendar and Drop extended props interfaces

### DIFF
--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -190,7 +190,13 @@ export interface BoxProps {
   wrap?: boolean | 'reverse';
 }
 
-declare const Box: React.FC<BoxProps & JSX.IntrinsicElements['div']>;
+export interface BoxExtendedProps
+  extends BoxProps,
+    Omit<JSX.IntrinsicElements['div'], keyof BoxProps> {}
+
+// Keep type alias for backwards compatibility.
 export type BoxTypes = BoxProps & JSX.IntrinsicElements['div'];
+
+declare const Box: React.FC<BoxExtendedProps>;
 
 export { Box };

--- a/src/js/components/Button/index.d.ts
+++ b/src/js/components/Button/index.d.ts
@@ -40,9 +40,14 @@ export interface ButtonProps {
   as?: PolymorphicType;
 }
 
-declare const Button: React.FC<ButtonProps &
-  Omit<JSX.IntrinsicElements['button'], 'color'>>;
+export interface ButtonExtendedProps
+  extends ButtonProps,
+    Omit<JSX.IntrinsicElements['button'], 'color'> {}
+
+// Keep type alias for backwards compatibility.
 export type ButtonType = ButtonProps &
   Omit<JSX.IntrinsicElements['button'], 'color'>;
+
+declare const Button: React.FC<ButtonExtendedProps>;
 
 export { Button };

--- a/src/js/components/Calendar/index.d.ts
+++ b/src/js/components/Calendar/index.d.ts
@@ -32,9 +32,14 @@ export interface CalendarProps {
   size?: 'small' | 'medium' | 'large' | string;
 }
 
-declare const Calendar: React.ComponentClass<CalendarProps &
-  JSX.IntrinsicElements['div']>;
+export interface CalendarExtendedProps
+  extends CalendarProps,
+    Omit<JSX.IntrinsicElements['div'], keyof CalendarProps> {}
+
+// Keep type alias for backwards compatibility.
 export type CalendarType = CalendarProps &
   Omit<JSX.IntrinsicElements['div'], 'onSelect'>;
+
+declare const Calendar: React.ComponentClass<CalendarExtendedProps>;
 
 export { Calendar };

--- a/src/js/components/Drop/index.d.ts
+++ b/src/js/components/Drop/index.d.ts
@@ -45,6 +45,6 @@ export interface DropExtendedProps extends DropProps, divProps {}
 // Keep type alias for backwards compatibility.
 export type DropType = DropProps & JSX.IntrinsicElements['div'];
 
-declare const Drop: React.ComponentClass<DropExtendedProps>;
+declare const Drop: React.FC<DropExtendedProps>;
 
 export { Drop };

--- a/src/js/components/Drop/index.d.ts
+++ b/src/js/components/Drop/index.d.ts
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { BackgroundType, ElevationType, KeyboardType, MarginType, RoundType } from '../../utils';
+import {
+  BackgroundType,
+  ElevationType,
+  KeyboardType,
+  MarginType,
+  RoundType,
+} from '../../utils';
 
 export interface DropProps {
   align?: {
@@ -32,8 +38,13 @@ export interface DropProps {
   round?: RoundType;
 }
 
-declare const Drop: React.ComponentClass<DropProps &
-  JSX.IntrinsicElements['div']>;
+type divProps = JSX.IntrinsicElements['div'];
+
+export interface DropExtendedProps extends DropProps, divProps {}
+
+// Keep type alias for backwards compatibility.
 export type DropType = DropProps & JSX.IntrinsicElements['div'];
+
+declare const Drop: React.ComponentClass<DropExtendedProps>;
 
 export { Drop };


### PR DESCRIPTION
#### What does this PR do?

This PR adds and exports `<component>ExtendedProps` declarations for the Box, Button, Calendar and Drop components, forming part of issue #4998

#### Where should the reviewer start?

The only files changed are the TS declaration files for each of the four mentioned components. All components previously defined a `<component>Type`, which has been kept in addition to the `<component>ExtendedProps` interfaces for backwards compatibility. The reviewer should double check that the changes are backwards compatible. I am happy to discuss potential deprecation warnings etc. and log a separate issue for deprecation notices if required.

#### What testing has been done on this PR?

No new tests were added, all tests passed locally on each commit's pre-commit hook.

#### How should this be manually tested?

Importing the extended prop interfaces from a separate project should allow `JSX.IntrinsicElements` keys to be passed through to the imported interface, e.g. importing `CalendarExtendedProps` should make `div` keys available, as well as general HTML keys like `children`. Also double check any keys included in `Omit<..., ...>` types for consistency with original intersected types.

#### Any background context you want to provide?

All background context is available in this discussion/design issue: #4978

#### What are the relevant issues?

Progress tracking: #4998
Design/discussion: #4978

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Not this PR specifically, but users should be made aware of the new extended prop type declarations.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.