### PR TITLE
Fix CheckBoxGroup options type

### DIFF
--- a/src/js/components/CheckBoxGroup/index.d.ts
+++ b/src/js/components/CheckBoxGroup/index.d.ts
@@ -18,7 +18,7 @@ export interface CheckBoxGroupProps {
   labelKey?: string;
   name?: string;
   onChange?: (event?: OnChangeEvent) => void;
-  options: CheckBoxType[];
+  options: (CheckBoxType | string)[];
   valueKey?: string;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Options can accept an array that contains string or CheckBoxType object. Previously, "string" was not included in this definition.

#### Where should the reviewer start?
src/js/components/CheckBoxGroup/index.d.ts

#### What testing has been done on this PR?
1. Converted Simple CheckBoxGroup example to TSX locally, got typescript error. 
2. Adjusted type definition.
3. Error was resolved.

#### How should this be manually tested?
Create TSX version of CheckBoxGroup story.

#### Any background context you want to provide?
CheckBoxGroup in TS projects was flagging use of array of strings for `options` prop even though it is an accepted type and is documented.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Fixed Typescript definition for CheckBoxGroup `options`.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.