### PR TITLE
Pagination update on page prop change

### DIFF
--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -1,4 +1,4 @@
-import React, { forwardRef, useContext, useState } from 'react';
+import React, { forwardRef, useContext, useEffect, useState } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 import { defaultProps } from '../../default-props';
 import { Box } from '../Box';
@@ -176,6 +176,10 @@ const Pagination = forwardRef(
       separator: control === 'more-prev' || control === 'more-next',
       ...navProps[control],
     }));
+
+    useEffect(() => {
+      setActivePage(pageProp || 1);
+    }, [pageProp]);
 
     return (
       <StyledPaginationContainer {...theme.pagination.container} {...rest}>

--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -42,6 +42,10 @@ const Pagination = forwardRef(
       Math.min(pageProp, totalPages) || 1,
     );
 
+    useEffect(() => {
+      setActivePage(pageProp || 1);
+    }, [pageProp]);
+
     /* Define page indices to display */
     const beginPages = getPageIndices(1, Math.min(numberEdgePages, totalPages));
     const endPages = getPageIndices(
@@ -176,10 +180,6 @@ const Pagination = forwardRef(
       separator: control === 'more-prev' || control === 'more-next',
       ...navProps[control],
     }));
-
-    useEffect(() => {
-      setActivePage(pageProp || 1);
-    }, [pageProp]);
 
     return (
       <StyledPaginationContainer {...theme.pagination.container} {...rest}>

--- a/src/js/components/Pagination/__tests__/Pagination-test.js
+++ b/src/js/components/Pagination/__tests__/Pagination-test.js
@@ -347,14 +347,15 @@ describe('Pagination', () => {
   });
 
   test(`should change the page on prop change`, () => {
-    const { container, rerender, getByText } = render(
+    const { container, rerender } = render(
       <Grommet>
         <Pagination numberItems={NUM_ITEMS} page={1} />
       </Grommet>,
     );
 
-    expect(getByText('1').className).not.toBe(getByText('3').className);
-    expect(getByText('2').className).toBe(getByText('3').className);
+    expect(container.querySelector(`[aria-current="page"]`).innerHTML).toBe(
+      '1',
+    );
 
     rerender(
       <Grommet>
@@ -362,8 +363,9 @@ describe('Pagination', () => {
       </Grommet>,
     );
 
-    expect(getByText('1').className).toBe(getByText('3').className);
-    expect(getByText('2').className).not.toBe(getByText('3').className);
+    expect(container.querySelector(`[aria-current="page"]`).innerHTML).toBe(
+      '2',
+    );
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/components/Pagination/__tests__/Pagination-test.js
+++ b/src/js/components/Pagination/__tests__/Pagination-test.js
@@ -345,4 +345,25 @@ describe('Pagination', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test(`should change the page on prop change`, () => {
+    const { container, rerender, getByText } = render(
+      <Grommet>
+        <Pagination numberItems={NUM_ITEMS} page={1} />
+      </Grommet>,
+    );
+
+    expect(getByText('1').className).not.toBe(getByText('3').className);
+    expect(getByText('2').className).toBe(getByText('3').className);
+
+    rerender(
+      <Grommet>
+        <Pagination numberItems={NUM_ITEMS} page={2} />
+      </Grommet>,
+    );
+
+    expect(getByText('1').className).toBe(getByText('3').className);
+    expect(getByText('2').className).not.toBe(getByText('3').className);
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/js/components/Pagination/__tests__/Pagination-test.js
+++ b/src/js/components/Pagination/__tests__/Pagination-test.js
@@ -19,7 +19,7 @@ for (let i = 0; i < 95; i += 1) {
 describe('Pagination', () => {
   afterEach(cleanup);
 
-  test(`should display the correct last page based on items length 
+  test(`should display the correct last page based on items length
   and step`, () => {
     const { container, getByText } = render(
       <Grommet>
@@ -67,7 +67,7 @@ describe('Pagination', () => {
 
   test('should show correct page when "page" is provided ', () => {});
 
-  test(`should disable previous and next controls when numberItems 
+  test(`should disable previous and next controls when numberItems
   < step`, () => {
     const { container } = render(
       <Grommet>
@@ -87,7 +87,7 @@ describe('Pagination', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test(`should disable previous and next controls when numberItems 
+  test(`should disable previous and next controls when numberItems
   === step`, () => {
     const { container } = render(
       <Grommet>
@@ -107,7 +107,7 @@ describe('Pagination', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test(`should disable previous and next controls when numberItems 
+  test(`should disable previous and next controls when numberItems
   === 0`, () => {
     const { container } = render(
       <Grommet>
@@ -127,7 +127,7 @@ describe('Pagination', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test(`should set page to last page if page prop > total possible 
+  test(`should set page to last page if page prop > total possible
   pages`, () => {
     const numberItems = 500;
     const step = 50;
@@ -147,7 +147,7 @@ describe('Pagination', () => {
   });
 
   // how to not hard code so many values
-  test(`should allow user to control page via state with page + 
+  test(`should allow user to control page via state with page +
   onChange`, () => {
     const onChange = jest.fn();
     const { container, getByLabelText } = render(
@@ -167,7 +167,7 @@ describe('Pagination', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test(`should display next page of results when "next" is 
+  test(`should display next page of results when "next" is
   selected`, () => {
     const onChange = jest.fn();
     const { container, getByLabelText } = render(
@@ -193,7 +193,7 @@ describe('Pagination', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test(`should display previous page of results when "previous" is 
+  test(`should display previous page of results when "previous" is
   selected`, () => {
     const onChange = jest.fn();
     const { container, getByLabelText } = render(
@@ -219,7 +219,7 @@ describe('Pagination', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test(`should display page 'n' of results when "page n" is 
+  test(`should display page 'n' of results when "page n" is
   selected`, () => {
     const { container, getByText } = render(
       <Grommet>

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Pagination should allow user to control page via state with page + 
+exports[`Pagination should allow user to control page via state with page +
   onChange 1`] = `
 .c7 {
   display: inline-block;
@@ -3346,7 +3346,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
 </div>
 `;
 
-exports[`Pagination should disable previous and next controls when numberItems 
+exports[`Pagination should disable previous and next controls when numberItems
   < step 1`] = `
 .c7 {
   display: inline-block;
@@ -3704,7 +3704,7 @@ exports[`Pagination should disable previous and next controls when numberItems
 </div>
 `;
 
-exports[`Pagination should disable previous and next controls when numberItems 
+exports[`Pagination should disable previous and next controls when numberItems
   === 0 1`] = `
 .c7 {
   display: inline-block;
@@ -3983,7 +3983,7 @@ exports[`Pagination should disable previous and next controls when numberItems
 </div>
 `;
 
-exports[`Pagination should disable previous and next controls when numberItems 
+exports[`Pagination should disable previous and next controls when numberItems
   === step 1`] = `
 .c7 {
   display: inline-block;
@@ -4883,7 +4883,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
 </div>
 `;
 
-exports[`Pagination should display next page of results when "next" is 
+exports[`Pagination should display next page of results when "next" is
   selected 1`] = `
 .c7 {
   display: inline-block;
@@ -5333,7 +5333,7 @@ exports[`Pagination should display next page of results when "next" is
 </div>
 `;
 
-exports[`Pagination should display next page of results when "next" is 
+exports[`Pagination should display next page of results when "next" is
   selected 2`] = `
 <div
   class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
@@ -5499,7 +5499,7 @@ exports[`Pagination should display next page of results when "next" is
 </div>
 `;
 
-exports[`Pagination should display page 'n' of results when "page n" is 
+exports[`Pagination should display page 'n' of results when "page n" is
   selected 1`] = `
 .c7 {
   display: inline-block;
@@ -5949,7 +5949,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
 </div>
 `;
 
-exports[`Pagination should display previous page of results when "previous" is 
+exports[`Pagination should display previous page of results when "previous" is
   selected 1`] = `
 .c7 {
   display: inline-block;
@@ -6399,7 +6399,7 @@ exports[`Pagination should display previous page of results when "previous" is
 </div>
 `;
 
-exports[`Pagination should display previous page of results when "previous" is 
+exports[`Pagination should display previous page of results when "previous" is
   selected 2`] = `
 <div
   class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
@@ -6565,7 +6565,7 @@ exports[`Pagination should display previous page of results when "previous" is
 </div>
 `;
 
-exports[`Pagination should display the correct last page based on items length 
+exports[`Pagination should display the correct last page based on items length
   and step 1`] = `
 .c7 {
   display: inline-block;
@@ -9061,7 +9061,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
 </div>
 `;
 
-exports[`Pagination should set page to last page if page prop > total possible 
+exports[`Pagination should set page to last page if page prop > total possible
   pages 1`] = `
 .c7 {
   display: inline-block;

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
@@ -2804,6 +2804,455 @@ exports[`Pagination should apply size 1`] = `
 </div>
 `;
 
+exports[`Pagination should change the page on prop change 1`] = `
+.c7 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c7 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c7 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c7 *[stroke*="#"],
+.c7 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*="#"],
+.c7 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 0px;
+}
+
+.c8 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 3px;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c9 > svg {
+  vertical-align: bottom;
+}
+
+.c9:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c5 > svg {
+  vertical-align: bottom;
+}
+
+.c5:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c5:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c5:focus > circle,
+.c5:focus > ellipse,
+.c5:focus > line,
+.c5:focus > path,
+.c5:focus > polygon,
+.c5:focus > polyline,
+.c5:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c5:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c6 > svg {
+  vertical-align: middle;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+.c11 {
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    width: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 Pagination__StyledPaginationContainer-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c2"
+    >
+      <ul
+        class="c3"
+      >
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to previous page"
+            class="c5 c6"
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c7"
+              viewBox="0 0 24 24"
+            >
+              <polyline
+                fill="none"
+                points="7 2 17 12 7 22"
+                stroke="#000"
+                stroke-width="2"
+                transform="matrix(-1 0 0 1 24 0)"
+              />
+            </svg>
+          </button>
+        </li>
+        <div
+          class="c8"
+        />
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to page 1"
+            class="c5 c6"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <div
+          class="c8"
+        />
+        <li
+          class="c4"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 2"
+            class="c9 c6"
+            type="button"
+          >
+            2
+          </button>
+        </li>
+        <div
+          class="c8"
+        />
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to page 3"
+            class="c5 c6"
+            type="button"
+          >
+            3
+          </button>
+        </li>
+        <div
+          class="c8"
+        />
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to page 4"
+            class="c5 c6"
+            type="button"
+          >
+            4
+          </button>
+        </li>
+        <div
+          class="c8"
+        />
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to page 5"
+            class="c5 c6"
+            type="button"
+          >
+            5
+          </button>
+        </li>
+        <div
+          class="c8"
+        />
+        <li
+          class="c4"
+        >
+          <span
+            class="c10 c11"
+          >
+            …
+          </span>
+        </li>
+        <div
+          class="c8"
+        />
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to page 24"
+            class="c5 c6"
+            type="button"
+          >
+            24
+          </button>
+        </li>
+        <div
+          class="c8"
+        />
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to next page"
+            class="c5 c6"
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c7"
+              viewBox="0 0 24 24"
+            >
+              <polyline
+                fill="none"
+                points="7 2 17 12 7 22"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
 exports[`Pagination should disable next button if on last page 1`] = `
 .c7 {
   display: inline-block;

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
@@ -3313,6 +3313,26 @@ exports[`Pagination should change the page on prop change 1`] = `
   border: 0;
 }
 
+.c9:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
 .c5 {
   display: inline-block;
   box-sizing: border-box;
@@ -3370,6 +3390,26 @@ exports[`Pagination should change the page on prop change 1`] = `
 }
 
 .c5:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c5:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c5:focus:not(:focus-visible) > circle,
+.c5:focus:not(:focus-visible) > ellipse,
+.c5:focus:not(:focus-visible) > line,
+.c5:focus:not(:focus-visible) > path,
+.c5:focus:not(:focus-visible) > polygon,
+.c5:focus:not(:focus-visible) > polyline,
+.c5:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c5:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Update pagination page state on page prop change. This will allow users to update the page from the parent component.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested manually and added 1 unit test.

#### How should this be manually tested?
Maybe editing one of the stories to verify this.

#### Any background context you want to provide?
I tested pagination components in 3 other UI frameworks.
They are updating the page on prop change. Also, they are not calling `onChange` on prop change.
One of the drawbacks for this change is an excess component re-render on click. I think we can leave it as is since it's not impacting performance a lot, but saving bytes with simple logic.

#### What are the relevant issues?
I didn't find any relevant issues.

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?
Maybe as a bug fix

#### Is this change backwards compatible or is it a breaking change?
