### PR TITLE
Fix DataTable Searchers wrap on small screens

### DIFF
--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -268,6 +268,7 @@ const Header = forwardRef(
                     justify={!align || align === 'start' ? 'between' : align}
                     gap={theme.dataTable.header.gap}
                     fill="vertical"
+                    wrap
                     style={onResize ? { position: 'relative' } : undefined}
                   >
                     {content}

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2747,6 +2747,9 @@ exports[`DataTable custom theme 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .c6 {
@@ -3351,7 +3354,7 @@ exports[`DataTable custom theme 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 wMcEB"
+            class="StyledBox-sc-13pk1d4-0 iHyeQa"
             style="position: relative;"
           >
             <div
@@ -10990,6 +10993,9 @@ exports[`DataTable resizeable 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .c5 {
@@ -12758,6 +12764,9 @@ exports[`DataTable search 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .c5 {
@@ -13044,7 +13053,7 @@ exports[`DataTable search 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 wMcEB"
+            class="StyledBox-sc-13pk1d4-0 iHyeQa"
           >
             <div
               class="StyledBox-sc-13pk1d4-0 dTCmQX"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Provides a fix for #5105 by forcing column headers to wrap content and thus avoiding them overflowing on top of each other on small screens.

Searcher and Resizer are handled in the same part of the code. They are added to a content `Box` alongside the column header content. Since it's a Box, we are able to force a `wrap` in case its content doesn't fit.

#### Where should the reviewer start?

`src/js/components/DataTable/Header.js`

#### What testing has been done on this PR?

Manual testing through storybook, as this requires a small screen size to be observed properly.

#### How should this be manually tested?

Storybook: Visualizations / DataTable / Sort

#### Any background context you want to provide?

#### What are the relevant issues?

#5105 

#### Screenshots (if appropriate)

![Peek 2021-03-29 02-38](https://user-images.githubusercontent.com/47114840/112791406-e258bf00-9037-11eb-8b36-0401630df7bb.gif)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
