### PR TITLE
Make DataTable's groupBy togglable

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -204,7 +204,7 @@ const Body = forwardRef(
               const isRowExpanded = rowExpand && rowExpand.includes(index);
               return (
                 <Row
-                  key={primaryValue || index}
+                  key={index}
                   rowRef={rowRef}
                   primaryValue={primaryValue}
                   isSelected={isSelected}

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -53,12 +53,24 @@ const normalizeProp = (prop, context) => {
   return undefined;
 };
 
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+const objectIs = (x, y) => {
+  if (x === y) {
+    return x !== 0 || 1 / x === 1 / y;
+  } else {
+    return x !== x && y !== y;
+  }
+};
+
+const equals = (x, y) =>
+  typeof Object.is === 'function' ? Object.is(x, y) : objectIs(x, y);
+
 const useStateWithDeps = (initialStateFn, deps) => {
   const [state, setState] = useState(initialStateFn);
   const [prevDeps, setPrevDeps] = useState(deps);
 
   for (let i = 0; i < deps.length; i++) {
-    if (prevDeps[i] !== deps[i]) {
+    if (!equals(prevDeps[i], deps[i])) {
       setPrevDeps(deps);
       const nextState = initialStateFn();
       setState(nextState);

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -53,6 +53,22 @@ const normalizeProp = (prop, context) => {
   return undefined;
 };
 
+const useStateWithDeps = (initialStateFn, deps) => {
+  const [state, setState] = useState(initialStateFn);
+  const [prevDeps, setPrevDeps] = useState(deps);
+
+  for (let i = 0; i < deps.length; i++) {
+    if (prevDeps[i] !== deps[i]) {
+      setPrevDeps(deps);
+      const nextState = initialStateFn();
+      setState(nextState);
+      return [nextState, setState];
+    }
+  }
+
+  return [state, setState];
+};
+
 const DataTable = ({
   background,
   border,
@@ -124,8 +140,9 @@ const DataTable = ({
   ]);
 
   // an object indicating which group values are expanded
-  const [groupState, setGroupState] = useState(
-    buildGroupState(groups, groupBy),
+  const [groupState, setGroupState] = useStateWithDeps(
+    () => buildGroupState(groups, groupBy),
+    [groups, groupBy],
   );
 
   const [selected, setSelected] = useState(

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -57,9 +57,8 @@ const normalizeProp = (prop, context) => {
 const objectIs = (x, y) => {
   if (x === y) {
     return x !== 0 || 1 / x === 1 / y;
-  } else {
-    return x !== x && y !== y;
   }
+  return x !== x && y !== y; // eslint-disable-line no-self-compare
 };
 
 const equals = (x, y) =>
@@ -69,6 +68,7 @@ const useStateWithDeps = (initialStateFn, deps) => {
   const [state, setState] = useState(initialStateFn);
   const [prevDeps, setPrevDeps] = useState(deps);
 
+  // eslint-disable-next-line no-plusplus
   for (let i = 0; i < deps.length; i++) {
     if (!equals(prevDeps[i], deps[i])) {
       setPrevDeps(deps);

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -496,7 +496,9 @@ describe('DataTable', () => {
 
       return (
         <Grommet>
-          <button onClick={toggle}>toggle</button>
+          <button type="button" onClick={toggle}>
+            toggle
+          </button>
           <DataTable
             columns={[
               { property: 'a', header: 'A' },

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -489,6 +489,40 @@ describe('DataTable', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('groupBy toggle', () => {
+    function TestComponent() {
+      const [groupBy, setGroupBy] = React.useState();
+      const toggle = () => setGroupBy(groupBy === undefined ? 'a' : undefined);
+
+      return (
+        <Grommet>
+          <button onClick={toggle}>toggle</button>
+          <DataTable
+            columns={[
+              { property: 'a', header: 'A' },
+              { property: 'b', header: 'B' },
+            ]}
+            data={[
+              { a: 'one', b: 1.1 },
+              { a: 'one', b: 1.2 },
+              { a: 'two', b: 2.1 },
+              { a: 'two', b: 2.2 },
+            ]}
+            groupBy={groupBy}
+          />
+        </Grommet>
+      );
+    }
+    const { container, getByText } = render(<TestComponent />);
+    expect(container.firstChild).toMatchSnapshot();
+
+    fireEvent.click(getByText('toggle'));
+    expect(container.firstChild).toMatchSnapshot();
+
+    fireEvent.click(getByText('toggle'));
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('click', () => {
     const onClickRow = jest.fn();
     const { container, getByText } = render(

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -6135,7 +6135,9 @@ exports[`DataTable groupBy toggle 1`] = `
 <div
   class="c0"
 >
-  <button>
+  <button
+    type="button"
+  >
     toggle
   </button>
   <table
@@ -6313,7 +6315,9 @@ exports[`DataTable groupBy toggle 2`] = `
 <div
   class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
-  <button>
+  <button
+    type="button"
+  >
     toggle
   </button>
   <table
@@ -6781,7 +6785,9 @@ exports[`DataTable groupBy toggle 3`] = `
 <div
   class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
-  <button>
+  <button
+    type="button"
+  >
     toggle
   </button>
   <table

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -24876,3960 +24876,1395 @@ exports[`DataTable should render new data when page changes 2`] = `
         <tbody
           class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-xrlyjm-3 jAEaWo"
         >
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-50
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   50
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-51
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   51
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-52
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   52
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-53
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   53
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-54
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   54
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-55
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   55
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-56
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   56
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-57
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   57
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-58
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   58
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-59
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   59
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-60
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   60
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-61
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   61
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-62
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   62
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-63
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   63
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-64
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   64
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-65
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   65
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-66
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   66
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-67
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   67
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-68
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   68
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-69
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   69
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-70
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   70
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-71
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   71
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-72
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   72
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-73
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   73
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-74
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   74
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-75
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   75
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-76
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   76
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-77
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   77
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-78
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   78
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-79
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   79
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-80
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   80
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-81
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   81
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-82
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   82
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-83
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   83
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-84
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   84
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-85
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   85
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-86
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   86
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-87
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   87
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-88
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   88
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-89
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   89
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-90
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   90
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-91
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   91
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-92
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   92
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-93
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   93
                 </span>
               </div>
             </td>
           </tr>
-          .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c0 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media all and (min--moz-device-pixel-ratio:0) {
-
-}
-
-<tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
           >
             <th
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
               scope="row"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c2"
+                  class="StyledText-sc-1sadyjn-0 JhXAc"
                 >
                   entry-94
                 </span>
               </div>
             </th>
             <td
-              class="c0 "
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 btpZjA StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
             >
               <div
-                class="c1"
+                class="StyledBox-sc-13pk1d4-0 dYebPD"
               >
                 <span
-                  class="c3"
+                  class="StyledText-sc-1sadyjn-0 DkZvS"
                 >
                   94
                 </span>

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -6031,6 +6031,979 @@ exports[`DataTable groupBy property 2`] = `
 </div>
 `;
 
+exports[`DataTable groupBy toggle 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c7 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c2 {
+  position: relative;
+  border-spacing: 0;
+  border-collapse: separate;
+  height: auto;
+}
+
+.c6:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  class="c0"
+>
+  <button>
+    toggle
+  </button>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-xrlyjm-4"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 c6"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c7 "
+          scope="row"
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c7 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              1.1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c7 "
+          scope="row"
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c7 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              1.2
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c7 "
+          scope="row"
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c7 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              2.1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c7 "
+          scope="row"
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c9"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c7 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              2.2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable groupBy toggle 2`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
+>
+  <button>
+    toggle
+  </button>
+  <table
+    class="StyledTable-sc-1m3u5g-6 kzMUEM StyledDataTable-xrlyjm-0 koIpgx"
+  >
+    <thead
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-xrlyjm-4"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
+      >
+        .c3 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: rgba(0,0,0,0.33);
+  stroke: rgba(0,0,0,0.33);
+}
+
+.c3 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c3 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c3 *[stroke*="#"],
+.c3 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c3 *[fill-rule],
+.c3 *[FILL-RULE],
+.c3 *[fill*="#"],
+.c3 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 6px;
+}
+
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c1:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus > circle,
+.c1:focus > ellipse,
+.c1:focus > line,
+.c1:focus > path,
+.c1:focus > polygon,
+.c1:focus > polyline,
+.c1:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  width: 48px;
+  max-width: 48px;
+  overflow: hidden;
+  vertical-align: top;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding: 0px;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 3px;
+  }
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+
+}
+
+<td
+          class="c0"
+        >
+          <button
+            aria-label="expand"
+            class="c1"
+            type="button"
+          >
+            <div
+              class="c2"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c3"
+                viewBox="0 0 24 24"
+              >
+                <polyline
+                  fill="none"
+                  points="18 9 12 15 6 9"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </button>
+        </td>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gAxdWq StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
+          scope="col"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 dTCmQX"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 DkZvS"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gAxdWq StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
+          scope="col"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 dTCmQX"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 DkZvS"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    .c4 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: rgba(0,0,0,0.33);
+  stroke: rgba(0,0,0,0.33);
+}
+
+.c4 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c4 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c4 *[stroke*="#"],
+.c4 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c4 *[fill-rule],
+.c4 *[FILL-RULE],
+.c4 *[fill*="#"],
+.c4 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 6px;
+}
+
+.c7 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c2:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
+.c2:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus > circle,
+.c2:focus > ellipse,
+.c2:focus > line,
+.c2:focus > path,
+.c2:focus > polygon,
+.c2:focus > polyline,
+.c2:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  width: 48px;
+  max-width: 48px;
+  overflow: hidden;
+  vertical-align: top;
+  text-align: start;
+  padding: 0px;
+}
+
+.c0:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    padding: 3px;
+  }
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+
+}
+
+<tbody
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 c0"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <td
+          class="c1"
+        >
+          <button
+            aria-label="expand"
+            class="c2"
+            type="button"
+          >
+            <div
+              class="c3"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c4"
+                viewBox="0 0 24 24"
+              >
+                <polyline
+                  fill="none"
+                  points="18 9 12 15 6 9"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </button>
+        </td>
+        <th
+          class="c5 "
+          scope="row"
+        >
+          <div
+            class="c6"
+          >
+            <span
+              class="c7"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c5 "
+        >
+          <div
+            class="c6"
+          />
+        </td>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <td
+          class="c1"
+        >
+          <button
+            aria-label="expand"
+            class="c2"
+            type="button"
+          >
+            <div
+              class="c3"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c4"
+                viewBox="0 0 24 24"
+              >
+                <polyline
+                  fill="none"
+                  points="18 9 12 15 6 9"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </button>
+        </td>
+        <th
+          class="c5 "
+          scope="row"
+        >
+          <div
+            class="c6"
+          >
+            <span
+              class="c7"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c5 "
+        >
+          <div
+            class="c6"
+          />
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable groupBy toggle 3`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
+>
+  <button>
+    toggle
+  </button>
+  <table
+    class="StyledTable-sc-1m3u5g-6 kzMUEM StyledDataTable-xrlyjm-0 koIpgx"
+  >
+    <thead
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-xrlyjm-4"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
+      >
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gAxdWq StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
+          scope="col"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 dTCmQX"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 DkZvS"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gAxdWq StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
+          scope="col"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 dTCmQX"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 DkZvS"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    .c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c1 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c0:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+
+}
+
+<tbody
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 c0"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c1 "
+          scope="row"
+        >
+          <div
+            class="c2"
+          >
+            <span
+              class="c3"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c1 "
+        >
+          <div
+            class="c2"
+          >
+            <span
+              class="c4"
+            >
+              1.1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c1 "
+          scope="row"
+        >
+          <div
+            class="c2"
+          >
+            <span
+              class="c3"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c1 "
+        >
+          <div
+            class="c2"
+          >
+            <span
+              class="c4"
+            >
+              1.2
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c1 "
+          scope="row"
+        >
+          <div
+            class="c2"
+          >
+            <span
+              class="c3"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c1 "
+        >
+          <div
+            class="c2"
+          >
+            <span
+              class="c4"
+            >
+              2.1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c1 "
+          scope="row"
+        >
+          <div
+            class="c2"
+          >
+            <span
+              class="c3"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c1 "
+        >
+          <div
+            class="c2"
+          >
+            <span
+              class="c4"
+            >
+              2.2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`DataTable onSelect + groupBy should render indeterminate checkbox on table and 
   group if subset of group items are selected 1`] = `
 .c6 {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Make DataTable's groupBy togglable.

#### Where should the reviewer start?

`DataTable.js`

#### What testing has been done on this PR?

Check if the error below was not thrown when toggle `groupBy` props between `undefined` and `"a"`.

>Uncaught [TypeError: Cannot read property 'expanded' of undefined]

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
