### PR TITLE
Text-Input can get ref

### DIFF
--- a/src/js/components/TextInput/index.d.ts
+++ b/src/js/components/TextInput/index.d.ts
@@ -44,6 +44,7 @@ export interface TextInputProps
   suggestions?: ({ label?: React.ReactNode; value?: any } | string)[];
   textAlign?: TextAlignType;
   value?: string | number;
+  ref?: React.Ref<HTMLInputElement>;
 }
 
 declare const TextInput: React.FC<TextInputProps>;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
It allows the text input to get ref as a prop
#### Where should the reviewer start?
N/A
#### What testing has been done on this PR?
Manual testing
#### How should this be manually tested?
Does not need
#### Any background context you want to provide?
When developing a custom component based on Grommet. Would be nice to have a ref prop on the component, In our case the typescript asks for that prop to be exported.
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Not breaking anything