### PR TITLE
Add role to CheckBoxGroup and RadioButtonGroup

### DIFF
--- a/src/js/components/CheckBoxGroup/CheckBoxGroup.js
+++ b/src/js/components/CheckBoxGroup/CheckBoxGroup.js
@@ -60,6 +60,7 @@ export const CheckBoxGroup = forwardRef(
     return (
       <StyledCheckBoxGroup
         ref={ref}
+        role="group"
         {...theme.checkBoxGroup.container}
         gap={
           gap ||

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
@@ -6,6 +6,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
 >
   <div
     class="StyledBox-sc-13pk1d4-0 ftUyAh StyledCheckBoxGroup-sc-2nhc5d-0"
+    role="group"
   >
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
@@ -56,6 +57,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
 >
   <div
     className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
+    role="group"
   >
     <label
       checked={false}
@@ -131,6 +133,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   </div>
   <div
     className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
+    role="group"
   >
     <label
       checked={false}
@@ -169,6 +172,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   </div>
   <div
     className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
+    role="group"
   >
     <label
       checked={false}
@@ -214,6 +218,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
 >
   <div
     className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
+    role="group"
   >
     <label
       checked={false}
@@ -345,6 +350,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
 >
   <div
     class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
+    role="group"
   >
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
@@ -395,6 +401,7 @@ exports[`CheckBoxGroup onChange 1`] = `
 >
   <div
     class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
+    role="group"
   >
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"
@@ -456,6 +463,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
 >
   <div
     class="StyledBox-sc-13pk1d4-0 eBvFNX StyledCheckBoxGroup-sc-2nhc5d-0"
+    role="group"
     tabindex="0"
   >
     <label
@@ -518,6 +526,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
 >
   <div
     class="StyledBox-sc-13pk1d4-0 eBvFNX StyledCheckBoxGroup-sc-2nhc5d-0"
+    role="group"
     tabindex="0"
   >
     <label
@@ -569,6 +578,7 @@ exports[`CheckBoxGroup options renders 1`] = `
 >
   <div
     className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
+    role="group"
   >
     <label
       checked={false}
@@ -643,6 +653,7 @@ exports[`CheckBoxGroup value renders 1`] = `
 >
   <div
     className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
+    role="group"
   >
     <label
       checked={true}
@@ -729,6 +740,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
 >
   <div
     class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
+    role="group"
   >
     <label
       class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 glaFmo"

--- a/src/js/components/CheckBoxGroup/stories/FormControlled.js
+++ b/src/js/components/CheckBoxGroup/stories/FormControlled.js
@@ -16,10 +16,11 @@ export const FormControlled = () => {
             console.log('Submit', values, touched)
           }
         >
-          <FormField name="controlled">
+          <FormField id="check-box-formfield-id" name="controlled">
             <CheckBoxGroup
               id="check-box-group-id"
               name="controlled"
+              aria-labelledby="check-box-formfield-id"
               value={value}
               onChange={({ value: nextValue }) => setValue(nextValue)}
               options={['Maui', 'Jerusalem', 'Wuhan']}

--- a/src/js/components/CheckBoxGroup/stories/FormUncontrolled.js
+++ b/src/js/components/CheckBoxGroup/stories/FormUncontrolled.js
@@ -33,10 +33,11 @@ export const FormUncontrolled = () => (
           console.log('Submit object options', value, touched)
         }
       >
-        <FormField name="drink">
+        <FormField name="drink" label="Drink" id="drink-formfield-id">
           <CheckBoxGroup
             name="drink"
             valueKey="id"
+            aria-labelledby="drink-formfield-id"
             options={[
               { label: 'Coffee', id: '1' },
               { label: 'Tea', id: '2' },

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -2798,6 +2798,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
         <div
           class="c19"
           id="test-radiobuttongroup"
+          role="radiogroup"
         >
           <label
             class="c20"
@@ -3018,6 +3019,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
         <div
           class="StyledBox-sc-13pk1d4-0 dYebPD"
           id="test-radiobuttongroup"
+          role="radiogroup"
         >
           <label
             class="StyledRadioButton__StyledRadioButtonContainer-g1f6ld-0 hnWETW"

--- a/src/js/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/js/components/RadioButtonGroup/RadioButtonGroup.js
@@ -105,6 +105,7 @@ const RadioButtonGroup = forwardRef(
       >
         <Box
           ref={ref}
+          role="radiogroup"
           {...theme.radioButtonGroup.container}
           gap={
             gap ||

--- a/src/js/components/RadioButtonGroup/__tests__/RadioButtonGroup-test.js
+++ b/src/js/components/RadioButtonGroup/__tests__/RadioButtonGroup-test.js
@@ -16,7 +16,7 @@ describe('RadioButtonGroup', () => {
   test('should have no accessibility violations', async () => {
     const { container } = render(
       <Grommet>
-        <RadioButtonGroup name="test" options={[]} />
+        <RadioButtonGroup name="test" options={['option1']} />
       </Grommet>,
     );
 

--- a/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
+++ b/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
@@ -131,6 +131,7 @@ exports[`RadioButtonGroup adding additional props 1`] = `
 >
   <div
     className="c1"
+    role="radiogroup"
   >
     <label
       className="c2"
@@ -370,6 +371,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
 >
   <div
     className="c1"
+    role="radiogroup"
   >
     <label
       className="c2"
@@ -574,6 +576,7 @@ exports[`RadioButtonGroup children 1`] = `
 >
   <div
     className="c1"
+    role="radiogroup"
   >
     <label
       className="c2"
@@ -812,6 +815,7 @@ exports[`RadioButtonGroup defaultValue 1`] = `
   >
     <div
       class="c1"
+      role="radiogroup"
     >
       <label
         class="c2"
@@ -1059,6 +1063,7 @@ exports[`RadioButtonGroup number options 1`] = `
 >
   <div
     className="c1"
+    role="radiogroup"
   >
     <label
       className="c2"
@@ -1279,6 +1284,7 @@ exports[`RadioButtonGroup object options 1`] = `
 >
   <div
     className="c1"
+    role="radiogroup"
   >
     <label
       className="c2"
@@ -1516,6 +1522,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
 >
   <div
     className="c1"
+    role="radiogroup"
   >
     <label
       className="c2"
@@ -1744,6 +1751,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
 >
   <div
     className="c1"
+    role="radiogroup"
   >
     <label
       className="c2"
@@ -1837,13 +1845,131 @@ exports[`RadioButtonGroup should have no accessibility violations 1`] = `
   flex-direction: column;
 }
 
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-right: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px rgba(0,0,0,0.15);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 100%;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: pointer;
+}
+
+.c2:hover input:not([disabled]) + div,
+.c2:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c4 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    border: solid 2px rgba(0,0,0,0.15);
+  }
+}
+
 <div>
   <div
     class="c0"
   >
     <div
       class="c1"
-    />
+      role="radiogroup"
+    >
+      <label
+        class="c2"
+        for="option1"
+      >
+        <div
+          class="c3 "
+        >
+          <input
+            class="c4"
+            id="option1"
+            name="test"
+            type="radio"
+            value="option1"
+          />
+          <div
+            class="c5 "
+          />
+        </div>
+        <span
+          class="StyledRadioButton__StyledRadioButtonLabel-g1f6ld-2"
+        >
+          option1
+        </span>
+      </label>
+    </div>
   </div>
 </div>
 `;
@@ -2025,6 +2151,7 @@ exports[`RadioButtonGroup string options 1`] = `
 >
   <div
     className="c1"
+    role="radiogroup"
   >
     <label
       className="c2"


### PR DESCRIPTION
Currently, CheckBoxGroup and RadioButtonGroup aren't read correctly by screen readers when they are in a Form/FormField. The screen readers can't tell they are in a group or are related, especially to their FormField label.

One typical solution suggested by #4108 is to make the group be in a `<fieldset>` with a `<legend>` which would allow the screen readers to read them more appropriately.

Because `<fieldset>` and `<legend>` come with some styling intent which is awkward to make match `FormField` labels and such from the themes, it's much simpler and cleaner to use ARIA `role="group"` or `role="radiogroup"` properties. Then the developer can also easily add `aria-labelledby` to the group to connect it with it's `FormField` as appropriate. Screen readers then correctly read the label with the inputs from the group when needed.

#### What does this PR do?
This PR adds `role="group"` to `CheckBoxGroup` and `role="radiogroup"` to `RadioButtonGroup`. It also changes a couple `Form` examples to show the `aria-labelledby` usage.

It would be nice to add the `aria-labelledby` automatically somehow although that seemed to involved and potentially error-prone.
 
#### Where should the reviewer start?
CheckBoxGroup.js and RadioButtonGroup.js

#### What testing has been done on this PR?
Tested in StoryBook, Jest tests and also tested with the NVDA screen reader.

#### How should this be manually tested?
Storybook FormControlled, preferably with NVDA or JAWS screen readers.

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #4108 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Might consider updating CheckBoxGroup or RadioButtonGroup docs to give some guidance on using aria-labelledby and maybe name and id attributes.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.