### PR TITLE
Updating List docs to fix html entities conversion.

### DIFF
--- a/src/js/components/List/README.md
+++ b/src/js/components/List/README.md
@@ -129,8 +129,7 @@ string
 Accepts a function that allows for a custom rendering
        of a component, it should be passed with an item and
         index of an array and return a react element
-      `action = ({item, index}) => <Content />`
-    />
+      'action = ({item, index}) => <Content />'
 
 ```
 function
@@ -216,8 +215,7 @@ Function that will be called when each data item is rendered.
       and an object indicating the state of the item, if any. It
       should return a react element.
       For example:
-      `children={(item, index, { active }) => <Box ...>{...}</Box>}`
-      
+      'children={(item, index, { active }) => <Box ...>{...}</Box>}'
 
 ```
 function

--- a/src/js/components/List/doc.js
+++ b/src/js/components/List/doc.js
@@ -60,8 +60,7 @@ export const doc = List => {
       `Accepts a function that allows for a custom rendering
        of a component, it should be passed with an item and
         index of an array and return a react element
-      \`action = ({item, index}) => <Content />\`
-    />`,
+      'action = ({item, index}) => <Content />'`,
     ),
     as: PropTypes.string
       .description('The DOM tag or react component to use for the element.')
@@ -83,8 +82,7 @@ export const doc = List => {
       and an object indicating the state of the item, if any. It
       should return a react element.
       For example:
-      \`children={(item, index, { active }) => <Box ...>{...}</Box>}\`
-      `,
+      'children={(item, index, { active }) => <Box ...>{...}</Box>}'`,
     ),
     itemProps: PropTypes.shape({}).description(
       `Item specific background, border, and pad, keyed by data index.

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11897,8 +11897,7 @@ string
 Accepts a function that allows for a custom rendering
        of a component, it should be passed with an item and
         index of an array and return a react element
-      \`action = ({item, index}) => <Content />\`
-    />
+      'action = ({item, index}) => <Content />'
 
 \`\`\`
 function
@@ -11984,8 +11983,7 @@ Function that will be called when each data item is rendered.
       and an object indicating the state of the item, if any. It
       should return a react element.
       For example:
-      \`children={(item, index, { active }) => <Box ...>{...}</Box>}\`
-      
+      'children={(item, index, { active }) => <Box ...>{...}</Box>}'
 
 \`\`\`
 function

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -5514,8 +5514,7 @@ string",
         "description": "Accepts a function that allows for a custom rendering
        of a component, it should be passed with an item and
         index of an array and return a react element
-      \`action = ({item, index}) => <Content />\`
-    />",
+      'action = ({item, index}) => <Content />'",
         "format": "function",
         "name": "action",
       },
@@ -5587,8 +5586,7 @@ end
       and an object indicating the state of the item, if any. It
       should return a react element.
       For example:
-      \`children={(item, index, { active }) => <Box ...>{...}</Box>}\`
-      ",
+      'children={(item, index, { active }) => <Box ...>{...}</Box>}'",
         "format": "function",
         "name": "children",
       },


### PR DESCRIPTION
Signed-off-by: Zack Urben <zackurben@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR updates the List element docs to fix the html entities conversion of `<` and `>` in the examples. Additionally removes a dangling `/>`. I followed the format used in the [DataTable Component](https://v2.grommet.io/datatable) for props with code examples, e.g. `onSelect` and `onSort`.

#### Where should the reviewer start?

Check the diff or [live docs](https://v2.grommet.io/list) for the `action` and `children` props.

#### What testing has been done on this PR?

`yarn generate-readme` and `yarn test-update`

#### How should this be manually tested?

I am not sure how to run the doc site locally to confirm changes. I'll gladly do some further testing/verification if I can get some guidance on how to do so.

#### Any background context you want to provide?

N/A

#### What are the relevant issues?

N/A

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/2689122/111908288-a5347180-8a26-11eb-8e48-579c9882579a.png)

![image](https://user-images.githubusercontent.com/2689122/111908388-1116da00-8a27-11eb-825a-31e96f3192f7.png)


#### Do the grommet docs need to be updated?

Yes

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

Backwards Compatible
