### PR TITLE
[TS] Fix DataTable pagination prop

### DIFF
--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -41,7 +41,6 @@ export interface ColumnConfig<TRowType> {
   aggregate?: 'avg' | 'max' | 'min' | 'sum';
   footer?: React.ReactNode | { aggregate?: boolean };
   header?: string | React.ReactNode | { aggregate?: boolean };
-  paginate?: boolean | PaginationType;
   pin?: boolean;
   primary?: boolean;
   property: string;
@@ -91,6 +90,7 @@ export interface DataTableProps<TRowType = any> {
         expand: Array<string>;
         onExpand: (expandedKeys: string[]) => void;
       };
+  paginate?: boolean | PaginationType;
   primaryKey?: string | boolean;
   select?: (string | number)[];
   sort?: { property: string; direction: 'asc' | 'desc'; external?: boolean };


### PR DESCRIPTION
Prop was added to Column typing, when it should be in the actual DataTable typings

Signed-off-by: Oskari Kantoniemi <oskari.kantoniemi@sofokus.com>


#### What does this PR do?
Fixes DataTable pagination usage with typescript

#### Where should the reviewer start?
src/js/components/DataTable/index.d.ts

#### What testing has been done on this PR?
* Without this PR using @ts-ignore works, because only the typings are wrong

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
