### PR TITLE
add an option to align the label and text in checkbox

### DIFF
--- a/src/js/components/CheckBox/README.md
+++ b/src/js/components/CheckBox/README.md
@@ -328,6 +328,17 @@ Defaults to
 undefined
 ```
 
+**checkBox.label.alignment**
+
+Weather the checkbox is aligned center or
+       in line with the text. Expects `string`.
+
+Defaults to
+
+```
+center
+```
+
 **checkBox.pad**
 
 The pad around the CheckBox and its label. Expects `string | object`.

--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -45,7 +45,11 @@ Object.setPrototypeOf(StyledCheckBoxIcon.defaultProps, defaultProps);
 const StyledCheckBoxContainer = styled.label`
   display: flex;
   flex-direction: row;
-  align-items: center;
+  align-items: ${props =>
+    (props.theme.checkBox &&
+      props.theme.checkBox.label &&
+      props.theme.checkBox.label.align) ||
+    'center'};
   user-select: none;
   ${props => (props.fillProp ? fillStyle() : 'width: fit-content;')}
   ${props =>

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -333,7 +333,7 @@ exports[`CheckBox controlled 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <label
-    class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+    class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"

--- a/src/js/components/CheckBox/doc.js
+++ b/src/js/components/CheckBox/doc.js
@@ -140,6 +140,12 @@ export const themeDoc = {
     type: 'React.Element',
     defaultValue: undefined,
   },
+  'checkBox.label.alignment': {
+    description: `Weather the checkbox is aligned center or
+       in line with the text.`,
+    type: 'string',
+    defaultValue: 'center',
+  },
   'checkBox.pad': {
     description: 'The pad around the CheckBox and its label.',
     type: 'string | object',

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
@@ -8,7 +8,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
     class="StyledBox-sc-13pk1d4-0 ftUyAh StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -29,7 +29,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 dLcqZl"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -59,7 +59,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ggIkvd"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hPWSvI"
       disabled={true}
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -96,7 +96,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     />
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ggIkvd"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hPWSvI"
       disabled={true}
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -134,7 +134,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ggIkvd"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hPWSvI"
       disabled={true}
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -172,7 +172,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 ggIkvd"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hPWSvI"
       disabled={true}
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -217,7 +217,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -250,7 +250,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
     />
     <label
       checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -295,7 +295,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
     />
     <label
       checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -347,7 +347,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
     class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -368,7 +368,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -397,7 +397,7 @@ exports[`CheckBoxGroup onChange 1`] = `
     class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -429,7 +429,7 @@ exports[`CheckBoxGroup onChange 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -459,7 +459,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
     tabindex="0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -491,7 +491,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -521,7 +521,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
     tabindex="0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -542,7 +542,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -572,7 +572,7 @@ exports[`CheckBoxGroup options renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -605,7 +605,7 @@ exports[`CheckBoxGroup options renders 1`] = `
     />
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -646,7 +646,7 @@ exports[`CheckBoxGroup value renders 1`] = `
   >
     <label
       checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -691,7 +691,7 @@ exports[`CheckBoxGroup value renders 1`] = `
     />
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -731,7 +731,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
     class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -752,7 +752,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -3511,7 +3511,7 @@ exports[`DataTable custom theme 2`] = `
           >
             <label
               aria-label="unselect alpha"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 bKvCBC"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dSsJRT"
               disabled=""
             >
               <div
@@ -3575,7 +3575,7 @@ exports[`DataTable custom theme 2`] = `
           >
             <label
               aria-label="select beta"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 bKvCBC"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dSsJRT"
               disabled=""
             >
               <div
@@ -10219,7 +10219,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           >
             <label
               aria-label="unselect all"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -10341,7 +10341,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           >
             <label
               aria-label="unselect one"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -10452,7 +10452,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           >
             <label
               aria-label="unselect two"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -10579,7 +10579,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           >
             <label
               aria-label="select all"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -10666,7 +10666,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           >
             <label
               aria-label="select one"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -10742,7 +10742,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           >
             <label
               aria-label="select two"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -18582,7 +18582,7 @@ exports[`DataTable select 2`] = `
           >
             <label
               aria-label="unselect all"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -18660,7 +18660,7 @@ exports[`DataTable select 2`] = `
           >
             <label
               aria-label="unselect alpha"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -18715,7 +18715,7 @@ exports[`DataTable select 2`] = `
           >
             <label
               aria-label="unselect beta"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fYMEIj"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -2812,7 +2812,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -3051,7 +3051,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1 iUyYoX"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -1333,7 +1333,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -1572,7 +1572,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1 iUyYoX"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -2981,7 +2981,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
         class="StyledBox-sc-13pk1d4-0 euBdwh FormField__FormFieldContentBox-m9hood-1"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
           for="test-checkbox"
         >
           <div

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5227,6 +5227,17 @@ Defaults to
 undefined
 \`\`\`
 
+**checkBox.label.alignment**
+
+Weather the checkbox is aligned center or
+       in line with the text. Expects \`string\`.
+
+Defaults to
+
+\`\`\`
+center
+\`\`\`
+
 **checkBox.pad**
 
 The pad around the CheckBox and its label. Expects \`string | object\`.

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -514,6 +514,9 @@ export interface ThemeType {
       color?: ColorType;
       width?: string;
     };
+    label?: {
+      align: string;
+    };
     check?: {
       extend?: ExtendType;
       radius?: string;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -591,6 +591,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         radius: '4px',
         thickness: '4px',
       },
+      // label :{
+      //   align: undefined
+      // },
       // color: { dark: undefined, light: undefined },
       // extend: undefined,
       // gap: undefined


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR allows an option in `checkbox` theme to change to alignment of the label of checkbox to the checkbox 
#### Where should the reviewer start?
checkbox.js
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
putting a long label in `checkbox` 

```
  checkBox: {
     label: {
       align: 'start'
},},
}

<Box width="medium">
<CheckBox label="Make the label a very long label and see how it is displayed /> 
</Box>

```


#### Any background context you want to provide?
In the HPE Design system the checkbox is not aligned with designs currently we have this:
<img width="533" alt="Screen Shot 2021-04-30 at 1 52 00 PM" src="https://user-images.githubusercontent.com/42451602/116747511-40701d80-a9bb-11eb-86e6-b9a0af1abfc5.png">

This is what the designs look like:
<img width="337" alt="Screen Shot 2021-04-30 at 1 52 48 PM" src="https://user-images.githubusercontent.com/42451602/116747584-5bdb2880-a9bb-11eb-84c3-69691d462673.png">

with this change it would look as following if we passed `start` in `theme.checkBox.label.align`

<img width="290" alt="Screen Shot 2021-04-30 at 1 16 28 PM" src="https://user-images.githubusercontent.com/42451602/116747629-6dbccb80-a9bb-11eb-9e0a-36cf37630d46.png">


#### What are the relevant issues?
design system
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
already done
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible