### PR TITLE
Fix InfiniteScroll loop when Data length changes

### DIFF
--- a/src/js/components/InfiniteScroll/InfiniteScroll.js
+++ b/src/js/components/InfiniteScroll/InfiniteScroll.js
@@ -151,12 +151,12 @@ const InfiniteScroll = ({
   }, [items.length, lastPage, onMore, pendingLength, renderPageBounds, step]);
 
   useEffect(() => {
-    if (lastPage === 0 && pendingLength !== 0) {
+    if (items.length === 0 && lastPage === 0 && pendingLength !== 0) {
       setPageHeights([]);
       setPendingLength(0);
       setRenderPageBounds([0, calculateLastPageBound(show, step)]);
     }
-  }, [lastPage, pendingLength, show, step]);
+  }, [lastPage, pendingLength, show, step, items.length]);
 
   // scroll to any 'show'
   useLayoutEffect(() => {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Introduces a patch to #5095,  introduced on PR #4936 .

This fix uses two states to help tracking changes to data length. On this approach, we avoid going back to using `items.length === 0` as a check and thus we wouldn't assume that the caller wants to reset the data to an empty array before repopulating it.

Please note that this covers a very specific use case ( #4934 ) where the reporter wanted to reset data to an empty array before setting it. The condition `lastPage === 0` will make this work only for situations where the modified length is smaller than the initial step. 

Would love to hear your thoughts on that @ShimiSun @halocline, and I'd suggest we open this matter to discussion so we can have a clear view of use cases we want to cover before any attempt of broadening the whole reset-onMore-calls thing.

#### Where should the reviewer start?

`src/js/components/InfiniteScroll/InfiniteScroll.js`

#### What testing has been done on this PR?

Manual testing as JSDom and Jest do not support calls such as getBoundingClientRect, making this PR unable to be tested using automated tests.

#### How should this be manually tested?

Code provided on PR #4936 and issue #5095.

#### Any background context you want to provide?

#### What are the relevant issues?

#5095

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
