### PR TITLE
Fix RangeSelector to respond to touch gestures

### DIFF
--- a/src/js/components/RangeSelector/RangeSelector.js
+++ b/src/js/components/RangeSelector/RangeSelector.js
@@ -68,8 +68,8 @@ const RangeSelector = forwardRef(
       [direction, max, min, step],
     );
 
-    useEffect(() => {
-      const mouseMove = event => {
+    const onMouseMove = useCallback(
+      event => {
         const value = valueForMouseCoord(event);
         let nextValues;
         if (changing === 'lower' && value <= values[1] && value !== moveValue) {
@@ -96,21 +96,33 @@ const RangeSelector = forwardRef(
           setMoveValue(value);
           onChange(nextValues);
         }
-      };
+      },
+      [
+        values,
+        changing,
+        moveValue,
+        max,
+        min,
+        setMoveValue,
+        onChange,
+        valueForMouseCoord,
+      ],
+    );
 
-      const mouseUp = () => setChanging(undefined);
+    useEffect(() => {
+      const onMouseUp = () => setChanging(undefined);
 
       if (changing) {
-        window.addEventListener('mousemove', mouseMove);
-        window.addEventListener('mouseup', mouseUp);
+        window.addEventListener('mousemove', onMouseMove);
+        window.addEventListener('mouseup', onMouseUp);
 
         return () => {
-          window.removeEventListener('mousemove', mouseMove);
-          window.removeEventListener('mouseup', mouseUp);
+          window.removeEventListener('mousemove', onMouseMove);
+          window.removeEventListener('mouseup', onMouseUp);
         };
       }
       return undefined;
-    }, [changing, max, min, moveValue, onChange, valueForMouseCoord, values]);
+    }, [changing, onMouseMove]);
 
     const onClick = useCallback(
       event => {
@@ -130,6 +142,14 @@ const RangeSelector = forwardRef(
         }
       },
       [lastChange, onChange, valueForMouseCoord, values],
+    );
+
+    const onTouchMove = useCallback(
+      event => {
+        const touchEvent = event.changedTouches[0];
+        onMouseMove(touchEvent);
+      },
+      [onMouseMove],
     );
 
     const [lower, upper] = values;
@@ -153,6 +173,7 @@ const RangeSelector = forwardRef(
         {...rest}
         tabIndex="-1"
         onClick={onChange ? onClick : undefined}
+        onTouchMove={onTouchMove}
       >
         <Box
           style={{ flex: `${lower - min} 0 0` }}
@@ -178,6 +199,7 @@ const RangeSelector = forwardRef(
           thickness={thickness}
           edge="lower"
           onMouseDown={onChange ? () => setChanging('lower') : undefined}
+          onTouchStart={onChange ? () => setChanging('lower') : undefined}
           onDecrease={
             onChange && lower - step >= min
               ? () => onChange([lower - step, upper])
@@ -220,6 +242,7 @@ const RangeSelector = forwardRef(
           thickness={thickness}
           edge="upper"
           onMouseDown={onChange ? () => setChanging('upper') : undefined}
+          onTouchStart={onChange ? () => setChanging('upper') : undefined}
           onDecrease={
             onChange && upper - step >= lower
               ? () => onChange([lower, upper - step])

--- a/src/js/components/RangeSelector/RangeSelector.js
+++ b/src/js/components/RangeSelector/RangeSelector.js
@@ -173,7 +173,7 @@ const RangeSelector = forwardRef(
         {...rest}
         tabIndex="-1"
         onClick={onChange ? onClick : undefined}
-        onTouchMove={onTouchMove}
+        onTouchMove={onChange ? onTouchMove : undefined}
       >
         <Box
           style={{ flex: `${lower - min} 0 0` }}

--- a/src/js/components/RangeSelector/__tests__/RangeSelector-test.js
+++ b/src/js/components/RangeSelector/__tests__/RangeSelector-test.js
@@ -219,8 +219,6 @@ describe('RangeSelector', () => {
     );
     const rangeContainer = container.firstChild.firstChild;
 
-    expect(container.firstChild).toMatchSnapshot();
-
     const lowerControl = getByLabelText('Lower Bounds');
     fireEvent.touchStart(lowerControl);
     fireEvent.touchMove(rangeContainer, {
@@ -244,5 +242,6 @@ describe('RangeSelector', () => {
       ],
     });
     expect(onChange).toBeCalled();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/components/RangeSelector/__tests__/RangeSelector-test.js
+++ b/src/js/components/RangeSelector/__tests__/RangeSelector-test.js
@@ -209,4 +209,40 @@ describe('RangeSelector', () => {
     fireEvent.mouseUp(document);
     expect(onChange).toBeCalled();
   });
+
+  test('handle touch gestures', () => {
+    const onChange = jest.fn();
+    const { container, getByLabelText } = render(
+      <Grommet>
+        <RangeSelector values={[10, 20]} onChange={onChange} />
+      </Grommet>,
+    );
+    const rangeContainer = container.firstChild.firstChild;
+
+    expect(container.firstChild).toMatchSnapshot();
+
+    const lowerControl = getByLabelText('Lower Bounds');
+    fireEvent.touchStart(lowerControl);
+    fireEvent.touchMove(rangeContainer, {
+      changedTouches: [
+        {
+          clientX: 0,
+          clientY: 0,
+        },
+      ],
+    });
+    expect(onChange).toBeCalled();
+
+    const upperControl = getByLabelText('Upper Bounds');
+    fireEvent.touchStart(upperControl);
+    fireEvent.touchMove(rangeContainer, {
+      changedTouches: [
+        {
+          clientX: 0,
+          clientY: 0,
+        },
+      ],
+    });
+    expect(onChange).toBeCalled();
+  });
 });

--- a/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
+++ b/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
@@ -147,7 +147,6 @@ exports[`RangeSelector basic 1`] = `
 >
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -386,7 +385,6 @@ exports[`RangeSelector color 1`] = `
 >
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -730,7 +728,6 @@ exports[`RangeSelector direction 1`] = `
 >
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -821,7 +818,6 @@ exports[`RangeSelector direction 1`] = `
   </div>
   <div
     className="c8 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -1666,7 +1662,6 @@ exports[`RangeSelector invert 1`] = `
 >
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -1757,7 +1752,6 @@ exports[`RangeSelector invert 1`] = `
   </div>
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -1996,7 +1990,6 @@ exports[`RangeSelector max 1`] = `
 >
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -2235,7 +2228,6 @@ exports[`RangeSelector min 1`] = `
 >
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -2509,7 +2501,6 @@ exports[`RangeSelector opacity 1`] = `
 >
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -2600,7 +2591,6 @@ exports[`RangeSelector opacity 1`] = `
   </div>
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -2691,7 +2681,6 @@ exports[`RangeSelector opacity 1`] = `
   </div>
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -3124,7 +3113,6 @@ exports[`RangeSelector round 1`] = `
 >
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -3215,7 +3203,6 @@ exports[`RangeSelector round 1`] = `
   </div>
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -3306,7 +3293,6 @@ exports[`RangeSelector round 1`] = `
   </div>
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -3397,7 +3383,6 @@ exports[`RangeSelector round 1`] = `
   </div>
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -3488,7 +3473,6 @@ exports[`RangeSelector round 1`] = `
   </div>
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -4130,7 +4114,6 @@ exports[`RangeSelector size 1`] = `
 >
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -4221,7 +4204,6 @@ exports[`RangeSelector size 1`] = `
   </div>
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -4312,7 +4294,6 @@ exports[`RangeSelector size 1`] = `
   </div>
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -4403,7 +4384,6 @@ exports[`RangeSelector size 1`] = `
   </div>
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -4494,7 +4474,6 @@ exports[`RangeSelector size 1`] = `
   </div>
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -4585,7 +4564,6 @@ exports[`RangeSelector size 1`] = `
   </div>
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -4676,7 +4654,6 @@ exports[`RangeSelector size 1`] = `
   </div>
   <div
     className="c1 c2"
-    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div

--- a/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
+++ b/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
@@ -147,6 +147,7 @@ exports[`RangeSelector basic 1`] = `
 >
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -385,6 +386,7 @@ exports[`RangeSelector color 1`] = `
 >
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -728,6 +730,7 @@ exports[`RangeSelector direction 1`] = `
 >
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -818,6 +821,7 @@ exports[`RangeSelector direction 1`] = `
   </div>
   <div
     className="c8 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -1301,6 +1305,202 @@ exports[`RangeSelector handle mouse 1`] = `
 </div>
 `;
 
+exports[`RangeSelector handle touch gestures 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  overflow: visible;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex-basis: 100%;
+  -ms-flex-preferred-size: 100%;
+  flex-basis: 100%;
+  height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 12px;
+  width: 12px;
+  border-radius: 100%;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: rgba(125,76,219,0.4);
+  color: #444444;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c2 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 c2"
+    tabindex="-1"
+  >
+    <div
+      class="c3"
+      style="flex: 10 0 0px;"
+    />
+    <div
+      class="c4"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Lower Bounds"
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
+      >
+        <div
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c7"
+      style="flex: 11 0 0px; cursor: ew-resize;"
+    />
+    <div
+      class="c4"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Upper Bounds"
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
+      >
+        <div
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c3"
+      style="flex: 80 0 0px;"
+    />
+  </div>
+</div>
+`;
+
 exports[`RangeSelector invert 1`] = `
 .c0 {
   font-size: 18px;
@@ -1466,6 +1666,7 @@ exports[`RangeSelector invert 1`] = `
 >
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -1556,6 +1757,7 @@ exports[`RangeSelector invert 1`] = `
   </div>
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -1794,6 +1996,7 @@ exports[`RangeSelector max 1`] = `
 >
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -2032,6 +2235,7 @@ exports[`RangeSelector min 1`] = `
 >
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -2305,6 +2509,7 @@ exports[`RangeSelector opacity 1`] = `
 >
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -2395,6 +2600,7 @@ exports[`RangeSelector opacity 1`] = `
   </div>
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -2485,6 +2691,7 @@ exports[`RangeSelector opacity 1`] = `
   </div>
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -2917,6 +3124,7 @@ exports[`RangeSelector round 1`] = `
 >
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -3007,6 +3215,7 @@ exports[`RangeSelector round 1`] = `
   </div>
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -3097,6 +3306,7 @@ exports[`RangeSelector round 1`] = `
   </div>
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -3187,6 +3397,7 @@ exports[`RangeSelector round 1`] = `
   </div>
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -3277,6 +3488,7 @@ exports[`RangeSelector round 1`] = `
   </div>
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -3918,6 +4130,7 @@ exports[`RangeSelector size 1`] = `
 >
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -4008,6 +4221,7 @@ exports[`RangeSelector size 1`] = `
   </div>
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -4098,6 +4312,7 @@ exports[`RangeSelector size 1`] = `
   </div>
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -4188,6 +4403,7 @@ exports[`RangeSelector size 1`] = `
   </div>
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -4278,6 +4494,7 @@ exports[`RangeSelector size 1`] = `
   </div>
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -4368,6 +4585,7 @@ exports[`RangeSelector size 1`] = `
   </div>
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div
@@ -4458,6 +4676,7 @@ exports[`RangeSelector size 1`] = `
   </div>
   <div
     className="c1 c2"
+    onTouchMove={[Function]}
     tabIndex="-1"
   >
     <div


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fix RangeSelector change events to able to respond to mobile touch gestures for when the user drag on of the edge points

#### Where should the reviewer start?

`src/js/components/RangeSelector/RangeSelector.js`

#### What testing has been done on this PR?

`yarn storybook`, `yarn test` and test on a real device

#### How should this be manually tested?

`yarn storybook`, go to a range selector story and then enabling device emulation on browser

#### Any background context you want to provide?

#### What are the relevant issues?

See #5076 

#### Screenshots (if appropriate)

![range-selector](https://user-images.githubusercontent.com/30840709/113495781-09950d80-94ca-11eb-88ac-c8c4040bfb9e.gif)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backwards compatible 
