### PR TITLE
Add ref to Select props type

### DIFF
--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -57,6 +57,7 @@ export interface SelectProps {
   emptySearchMessage?: string;
 }
 
-declare const Select: React.FC<SelectProps>;
+declare const Select: React.FC<SelectProps &
+  React.RefAttributes<HTMLButtonElement>>;
 
 export { Select };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR fixes #5134 by adding typings for `ref` on the `Select` component type definitions.

#### Where should the reviewer start?

src/js/components/Select/index.d.ts

#### What testing has been done on this PR?

* Tested the changes on a real world project using `patch-package`

#### How should this be manually tested?

No type errors should occur with the following:

```typescript
const Example = () => {
  const ref = useRef<HTMLButtonElement>();
  return <Select options={[]} ref={ref} />;
};
```

#### Any background context you want to provide?

#### What are the relevant issues?

#5134 

#### Screenshots (if appropriate)

N/A

#### Do the grommet docs need to be updated?

No docs updates needed

#### Is this change backwards compatible or is it a breaking change?

It's backward compatible