### PR TITLE
Pass aria-label prop through as button attribute.

### DIFF
--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -98,6 +98,7 @@ const Button = forwardRef(
       a11yTitle,
       active,
       align = 'center',
+      'aria-label': ariaLabel,
       color, // munged to avoid styled-components putting it in the DOM
       children,
       disabled,
@@ -300,7 +301,7 @@ const Button = forwardRef(
           {...rest}
           as={domTag}
           ref={ref}
-          aria-label={a11yTitle}
+          aria-label={ariaLabel || a11yTitle}
           colorValue={color}
           active={active}
           selected={selected}

--- a/src/js/components/Button/__tests__/Button-test.js
+++ b/src/js/components/Button/__tests__/Button-test.js
@@ -26,6 +26,22 @@ describe('Button', () => {
     expect(results).toHaveNoViolations();
   });
 
+  test('passes through the aria-label prop', async () => {
+    const TEST_LABEL = 'Test Label';
+    const { container, getByText } = render(
+      <Grommet>
+        <Button aria-label={TEST_LABEL} label="Test" onClick={() => {}} />
+      </Grommet>,
+    );
+
+    const button = container.querySelector('button');
+    expect(button.getAttribute('aria-label')).toEqual(TEST_LABEL);
+
+    fireEvent.click(getByText('Test'));
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   test('basic', () => {
     const component = renderer.create(
       <Grommet>
@@ -327,7 +343,18 @@ describe('Button', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  test(`disabled state cursor should indicate the button cannot be 
+  test('a11yTitle', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Button a11yTitle="Title" />
+        <Button aria-label="Title" />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test(`disabled state cursor should indicate the button cannot be
   clicked`, () => {
     const { getByText } = render(
       <Grommet>

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -1,5 +1,89 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Button a11yTitle 1`] = `
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c1:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus > circle,
+.c1:focus > ellipse,
+.c1:focus > line,
+.c1:focus > path,
+.c1:focus > polygon,
+.c1:focus > polyline,
+.c1:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+  className="c0"
+>
+  <button
+    aria-label="Title"
+    className="c1"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
+    type="button"
+  />
+  <button
+    aria-label="Title"
+    className="c1"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
+    type="button"
+  />
+</div>
+`;
+
 exports[`Button active + primary 1`] = `
 .c1 {
   display: inline-block;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Previously we only used the a11yTitle prop for button aria labels. This is a little unintuitive to someone who is already familiar with a11y. Rather than deprecate the a11yTitle prop we allow for it in addition to aria-label.

#### Where should the reviewer start?

At the Button component.

#### What testing has been done on this PR?

Added a unit test to ensure the Button has no aXe a11y violations, manually tested to see the attribute rendered.

#### How should this be manually tested?

Create a Button, passing in aria-label. Then, check to see that the rendered button does in fact contain the given `aria-label` attribute.

#### Any background context you want to provide?

I created a `Button` and gave it an `aria-label`. TypeScript allowed this, which tripped me up. An alternative here is to just ensure that the [ButtonExtendedProps](https://github.com/kid-icarus/grommet/blob/cea630132b637c223dd155292afdcd5399afbdce/src/js/components/Button/index.d.ts#L45) disallows `aria-label`, which I tried, but was unable to get it to work properly by adding `aria-label` to the list of Omitted keys.

#### What are the relevant issues?

Someone mentioned this [here](https://github.com/grommet/grommet/issues/2529)

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

It is technically modifying the API, a minor bump may be warranted.

#### Is this change backwards compatible or is it a breaking change?

It is backwards compatible
