### PR TITLE
made select column pay attention to table pin property

### DIFF
--- a/src/js/components/DataTable/Footer.js
+++ b/src/js/components/DataTable/Footer.js
@@ -8,29 +8,7 @@ import { TableCell } from '../TableCell';
 
 import { Cell } from './Cell';
 import { StyledDataTableCell, StyledDataTableFooter } from './StyledDataTable';
-import { normalizeBackgroundColor } from './buildState';
-
-const calcBackground = (backgroundProp, pin, theme) => {
-  let background;
-  if (backgroundProp) background = backgroundProp;
-  else if (
-    pin.length > 0 &&
-    theme.dataTable.pinned &&
-    theme.dataTable.pinned.footer
-  ) {
-    background = theme.dataTable.pinned.footer.background;
-    if (!background.color && theme.background) {
-      // theme context has an active background color but the
-      // theme doesn't set an explicit color, repeat the context
-      // background explicitly
-      background = {
-        ...background,
-        color: normalizeBackgroundColor(theme),
-      };
-    }
-  } else background = undefined;
-  return background;
-};
+import { calcPinnedBackground } from './buildState';
 
 const Footer = forwardRef(
   (
@@ -61,7 +39,12 @@ const Footer = forwardRef(
           )}
           {(selected || onSelect) && (
             <StyledDataTableCell
-              background={calcBackground(background, pin, theme)}
+              background={calcPinnedBackground(
+                background,
+                pin,
+                theme,
+                'footer',
+              )}
               pin={pin}
             />
           )}

--- a/src/js/components/DataTable/Footer.js
+++ b/src/js/components/DataTable/Footer.js
@@ -45,6 +45,7 @@ const Footer = forwardRef(
                 theme,
                 'footer',
               )}
+              context="footer"
               pin={pin}
             />
           )}

--- a/src/js/components/DataTable/Footer.js
+++ b/src/js/components/DataTable/Footer.js
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useContext } from 'react';
+import { ThemeContext } from 'styled-components';
 
 import { defaultProps } from '../../default-props';
 
@@ -6,7 +7,30 @@ import { TableRow } from '../TableRow';
 import { TableCell } from '../TableCell';
 
 import { Cell } from './Cell';
-import { StyledDataTableFooter } from './StyledDataTable';
+import { StyledDataTableCell, StyledDataTableFooter } from './StyledDataTable';
+import { normalizeBackgroundColor } from './buildState';
+
+const calcBackground = (backgroundProp, pin, theme) => {
+  let background;
+  if (backgroundProp) background = backgroundProp;
+  else if (
+    pin.length > 0 &&
+    theme.dataTable.pinned &&
+    theme.dataTable.pinned.footer
+  ) {
+    background = theme.dataTable.pinned.footer.background;
+    if (!background.color && theme.background) {
+      // theme context has an active background color but the
+      // theme doesn't set an explicit color, repeat the context
+      // background explicitly
+      background = {
+        ...background,
+        color: normalizeBackgroundColor(theme),
+      };
+    }
+  } else background = undefined;
+  return background;
+};
 
 const Footer = forwardRef(
   (
@@ -25,34 +49,43 @@ const Footer = forwardRef(
       ...rest
     },
     ref,
-  ) => (
-    <StyledDataTableFooter ref={ref} fillProp={fill} pin={tablePin} {...rest}>
-      <TableRow>
-        {groups && (
-          <TableCell plain size="xxsmall" pad="none" verticalAlign="top" />
-        )}
-        {(selected || onSelect) && <TableCell background={background} />}
-        {columns.map(column => {
-          const pin = [];
-          if (tablePin) pin.push('bottom');
-          if (column.pin) pin.push('left');
-          return (
-            <Cell
-              key={column.property}
-              background={background}
-              border={border}
-              context="footer"
-              column={column}
-              datum={footerValues}
-              pad={pad}
-              pin={pin.length ? pin : undefined}
-              primaryProperty={primaryProperty}
+  ) => {
+    const theme = useContext(ThemeContext) || defaultProps.theme;
+    const pin = tablePin ? ['bottom'] : [];
+
+    return (
+      <StyledDataTableFooter ref={ref} fillProp={fill} pin={tablePin} {...rest}>
+        <TableRow>
+          {groups && (
+            <TableCell plain size="xxsmall" pad="none" verticalAlign="top" />
+          )}
+          {(selected || onSelect) && (
+            <StyledDataTableCell
+              background={calcBackground(background, pin, theme)}
+              pin={pin}
             />
-          );
-        })}
-      </TableRow>
-    </StyledDataTableFooter>
-  ),
+          )}
+          {columns.map(column => {
+            const cellPin = [...pin];
+            if (column.pin) cellPin.push('left');
+            return (
+              <Cell
+                key={column.property}
+                background={background}
+                border={border}
+                context="footer"
+                column={column}
+                datum={footerValues}
+                pad={pad}
+                pin={pin.length ? pin : undefined}
+                primaryProperty={primaryProperty}
+              />
+            );
+          })}
+        </TableRow>
+      </StyledDataTableFooter>
+    );
+  },
 );
 
 Footer.displayName = 'Footer';

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -143,6 +143,8 @@ const Header = forwardRef(
               }
               plain="noPad"
               size="auto"
+              context="header"
+              scope="col"
               pin={pin}
             >
               {onSelect && (

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -17,7 +17,7 @@ import {
   StyledDataTableHeader,
   StyledDataTableRow,
 } from './StyledDataTable';
-import { datumValue, normalizeBackgroundColor } from './buildState';
+import { datumValue, calcPinnedBackground } from './buildState';
 import { kindPartStyles } from '../../utils/styles';
 import { normalizeColor } from '../../utils/colors';
 
@@ -88,28 +88,6 @@ const StyledContentBox = styled(Box)`
   ${props => props.extend}
 `;
 
-const calcBackground = (backgroundProp, pin, theme) => {
-  let background;
-  if (backgroundProp) background = backgroundProp;
-  else if (
-    pin.length > 0 &&
-    theme.dataTable.pinned &&
-    theme.dataTable.pinned.header
-  ) {
-    background = theme.dataTable.pinned.header.background;
-    if (!background.color && theme.background) {
-      // theme context has an active background color but the
-      // theme doesn't set an explicit color, repeat the context
-      // background explicitly
-      background = {
-        ...background,
-        color: normalizeBackgroundColor(theme),
-      };
-    }
-  } else background = undefined;
-  return background;
-};
-
 const Header = forwardRef(
   (
     {
@@ -160,7 +138,7 @@ const Header = forwardRef(
           {(selected || onSelect) && (
             <StyledDataTableCell
               background={
-                calcBackground(backgroundProp, pin, theme) ||
+                calcPinnedBackground(backgroundProp, pin, theme, 'header') ||
                 cellProps.background
               }
               plain="noPad"
@@ -323,7 +301,12 @@ const Header = forwardRef(
               const cellPin = [...pin];
               if (columnPin) cellPin.push('left');
 
-              const background = calcBackground(backgroundProp, cellPin, theme);
+              const background = calcPinnedBackground(
+                backgroundProp,
+                cellPin,
+                theme,
+                'header',
+              );
 
               return (
                 <StyledDataTableCell

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -3196,8 +3196,9 @@ exports[`DataTable custom theme 1`] = `
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
-        <td
+        <th
           class="c3 "
+          scope="col"
         />
         <th
           class="c4 "
@@ -3383,8 +3384,9 @@ exports[`DataTable custom theme 2`] = `
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
       >
-        <td
+        <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 gnXESi StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
+          scope="col"
         />
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 cMrTAl StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
@@ -6547,8 +6549,9 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
             </div>
           </button>
         </td>
-        <td
+        <th
           class="c7 "
+          scope="col"
         >
           <div
             class="c8"
@@ -6582,7 +6585,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
               </div>
             </label>
           </div>
-        </td>
+        </th>
         <th
           class="c15 "
           scope="col"
@@ -7344,8 +7347,9 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
             </div>
           </button>
         </td>
-        <td
+        <th
           class="c7 "
+          scope="col"
         >
           <div
             class="c8"
@@ -7379,7 +7383,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
               </div>
             </label>
           </div>
-        </td>
+        </th>
         <th
           class="c15 "
           scope="col"
@@ -8033,8 +8037,9 @@ exports[`DataTable onSelect + groupBy should select all items within a group 1`]
             </div>
           </button>
         </td>
-        <td
+        <th
           class="c7 "
+          scope="col"
         >
           <div
             class="c8"
@@ -8068,7 +8073,7 @@ exports[`DataTable onSelect + groupBy should select all items within a group 1`]
               </div>
             </label>
           </div>
-        </td>
+        </th>
         <th
           class="c15 "
           scope="col"
@@ -8682,8 +8687,9 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
             </div>
           </button>
         </td>
-        <td
+        <th
           class="c7 "
+          scope="col"
         >
           <div
             class="c8"
@@ -8706,7 +8712,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
               </div>
             </label>
           </div>
-        </td>
+        </th>
         <th
           class="c14 "
           scope="col"
@@ -8936,8 +8942,9 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
             </div>
           </button>
         </td>
-        <td
+        <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 dXtGdS StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
+          scope="col"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 htEqSX"
@@ -8995,7 +9002,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
               </div>
             </label>
           </div>
-        </td>
+        </th>
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 gAxdWq StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
           scope="col"
@@ -9295,8 +9302,9 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
             </div>
           </button>
         </td>
-        <td
+        <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 dXtGdS StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
+          scope="col"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 htEqSX"
@@ -9319,7 +9327,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
               </div>
             </label>
           </div>
-        </td>
+        </th>
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 gAxdWq StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
           scope="col"
@@ -16957,8 +16965,9 @@ exports[`DataTable select 1`] = `
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
-        <td
+        <th
           class="c3 "
+          scope="col"
         >
           <div
             class="c4"
@@ -16992,7 +17001,7 @@ exports[`DataTable select 1`] = `
               </div>
             </label>
           </div>
-        </td>
+        </th>
         <th
           class="c11 "
           scope="col"
@@ -17128,8 +17137,9 @@ exports[`DataTable select 2`] = `
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
       >
-        <td
+        <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 dXtGdS StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
+          scope="col"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 htEqSX"
@@ -17183,7 +17193,7 @@ exports[`DataTable select 2`] = `
               </div>
             </label>
           </div>
-        </td>
+        </th>
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 gAxdWq StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
           scope="col"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -3197,7 +3197,7 @@ exports[`DataTable custom theme 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <td
-          class="c3"
+          class="c3 "
         />
         <th
           class="c4 "
@@ -3384,7 +3384,7 @@ exports[`DataTable custom theme 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gnXESi"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gnXESi StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
         />
         <th
           class="StyledTable__StyledTableCell-sc-1m3u5g-0 cMrTAl StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
@@ -6548,7 +6548,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
           </button>
         </td>
         <td
-          class="c7"
+          class="c7 "
         >
           <div
             class="c8"
@@ -7345,7 +7345,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
           </button>
         </td>
         <td
-          class="c7"
+          class="c7 "
         >
           <div
             class="c8"
@@ -8034,7 +8034,7 @@ exports[`DataTable onSelect + groupBy should select all items within a group 1`]
           </button>
         </td>
         <td
-          class="c7"
+          class="c7 "
         >
           <div
             class="c8"
@@ -8683,7 +8683,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
           </button>
         </td>
         <td
-          class="c7"
+          class="c7 "
         >
           <div
             class="c8"
@@ -8937,7 +8937,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </button>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dXtGdS"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dXtGdS StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 htEqSX"
@@ -9296,7 +9296,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </button>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dXtGdS"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dXtGdS StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 htEqSX"
@@ -11558,7 +11558,7 @@ exports[`DataTable pin + background 1`] = `
   padding-bottom: 6px;
 }
 
-.c18 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -11571,7 +11571,7 @@ exports[`DataTable pin + background 1`] = `
   padding-bottom: 6px;
 }
 
-.c19 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -11631,14 +11631,6 @@ exports[`DataTable pin + background 1`] = `
 }
 
 .c16 {
-  position: -webkit-sticky;
-  position: sticky;
-  bottom: 0;
-  left: 0;
-  z-index: 2;
-}
-
-.c17 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0;
@@ -11779,7 +11771,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </td>
         <td
-          class="c15 c17"
+          class="c15 c16"
         >
           <div
             class="c11"
@@ -11913,7 +11905,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </td>
         <td
-          class="c18 "
+          class="c17 "
         >
           <div
             class="c11"
@@ -11946,7 +11938,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </th>
         <th
-          class="c19 "
+          class="c18 "
           scope="col"
         >
           <div
@@ -12047,7 +12039,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </td>
         <td
-          class="c15 c17"
+          class="c15 c16"
         >
           <div
             class="c11"
@@ -12117,7 +12109,7 @@ exports[`DataTable pin + background context 1`] = `
   flex-direction: column;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12133,7 +12125,7 @@ exports[`DataTable pin + background context 1`] = `
   flex-direction: column;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12202,7 +12194,7 @@ exports[`DataTable pin + background context 1`] = `
   padding-bottom: 6px;
 }
 
-.c19 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -12217,7 +12209,7 @@ exports[`DataTable pin + background context 1`] = `
   padding-bottom: 6px;
 }
 
-.c20 {
+.c19 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -12232,7 +12224,7 @@ exports[`DataTable pin + background context 1`] = `
   padding-bottom: 6px;
 }
 
-.c22 {
+.c21 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -12247,7 +12239,7 @@ exports[`DataTable pin + background context 1`] = `
   padding-bottom: 6px;
 }
 
-.c23 {
+.c22 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -12309,14 +12301,6 @@ exports[`DataTable pin + background context 1`] = `
 }
 
 .c16 {
-  position: -webkit-sticky;
-  position: sticky;
-  bottom: 0;
-  left: 0;
-  z-index: 2;
-}
-
-.c17 {
   position: -webkit-sticky;
   position: sticky;
   bottom: 0;
@@ -12460,7 +12444,7 @@ exports[`DataTable pin + background context 1`] = `
             </div>
           </td>
           <td
-            class="c15 c17"
+            class="c15 c16"
           >
             <div
               class="c12"
@@ -12471,7 +12455,7 @@ exports[`DataTable pin + background context 1`] = `
     </table>
   </div>
   <div
-    class="c18"
+    class="c17"
   >
     <table
       class="c2 c3"
@@ -12483,7 +12467,7 @@ exports[`DataTable pin + background context 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c19 c5"
+            class="c18 c5"
             scope="col"
           >
             <div
@@ -12497,7 +12481,7 @@ exports[`DataTable pin + background context 1`] = `
             </div>
           </th>
           <th
-            class="c19 c8"
+            class="c18 c8"
             scope="col"
           >
             <div
@@ -12585,7 +12569,7 @@ exports[`DataTable pin + background context 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2"
         >
           <td
-            class="c20 c16"
+            class="c19 c16"
           >
             <div
               class="c12"
@@ -12598,7 +12582,7 @@ exports[`DataTable pin + background context 1`] = `
             </div>
           </td>
           <td
-            class="c20 c17"
+            class="c19 c16"
           >
             <div
               class="c12"
@@ -12609,7 +12593,7 @@ exports[`DataTable pin + background context 1`] = `
     </table>
   </div>
   <div
-    class="c21"
+    class="c20"
   >
     <table
       class="c2 c3"
@@ -12621,7 +12605,7 @@ exports[`DataTable pin + background context 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c22 c5"
+            class="c21 c5"
             scope="col"
           >
             <div
@@ -12635,7 +12619,7 @@ exports[`DataTable pin + background context 1`] = `
             </div>
           </th>
           <th
-            class="c22 c8"
+            class="c21 c8"
             scope="col"
           >
             <div
@@ -12723,7 +12707,7 @@ exports[`DataTable pin + background context 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2"
         >
           <td
-            class="c23 c16"
+            class="c22 c16"
           >
             <div
               class="c12"
@@ -12736,7 +12720,7 @@ exports[`DataTable pin + background context 1`] = `
             </div>
           </td>
           <td
-            class="c23 c17"
+            class="c22 c16"
           >
             <div
               class="c12"
@@ -12890,14 +12874,6 @@ exports[`DataTable pin 1`] = `
   position: -webkit-sticky;
   position: sticky;
   bottom: 0;
-  left: 0;
-  z-index: 2;
-}
-
-.c16 {
-  position: -webkit-sticky;
-  position: sticky;
-  bottom: 0;
   z-index: 1;
 }
 
@@ -13035,7 +13011,7 @@ exports[`DataTable pin 1`] = `
           </div>
         </td>
         <td
-          class="c14 c16"
+          class="c14 c15"
         >
           <div
             class="c11"
@@ -13303,7 +13279,7 @@ exports[`DataTable pin 1`] = `
           </div>
         </td>
         <td
-          class="c14 c16"
+          class="c14 c15"
         >
           <div
             class="c11"
@@ -16982,7 +16958,7 @@ exports[`DataTable select 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <td
-          class="c3"
+          class="c3 "
         >
           <div
             class="c4"
@@ -17153,7 +17129,7 @@ exports[`DataTable select 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 iYhgEa"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dXtGdS"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dXtGdS StyledDataTable__StyledDataTableCell-xrlyjm-6 dOXSQl"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 htEqSX"

--- a/src/js/components/DataTable/buildState.js
+++ b/src/js/components/DataTable/buildState.js
@@ -218,3 +218,36 @@ export const normalizeBackgroundColor = theme => {
   if (background.color) return background.color;
   return undefined;
 };
+
+// calculate a header or footer cell background based
+// on the table background prop and whether it's pinned.
+// Pin is an array of side strings, empty if not pinned.
+// If pinned, the background comes from the
+// datable.pinned[themeContext].background in the theme
+// where themeContext is either 'header' or 'footer'.
+export const calcPinnedBackground = (
+  backgroundProp,
+  pin,
+  theme,
+  themeContext,
+) => {
+  let background;
+  if (backgroundProp) background = backgroundProp;
+  else if (
+    pin.length > 0 &&
+    theme.dataTable.pinned &&
+    theme.dataTable.pinned.header
+  ) {
+    background = theme.dataTable.pinned[themeContext].background;
+    if (!background.color && theme.background) {
+      // theme context has an active background color but the
+      // theme doesn't set an explicit color, repeat the context
+      // background explicitly
+      background = {
+        ...background,
+        color: normalizeBackgroundColor(theme),
+      };
+    }
+  } else background = undefined;
+  return background;
+};


### PR DESCRIPTION
When a DataTable has a pinned header and selectable rows, the select checkbox column header cell (and footer cell) doesn't stay pinned on scroll like the other cells.

#### What does this PR do?

This PR changes the select checkbox column to stay pinned like other header/footer cells in a DataTable that has the `pin` property set. The background styling of the header and footer cell for the select checkbox now also comes from the theme `pinned` header and footer styling.

#### Where should the reviewer start?
DataTable/Header.js

#### What testing has been done on this PR?
Manual testing via storybook and Jest.

#### How should this be manually tested?
See the simple example from issue #5070 

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #5070 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
