### PR TITLE
Type object added as a type on row grid prop

### DIFF
--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -98,6 +98,26 @@ export interface GridProps {
     | 'medium'
     | 'large'
     | 'xlarge'
+    | {
+      count?: 'fit' | 'fill' | number;
+      size?:
+        | 'xsmall'
+        | 'small'
+        | 'medium'
+        | 'large'
+        | 'xlarge'
+        | 'full'
+        | '1/2'
+        | '1/3'
+        | '2/3'
+        | '1/4'
+        | '2/4'
+        | '3/4'
+        | 'flex'
+        | 'auto'
+        | string
+        | string[];
+    }
     | string;
   tag?: PolymorphicType;
 }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds an additional type on the row property.

#### Where should the reviewer start?
By comparing the Grid Documentation (scroll down to row and check the recommended types) vs the Grid/stories/Responsive.js and checking the "const rows" what is passed as a value.

#### What testing has been done on this PR?
The default ones

#### How should this be manually tested?
Create a reusable Grid component on top of the grommet on, in TypeScript, and assign an object to the row prop.

#### Any background context you want to provide?
We have built a custom Responsive Grid component on top of the Grommet one but using TypeScript when we are passing an object on the row property, the compiler will give us "Object not assignable to type...etc". Because the one in Grommet is built in Javascript, it won't check for the type and the tests are not failing.


#### What are the relevant issues?
We have built a custom Responsive Grid component on top of the Grommet one but using TypeScript when we are passing an object on the row property, the compiler will give us "Object not assignable to type...etc". Because the one in Grommet is built in Javascript, it won't check for the type and the tests are not failing.

#### Screenshots (if appropriate)
[Screenshot](https://ibb.co/VVDfznh)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backward compatible