### PR TITLE
Fix CheckBox fill prop behavior and type warnings

### DIFF
--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -195,9 +195,7 @@ const CheckBox = forwardRef(
     return (
       <StyledCheckBoxContainer
         aria-label={a11yTitle}
-        // Note: StyledCheckBoxContainer is based on `styled.label`, which for
-        // some reason requires the `fill` prop to be of type string.
-        fill={fill && 'true'}
+        fillProp={fill}
         reverse={reverse}
         {...removeUndefined({ htmlFor: id, disabled })}
         checked={checked}

--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -195,7 +195,9 @@ const CheckBox = forwardRef(
     return (
       <StyledCheckBoxContainer
         aria-label={a11yTitle}
-        fill={fill}
+        // Note: StyledCheckBoxContainer is based on `styled.label`, which for
+        // some reason requires the `fill` prop to be of type string.
+        fill={fill && 'true'}
         reverse={reverse}
         {...removeUndefined({ htmlFor: id, disabled })}
         checked={checked}

--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -8,6 +8,7 @@ const fillStyle = () => `
       height: 100%;
       max-width: none;
       flex: 1 0 auto;
+      justify-content: space-between;
     `;
 
 const disabledStyle = `
@@ -43,10 +44,7 @@ const StyledCheckBoxContainer = styled.label`
   flex-direction: row;
   align-items: center;
   user-select: none;
-  ${props =>
-    props.fill
-      ? fillStyle() && `justify-content: space-between;`
-      : 'width: fit-content;'}
+  ${props => (props.fill ? fillStyle() : 'width: fit-content;')}
   ${props =>
     (props.pad || props.theme.checkBox.pad) &&
     edgeStyle(

--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -3,6 +3,9 @@ import styled, { css } from 'styled-components';
 import { edgeStyle, focusStyle, normalizeColor } from '../../utils';
 import { defaultProps } from '../../default-props';
 
+// Note: since `fillStyle` is only used in one place, `justify-content` was
+// added to it to simplify its logic. If this is ever reused somewhere else,
+// consider the need of separating those once again.
 const fillStyle = () => `
       width: 100%;
       height: 100%;
@@ -44,7 +47,7 @@ const StyledCheckBoxContainer = styled.label`
   flex-direction: row;
   align-items: center;
   user-select: none;
-  ${props => (props.fill ? fillStyle() : 'width: fit-content;')}
+  ${props => (props.fillProp ? fillStyle() : 'width: fit-content;')}
   ${props =>
     (props.pad || props.theme.checkBox.pad) &&
     edgeStyle(

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -1837,6 +1837,12 @@ exports[`CheckBox reverse toggle fill 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
@@ -1913,7 +1919,7 @@ exports[`CheckBox reverse toggle fill 1`] = `
   <label
     checked={false}
     className="c1"
-    fill={true}
+    fill="true"
     onClick={[Function]}
   >
     <span>
@@ -1945,7 +1951,7 @@ exports[`CheckBox reverse toggle fill 1`] = `
   <label
     checked={false}
     className="c1"
-    fill={true}
+    fill="true"
     onClick={[Function]}
   >
     <div

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -1919,7 +1919,6 @@ exports[`CheckBox reverse toggle fill 1`] = `
   <label
     checked={false}
     className="c1"
-    fill="true"
     onClick={[Function]}
   >
     <span>
@@ -1951,7 +1950,6 @@ exports[`CheckBox reverse toggle fill 1`] = `
   <label
     checked={false}
     className="c1"
-    fill="true"
     onClick={[Function]}
   >
     <div


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Addresses CheckBox `fill` property behavior issues and `type` warnings while using the same prop. 

- `fill` prop behavior

CheckBox component can have the checkbox itself and a label, both wrapped on a div Container. Right now, setting the `fill` prop doesn't result in any changes, where it should expand this Container to the limits of the parent component. 
After some debugging, I ended up discovering that this happens due to fill styling not being properly applied:

https://github.com/grommet/grommet/blob/adfc3091a933958aa5762c9bd493dbe059fb4e61/src/js/components/CheckBox/StyledCheckBox.js#L46-L49

Since `fillStyle` isn't used anywhere else, we can incorporate the `justify-content` prop to it, and call this function if `fill` prop is set.

- `fill` prop type warnings

The warnings mentioned on the issue can easily be associated with the `fill` prop from CheckBox. However, it's related to `StyledCheckBoxContainer`, an internal component that represents the wrapping div of CheckBox. As seen below, it's created based on `styled.label`:

https://github.com/grommet/grommet/blob/adfc3091a933958aa5762c9bd493dbe059fb4e61/src/js/components/CheckBox/StyledCheckBox.js#L41

For some reason, `label` is required to be `true` or `false`, but with the type of string, so, not an issue related to Grommet. Based on that, I added a bypass to that, alongside a Note for future reference so we can update it once it's fixed on `styled-components` end.

I ended up not going further with this as it's not the point of #5172, but those changes made me consider: 
1. Enhancing fill prop to support different alignment options besides `space-between`;
2. Use Box component as base for `StyledCheckBoxContainer` instead of `styled.label`.

Would love to hear our community's inputs on those. 

#### Where should the reviewer start?

`src/js/components/CheckBox/CheckBox.js`
`src/js/components/CheckBox/StyledCheckBox.js`

#### What testing has been done on this PR?

Manual testing and updating existing unit tests. Don't think there's a need to add new ones as the prop usage is already covered.

#### How should this be manually tested?

```js
import React from "react";
import { grommet, Box, CheckBox, Grommet } from "grommet";

export default function App() {
  return (
    <Grommet theme={grommet}>
      <Box fill background="accent-1" pad="small">
        <CheckBox fill reverse label="Check me out" />
      </Box>
    </Grommet>
  );
}
```

#### Any background context you want to provide?

-

#### What are the relevant issues?

#5172 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Breaking change, but fixes the property to work as intended.