### PR TITLE
DateInput leading zeros and 2 digit year format option

### DIFF
--- a/src/js/components/DateInput/README.md
+++ b/src/js/components/DateInput/README.md
@@ -61,7 +61,8 @@ Any properties to pass on to the underlying Drop when not inline. Defaults to `{
 The date format to use. If not specified, the date value will not
       be displayed as a text string and the user will not be able to enter
       a date by typing. For example: 'mm/dd/yyyy', or for a range:
-      'mm/dd/yyyy-mm/dd/yyyy'. This property should be used when in a Form.
+      'mm/dd/yyyy-mm/dd/yyyy'. For a date without leading zeros: 'm/d/yyyy'. 
+      This property should be used when in a Form.
 
 ```
 string

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
@@ -572,7 +572,7 @@ exports[`DateInput focus 1`] = `
       id="item"
       name="item"
       placeholder="mm/dd/yyyy"
-      value="7/2/2020"
+      value="07/02/2020"
     />
   </div>
 </div>
@@ -1878,7 +1878,7 @@ exports[`DateInput format 1`] = `
       onFocus={[Function]}
       onKeyDown={[Function]}
       placeholder="mm/dd/yyyy"
-      value="7/2/2020"
+      value="07/02/2020"
     />
   </div>
 </div>
@@ -2050,7 +2050,7 @@ exports[`DateInput format disabled 1`] = `
       onFocus={[Function]}
       onKeyDown={[Function]}
       placeholder="mm/dd/yyyy"
-      value="7/2/2020"
+      value="07/02/2020"
     />
   </div>
 </div>
@@ -2492,7 +2492,7 @@ exports[`DateInput format inline 1`] = `
         onFocus={[Function]}
         onKeyDown={[Function]}
         placeholder="mm/dd/yyyy"
-        value="7/2/2020"
+        value="07/02/2020"
       />
     </div>
     <div
@@ -5085,7 +5085,7 @@ exports[`DateInput range format 1`] = `
       onFocus={[Function]}
       onKeyDown={[Function]}
       placeholder="mm/dd/yyyy-mm/dd/yyyy"
-      value="7/2/2020-7/7/2020"
+      value="07/02/2020-07/07/2020"
     />
   </div>
 </div>
@@ -5545,7 +5545,7 @@ exports[`DateInput range format inline 1`] = `
         onFocus={[Function]}
         onKeyDown={[Function]}
         placeholder="mm/dd/yyyy-mm/dd/yyyy"
-        value="7/2/2020-7/7/2020"
+        value="07/02/2020-07/07/2020"
       />
     </div>
     <div
@@ -8037,7 +8037,7 @@ exports[`DateInput select format 1`] = `
       id="item"
       name="item"
       placeholder="mm/dd/yyyy"
-      value="7/2/2020"
+      value="07/02/2020"
     />
   </div>
 </div>
@@ -8072,7 +8072,7 @@ exports[`DateInput select format 2`] = `
       id="item"
       name="item"
       placeholder="mm/dd/yyyy"
-      value="7/2/2020"
+      value="07/02/2020"
     />
   </div>
 </div>
@@ -9647,7 +9647,7 @@ exports[`DateInput select format inline 1`] = `
         id="item"
         name="item"
         placeholder="mm/dd/yyyy"
-        value="7/2/2020"
+        value="07/02/2020"
       />
     </div>
     <div
@@ -10453,7 +10453,7 @@ exports[`DateInput select format inline 2`] = `
         id="item"
         name="item"
         placeholder="mm/dd/yyyy"
-        value="7/20/2020"
+        value="07/20/2020"
       />
     </div>
     <div
@@ -11677,7 +11677,7 @@ exports[`DateInput select format inline range 1`] = `
         id="item"
         name="item"
         placeholder="mm/dd/yyyy-mm/dd/yyyy"
-        value="7/2/2020-7/7/2020"
+        value="07/02/2020-07/07/2020"
       />
     </div>
     <div
@@ -12483,7 +12483,7 @@ exports[`DateInput select format inline range 2`] = `
         id="item"
         name="item"
         placeholder="mm/dd/yyyy-mm/dd/yyyy"
-        value="7/10/2020-7/10/2020"
+        value="07/10/2020-07/10/2020"
       />
     </div>
     <div
@@ -14778,7 +14778,7 @@ exports[`DateInput type format inline 1`] = `
         id="item"
         name="item"
         placeholder="mm/dd/yyyy"
-        value="7/2/2020"
+        value="07/02/2020"
       />
     </div>
     <div

--- a/src/js/components/DateInput/doc.js
+++ b/src/js/components/DateInput/doc.js
@@ -33,7 +33,8 @@ export const doc = DateInput => {
       `The date format to use. If not specified, the date value will not
       be displayed as a text string and the user will not be able to enter
       a date by typing. For example: 'mm/dd/yyyy', or for a range:
-      'mm/dd/yyyy-mm/dd/yyyy'. This property should be used when in a Form.`,
+      'mm/dd/yyyy-mm/dd/yyyy'. For a date without leading zeros: 'm/d/yyyy'. 
+      This property should be used when in a Form.`,
     ),
     id: PropTypes.string.description('The id of the input.'),
     inline: PropTypes.bool

--- a/src/js/components/DateInput/stories/Format.js
+++ b/src/js/components/DateInput/stories/Format.js
@@ -14,7 +14,7 @@ export const Format = () => {
     <Grommet theme={grommet}>
       <Box align="center" pad="large">
         <Box width="medium">
-          <DateInput format="mm/dd/yyyy" value={value} onChange={onChange} />
+          <DateInput format="m/d/yy" value={value} onChange={onChange} />
         </Box>
       </Box>
     </Grommet>

--- a/src/js/components/DateInput/utils.js
+++ b/src/js/components/DateInput/utils.js
@@ -37,22 +37,34 @@ export const valueToText = (value, schema) => {
     while (
       dateIndex < dates.length &&
       (Number.isNaN(dates[dateIndex].date) ||
-        ((char === 'm' || char === 'd' || char === 'y') && parts[char]))
+        ((char === 'm' || char === 'd' || char === 'y') && parts[part]))
     ) {
       dateIndex += 1;
       parts = {};
     }
     const date = dates[dateIndex];
 
-    if (date && char === 'm') {
+    if (date && part === 'm') {
       text += date.getMonth() + 1;
-      parts[char] = true;
-    } else if (date && char === 'd') {
+      parts[part] = true;
+    } else if (date && part === 'mm') {
+      text += `0${date.getMonth() + 1}`.slice(-2);
+      parts[part] = true;
+    } else if (date && part === 'd') {
       text += date.getDate();
-      parts[char] = true;
-    } else if (date && char === 'y') {
+      parts[part] = true;
+    } else if (date && part === 'dd') {
+      text += `0${date.getDate()}`.slice(-2);
+      parts[part] = true;
+    } else if (date && part === 'yy') {
+      text += date
+        .getFullYear()
+        .toString()
+        .slice(-2);
+      parts[part] = true;
+    } else if (date && part === 'yyyy') {
       text += date.getFullYear();
-      parts[char] = true;
+      parts[part] = true;
     } else text += part;
   });
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -7682,7 +7682,8 @@ Any properties to pass on to the underlying Drop when not inline. Defaults to \`
 The date format to use. If not specified, the date value will not
       be displayed as a text string and the user will not be able to enter
       a date by typing. For example: 'mm/dd/yyyy', or for a range:
-      'mm/dd/yyyy-mm/dd/yyyy'. This property should be used when in a Form.
+      'mm/dd/yyyy-mm/dd/yyyy'. For a date without leading zeros: 'm/d/yyyy'. 
+      This property should be used when in a Form.
 
 \`\`\`
 string

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -3193,7 +3193,8 @@ string",
         "description": "The date format to use. If not specified, the date value will not
       be displayed as a text string and the user will not be able to enter
       a date by typing. For example: 'mm/dd/yyyy', or for a range:
-      'mm/dd/yyyy-mm/dd/yyyy'. This property should be used when in a Form.",
+      'mm/dd/yyyy-mm/dd/yyyy'. For a date without leading zeros: 'm/d/yyyy'. 
+      This property should be used when in a Form.",
         "format": "string",
         "name": "format",
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds the ability to specify if you want leading zeros in the displayed date for DateInput. If the format 'mm/dd/yyyy' is used, leading zeros are shown. If the format 'm/d/yyyy' is used leading zeros are not shown. Previously leading zeros were not shown by default.

Also adds the ability have the displayed year show with 2 digits or 4 digits. For 2 digit year format='mm/dd/yy' for 4 digit year format='mm/dd/yyyy'.

I also changed the DateInput/Format story to show a format without leading zeros and a two digit year. Leading zeros and 4 digit year are shown in other stories.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with storybook DateInput/Format story

#### How should this be manually tested?
storybook

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #5036 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, done

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible