### PR TITLE
Fix Layer animation on exit

### DIFF
--- a/src/js/components/Layer/Layer.js
+++ b/src/js/components/Layer/Layer.js
@@ -1,4 +1,10 @@
-import React, { forwardRef, useContext, useEffect, useState } from 'react';
+import React, {
+  forwardRef,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useState,
+} from 'react';
 import { createPortal } from 'react-dom';
 
 import { getNewContainer } from '../../utils';
@@ -20,7 +26,7 @@ const Layer = forwardRef((props, ref) => {
   );
 
   // just a few things to clean up when the Layer is unmounted
-  useEffect(
+  useLayoutEffect(
     () => () => {
       if (originalFocusedElement) {
         if (originalFocusedElement.focus) {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes a bug where layer was no longer animating on exit after upgrading to react-dom v17. In react-dom 17 `useEffect` changed effects to run asynchronously. `useLayoutEffect` should now be used instead when you are using an effect that is mutating the DOM and will change a change in the appearance of the DOM node between the time that it is rendered and your effect mutates it. `useLayoutEffect` runs synchronously. Since the animation is effecting how the DOM node looks it should use `useLayoutEffect` instead of `useEffect`

more info here: https://kentcdodds.com/blog/useeffect-vs-uselayouteffect
and here: https://reactjs.org/blog/2020/08/10/react-v17-rc.html#fixing-potential-issues

#### Where should the reviewer start?
Layer.js

#### What testing has been done on this PR?
Storybook

#### How should this be manually tested?
with the Layer/Notification story check to see that the layer is animating on exit instead of just being removed.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #4809

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible