### PR TITLE
add new fill prop to checkbox

### DIFF
--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -33,6 +33,7 @@ const CheckBox = forwardRef(
       checked: checkedProp,
       defaultChecked = false,
       disabled,
+      fill,
       focus: focusProp,
       id,
       label,
@@ -194,6 +195,7 @@ const CheckBox = forwardRef(
     return (
       <StyledCheckBoxContainer
         aria-label={a11yTitle}
+        fillProp={fill}
         reverse={reverse}
         {...removeUndefined({ htmlFor: id, disabled })}
         checked={checked}

--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -195,7 +195,7 @@ const CheckBox = forwardRef(
     return (
       <StyledCheckBoxContainer
         aria-label={a11yTitle}
-        fillProp={fill}
+        fill={fill}
         reverse={reverse}
         {...removeUndefined({ htmlFor: id, disabled })}
         checked={checked}

--- a/src/js/components/CheckBox/README.md
+++ b/src/js/components/CheckBox/README.md
@@ -40,9 +40,7 @@ boolean
 **fill**
 
 Whether the checkbox and label expand to fill all of the available
-         width and/or height of their container. When fill === true,
-         any additional space around the checkbox and label will be
-         applied as justify="between".
+         width and/or height of their container.
 
 ```
 boolean

--- a/src/js/components/CheckBox/README.md
+++ b/src/js/components/CheckBox/README.md
@@ -39,9 +39,10 @@ boolean
 
 **fill**
 
-Whether the checkbox expands to fill all of the available width and/or 
-          height, in order to have set the label and checkbox/toggle justify
-          content to space between.
+Whether the checkbox and label expand to fill all of the available
+         width and/or height of their container. When fill === true,
+         any additional space around the checkbox and label will be
+         applied as justify="between".
 
 ```
 boolean

--- a/src/js/components/CheckBox/README.md
+++ b/src/js/components/CheckBox/README.md
@@ -37,6 +37,16 @@ Same as React <input disabled={} />. Also adds a hidden input element
 boolean
 ```
 
+**fill**
+
+Whether the checkbox expands to fill all of the available width and/or 
+          height, in order to have set the label and checkbox/toggle justify
+          content to space between.
+
+```
+boolean
+```
+
 **id**
 
 The DOM id attribute value to use for the underlying <input/> element.

--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -3,6 +3,18 @@ import styled, { css } from 'styled-components';
 import { edgeStyle, focusStyle, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';
 
+const fillStyle = fillContainer => {
+  if (fillContainer) {
+    return `
+      width: 100%;
+      height: 100%;
+      max-width: none;
+      flex: 1 0 auto;
+    `;
+  }
+  return undefined;
+};
+
 const disabledStyle = `
   opacity: 0.5;
   cursor: default;
@@ -36,7 +48,11 @@ const StyledCheckBoxContainer = styled.label`
   flex-direction: row;
   align-items: center;
   user-select: none;
-  width: fit-content;
+  ${props =>
+    props.fillProp &&
+    fillStyle(props.fillProp) &&
+    `justify-content: space-between;`} ${props =>
+  !props.fillProp && 'width: fit-content;'}
   ${props =>
     (props.pad || props.theme.checkBox.pad) &&
     edgeStyle(

--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -3,16 +3,13 @@ import styled, { css } from 'styled-components';
 import { edgeStyle, focusStyle, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';
 
-const fillStyle = fillContainer => {
-  if (fillContainer) {
+const fillStyle = () => {
     return `
       width: 100%;
       height: 100%;
       max-width: none;
       flex: 1 0 auto;
     `;
-  }
-  return undefined;
 };
 
 const disabledStyle = `
@@ -50,7 +47,7 @@ const StyledCheckBoxContainer = styled.label`
   user-select: none;
   ${props =>
     props.fill
-      ? fillStyle(props.fill) && `justify-content: space-between;`
+      ? fillStyle() && `justify-content: space-between;`
       : 'width: fit-content;'}
   ${props =>
     (props.pad || props.theme.checkBox.pad) &&

--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -3,14 +3,12 @@ import styled, { css } from 'styled-components';
 import { edgeStyle, focusStyle, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';
 
-const fillStyle = () => {
-    return `
+const fillStyle = () => `
       width: 100%;
       height: 100%;
       max-width: none;
       flex: 1 0 auto;
     `;
-};
 
 const disabledStyle = `
   opacity: 0.5;

--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -49,10 +49,9 @@ const StyledCheckBoxContainer = styled.label`
   align-items: center;
   user-select: none;
   ${props =>
-    props.fillProp &&
-    fillStyle(props.fillProp) &&
-    `justify-content: space-between;`} ${props =>
-  !props.fillProp && 'width: fit-content;'}
+    props.fill
+      ? fillStyle(props.fill) && `justify-content: space-between;`
+      : 'width: fit-content;'}
   ${props =>
     (props.pad || props.theme.checkBox.pad) &&
     edgeStyle(

--- a/src/js/components/CheckBox/__tests__/CheckBox-test.js
+++ b/src/js/components/CheckBox/__tests__/CheckBox-test.js
@@ -109,6 +109,17 @@ describe('CheckBox', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  test('reverse toggle fill', () => {
+    const component = renderer.create(
+      <Grommet>
+        <CheckBox label="test label" reverse fill toggle />
+        <CheckBox fill toggle label="test label" />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   test('indeterminate renders', () => {
     const component = renderer.create(
       <Grommet>

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -329,7 +329,7 @@ exports[`CheckBox controlled 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <label
-    class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+    class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -1913,6 +1913,7 @@ exports[`CheckBox reverse toggle fill 1`] = `
   <label
     checked={false}
     className="c1"
+    fill={true}
     onClick={[Function]}
   >
     <span>
@@ -1944,6 +1945,7 @@ exports[`CheckBox reverse toggle fill 1`] = `
   <label
     checked={false}
     className="c1"
+    fill={true}
     onClick={[Function]}
   >
     <div

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -329,7 +329,7 @@ exports[`CheckBox controlled 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <label
-    class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+    class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -1760,6 +1760,217 @@ exports[`CheckBox reverse renders 1`] = `
         className="c5 "
       />
     </div>
+  </label>
+</div>
+`;
+
+exports[`CheckBox reverse toggle fill 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-left: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-right: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.c1:hover input:not([disabled]) + div,
+.c1:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c4 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.c4:checked + span > span {
+  left: calc( 48px - 24px );
+  background: #7D4CDB;
+}
+
+.c5 {
+  box-sizing: border-box;
+  vertical-align: middle;
+  display: inline-block;
+  width: 48px;
+  height: 24px;
+  border: 2px solid;
+  border-color: rgba(0,0,0,0.15);
+  border-radius: 24px;
+  background-color: transparent;
+}
+
+.c6 {
+  box-sizing: border-box;
+  position: relative;
+  display: inherit;
+  top: -2px;
+  left: -2px;
+  -webkit-transition: all 0.3s;
+  transition: all 0.3s;
+  width: 24px;
+  height: 24px;
+  background: #d9d9d9;
+  border-radius: 24px;
+}
+
+.c3 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin-left: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    margin-right: 6px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <label
+    checked={false}
+    className="c1"
+    onClick={[Function]}
+  >
+    <span>
+      test label
+    </span>
+    <div
+      checked={false}
+      className="c2 c3"
+    >
+      <input
+        checked={false}
+        className="c4"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        type="checkbox"
+      />
+      <span
+        checked={false}
+        className="c5"
+      >
+        <span
+          checked={false}
+          className="c6"
+        />
+      </span>
+    </div>
+  </label>
+  <label
+    checked={false}
+    className="c1"
+    onClick={[Function]}
+  >
+    <div
+      checked={false}
+      className="c7 c3"
+    >
+      <input
+        checked={false}
+        className="c4"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        type="checkbox"
+      />
+      <span
+        checked={false}
+        className="c5"
+      >
+        <span
+          checked={false}
+          className="c6"
+        />
+      </span>
+    </div>
+    <span>
+      test label
+    </span>
   </label>
 </div>
 `;

--- a/src/js/components/CheckBox/doc.js
+++ b/src/js/components/CheckBox/doc.js
@@ -30,9 +30,7 @@ export const doc = CheckBox => {
     fill: PropTypes.bool
       .description(
         `Whether the checkbox and label expand to fill all of the available
-         width and/or height of their container. When fill === true,
-         any additional space around the checkbox and label will be
-         applied as justify="between".`,
+         width and/or height of their container.`,
       )
       .defaultValue(undefined),
     id: PropTypes.string.description(

--- a/src/js/components/CheckBox/doc.js
+++ b/src/js/components/CheckBox/doc.js
@@ -29,9 +29,10 @@ export const doc = CheckBox => {
       .defaultValue(false),
     fill: PropTypes.bool
       .description(
-        `Whether the checkbox expands to fill all of the available width and/or 
-          height, in order to have set the label and checkbox/toggle justify
-          content to space between.`,
+        `Whether the checkbox and label expand to fill all of the available
+         width and/or height of their container. When fill === true,
+         any additional space around the checkbox and label will be
+         applied as justify="between".`,
       )
       .defaultValue(undefined),
     id: PropTypes.string.description(

--- a/src/js/components/CheckBox/doc.js
+++ b/src/js/components/CheckBox/doc.js
@@ -27,6 +27,13 @@ export const doc = CheckBox => {
       with the same name so form submissions work.`,
       )
       .defaultValue(false),
+    fill: PropTypes.bool
+      .description(
+        `Whether the checkbox expands to fill all of the available width and/or 
+          height, in order to have set the label and checkbox/toggle justify
+          content to space between.`,
+      )
+      .defaultValue(false),
     id: PropTypes.string.description(
       'The DOM id attribute value to use for the underlying <input/> element.',
     ),

--- a/src/js/components/CheckBox/doc.js
+++ b/src/js/components/CheckBox/doc.js
@@ -33,7 +33,7 @@ export const doc = CheckBox => {
           height, in order to have set the label and checkbox/toggle justify
           content to space between.`,
       )
-      .defaultValue(false),
+      .defaultValue(undefined),
     id: PropTypes.string.description(
       'The DOM id attribute value to use for the underlying <input/> element.',
     ),

--- a/src/js/components/CheckBox/index.d.ts
+++ b/src/js/components/CheckBox/index.d.ts
@@ -5,6 +5,7 @@ export interface CheckBoxProps {
   a11yTitle?: A11yTitleType;
   checked?: boolean;
   disabled?: boolean;
+  fill?: boolean;
   id?: string;
   label?: React.ReactNode;
   name?: string;

--- a/src/js/components/CheckBox/stories/InsideFormField.js
+++ b/src/js/components/CheckBox/stories/InsideFormField.js
@@ -40,7 +40,7 @@ export const InsideFormField = props => (
         >
           <Box pad={{ horizontal: 'small', vertical: 'xsmall' }}>
             <CheckBox
-              id="check-box-toggle"
+              id="check-box-fill-toggle"
               name="toggle"
               label="CheckBox"
               toggle

--- a/src/js/components/CheckBox/stories/InsideFormField.js
+++ b/src/js/components/CheckBox/stories/InsideFormField.js
@@ -32,6 +32,23 @@ export const InsideFormField = props => (
             />
           </Box>
         </FormField>
+        <FormField
+          label="Toggle fill"
+          name="toggle"
+          htmlFor="check-box-toggle"
+          {...props}
+        >
+          <Box pad={{ horizontal: 'small', vertical: 'xsmall' }}>
+            <CheckBox
+              id="check-box-toggle"
+              name="toggle"
+              label="CheckBox"
+              toggle
+              fill
+              reverse
+            />
+          </Box>
+        </FormField>
         <FormField label="Default" name="checkbox" htmlFor="check-box" required>
           <Box pad={{ horizontal: 'small', vertical: 'xsmall' }}>
             <CheckBox id="check-box" name="checkbox" label="Required" />

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
@@ -8,7 +8,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
     class="StyledBox-sc-13pk1d4-0 ftUyAh StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -29,7 +29,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 dLcqZl"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -59,7 +59,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gBBkPY"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ggIkvd"
       disabled={true}
       onClick={[Function]}
     >
@@ -92,7 +92,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     />
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gBBkPY"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ggIkvd"
       disabled={true}
       onClick={[Function]}
     >
@@ -126,7 +126,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gBBkPY"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ggIkvd"
       disabled={true}
       onClick={[Function]}
     >
@@ -160,7 +160,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gBBkPY"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ggIkvd"
       disabled={true}
       onClick={[Function]}
     >
@@ -201,7 +201,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
       onClick={[Function]}
     >
       <div
@@ -230,7 +230,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
     />
     <label
       checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
       onClick={[Function]}
     >
       <div
@@ -271,7 +271,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
     />
     <label
       checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
       onClick={[Function]}
     >
       <div
@@ -319,7 +319,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
     class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -340,7 +340,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -369,7 +369,7 @@ exports[`CheckBoxGroup onChange 1`] = `
     class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -401,7 +401,7 @@ exports[`CheckBoxGroup onChange 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -431,7 +431,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
     tabindex="0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -463,7 +463,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -493,7 +493,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
     tabindex="0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -514,7 +514,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -544,7 +544,7 @@ exports[`CheckBoxGroup options renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
       onClick={[Function]}
     >
       <div
@@ -573,7 +573,7 @@ exports[`CheckBoxGroup options renders 1`] = `
     />
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
       onClick={[Function]}
     >
       <div
@@ -610,7 +610,7 @@ exports[`CheckBoxGroup value renders 1`] = `
   >
     <label
       checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
       onClick={[Function]}
     >
       <div
@@ -651,7 +651,7 @@ exports[`CheckBoxGroup value renders 1`] = `
     />
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
       onClick={[Function]}
     >
       <div
@@ -687,7 +687,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
     class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -708,7 +708,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
@@ -8,7 +8,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
     class="StyledBox-sc-13pk1d4-0 ftUyAh StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -29,7 +29,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 dLcqZl"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -59,7 +59,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 blBbHc"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gBBkPY"
       disabled={true}
       onClick={[Function]}
     >
@@ -92,7 +92,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     />
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 blBbHc"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gBBkPY"
       disabled={true}
       onClick={[Function]}
     >
@@ -126,7 +126,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 blBbHc"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gBBkPY"
       disabled={true}
       onClick={[Function]}
     >
@@ -160,7 +160,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 blBbHc"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gBBkPY"
       disabled={true}
       onClick={[Function]}
     >
@@ -201,7 +201,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
       onClick={[Function]}
     >
       <div
@@ -230,7 +230,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
     />
     <label
       checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
       onClick={[Function]}
     >
       <div
@@ -271,7 +271,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
     />
     <label
       checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
       onClick={[Function]}
     >
       <div
@@ -319,7 +319,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
     class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -340,7 +340,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -369,7 +369,7 @@ exports[`CheckBoxGroup onChange 1`] = `
     class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -401,7 +401,7 @@ exports[`CheckBoxGroup onChange 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -431,7 +431,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
     tabindex="0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -463,7 +463,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -493,7 +493,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
     tabindex="0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -514,7 +514,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -544,7 +544,7 @@ exports[`CheckBoxGroup options renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
       onClick={[Function]}
     >
       <div
@@ -573,7 +573,7 @@ exports[`CheckBoxGroup options renders 1`] = `
     />
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
       onClick={[Function]}
     >
       <div
@@ -610,7 +610,7 @@ exports[`CheckBoxGroup value renders 1`] = `
   >
     <label
       checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
       onClick={[Function]}
     >
       <div
@@ -651,7 +651,7 @@ exports[`CheckBoxGroup value renders 1`] = `
     />
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
       onClick={[Function]}
     >
       <div
@@ -687,7 +687,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
     class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -708,7 +708,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -3453,7 +3453,7 @@ exports[`DataTable custom theme 2`] = `
           >
             <label
               aria-label="unselect alpha"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 jggAlD"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dinWmP"
               disabled=""
             >
               <div
@@ -3517,7 +3517,7 @@ exports[`DataTable custom theme 2`] = `
           >
             <label
               aria-label="select beta"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 jggAlD"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dinWmP"
               disabled=""
             >
               <div
@@ -8945,7 +8945,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           >
             <label
               aria-label="unselect all"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 iXrDFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -9067,7 +9067,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           >
             <label
               aria-label="unselect one"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 iXrDFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -9178,7 +9178,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           >
             <label
               aria-label="unselect two"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 iXrDFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -9304,7 +9304,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           >
             <label
               aria-label="select all"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 iXrDFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -9391,7 +9391,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           >
             <label
               aria-label="select one"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 iXrDFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -9467,7 +9467,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           >
             <label
               aria-label="select two"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 iXrDFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -17161,7 +17161,7 @@ exports[`DataTable select 2`] = `
           >
             <label
               aria-label="unselect all"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 iXrDFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -17239,7 +17239,7 @@ exports[`DataTable select 2`] = `
           >
             <label
               aria-label="unselect alpha"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 iXrDFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -17294,7 +17294,7 @@ exports[`DataTable select 2`] = `
           >
             <label
               aria-label="unselect beta"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 iXrDFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -3453,7 +3453,7 @@ exports[`DataTable custom theme 2`] = `
           >
             <label
               aria-label="unselect alpha"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dinWmP"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 bKvCBC"
               disabled=""
             >
               <div
@@ -3517,7 +3517,7 @@ exports[`DataTable custom theme 2`] = `
           >
             <label
               aria-label="select beta"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dinWmP"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 bKvCBC"
               disabled=""
             >
               <div
@@ -8945,7 +8945,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           >
             <label
               aria-label="unselect all"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -9067,7 +9067,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           >
             <label
               aria-label="unselect one"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -9178,7 +9178,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           >
             <label
               aria-label="unselect two"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -9304,7 +9304,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           >
             <label
               aria-label="select all"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -9391,7 +9391,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           >
             <label
               aria-label="select one"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -9467,7 +9467,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           >
             <label
               aria-label="select two"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -17161,7 +17161,7 @@ exports[`DataTable select 2`] = `
           >
             <label
               aria-label="unselect all"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -17239,7 +17239,7 @@ exports[`DataTable select 2`] = `
           >
             <label
               aria-label="unselect alpha"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -17294,7 +17294,7 @@ exports[`DataTable select 2`] = `
           >
             <label
               aria-label="unselect beta"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ghEdFu"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -2612,7 +2612,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -2851,7 +2851,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1 iUyYoX"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -2612,7 +2612,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -2851,7 +2851,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1 iUyYoX"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -1293,7 +1293,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -1532,7 +1532,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1 iUyYoX"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -2901,7 +2901,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
           for="test-checkbox"
         >
           <div

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -1293,7 +1293,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -1532,7 +1532,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1 iUyYoX"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -2901,7 +2901,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 beIzsx"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dsPMvl"
           for="test-checkbox"
         >
           <div

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4936,9 +4936,10 @@ boolean
 
 **fill**
 
-Whether the checkbox expands to fill all of the available width and/or 
-          height, in order to have set the label and checkbox/toggle justify
-          content to space between.
+Whether the checkbox and label expand to fill all of the available
+         width and/or height of their container. When fill === true,
+         any additional space around the checkbox and label will be
+         applied as justify=\\"between\\".
 
 \`\`\`
 boolean

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4934,6 +4934,16 @@ Same as React <input disabled={} />. Also adds a hidden input element
 boolean
 \`\`\`
 
+**fill**
+
+Whether the checkbox expands to fill all of the available width and/or 
+          height, in order to have set the label and checkbox/toggle justify
+          content to space between.
+
+\`\`\`
+boolean
+\`\`\`
+
 **id**
 
 The DOM id attribute value to use for the underlying <input/> element.

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -4937,9 +4937,7 @@ boolean
 **fill**
 
 Whether the checkbox and label expand to fill all of the available
-         width and/or height of their container. When fill === true,
-         any additional space around the checkbox and label will be
-         applied as justify=\\"between\\".
+         width and/or height of their container.
 
 \`\`\`
 boolean

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2296,9 +2296,10 @@ point",
       },
       Object {
         "defaultValue": undefined,
-        "description": "Whether the checkbox expands to fill all of the available width and/or 
-          height, in order to have set the label and checkbox/toggle justify
-          content to space between.",
+        "description": "Whether the checkbox and label expand to fill all of the available
+         width and/or height of their container. When fill === true,
+         any additional space around the checkbox and label will be
+         applied as justify=\\"between\\".",
         "format": "boolean",
         "name": "fill",
       },

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2295,7 +2295,7 @@ point",
         "name": "disabled",
       },
       Object {
-        "defaultValue": false,
+        "defaultValue": undefined,
         "description": "Whether the checkbox expands to fill all of the available width and/or 
           height, in order to have set the label and checkbox/toggle justify
           content to space between.",

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2295,6 +2295,14 @@ point",
         "name": "disabled",
       },
       Object {
+        "defaultValue": false,
+        "description": "Whether the checkbox expands to fill all of the available width and/or 
+          height, in order to have set the label and checkbox/toggle justify
+          content to space between.",
+        "format": "boolean",
+        "name": "fill",
+      },
+      Object {
         "description": "The DOM id attribute value to use for the underlying <input/> element.",
         "format": "string",
         "name": "id",

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2297,9 +2297,7 @@ point",
       Object {
         "defaultValue": undefined,
         "description": "Whether the checkbox and label expand to fill all of the available
-         width and/or height of their container. When fill === true,
-         any additional space around the checkbox and label will be
-         applied as justify=\\"between\\".",
+         width and/or height of their container.",
         "format": "boolean",
         "name": "fill",
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Orginal work was done [here](https://github.com/grommet/grommet/pull/5019) 

This PR adds a new `fill` prop to `checkbox` 
When a user includes the `fill` prop the box containing the label and checkbox/toggle will fill the width and set `justify-content:  space-between`
#### Where should the reviewer start?
styledcheckbox.js
#### What testing has been done on this PR?
storybook and added a test for using the fill prop
#### How should this be manually tested?
```

        <FormField
          label="Toggle fill"
          name="toggle"
          htmlFor="check-box-toggle"
          {...props}
        >
          <Box pad={{ horizontal: 'small', vertical: 'xsmall' }}>
            <CheckBox
              id="check-box-toggle"
              name="toggle"
              label="CheckBox"
              toggle
              fill
              reverse
            />
          </Box>
        </FormField>
```
#### Any background context you want to provide?
feature request: see below
<img width="506" alt="Screen Shot 2021-04-08 at 9 42 29 AM" src="https://user-images.githubusercontent.com/42451602/114056285-be268a80-984e-11eb-9515-ee97ff2b046f.png">

#### What are the relevant issues?
closes  #5001 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
already done
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible