### PR TITLE
Trigger `change` event when Select value changes

### DIFF
--- a/src/js/components/Form/__tests__/Form-test-uncontrolled.js
+++ b/src/js/components/Form/__tests__/Form-test-uncontrolled.js
@@ -468,6 +468,9 @@ describe('Form uncontrolled', () => {
 
   test('validate on change', async () => {
     jest.useFakeTimers();
+    const onChange = jest.fn();
+    window.scrollTo = jest.fn();
+
     const { getByPlaceholderText, queryAllByText } = render(
       <Grommet>
         <Form validate="change">
@@ -501,6 +504,29 @@ describe('Form uncontrolled', () => {
               placeholder="email"
             />
           </FormField>
+          <FormField
+            label="Size"
+            name="test-select"
+            htmlFor="test-select__input"
+            required
+            validate={val => {
+              if (val === 'small')
+                return {
+                  message: 'good',
+                  status: 'info',
+                };
+              return undefined;
+            }}
+          >
+            <Select
+              a11yTitle="select form"
+              id="test-select"
+              name="test-select"
+              placeholder="test input"
+              options={['small', 'medium', 'large']}
+              onChange={onChange}
+            />
+          </FormField>
           <Button label="submit" type="submit" />
         </Form>
       </Grommet>,
@@ -524,8 +550,15 @@ describe('Form uncontrolled', () => {
       target: { value: 'a' },
     });
     act(() => jest.advanceTimersByTime(1000)); // allow validations to run
+    // change value of select
+    fireEvent.click(getByPlaceholderText('test input'));
+    fireEvent.click(document.activeElement.querySelector('button'));
+    window.scrollTo.mockRestore();
+    act(() => jest.advanceTimersByTime(1000)); // allow validations to run
+
     expect(queryAllByText('required')).toHaveLength(1);
     expect(queryAllByText('must be >1 character')).toHaveLength(1);
+    expect(queryAllByText('good')).toHaveLength(1);
   });
 
   test('validate on blur', async () => {

--- a/src/js/components/Form/__tests__/Form-test-uncontrolled.js
+++ b/src/js/components/Form/__tests__/Form-test-uncontrolled.js
@@ -507,7 +507,7 @@ describe('Form uncontrolled', () => {
           <FormField
             label="Size"
             name="test-select"
-            htmlFor="test-select__input"
+            htmlFor="test-select"
             required
             validate={val => {
               if (val === 'small')

--- a/src/js/components/Form/stories/ValidateOnChange.js
+++ b/src/js/components/Form/stories/ValidateOnChange.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Box, Button, Grommet, Form, FormField } from 'grommet';
+import { Box, Button, Grommet, Form, FormField, Select } from 'grommet';
 import { grommet } from 'grommet/themes';
 
 export const ValidateOnChange = () => {
@@ -46,7 +46,24 @@ export const ValidateOnChange = () => {
                 },
               ]}
             />
-
+            <FormField
+              label="Size"
+              name="select-size"
+              htmlFor="select-size__input"
+              required
+              validate={val => {
+                if (val === 'small') {
+                  return { message: 'Only 10 left in stock!', status: 'info' };
+                }
+                return undefined;
+              }}
+            >
+              <Select
+                name="select-size"
+                id="select-size"
+                options={['small', 'medium', 'large']}
+              />
+            </FormField>
             <Box direction="row" justify="between" margin={{ top: 'medium' }}>
               <Button label="Cancel" />
               <Button type="reset" label="Reset" />

--- a/src/js/components/Form/stories/ValidateOnChange.js
+++ b/src/js/components/Form/stories/ValidateOnChange.js
@@ -49,7 +49,7 @@ export const ValidateOnChange = () => {
             <FormField
               label="Size"
               name="select-size"
-              htmlFor="select-size__input"
+              htmlFor="select-size"
               required
               validate={val => {
                 if (val === 'small') {

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -169,9 +169,9 @@ const Select = forwardRef(
     const onSelectChange = useCallback(
       (event, { option, value: nextValue, selected: nextSelected }) => {
         if (closeOnChange) onRequestClose();
-        // value must not be of type object to set value directly on the
+        // nextValue must not be of type object to set value directly on the
         // input. if it is an object, then the user has not provided necessary
-        // props to reduce complex option object
+        // props to reduce object option
         if (typeof nextValue !== 'object' && nextValue !== event.target.value) {
           // select registers changing option as a click event or keydown.
           // when in a form, we need to programatically trigger a change

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -173,7 +173,7 @@ const Select = forwardRef(
       (event, { option, value: nextValue, selected: nextSelected }) => {
         if (closeOnChange) onRequestClose();
         if (name && nextValue !== event.target.value) {
-          // select registers changing option as a click event or keydown
+          // select registers changing option as a click event or keydown.
           // when in a form, we need to programatically trigger a change
           // event in order for the change event to be registered upstream
           // necessary for change validation in form

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -152,22 +152,19 @@ const Select = forwardRef(
       if (onClose) onClose();
     }, [onClose]);
 
-    const triggerChangeEvent = useCallback(
-      nextValue => {
-        // Calling set value function directly on input because React library
-        // overrides setter `event.target.value =` and loses original event
-        // target fidelity.
-        // https://stackoverflow.com/a/46012210
-        const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-          window.HTMLInputElement.prototype,
-          'value',
-        ).set;
-        nativeInputValueSetter.call(inputRef.current, nextValue);
-        const event = new Event('input', { bubbles: true });
-        inputRef.current.dispatchEvent(event);
-      },
-      [inputRef],
-    );
+    const triggerChangeEvent = useCallback(nextValue => {
+      // Calling set value function directly on input because React library
+      // overrides setter `event.target.value =` and loses original event
+      // target fidelity.
+      // https://stackoverflow.com/a/46012210
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      ).set;
+      nativeInputValueSetter.call(inputRef.current, nextValue);
+      const event = new Event('input', { bubbles: true });
+      inputRef.current.dispatchEvent(event);
+    }, []);
 
     const onSelectChange = useCallback(
       (event, { option, value: nextValue, selected: nextSelected }) => {

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -172,7 +172,10 @@ const Select = forwardRef(
     const onSelectChange = useCallback(
       (event, { option, value: nextValue, selected: nextSelected }) => {
         if (closeOnChange) onRequestClose();
-        if (name && nextValue !== event.target.value) {
+        // value must not be of type object to set value directly on the
+        // input. if it is an object, then the user has not provided necessary
+        // props to reduce complex option object
+        if (typeof nextValue !== 'object' && nextValue !== event.target.value) {
           // select registers changing option as a click event or keydown.
           // when in a form, we need to programatically trigger a change
           // event in order for the change event to be registered upstream
@@ -191,14 +194,7 @@ const Select = forwardRef(
         }
         setSearch();
       },
-      [
-        closeOnChange,
-        name,
-        onChange,
-        onRequestClose,
-        setValue,
-        triggerChangeEvent,
-      ],
+      [closeOnChange, onChange, onRequestClose, setValue, triggerChangeEvent],
     );
 
     let SelectIcon;

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -196,8 +196,8 @@ const Select = forwardRef(
         name,
         onChange,
         onRequestClose,
-        triggerChangeEvent,
         setValue,
+        triggerChangeEvent,
       ],
     );
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR ensures that when Select value changes, a `change` event is dispatched in order for upstream elements, such as FormField/Form to register this change event and trigger any validations (when necessary).

The way Grommet Select results in only `click` or `keyDown` event type to occur when a Select option is chosen. However, FormField validation relies on a `change` event bubbling up from the contained component to run validations. This PR mirrors what is implemented in MaskedInput and was inspired by this [Stack Overflow discussion](https://stackoverflow.com/questions/23892547/what-is-the-best-way-to-trigger-onchange-event-in-react-js/46012210#46012210). If a select value is changing and it has a `name` prop, we ensure that a change event is triggered on the underlying input so it will bubble up to the FormField and trigger validation to run.

#### Where should the reviewer start?
src/js/components/Select/Select.js

#### What testing has been done on this PR?
Added jest test and adjusted Validate onChange storybook example. Choose "small" from the Select to see the validation run.

#### How should this be manually tested?
With Validate onChange storybook example.

#### Any background context you want to provide?
Grommet Select option change results in a `click` or `keyDown` event type but in order for validation to run `onChange`, an event type of `change` needs to bubble up.

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/5122

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Fixed Select onChange validation in Form.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.