### PR TITLE
Adjust rightOffset when caller applies pad on FileInput

### DIFF
--- a/src/js/components/FileInput/FileInput.js
+++ b/src/js/components/FileInput/FileInput.js
@@ -111,6 +111,25 @@ const FileInput = forwardRef(
         : result;
     };
 
+    let rightPad;
+    if (mergeTheme('pad')) {
+      const { horizontal, right } = mergeTheme('pad');
+      if (right) {
+        rightPad = theme.global.edgeSize[right] || right;
+      } else if (horizontal) {
+        rightPad = theme.global.edgeSize[horizontal] || horizontal;
+      }
+    }
+
+    let rightOffset;
+    if (removeRef.current) {
+      if (rightPad && typeof rightPad === 'string')
+        rightOffset =
+          removeRef.current.getBoundingClientRect().width +
+          rightPad.replace('px', '');
+      else rightOffset = removeRef.current.getBoundingClientRect().width;
+    }
+
     return (
       <Keyboard
         onSpace={event => {
@@ -210,10 +229,7 @@ const FileInput = forwardRef(
             multiple={multiple}
             disabled={disabled}
             plain
-            rightOffset={
-              removeRef.current &&
-              removeRef.current.getBoundingClientRect().width
-            }
+            rightOffset={rightOffset}
             {...rest}
             onDragOver={() => setDragOver(true)}
             onDragLeave={() => setDragOver(false)}

--- a/src/js/components/FileInput/FileInput.js
+++ b/src/js/components/FileInput/FileInput.js
@@ -121,6 +121,9 @@ const FileInput = forwardRef(
       }
     }
 
+    // rightPad needs to be included in the rightOffset
+    // otherwise input may cover the RemoveButton, making it
+    // unreachable by mouse click.
     let rightOffset;
     if (removeRef.current) {
       if (rightPad && typeof rightPad === 'string')

--- a/src/js/components/FileInput/README.md
+++ b/src/js/components/FileInput/README.md
@@ -89,7 +89,7 @@ Provides custom rendering of the file. If not provided, the file's
       an argument. For example: (file) => <Text>{file.name}</Text>
 
 ```
-node
+function
 ```
   
 ## Intrinsic element

--- a/src/js/components/FileInput/doc.js
+++ b/src/js/components/FileInput/doc.js
@@ -59,7 +59,7 @@ export const doc = FileInput => {
       `Function that will be called when one or more files are added to 
       the input. The file(s) can be found in event.target.files.`,
     ),
-    renderFile: PropTypes.node.description(
+    renderFile: PropTypes.func.description(
       `Provides custom rendering of the file. If not provided, the file's
       name will be shown. It will be passed the browser File object as
       an argument. For example: (file) => <Text>{file.name}</Text>`,

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -8819,7 +8819,7 @@ Provides custom rendering of the file. If not provided, the file's
       an argument. For example: (file) => <Text>{file.name}</Text>
 
 \`\`\`
-node
+function
 \`\`\`
   
 ## Intrinsic element

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -3855,7 +3855,7 @@ string",
         "description": "Provides custom rendering of the file. If not provided, the file's
       name will be shown. It will be passed the browser File object as
       an argument. For example: (file) => <Text>{file.name}</Text>",
-        "format": "node",
+        "format": "function",
         "name": "renderFile",
       },
     ],


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
When caller applies pad to FileInput, the dimensions of the pad need to be taken into account in the rightOffset of the `input`. If not, the `input` will cover the RemoveButton which allows the user to delete a file they have uploaded.

Previously, the pad was not taken into account which meant that the RemoveButton would at times be inaccessible by the mouse.

Also resolved incorrect propType in docs for `renderFile`.

#### Where should the reviewer start?
src/js/components/FileInput/FileInput.js

#### What testing has been done on this PR?
Test in Custom Story.

#### How should this be manually tested?
In CustomStory. Upload a file then click to remove.

#### Any background context you want to provide?
Previously, the input would cover the remove button when pad was applied.
<img width="460" alt="Screen Shot 2021-03-22 at 7 50 25 PM" src="https://user-images.githubusercontent.com/12522275/112088099-67316d80-8b4c-11eb-9752-f1908f02286b.png">

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Updated here.

#### Should this PR be mentioned in the release notes?
New component.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.