### PR TITLE
BoxSnowpack test component -- Revert before next release

### DIFF
--- a/src/js/components/BoxSnowpack/BoxSnowpack.js
+++ b/src/js/components/BoxSnowpack/BoxSnowpack.js
@@ -1,0 +1,169 @@
+import React, {
+  Children,
+  forwardRef,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+import { ThemeContext } from 'styled-components';
+import { defaultProps } from '../../default-props';
+import { backgroundIsDark } from '../../utils';
+import { Keyboard } from '../Keyboard';
+
+import { StyledBox, StyledBoxGap } from '../Box/StyledBox';
+
+const BoxSnowpack = forwardRef(
+  (
+    {
+      a11yTitle,
+      background,
+      border,
+      children,
+      direction = 'column',
+      elevation, // munged to avoid styled-components putting it in the DOM
+      fill, // munged to avoid styled-components putting it in the DOM
+      gap,
+      onBlur,
+      onClick,
+      onFocus,
+      overflow, // munged to avoid styled-components putting it in the DOM
+      responsive = true,
+      tag,
+      as,
+      wrap, // munged to avoid styled-components putting it in the DOM,
+      width, // munged to avoid styled-components putting it in the DOM
+      height, // munged to avoid styled-components putting it in the DOM
+      tabIndex,
+      ...rest
+    },
+    ref,
+  ) => {
+    const theme = useContext(ThemeContext) || defaultProps.theme;
+
+    const focusable = useMemo(() => onClick && !(tabIndex < 0), [
+      onClick,
+      tabIndex,
+    ]);
+
+    const [focus, setFocus] = useState();
+
+    const clickProps = useMemo(() => {
+      if (focusable) {
+        return {
+          onClick,
+          onFocus: event => {
+            setFocus(true);
+            if (onFocus) onFocus(event);
+          },
+          onBlur: event => {
+            setFocus(false);
+            if (onBlur) onBlur(event);
+          },
+        };
+      }
+      const result = {};
+      if (onBlur) result.onBlur = onBlur;
+      if (onClick) result.onClick = onClick;
+      if (onFocus) result.onFocus = onFocus;
+      return result;
+    }, [focusable, onClick, onFocus, onBlur]);
+
+    const adjustedTabIndex = useMemo(() => {
+      if (tabIndex !== undefined) return tabIndex;
+      if (focusable) return 0;
+      return undefined;
+    }, [focusable, tabIndex]);
+
+    if (
+      (border === 'between' || (border && border.side === 'between')) &&
+      !gap
+    ) {
+      console.warn('Box must have a gap to use border between');
+    }
+
+    let contents = children;
+    if (gap && gap !== 'none') {
+      const boxAs = !as && tag ? tag : as;
+      contents = [];
+      let firstIndex;
+      Children.forEach(children, (child, index) => {
+        if (child) {
+          if (firstIndex === undefined) {
+            firstIndex = index;
+          } else {
+            contents.push(
+              <StyledBoxGap
+                // eslint-disable-next-line react/no-array-index-key
+                key={`gap-${index}`}
+                as={boxAs === 'span' ? boxAs : 'div'}
+                gap={gap}
+                directionProp={direction}
+                responsive={responsive}
+                border={border}
+              />,
+            );
+          }
+        }
+        contents.push(child);
+      });
+    }
+
+    const themeProviderValue = { ...theme };
+
+    if (background || theme.darkChanged) {
+      const dark = backgroundIsDark(background, theme);
+      const darkChanged = dark !== undefined && dark !== theme.dark;
+      if (darkChanged || theme.darkChanged) {
+        themeProviderValue.dark = dark === undefined ? theme.dark : dark;
+        themeProviderValue.background = background;
+      } else if (background) {
+        // This allows DataTable to intelligently set the
+        // background of a pinned header or footer.
+        themeProviderValue.background = background;
+      }
+    }
+
+    contents = (
+      <ThemeContext.Provider value={themeProviderValue}>
+        {contents}
+      </ThemeContext.Provider>
+    );
+
+    let content = (
+      <StyledBox
+        as={!as && tag ? tag : as}
+        aria-label={a11yTitle}
+        background={background}
+        border={border}
+        ref={ref}
+        directionProp={direction}
+        elevationProp={elevation}
+        fillProp={fill}
+        focus={focus}
+        overflowProp={overflow}
+        wrapProp={wrap}
+        widthProp={width}
+        heightProp={height}
+        responsive={responsive}
+        tabIndex={adjustedTabIndex}
+        {...clickProps}
+        {...rest}
+      >
+        {contents}
+      </StyledBox>
+    );
+
+    if (onClick) {
+      content = <Keyboard onEnter={onClick}>{content}</Keyboard>;
+    }
+
+    return content;
+  },
+);
+
+BoxSnowpack.displayName = 'BoxSnowpack';
+
+const BoxWrapper = BoxSnowpack;
+
+export { BoxWrapper as BoxSnowpack };

--- a/src/js/components/BoxSnowpack/README.md
+++ b/src/js/components/BoxSnowpack/README.md
@@ -1,0 +1,1048 @@
+## BoxSnowpack
+A container that lays out its contents in one direction. Box
+      provides CSS flexbox capabilities for layout, as well as general
+      styling of things like background color, border, and animation.
+
+[![](https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png)](https://storybook.grommet.io/?selectedKind=Layout-Box&full=0&stories=1&panelRight=0) [![](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=/box&module=%2Fsrc%2FBox.js)
+## Usage
+
+```javascript
+import { BoxSnowpack } from 'grommet';
+<BoxSnowpack />
+```
+
+## Properties
+
+**a11yTitle**
+
+Custom label to be used by screen readers. When provided, an aria-label will
+   be added to the element.
+
+```
+string
+```
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+```
+start
+center
+end
+stretch
+```
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+```
+string
+```
+
+**margin**
+
+The amount of margin around the component. An object can
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  end: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  start: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
+**align**
+
+How to align the contents along the cross axis.
+
+```
+start
+center
+end
+baseline
+stretch
+```
+
+**alignContent**
+
+How to align the contents when there is extra space in
+        the cross axis. Defaults to `stretch`.
+
+```
+start
+center
+end
+between
+around
+stretch
+```
+
+**animation**
+
+Animation effect(s) to use. 'duration' and 'delay' should
+        be in milliseconds. 'jiggle' and 'pulse' types are intended for
+        small elements, like icons.
+
+```
+fadeIn
+fadeOut
+jiggle
+pulse
+rotateLeft
+rotateRight
+slideUp
+slideDown
+slideLeft
+slideRight
+zoomIn
+zoomOut
+{
+  type: 
+    fadeIn
+    fadeOut
+    jiggle
+    pulse
+    rotateLeft
+    rotateRight
+    slideUp
+    slideDown
+    slideLeft
+    slideRight
+    zoomIn
+    zoomOut,
+  delay: number,
+  duration: number,
+  size: 
+    xsmall
+    small
+    medium
+    large
+    xlarge
+}
+[
+  fadeIn
+  fadeOut
+  jiggle
+  pulse
+  rotateLeft
+  rotateRight
+  slideUp
+  slideDown
+  slideLeft
+  slideRight
+  zoomIn
+  zoomOut
+  {
+    type: 
+      fadeIn
+      fadeOut
+      jiggle
+      pulse
+      rotateLeft
+      rotateRight
+      slideUp
+      slideDown
+      slideLeft
+      slideRight
+      zoomIn
+      zoomOut,
+    delay: number,
+    duration: number,
+    size: 
+      xsmall
+      small
+      medium
+      large
+      xlarge
+  }
+]
+```
+
+**background**
+
+Either a color 
+identifier to use for the background color. For example: 'neutral-1'. Or, a 
+'url()' for an image. Dark is not needed if color is provided.
+
+```
+string
+{
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
+  dark: 
+    boolean
+    string,
+  image: string,
+  position: string,
+  opacity: 
+    string
+    boolean
+    number
+    weak
+    medium
+    strong,
+  repeat: 
+    no-repeat
+    repeat
+    string,
+  size: 
+    cover
+    contain
+    string,
+  light: string
+}
+```
+
+**basis**
+
+A fixed or relative size along its container's main axis.
+
+```
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+xxlarge
+full
+1/2
+1/3
+2/3
+1/4
+2/4
+3/4
+auto
+string
+```
+
+**border**
+
+Include a border. 'between' will place a border in the gap between
+      child elements. You must have a 'gap' to use 'between'.
+
+```
+boolean
+top
+left
+bottom
+right
+start
+end
+horizontal
+vertical
+all
+between
+{
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
+  side: 
+    top
+    left
+    bottom
+    right
+    start
+    end
+    horizontal
+    vertical
+    all
+    between,
+  size: 
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  style: 
+    solid
+    dashed
+    dotted
+    double
+    groove
+    ridge
+    inset
+    outset
+    hidden
+}
+[{
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
+  side: 
+    top
+    left
+    bottom
+    right
+    start
+    end
+    horizontal
+    vertical
+    all
+    between,
+  size: 
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  style: 
+    solid
+    dashed
+    dotted
+    double
+    groove
+    ridge
+    inset
+    outset
+    hidden
+}]
+```
+
+**direction**
+
+The orientation to layout the child components in. Defaults to `column`.
+
+```
+row
+column
+row-responsive
+row-reverse
+column-reverse
+```
+
+**elevation**
+
+Elevated height above the underlying context, indicated
+        via a drop shadow. Defaults to `none`.
+
+```
+none
+xsmall
+small
+medium
+large
+xlarge
+string
+```
+
+**flex**
+
+Whether flex-grow and/or flex-shrink is true and at a desired factor.
+
+```
+grow
+shrink
+boolean
+{
+  grow: number,
+  shrink: number
+}
+```
+
+**fill**
+
+Whether the width and/or height should fill the container.
+
+```
+horizontal
+vertical
+boolean
+```
+
+**focusIndicator**
+
+When interactive via 'onClick', whether it should receive a focus
+        outline. Defaults to `true`.
+
+```
+boolean
+```
+
+**gap**
+
+The amount of spacing between child elements. This
+        should not be used in conjunction with 'wrap' as the gap elements
+        will not wrap gracefully. If a child is a Fragment,
+        BoxSnowpack will not add a gap between the children of the Fragment.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+string
+```
+
+**height**
+
+A fixed height.
+
+```
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+xxlarge
+string
+{
+  min: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  max: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string
+}
+```
+
+**hoverIndicator**
+
+When 'onClick' has been specified, the hover indicator to apply
+        when the user is mousing over the boxSnowpack.
+
+```
+boolean
+string
+background
+string
+{
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
+  dark: 
+    boolean
+    string,
+  image: string,
+  position: string,
+  opacity: 
+    string
+    boolean
+    number
+    weak
+    medium
+    strong,
+  repeat: 
+    no-repeat
+    repeat
+    string,
+  size: 
+    cover
+    contain
+    string,
+  light: string
+}
+{
+  background: 
+    string
+    {
+      color: 
+        string
+        {
+          dark: string,
+          light: string
+        },
+      dark: 
+        boolean
+        string,
+      image: string,
+      position: string,
+      opacity: 
+        string
+        boolean
+        number
+        weak
+        medium
+        strong,
+      repeat: 
+        no-repeat
+        repeat
+        string,
+      size: 
+        cover
+        contain
+        string,
+      light: string
+    },
+  elevation: 
+    none
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+```
+
+**justify**
+
+How to align the contents along the main axis. Defaults to `stretch`.
+
+```
+around
+between
+center
+end
+evenly
+start
+stretch
+```
+
+**onClick**
+
+Click handler. Setting this property adds additional attributes to
+      the DOM for accessibility.
+
+```
+function
+```
+
+**overflow**
+
+boxSnowpack overflow.
+
+```
+auto
+hidden
+scroll
+visible
+{
+  horizontal: 
+    auto
+    hidden
+    scroll
+    visible,
+  vertical: 
+    auto
+    hidden
+    scroll
+    visible
+}
+string
+```
+
+**pad**
+
+The amount of padding around the box contents. An
+    object can be specified to distinguish horizontal padding, vertical
+    padding, and padding on a particular side of the box Defaults to `none`.
+
+```
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  end: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  start: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+```
+
+**responsive**
+
+Whether margin, pad, and border
+      sizes should be scaled for mobile environments. Defaults to `true`.
+
+```
+boolean
+```
+
+**round**
+
+How much to round the corners.
+
+```
+boolean
+xsmall
+small
+medium
+large
+xlarge
+full
+string
+{
+  corner: 
+    top
+    left
+    bottom
+    right
+    top-left
+    top-right
+    bottom-left
+    bottom-right,
+  size: 
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+```
+
+**tag**
+
+The DOM tag to use for the element. NOTE: This is deprecated in favor
+of indicating the DOM tag via the 'as' property.
+
+```
+string
+function
+```
+
+**as**
+
+The DOM tag or react component to use for the element. Defaults to `div`.
+
+```
+string
+function
+```
+
+**width**
+
+A fixed width.
+
+```
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+xxlarge
+string
+{
+  width: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  min: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  max: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string
+}
+```
+
+**wrap**
+
+Whether children can wrap if they can't all fit.
+
+```
+boolean
+reverse
+```
+  
+## Intrinsic element
+
+```
+div
+```
+## Theme
+  
+**global.animation**
+
+The animation configuration for the BoxSnowpack. Expects `object`.
+
+Defaults to
+
+```
+{
+  duration: '1s',
+  jiggle: {
+    duration: '0.1s',
+  },
+}
+```
+
+**global.borderSize**
+
+The possible border sizes in the BoxSnowpack. Expects `object`.
+
+Defaults to
+
+```
+{
+  xsmall: '1px',
+  small: '2px',
+  medium: '4px',
+  large: '12px',
+  xlarge: '24px,
+}
+```
+
+**global.elevation**
+
+The possible shadows in BoxSnowpack elevation. Expects `object`.
+
+Defaults to
+
+```
+{
+  light: {
+    none: 'none',
+    xsmall: '0px 1px 2px rgba(100, 100, 100, 0.50)',
+    small: '0px 2px 4px rgba(100, 100, 100, 0.50)',
+    medium: '0px 3px 8px rgba(100, 100, 100, 0.50)',
+    large: '0px 6px 12px rgba(100, 100, 100, 0.50)',
+    xlarge: '0px 8px 16px rgba(100, 100, 100, 0.50)',
+  },
+  dark: {
+    none: 'none',
+    xsmall: '0px 2px 2px rgba(255, 255, 255, 0.40)',
+    small: '0px 4px 4px rgba(255, 255, 255, 0.40)',
+    medium: '0px 6px 8px rgba(255, 255, 255, 0.40)',
+    large: '0px 8px 16px rgba(255, 255, 255, 0.40)',
+    xlarge: '0px 10px 24px rgba(255, 255, 255, 0.40)',
+  },
+}
+```
+
+**global.colors.border**
+
+The color of the border Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+{ dark: rgba(255, 255, 255, 0.33), light: rgba(0, 0, 0, 0.33), }
+```
+
+**global.hover.background.color**
+
+The color of the default background when hovering Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+active
+```
+
+**global.hover.background.opacity**
+
+The opacity of the default background when hovering Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+medium
+```
+
+**global.hover.color**
+
+The color of the default background when hovering Expects `string | { dark: string, light: string }`.
+
+Defaults to
+
+```
+{ dark: "white", light: "black" }
+```
+
+**global.opacity.medium**
+
+The value used when background opacity is set to true. Expects `number`.
+
+Defaults to
+
+```
+0.4
+```
+
+**global.size**
+
+The possible sizes for width, height, and basis. Expects `object`.
+
+Defaults to
+
+```
+{
+  xxsmall: '48px',
+  xsmall: '96px',
+  small: '192px',
+  medium: '384px',
+  large: '768px',
+  xlarge: '1152px',
+  xxlarge: '1536px',
+  full: '100%',
+}
+```
+
+**box.extend**
+
+Any additional style for the BoxSnowpack. Expects `string | (props) => {}`.
+
+Defaults to
+
+```
+undefined
+```
+
+**box.responsiveBreakpoint**
+
+The actual breakpoint to trigger changes in the border, 
+    direction, gap, margin, pad, and round. Expects `string`.
+
+Defaults to
+
+```
+small
+```
+
+**global.edgeSize**
+
+The possible sizes for any of gap, margin, and pad. Expects `object`.
+
+Defaults to
+
+```
+{
+    edgeSize: {
+      none: '0px',
+      hair: '1px',
+      xxsmall: '3px',
+      xsmall: '6px',
+      small: '12px',
+      medium: '24px',
+      large: '48px',
+      xlarge: '96px',
+      responsiveBreakpoint: 'small',
+    },
+  }
+```
+
+**global.breakpoints**
+
+The possible breakpoints that could affect border, direction, gap, margin, 
+    pad, and round. Expects `object`.
+
+Defaults to
+
+```
+{
+    small: {
+      value: '768px',
+      borderSize: {
+        xsmall: '1px',
+        small: '2px',
+        medium: '4px',
+        large: '6px',
+        xlarge: '12px',
+      },
+      edgeSize: {
+        none: '0px',
+        hair: '1px',
+        xxsmall: '2px',
+        xsmall: '3px',
+        small: '6px',
+        medium: '12px',
+        large: '24px',
+        xlarge: '48px',
+      },
+      size: {
+        xxsmall: '24px',
+        xsmall: '48px',
+        small: '96px',
+        medium: '192px',
+        large: '384px',
+        xlarge: '768px',
+        full: '100%',
+      },
+    },
+    medium: {
+      value: '1536px',
+    },
+    large: {},
+  }
+```

--- a/src/js/components/BoxSnowpack/doc.js
+++ b/src/js/components/BoxSnowpack/doc.js
@@ -1,0 +1,416 @@
+import { describe, PropTypes } from 'react-desc';
+
+import {
+  backgroundDoc,
+  elevationPropType,
+  genericProps,
+  getBorderPropType,
+  hoverIndicatorPropType,
+  padPropType,
+  roundPropType,
+} from '../../utils/prop-types';
+import { getAvailableAtBadge } from '../../utils/mixins';
+import { themeDocUtils } from '../../utils/themeDocUtils';
+
+export const OVERFLOW_VALUES = ['auto', 'hidden', 'scroll', 'visible'];
+
+const ANIMATION_TYPE = PropTypes.oneOf([
+  'fadeIn',
+  'fadeOut',
+  'jiggle',
+  'pulse',
+  'rotateLeft',
+  'rotateRight',
+  'slideUp',
+  'slideDown',
+  'slideLeft',
+  'slideRight',
+  'zoomIn',
+  'zoomOut',
+]);
+const ANIMATION_SHAPE = PropTypes.shape({
+  type: ANIMATION_TYPE,
+  delay: PropTypes.number,
+  duration: PropTypes.number,
+  size: PropTypes.oneOf(['xsmall', 'small', 'medium', 'large', 'xlarge']),
+});
+
+const BORDER_SHAPE = getBorderPropType({ includeBetween: true });
+
+// if you update values here, make sure to update in Drop/doc too.
+const overflowPropType = PropTypes.oneOfType([
+  PropTypes.oneOf(OVERFLOW_VALUES),
+  PropTypes.shape({
+    horizontal: PropTypes.oneOf(OVERFLOW_VALUES),
+    vertical: PropTypes.oneOf(OVERFLOW_VALUES),
+  }),
+  PropTypes.string,
+]);
+
+export const doc = BoxSnowpack => {
+  const DocumentedBoxSnowpack = describe(BoxSnowpack)
+    .availableAt(getAvailableAtBadge('Box', 'Layout'))
+    .description(
+      `A container that lays out its contents in one direction. Box
+      provides CSS flexbox capabilities for layout, as well as general
+      styling of things like background color, border, and animation.`,
+    )
+    .usage("import { BoxSnowpack } from 'grommet';\n<BoxSnowpack />")
+    .intrinsicElement('div');
+  DocumentedBoxSnowpack.propTypes = {
+    ...genericProps,
+    align: PropTypes.oneOf([
+      'start',
+      'center',
+      'end',
+      'baseline',
+      'stretch',
+    ]).description('How to align the contents along the cross axis.'),
+    alignContent: PropTypes.oneOf([
+      'start',
+      'center',
+      'end',
+      'between',
+      'around',
+      'stretch',
+    ])
+      .description(
+        `How to align the contents when there is extra space in
+        the cross axis.`,
+      )
+      .defaultValue('stretch'),
+    animation: PropTypes.oneOfType([
+      ANIMATION_TYPE,
+      ANIMATION_SHAPE,
+      PropTypes.arrayOf(PropTypes.oneOfType([ANIMATION_TYPE, ANIMATION_SHAPE])),
+    ]).description(`Animation effect(s) to use. 'duration' and 'delay' should
+        be in milliseconds. 'jiggle' and 'pulse' types are intended for
+        small elements, like icons.`),
+    background: backgroundDoc,
+    basis: PropTypes.oneOfType([
+      PropTypes.oneOf([
+        'xxsmall',
+        'xsmall',
+        'small',
+        'medium',
+        'large',
+        'xlarge',
+        'xxlarge',
+        'full',
+        '1/2',
+        '1/3',
+        '2/3',
+        '1/4',
+        '2/4',
+        '3/4',
+        'auto',
+      ]),
+      PropTypes.string,
+    ]).description("A fixed or relative size along its container's main axis."),
+    border: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.oneOf([
+        'top',
+        'left',
+        'bottom',
+        'right',
+        'start',
+        'end',
+        'horizontal',
+        'vertical',
+        'all',
+        'between',
+      ]),
+      BORDER_SHAPE,
+      PropTypes.arrayOf(BORDER_SHAPE),
+    ]).description(
+      `Include a border. 'between' will place a border in the gap between
+      child elements. You must have a 'gap' to use 'between'.`,
+    ),
+    direction: PropTypes.oneOf([
+      'row',
+      'column',
+      'row-responsive',
+      'row-reverse',
+      'column-reverse',
+    ])
+      .description('The orientation to layout the child components in.')
+      .defaultValue('column'),
+    elevation: elevationPropType
+      .description(
+        `Elevated height above the underlying context, indicated
+        via a drop shadow.`,
+      )
+      .defaultValue('none'),
+    flex: PropTypes.oneOfType([
+      PropTypes.oneOf(['grow', 'shrink']),
+      PropTypes.bool,
+      PropTypes.shape({
+        grow: PropTypes.number,
+        shrink: PropTypes.number,
+      }),
+    ]).description(
+      'Whether flex-grow and/or flex-shrink is true and at a desired factor.',
+    ),
+    fill: PropTypes.oneOfType([
+      PropTypes.oneOf(['horizontal', 'vertical']),
+      PropTypes.bool,
+    ]).description(
+      'Whether the width and/or height should fill the container.',
+    ),
+    focusIndicator: PropTypes.bool
+      .description(
+        `When interactive via 'onClick', whether it should receive a focus
+        outline.`,
+      )
+      .defaultValue(true),
+    gap: PropTypes.oneOfType([
+      PropTypes.oneOf([
+        'none',
+        'xxsmall',
+        'xsmall',
+        'small',
+        'medium',
+        'large',
+        'xlarge',
+      ]),
+      PropTypes.string,
+    ]).description(`The amount of spacing between child elements. This
+        should not be used in conjunction with 'wrap' as the gap elements
+        will not wrap gracefully. If a child is a Fragment,
+        BoxSnowpack will not add a gap between the children of the Fragment.`),
+    height: PropTypes.oneOfType([
+      PropTypes.oneOf([
+        'xxsmall',
+        'xsmall',
+        'small',
+        'medium',
+        'large',
+        'xlarge',
+        'xxlarge',
+      ]),
+      PropTypes.string,
+      PropTypes.shape({
+        min: PropTypes.oneOfType([
+          PropTypes.oneOf([
+            'xxsmall',
+            'xsmall',
+            'small',
+            'medium',
+            'large',
+            'xlarge',
+            'xxlarge',
+          ]),
+          PropTypes.string,
+        ]),
+        max: PropTypes.oneOfType([
+          PropTypes.oneOf([
+            'xxsmall',
+            'xsmall',
+            'small',
+            'medium',
+            'large',
+            'xlarge',
+            'xxlarge',
+          ]),
+          PropTypes.string,
+        ]),
+      }),
+    ]).description('A fixed height.'),
+    hoverIndicator: hoverIndicatorPropType
+      .description(
+        `When 'onClick' has been specified, the hover indicator to apply
+        when the user is mousing over the boxSnowpack.`,
+      )
+      .defaultValue(false),
+    justify: PropTypes.oneOf([
+      'around',
+      'between',
+      'center',
+      'end',
+      'evenly',
+      'start',
+      'stretch',
+    ])
+      .description('How to align the contents along the main axis.')
+      .defaultValue('stretch'),
+    onClick: PropTypes.func.description(
+      `Click handler. Setting this property adds additional attributes to
+      the DOM for accessibility.`,
+    ),
+    overflow: overflowPropType.description('boxSnowpack overflow.'),
+    pad: padPropType,
+    responsive: PropTypes.bool
+      .description(
+        `Whether margin, pad, and border
+      sizes should be scaled for mobile environments.`,
+      )
+      .defaultValue(true),
+    round: roundPropType,
+    tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).description(
+      `The DOM tag to use for the element. NOTE: This is deprecated in favor
+of indicating the DOM tag via the 'as' property.`,
+    ),
+    as: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+      .description('The DOM tag or react component to use for the element.')
+      .defaultValue('div'),
+    width: PropTypes.oneOfType([
+      PropTypes.oneOf([
+        'xxsmall',
+        'xsmall',
+        'small',
+        'medium',
+        'large',
+        'xlarge',
+        'xxlarge',
+      ]),
+      PropTypes.string,
+      PropTypes.shape({
+        width: PropTypes.oneOfType([
+          PropTypes.oneOf([
+            'xxsmall',
+            'xsmall',
+            'small',
+            'medium',
+            'large',
+            'xlarge',
+            'xxlarge',
+          ]),
+          PropTypes.string,
+        ]),
+        min: PropTypes.oneOfType([
+          PropTypes.oneOf([
+            'xxsmall',
+            'xsmall',
+            'small',
+            'medium',
+            'large',
+            'xlarge',
+            'xxlarge',
+          ]),
+          PropTypes.string,
+        ]),
+        max: PropTypes.oneOfType([
+          PropTypes.oneOf([
+            'xxsmall',
+            'xsmall',
+            'small',
+            'medium',
+            'large',
+            'xlarge',
+            'xxlarge',
+          ]),
+          PropTypes.string,
+        ]),
+      }),
+    ]).description('A fixed width.'),
+    wrap: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['reverse'])])
+      .description(`Whether children can wrap if they can't all fit.`)
+      .defaultValue(false),
+  };
+  return DocumentedBoxSnowpack;
+};
+
+export const themeDoc = {
+  'global.animation': {
+    description: 'The animation configuration for the BoxSnowpack.',
+    type: 'object',
+    defaultValue: `{
+  duration: '1s',
+  jiggle: {
+    duration: '0.1s',
+  },
+}`,
+  },
+  'global.borderSize': {
+    description: 'The possible border sizes in the BoxSnowpack.',
+    type: 'object',
+    defaultValue: `{
+  xsmall: '1px',
+  small: '2px',
+  medium: '4px',
+  large: '12px',
+  xlarge: '24px,
+}`,
+  },
+  'global.elevation': {
+    description: 'The possible shadows in BoxSnowpack elevation.',
+    type: 'object',
+    defaultValue: `{
+  light: {
+    none: 'none',
+    xsmall: '0px 1px 2px rgba(100, 100, 100, 0.50)',
+    small: '0px 2px 4px rgba(100, 100, 100, 0.50)',
+    medium: '0px 3px 8px rgba(100, 100, 100, 0.50)',
+    large: '0px 6px 12px rgba(100, 100, 100, 0.50)',
+    xlarge: '0px 8px 16px rgba(100, 100, 100, 0.50)',
+  },
+  dark: {
+    none: 'none',
+    xsmall: '0px 2px 2px rgba(255, 255, 255, 0.40)',
+    small: '0px 4px 4px rgba(255, 255, 255, 0.40)',
+    medium: '0px 6px 8px rgba(255, 255, 255, 0.40)',
+    large: '0px 8px 16px rgba(255, 255, 255, 0.40)',
+    xlarge: '0px 10px 24px rgba(255, 255, 255, 0.40)',
+  },
+}`,
+  },
+  'global.colors.border': {
+    description: 'The color of the border',
+    type: 'string | { dark: string, light: string }',
+    defaultValue:
+      '{ dark: rgba(255, 255, 255, 0.33), light: rgba(0, 0, 0, 0.33), }',
+  },
+  'global.hover.background.color': {
+    description: 'The color of the default background when hovering',
+    type: 'string | { dark: string, light: string }',
+    defaultValue: 'active',
+  },
+  'global.hover.background.opacity': {
+    description: 'The opacity of the default background when hovering',
+    type: 'string | { dark: string, light: string }',
+    defaultValue: 'medium',
+  },
+  'global.hover.color': {
+    description: 'The color of the default background when hovering',
+    type: 'string | { dark: string, light: string }',
+    defaultValue: '{ dark: "white", light: "black" }',
+  },
+  'global.opacity.medium': {
+    description: 'The value used when background opacity is set to true.',
+    type: 'number',
+    defaultValue: '0.4',
+  },
+  'global.size': {
+    description: 'The possible sizes for width, height, and basis.',
+    type: 'object',
+    defaultValue: `{
+  xxsmall: '48px',
+  xsmall: '96px',
+  small: '192px',
+  medium: '384px',
+  large: '768px',
+  xlarge: '1152px',
+  xxlarge: '1536px',
+  full: '100%',
+}`,
+  },
+  'box.extend': {
+    description: 'Any additional style for the BoxSnowpack.',
+    type: 'string | (props) => {}',
+    defaultValue: undefined,
+  },
+  'box.responsiveBreakpoint': {
+    description: `The actual breakpoint to trigger changes in the border, 
+    direction, gap, margin, pad, and round.`,
+    type: 'string',
+    defaultValue: 'small',
+  },
+  ...themeDocUtils.edgeStyle(
+    'The possible sizes for any of gap, margin, and pad.',
+  ),
+  ...themeDocUtils.breakpointStyle(
+    `The possible breakpoints that could affect border, direction, gap, margin, 
+    pad, and round.`,
+  ),
+};

--- a/src/js/components/BoxSnowpack/index.d.ts
+++ b/src/js/components/BoxSnowpack/index.d.ts
@@ -1,0 +1,202 @@
+import * as React from 'react';
+import {
+  A11yTitleType,
+  AlignContentType,
+  AlignSelfType,
+  BackgroundType,
+  BasisType,
+  BorderType,
+  DirectionType,
+  ElevationType,
+  FillType,
+  GapType,
+  GridAreaType,
+  MarginType,
+  PadType,
+  PolymorphicType,
+  RoundType,
+} from '../../utils';
+
+export interface BoxSnowpackProps {
+  a11yTitle?: A11yTitleType;
+  alignSelf?: AlignSelfType;
+  gridArea?: GridAreaType;
+  margin?: MarginType;
+  align?: 'start' | 'center' | 'end' | 'baseline' | 'stretch';
+  alignContent?: AlignContentType;
+  animation?:
+    | 'fadeIn'
+    | 'fadeOut'
+    | 'jiggle'
+    | 'pulse'
+    | 'rotateLeft'
+    | 'rotateRight'
+    | 'slideUp'
+    | 'slideDown'
+    | 'slideLeft'
+    | 'slideRight'
+    | 'zoomIn'
+    | 'zoomOut'
+    | {
+        type?:
+          | 'fadeIn'
+          | 'fadeOut'
+          | 'jiggle'
+          | 'pulse'
+          | 'rotateLeft'
+          | 'rotateRight'
+          | 'slideUp'
+          | 'slideDown'
+          | 'slideLeft'
+          | 'slideRight'
+          | 'zoomIn'
+          | 'zoomOut';
+        delay?: number;
+        duration?: number;
+        size?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge';
+      }
+    | (
+        | 'fadeIn'
+        | 'fadeOut'
+        | 'jiggle'
+        | 'pulse'
+        | 'slideUp'
+        | 'slideDown'
+        | 'slideLeft'
+        | 'slideRight'
+        | 'zoomIn'
+        | 'zoomOut'
+        | {
+            type?:
+              | 'fadeIn'
+              | 'fadeOut'
+              | 'jiggle'
+              | 'pulse'
+              | 'slideUp'
+              | 'slideDown'
+              | 'slideLeft'
+              | 'slideRight'
+              | 'zoomIn'
+              | 'zoomOut';
+            delay?: number;
+            duration?: number;
+            size?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge';
+          }
+      )[];
+  background?: BackgroundType;
+  basis?: BasisType;
+  border?: BorderType;
+  direction?: DirectionType;
+  elevation?: ElevationType;
+  flex?: 'grow' | 'shrink' | boolean | { grow?: number; shrink?: number };
+  fill?: FillType;
+  focusIndicator?: boolean;
+  gap?: GapType;
+  height?:
+    | 'xxsmall'
+    | 'xsmall'
+    | 'small'
+    | 'medium'
+    | 'large'
+    | 'xlarge'
+    | 'xxlarge'
+    | string
+    | {
+        max?:
+          | 'xxsmall'
+          | 'xsmall'
+          | 'small'
+          | 'medium'
+          | 'large'
+          | 'xlarge'
+          | 'xxlarge'
+          | string;
+        min?:
+          | 'xxsmall'
+          | 'xsmall'
+          | 'small'
+          | 'medium'
+          | 'large'
+          | 'xlarge'
+          | 'xxlarge'
+          | string;
+      };
+  hoverIndicator?:
+    | { background?: BackgroundType; elevation?: ElevationType }
+    | BackgroundType
+    | boolean;
+  justify?:
+    | 'around'
+    | 'between'
+    | 'center'
+    | 'end'
+    | 'evenly'
+    | 'start'
+    | 'stretch';
+  onClick?: (...args: any[]) => any;
+  overflow?:
+    | 'auto'
+    | 'hidden'
+    | 'scroll'
+    | 'visible'
+    | {
+        horizontal?: 'auto' | 'hidden' | 'scroll' | 'visible';
+        vertical?: 'auto' | 'hidden' | 'scroll' | 'visible';
+      }
+    | string;
+  pad?: PadType;
+  responsive?: boolean;
+  round?: RoundType;
+  tag?: PolymorphicType;
+  as?: PolymorphicType;
+  width?:
+    | 'xxsmall'
+    | 'xsmall'
+    | 'small'
+    | 'medium'
+    | 'large'
+    | 'xlarge'
+    | 'xxlarge'
+    | string
+    | {
+        width?:
+          | 'xxsmall'
+          | 'xsmall'
+          | 'small'
+          | 'medium'
+          | 'large'
+          | 'xlarge'
+          | 'xxlarge'
+          | string;
+        max?:
+          | 'xxsmall'
+          | 'xsmall'
+          | 'small'
+          | 'medium'
+          | 'large'
+          | 'xlarge'
+          | 'xxlarge'
+          | string;
+        min?:
+          | 'xxsmall'
+          | 'xsmall'
+          | 'small'
+          | 'medium'
+          | 'large'
+          | 'xlarge'
+          | 'xxlarge'
+          | string;
+      };
+  wrap?: boolean | 'reverse';
+}
+
+export interface BoxSnowpackExtendedProps
+  extends BoxSnowpackProps,
+    Omit<JSX.IntrinsicElements['div'], keyof BoxSnowpackProps> {}
+
+// Keep type alias for backwards compatibility.
+export type BoxSnowpackTypes = BoxSnowpackProps & JSX.IntrinsicElements['div'];
+
+declare const BoxSnowpack: React.FC<BoxSnowpackExtendedProps>;
+
+export { BoxSnowpack };

--- a/src/js/components/BoxSnowpack/index.js
+++ b/src/js/components/BoxSnowpack/index.js
@@ -1,0 +1,1 @@
+export { BoxSnowpack } from './BoxSnowpack';

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
@@ -627,14 +627,14 @@ exports[`DateInput dates initialized with empty array 1`] = `
           <h3
             class="c5"
           >
-            April 2021
+            May 2021
           </h3>
         </div>
         <div
           class="c6"
         >
           <button
-            aria-label="March 2021"
+            aria-label="April 2021"
             class="c7"
             type="button"
           >
@@ -653,7 +653,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
             </svg>
           </button>
           <button
-            aria-label="May 2021"
+            aria-label="June 2021"
             class="c7"
             type="button"
           >
@@ -686,477 +686,13 @@ exports[`DateInput dates initialized with empty array 1`] = `
               class="c12"
             >
               <button
-                aria-label="Sun Mar 28 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c14"
-                >
-                  28
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Mon Mar 29 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c14"
-                >
-                  29
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Tue Mar 30 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c14"
-                >
-                  30
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Wed Mar 31 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c14"
-                >
-                  31
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Thu Apr 01 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  1
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Fri Apr 02 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  2
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sat Apr 03 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  3
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="c11"
-          >
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sun Apr 04 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  4
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Mon Apr 05 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  5
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Tue Apr 06 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  6
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Wed Apr 07 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  7
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Thu Apr 08 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  8
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Fri Apr 09 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  9
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sat Apr 10 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  10
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="c11"
-          >
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sun Apr 11 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  11
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Mon Apr 12 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  12
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Tue Apr 13 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  13
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Wed Apr 14 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  14
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Thu Apr 15 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  15
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Fri Apr 16 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  16
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sat Apr 17 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  17
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="c11"
-          >
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sun Apr 18 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  18
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Mon Apr 19 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  19
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Tue Apr 20 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  20
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Wed Apr 21 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  21
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Thu Apr 22 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  22
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Fri Apr 23 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  23
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sat Apr 24 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  24
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="c11"
-          >
-            <div
-              class="c12"
-            >
-              <button
                 aria-label="Sun Apr 25 2021"
                 class="c13"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c14"
                 >
                   25
                 </div>
@@ -1172,7 +708,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c14"
                 >
                   26
                 </div>
@@ -1188,7 +724,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c14"
                 >
                   27
                 </div>
@@ -1204,7 +740,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c14"
                 >
                   28
                 </div>
@@ -1220,7 +756,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c14"
                 >
                   29
                 </div>
@@ -1236,7 +772,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c14"
                 >
                   30
                 </div>
@@ -1252,7 +788,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   1
                 </div>
@@ -1272,7 +808,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   2
                 </div>
@@ -1288,7 +824,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   3
                 </div>
@@ -1304,7 +840,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   4
                 </div>
@@ -1320,7 +856,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   5
                 </div>
@@ -1336,7 +872,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   6
                 </div>
@@ -1352,7 +888,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   7
                 </div>
@@ -1368,9 +904,473 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   8
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+          >
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Sun May 09 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  9
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Mon May 10 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  10
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Tue May 11 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  11
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Wed May 12 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  12
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Thu May 13 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  13
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Fri May 14 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  14
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Sat May 15 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  15
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+          >
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Sun May 16 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  16
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Mon May 17 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  17
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Tue May 18 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  18
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Wed May 19 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  19
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Thu May 20 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  20
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Fri May 21 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  21
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Sat May 22 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  22
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+          >
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Sun May 23 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  23
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Mon May 24 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  24
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Tue May 25 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  25
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Wed May 26 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  26
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Thu May 27 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  27
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Fri May 28 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  28
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Sat May 29 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  29
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+          >
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Sun May 30 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  30
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Mon May 31 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  31
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Tue Jun 01 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  1
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Wed Jun 02 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  2
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Thu Jun 03 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  3
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Fri Jun 04 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  4
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Sat Jun 05 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  5
                 </div>
               </button>
             </div>
@@ -1402,14 +1402,14 @@ exports[`DateInput dates initialized with empty array 2`] = `
           <h3
             class="StyledHeading-sc-1rdh4aw-0 nltgZ"
           >
-            April 2021
+            May 2021
           </h3>
         </div>
         <div
           class="StyledBox-sc-13pk1d4-0 cYAyEW"
         >
           <button
-            aria-label="March 2021"
+            aria-label="April 2021"
             class="StyledButton-sc-323bzc-0 jLnPHV"
             type="button"
           >
@@ -1428,7 +1428,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
             </svg>
           </button>
           <button
-            aria-label="May 2021"
+            aria-label="June 2021"
             class="StyledButton-sc-323bzc-0 jLnPHV"
             type="button"
           >
@@ -1461,477 +1461,13 @@ exports[`DateInput dates initialized with empty array 2`] = `
               class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
-                aria-label="Sun Mar 28 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
-                >
-                  28
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Mon Mar 29 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
-                >
-                  29
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Tue Mar 30 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
-                >
-                  30
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Wed Mar 31 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
-                >
-                  31
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Thu Apr 01 2021"
-                class="StyledButton-sc-323bzc-0 egeuHr"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  1
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Fri Apr 02 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  2
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Sat Apr 03 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  3
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
-          >
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Sun Apr 04 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  4
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Mon Apr 05 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  5
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Tue Apr 06 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  6
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Wed Apr 07 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  7
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Thu Apr 08 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  8
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Fri Apr 09 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  9
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Sat Apr 10 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  10
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
-          >
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Sun Apr 11 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  11
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Mon Apr 12 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  12
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Tue Apr 13 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  13
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Wed Apr 14 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  14
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Thu Apr 15 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  15
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Fri Apr 16 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  16
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Sat Apr 17 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  17
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
-          >
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Sun Apr 18 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  18
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Mon Apr 19 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  19
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Tue Apr 20 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dyzXnK"
-                >
-                  20
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Wed Apr 21 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  21
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Thu Apr 22 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  22
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Fri Apr 23 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  23
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Sat Apr 24 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  24
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
-          >
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
                 aria-label="Sun Apr 25 2021"
                 class="StyledButton-sc-323bzc-0 dsmCNz"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
                 >
                   25
                 </div>
@@ -1947,7 +1483,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
                 >
                   26
                 </div>
@@ -1963,7 +1499,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
                 >
                   27
                 </div>
@@ -1979,7 +1515,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
                 >
                   28
                 </div>
@@ -1995,7 +1531,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
                 >
                   29
                 </div>
@@ -2011,7 +1547,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
                 >
                   30
                 </div>
@@ -2022,12 +1558,12 @@ exports[`DateInput dates initialized with empty array 2`] = `
             >
               <button
                 aria-label="Sat May 01 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
+                class="StyledButton-sc-323bzc-0 egeuHr"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
                 >
                   1
                 </div>
@@ -2047,7 +1583,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
                 >
                   2
                 </div>
@@ -2063,7 +1599,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
                 >
                   3
                 </div>
@@ -2079,7 +1615,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
                 >
                   4
                 </div>
@@ -2095,7 +1631,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
                 >
                   5
                 </div>
@@ -2111,7 +1647,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
                 >
                   6
                 </div>
@@ -2127,7 +1663,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
                 >
                   7
                 </div>
@@ -2143,9 +1679,473 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
                 >
                   8
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
+          >
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Sun May 09 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  9
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Mon May 10 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  10
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Tue May 11 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  11
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Wed May 12 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  12
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Thu May 13 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  13
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Fri May 14 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  14
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Sat May 15 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  15
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
+          >
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Sun May 16 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  16
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Mon May 17 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  17
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Tue May 18 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  18
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Wed May 19 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  19
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Thu May 20 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dyzXnK"
+                >
+                  20
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Fri May 21 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  21
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Sat May 22 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  22
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
+          >
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Sun May 23 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  23
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Mon May 24 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  24
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Tue May 25 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  25
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Wed May 26 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  26
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Thu May 27 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  27
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Fri May 28 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  28
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Sat May 29 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  29
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
+          >
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Sun May 30 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  30
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Mon May 31 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  31
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Tue Jun 01 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                >
+                  1
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Wed Jun 02 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                >
+                  2
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Thu Jun 03 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                >
+                  3
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Fri Jun 04 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                >
+                  4
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Sat Jun 05 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                >
+                  5
                 </div>
               </button>
             </div>

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -2047,6 +2047,1055 @@ Defaults to
   }
 \`\`\`
 ",
+  "BoxSnowpack": "## BoxSnowpack
+A container that lays out its contents in one direction. Box
+      provides CSS flexbox capabilities for layout, as well as general
+      styling of things like background color, border, and animation.
+
+[![](https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png)](https://storybook.grommet.io/?selectedKind=Layout-Box&full=0&stories=1&panelRight=0) [![](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=/box&module=%2Fsrc%2FBox.js)
+## Usage
+
+\`\`\`javascript
+import { BoxSnowpack } from 'grommet';
+<BoxSnowpack />
+\`\`\`
+
+## Properties
+
+**a11yTitle**
+
+Custom label to be used by screen readers. When provided, an aria-label will
+   be added to the element.
+
+\`\`\`
+string
+\`\`\`
+
+**alignSelf**
+
+How to align along the cross axis when contained in
+      a Box or along the column axis when contained in a Grid.
+
+\`\`\`
+start
+center
+end
+stretch
+\`\`\`
+
+**gridArea**
+
+The name of the area to place
+    this inside a parent Grid.
+
+\`\`\`
+string
+\`\`\`
+
+**margin**
+
+The amount of margin around the component. An object can
+    be specified to distinguish horizontal margin, vertical margin, and
+    margin on a particular side.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  end: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  start: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
+**align**
+
+How to align the contents along the cross axis.
+
+\`\`\`
+start
+center
+end
+baseline
+stretch
+\`\`\`
+
+**alignContent**
+
+How to align the contents when there is extra space in
+        the cross axis. Defaults to \`stretch\`.
+
+\`\`\`
+start
+center
+end
+between
+around
+stretch
+\`\`\`
+
+**animation**
+
+Animation effect(s) to use. 'duration' and 'delay' should
+        be in milliseconds. 'jiggle' and 'pulse' types are intended for
+        small elements, like icons.
+
+\`\`\`
+fadeIn
+fadeOut
+jiggle
+pulse
+rotateLeft
+rotateRight
+slideUp
+slideDown
+slideLeft
+slideRight
+zoomIn
+zoomOut
+{
+  type: 
+    fadeIn
+    fadeOut
+    jiggle
+    pulse
+    rotateLeft
+    rotateRight
+    slideUp
+    slideDown
+    slideLeft
+    slideRight
+    zoomIn
+    zoomOut,
+  delay: number,
+  duration: number,
+  size: 
+    xsmall
+    small
+    medium
+    large
+    xlarge
+}
+[
+  fadeIn
+  fadeOut
+  jiggle
+  pulse
+  rotateLeft
+  rotateRight
+  slideUp
+  slideDown
+  slideLeft
+  slideRight
+  zoomIn
+  zoomOut
+  {
+    type: 
+      fadeIn
+      fadeOut
+      jiggle
+      pulse
+      rotateLeft
+      rotateRight
+      slideUp
+      slideDown
+      slideLeft
+      slideRight
+      zoomIn
+      zoomOut,
+    delay: number,
+    duration: number,
+    size: 
+      xsmall
+      small
+      medium
+      large
+      xlarge
+  }
+]
+\`\`\`
+
+**background**
+
+Either a color 
+identifier to use for the background color. For example: 'neutral-1'. Or, a 
+'url()' for an image. Dark is not needed if color is provided.
+
+\`\`\`
+string
+{
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
+  dark: 
+    boolean
+    string,
+  image: string,
+  position: string,
+  opacity: 
+    string
+    boolean
+    number
+    weak
+    medium
+    strong,
+  repeat: 
+    no-repeat
+    repeat
+    string,
+  size: 
+    cover
+    contain
+    string,
+  light: string
+}
+\`\`\`
+
+**basis**
+
+A fixed or relative size along its container's main axis.
+
+\`\`\`
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+xxlarge
+full
+1/2
+1/3
+2/3
+1/4
+2/4
+3/4
+auto
+string
+\`\`\`
+
+**border**
+
+Include a border. 'between' will place a border in the gap between
+      child elements. You must have a 'gap' to use 'between'.
+
+\`\`\`
+boolean
+top
+left
+bottom
+right
+start
+end
+horizontal
+vertical
+all
+between
+{
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
+  side: 
+    top
+    left
+    bottom
+    right
+    start
+    end
+    horizontal
+    vertical
+    all
+    between,
+  size: 
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  style: 
+    solid
+    dashed
+    dotted
+    double
+    groove
+    ridge
+    inset
+    outset
+    hidden
+}
+[{
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
+  side: 
+    top
+    left
+    bottom
+    right
+    start
+    end
+    horizontal
+    vertical
+    all
+    between,
+  size: 
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  style: 
+    solid
+    dashed
+    dotted
+    double
+    groove
+    ridge
+    inset
+    outset
+    hidden
+}]
+\`\`\`
+
+**direction**
+
+The orientation to layout the child components in. Defaults to \`column\`.
+
+\`\`\`
+row
+column
+row-responsive
+row-reverse
+column-reverse
+\`\`\`
+
+**elevation**
+
+Elevated height above the underlying context, indicated
+        via a drop shadow. Defaults to \`none\`.
+
+\`\`\`
+none
+xsmall
+small
+medium
+large
+xlarge
+string
+\`\`\`
+
+**flex**
+
+Whether flex-grow and/or flex-shrink is true and at a desired factor.
+
+\`\`\`
+grow
+shrink
+boolean
+{
+  grow: number,
+  shrink: number
+}
+\`\`\`
+
+**fill**
+
+Whether the width and/or height should fill the container.
+
+\`\`\`
+horizontal
+vertical
+boolean
+\`\`\`
+
+**focusIndicator**
+
+When interactive via 'onClick', whether it should receive a focus
+        outline. Defaults to \`true\`.
+
+\`\`\`
+boolean
+\`\`\`
+
+**gap**
+
+The amount of spacing between child elements. This
+        should not be used in conjunction with 'wrap' as the gap elements
+        will not wrap gracefully. If a child is a Fragment,
+        BoxSnowpack will not add a gap between the children of the Fragment.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+string
+\`\`\`
+
+**height**
+
+A fixed height.
+
+\`\`\`
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+xxlarge
+string
+{
+  min: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  max: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string
+}
+\`\`\`
+
+**hoverIndicator**
+
+When 'onClick' has been specified, the hover indicator to apply
+        when the user is mousing over the boxSnowpack.
+
+\`\`\`
+boolean
+string
+background
+string
+{
+  color: 
+    string
+    {
+      dark: string,
+      light: string
+    },
+  dark: 
+    boolean
+    string,
+  image: string,
+  position: string,
+  opacity: 
+    string
+    boolean
+    number
+    weak
+    medium
+    strong,
+  repeat: 
+    no-repeat
+    repeat
+    string,
+  size: 
+    cover
+    contain
+    string,
+  light: string
+}
+{
+  background: 
+    string
+    {
+      color: 
+        string
+        {
+          dark: string,
+          light: string
+        },
+      dark: 
+        boolean
+        string,
+      image: string,
+      position: string,
+      opacity: 
+        string
+        boolean
+        number
+        weak
+        medium
+        strong,
+      repeat: 
+        no-repeat
+        repeat
+        string,
+      size: 
+        cover
+        contain
+        string,
+      light: string
+    },
+  elevation: 
+    none
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+\`\`\`
+
+**justify**
+
+How to align the contents along the main axis. Defaults to \`stretch\`.
+
+\`\`\`
+around
+between
+center
+end
+evenly
+start
+stretch
+\`\`\`
+
+**onClick**
+
+Click handler. Setting this property adds additional attributes to
+      the DOM for accessibility.
+
+\`\`\`
+function
+\`\`\`
+
+**overflow**
+
+boxSnowpack overflow.
+
+\`\`\`
+auto
+hidden
+scroll
+visible
+{
+  horizontal: 
+    auto
+    hidden
+    scroll
+    visible,
+  vertical: 
+    auto
+    hidden
+    scroll
+    visible
+}
+string
+\`\`\`
+
+**pad**
+
+The amount of padding around the box contents. An
+    object can be specified to distinguish horizontal padding, vertical
+    padding, and padding on a particular side of the box Defaults to \`none\`.
+
+\`\`\`
+none
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+{
+  bottom: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  end: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  horizontal: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  left: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  right: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  start: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  top: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string,
+  vertical: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+string
+\`\`\`
+
+**responsive**
+
+Whether margin, pad, and border
+      sizes should be scaled for mobile environments. Defaults to \`true\`.
+
+\`\`\`
+boolean
+\`\`\`
+
+**round**
+
+How much to round the corners.
+
+\`\`\`
+boolean
+xsmall
+small
+medium
+large
+xlarge
+full
+string
+{
+  corner: 
+    top
+    left
+    bottom
+    right
+    top-left
+    top-right
+    bottom-left
+    bottom-right,
+  size: 
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    string
+}
+\`\`\`
+
+**tag**
+
+The DOM tag to use for the element. NOTE: This is deprecated in favor
+of indicating the DOM tag via the 'as' property.
+
+\`\`\`
+string
+function
+\`\`\`
+
+**as**
+
+The DOM tag or react component to use for the element. Defaults to \`div\`.
+
+\`\`\`
+string
+function
+\`\`\`
+
+**width**
+
+A fixed width.
+
+\`\`\`
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+xxlarge
+string
+{
+  width: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  min: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  max: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string
+}
+\`\`\`
+
+**wrap**
+
+Whether children can wrap if they can't all fit.
+
+\`\`\`
+boolean
+reverse
+\`\`\`
+  
+## Intrinsic element
+
+\`\`\`
+div
+\`\`\`
+## Theme
+  
+**global.animation**
+
+The animation configuration for the BoxSnowpack. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+  duration: '1s',
+  jiggle: {
+    duration: '0.1s',
+  },
+}
+\`\`\`
+
+**global.borderSize**
+
+The possible border sizes in the BoxSnowpack. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+  xsmall: '1px',
+  small: '2px',
+  medium: '4px',
+  large: '12px',
+  xlarge: '24px,
+}
+\`\`\`
+
+**global.elevation**
+
+The possible shadows in BoxSnowpack elevation. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+  light: {
+    none: 'none',
+    xsmall: '0px 1px 2px rgba(100, 100, 100, 0.50)',
+    small: '0px 2px 4px rgba(100, 100, 100, 0.50)',
+    medium: '0px 3px 8px rgba(100, 100, 100, 0.50)',
+    large: '0px 6px 12px rgba(100, 100, 100, 0.50)',
+    xlarge: '0px 8px 16px rgba(100, 100, 100, 0.50)',
+  },
+  dark: {
+    none: 'none',
+    xsmall: '0px 2px 2px rgba(255, 255, 255, 0.40)',
+    small: '0px 4px 4px rgba(255, 255, 255, 0.40)',
+    medium: '0px 6px 8px rgba(255, 255, 255, 0.40)',
+    large: '0px 8px 16px rgba(255, 255, 255, 0.40)',
+    xlarge: '0px 10px 24px rgba(255, 255, 255, 0.40)',
+  },
+}
+\`\`\`
+
+**global.colors.border**
+
+The color of the border Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+{ dark: rgba(255, 255, 255, 0.33), light: rgba(0, 0, 0, 0.33), }
+\`\`\`
+
+**global.hover.background.color**
+
+The color of the default background when hovering Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+active
+\`\`\`
+
+**global.hover.background.opacity**
+
+The opacity of the default background when hovering Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+medium
+\`\`\`
+
+**global.hover.color**
+
+The color of the default background when hovering Expects \`string | { dark: string, light: string }\`.
+
+Defaults to
+
+\`\`\`
+{ dark: \\"white\\", light: \\"black\\" }
+\`\`\`
+
+**global.opacity.medium**
+
+The value used when background opacity is set to true. Expects \`number\`.
+
+Defaults to
+
+\`\`\`
+0.4
+\`\`\`
+
+**global.size**
+
+The possible sizes for width, height, and basis. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+  xxsmall: '48px',
+  xsmall: '96px',
+  small: '192px',
+  medium: '384px',
+  large: '768px',
+  xlarge: '1152px',
+  xxlarge: '1536px',
+  full: '100%',
+}
+\`\`\`
+
+**box.extend**
+
+Any additional style for the BoxSnowpack. Expects \`string | (props) => {}\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
+**box.responsiveBreakpoint**
+
+The actual breakpoint to trigger changes in the border, 
+    direction, gap, margin, pad, and round. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+small
+\`\`\`
+
+**global.edgeSize**
+
+The possible sizes for any of gap, margin, and pad. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+    edgeSize: {
+      none: '0px',
+      hair: '1px',
+      xxsmall: '3px',
+      xsmall: '6px',
+      small: '12px',
+      medium: '24px',
+      large: '48px',
+      xlarge: '96px',
+      responsiveBreakpoint: 'small',
+    },
+  }
+\`\`\`
+
+**global.breakpoints**
+
+The possible breakpoints that could affect border, direction, gap, margin, 
+    pad, and round. Expects \`object\`.
+
+Defaults to
+
+\`\`\`
+{
+    small: {
+      value: '768px',
+      borderSize: {
+        xsmall: '1px',
+        small: '2px',
+        medium: '4px',
+        large: '6px',
+        xlarge: '12px',
+      },
+      edgeSize: {
+        none: '0px',
+        hair: '1px',
+        xxsmall: '2px',
+        xsmall: '3px',
+        small: '6px',
+        medium: '12px',
+        large: '24px',
+        xlarge: '48px',
+      },
+      size: {
+        xxsmall: '24px',
+        xsmall: '48px',
+        small: '96px',
+        medium: '192px',
+        large: '384px',
+        xlarge: '768px',
+        full: '100%',
+      },
+    },
+    medium: {
+      value: '1536px',
+    },
+    large: {},
+  }
+\`\`\`
+",
   "Button": "## Button
 A button.
 

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1144,6 +1144,10 @@ reverse",
     "usage": "import { Box } from 'grommet';
 <Box />",
   },
+  "BoxSnowpack": Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "render": [Function],
+  },
   "Button": Object {
     "availableAt": Array [
       Object {

--- a/src/js/components/index.js
+++ b/src/js/components/index.js
@@ -3,6 +3,7 @@ export * from './AccordionPanel';
 export * from './Anchor';
 export * from './Avatar';
 export * from './Box';
+export * from './BoxSnowpack';
 export * from './Button';
 export * from './Calendar';
 export * from './Card';

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -3,6 +3,7 @@ export * from './components/AccordionPanel';
 export * from './components/Anchor';
 export * from './components/Avatar';
 export * from './components/Box';
+export * from './components/BoxSnowpack';
 export * from './components/Button';
 export * from './components/Calendar';
 export * from './components/Carousel';


### PR DESCRIPTION
#### What does this PR do?
This is a test component to be used for testing a snowpack project using Grommet. It will be removed after testing and will never be officially released.

The component is exactly the same as the Box component but it doesn't have `BoxDoc = require('./doc').doc(Box);`. I think that the require statements in the component files are causing problems with snowpack. The goal of this component is to test if removing the require statement will solve the problems with using grommet and snowpack as discussed in [this issue](https://github.com/grommet/grommet/issues/4895) or if there are other problems that need to be fixed as well to get grommet working in a snowpack project.

I also included a doc.js file for this component to see how the documentation for BoxSnowpack will behave without the require statement. Originally I thought that the require statement was being used by the grommet-site for the component docs. However, the code that imports the docs for each component is `import { doc, themeDoc } from 'grommet/components/Grommet/doc';` so the documentation isn't coming from the require statement with the <component>.js file so I am curious to see if the documentation for BoxSnowpack will work normally without the require statement.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Related to #4895 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible