### PR TITLE
Fixed Box to always render ThemeContext.Provider

### DIFF
--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -109,26 +109,26 @@ const Box = forwardRef(
       });
     }
 
+    const themeProviderValue = { ...theme };
+
     if (background || theme.darkChanged) {
-      let dark = backgroundIsDark(background, theme);
+      const dark = backgroundIsDark(background, theme);
       const darkChanged = dark !== undefined && dark !== theme.dark;
       if (darkChanged || theme.darkChanged) {
-        dark = dark === undefined ? theme.dark : dark;
-        contents = (
-          <ThemeContext.Provider value={{ ...theme, dark, background }}>
-            {contents}
-          </ThemeContext.Provider>
-        );
+        themeProviderValue.dark = dark === undefined ? theme.dark : dark;
+        themeProviderValue.background = background;
       } else if (background) {
         // This allows DataTable to intelligently set the background of a pinned
         // header or footer.
-        contents = (
-          <ThemeContext.Provider value={{ ...theme, background }}>
-            {contents}
-          </ThemeContext.Provider>
-        );
+        themeProviderValue.background = background;
       }
     }
+
+    contents = (
+      <ThemeContext.Provider value={themeProviderValue}>
+        {contents}
+      </ThemeContext.Provider>
+    );
 
     let content = (
       <StyledBox


### PR DESCRIPTION
Currently Box only inserts a `<ThemeContext.Provider>` around the content if it needs to supply a background and/or a value for `dark` based on the background. However if the background changes (like when a validation error causes `FormField` to set the background of it's content `Box` to red or back to no background) this addition or removal of the `ThemeContext.Provider` causes the content in the Box to get re-constructed, losing any state. This manifested in issue #5146 

#### What does this PR do?
Change Box to always render a `<ThemeContext.provider>` for a consistent component hierarchy. This allows the child component specified by the user for the box to maintain state and render more efficiently.

#### Where should the reviewer start?
Box.js

#### What testing has been done on this PR?
Storybook and Jest tests

#### How should this be manually tested?
Any FormField  using the HPE theme and marked required with a TextInput child and a submit button. (See #5146 ) 

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #5146 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
