### PR TITLE
Don't let Layer elevation leak to DOM, don't apply elevation when plain

### DIFF
--- a/src/js/components/Layer/README.md
+++ b/src/js/components/Layer/README.md
@@ -187,7 +187,8 @@ function
 
 **plain**
 
-Whether this is a plain Layer with no background color or border.
+Whether this is a plain Layer with no background color, border, or 
+        elevation.
 
 ```
 boolean

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -774,7 +774,12 @@ const elevationStyle = css`
     ]};
 `;
 
-const StyledContainer = styled.div`
+const StyledContainer = styled.div.withConfig({
+  // don't let elevation leak to DOM
+  // https://styled-components.com/docs/api#shouldforwardprop
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    !['elevation'].includes(prop) && defaultValidatorFn(prop),
+})`
   ${props => (!props.modal ? baseStyle : '')}
   display: flex;
   flex-direction: column;
@@ -788,7 +793,8 @@ const StyledContainer = styled.div`
     )} outline: none;
   pointer-events: all;
   z-index: ${props => props.theme.layer.container.zIndex};
-  ${props => props.theme.layer.container.elevation && elevationStyle}
+  ${props =>
+    !props.plain && props.theme.layer.container.elevation && elevationStyle}
   ${desktopContainerStyle}
   ${props => {
     if (props.responsive && props.theme.layer.responsiveBreakpoint) {

--- a/src/js/components/Layer/__tests__/Layer-test.js
+++ b/src/js/components/Layer/__tests__/Layer-test.js
@@ -175,8 +175,17 @@ describe('Layer', () => {
   });
 
   test('plain', () => {
+    // elevation should not be applied when Layer is plain
+    const theme = {
+      layer: {
+        container: {
+          elevation: 'large',
+        },
+      },
+    };
+
     render(
-      <Grommet>
+      <Grommet theme={theme}>
         <Layer id="plain-test" plain>
           This is a plain layer
         </Layer>

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -1005,7 +1005,6 @@ exports[`Layer custom theme 1`] = `
   <div
     class="c2"
     data-g-portal-id="0"
-    elevation="large"
     id="custom-theme-test"
   >
     <a

--- a/src/js/components/Layer/doc.js
+++ b/src/js/components/Layer/doc.js
@@ -104,7 +104,8 @@ particular side of the layer`,
     ),
     plain: PropTypes.bool
       .description(
-        'Whether this is a plain Layer with no background color or border.',
+        `Whether this is a plain Layer with no background color, border, or 
+        elevation.`,
       )
       .defaultValue(false),
     position: PropTypes.oneOf([

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11555,7 +11555,8 @@ function
 
 **plain**
 
-Whether this is a plain Layer with no background color or border.
+Whether this is a plain Layer with no background color, border, or 
+        elevation.
 
 \`\`\`
 boolean

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -5353,7 +5353,8 @@ string",
       },
       Object {
         "defaultValue": false,
-        "description": "Whether this is a plain Layer with no background color or border.",
+        "description": "Whether this is a plain Layer with no background color, border, or 
+        elevation.",
         "format": "boolean",
         "name": "plain",
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Checks if Layer is plain before applying elevation. Also, used styled-components `withConfig` to ensure that the elevation prop doesn't leak to the DOM.

#### Where should the reviewer start?
src/js/components/Layer/StyledLayer.js

#### What testing has been done on this PR?
Tested with this code snippet, no elevation was applied. Updated jest test.

```
<Layer
       position="bottom"
       modal={false}
       margin={{ vertical: 'medium', horizontal: 'small' }}
       responsive={false}
       plain
 >
      <Text> example layer </Text>
 </Layer>
```

#### How should this be manually tested?
With code snippet above, make a theme that has a value for `theme.layer.container.elevation`.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #5129 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Updated here to clarify that Layer `plain` will not apply elevation.

#### Should this PR be mentioned in the release notes?
Fixed Layer elevation styling, should not apply when plain.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.