### PR TITLE
Allow SkipLinks to have single child

### DIFF
--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
@@ -627,14 +627,14 @@ exports[`DateInput dates initialized with empty array 1`] = `
           <h3
             class="c5"
           >
-            April 2021
+            May 2021
           </h3>
         </div>
         <div
           class="c6"
         >
           <button
-            aria-label="March 2021"
+            aria-label="April 2021"
             class="c7"
             type="button"
           >
@@ -653,7 +653,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
             </svg>
           </button>
           <button
-            aria-label="May 2021"
+            aria-label="June 2021"
             class="c7"
             type="button"
           >
@@ -686,477 +686,13 @@ exports[`DateInput dates initialized with empty array 1`] = `
               class="c12"
             >
               <button
-                aria-label="Sun Mar 28 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c14"
-                >
-                  28
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Mon Mar 29 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c14"
-                >
-                  29
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Tue Mar 30 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c14"
-                >
-                  30
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Wed Mar 31 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c14"
-                >
-                  31
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Thu Apr 01 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  1
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Fri Apr 02 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  2
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sat Apr 03 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  3
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="c11"
-          >
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sun Apr 04 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  4
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Mon Apr 05 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  5
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Tue Apr 06 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  6
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Wed Apr 07 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  7
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Thu Apr 08 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  8
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Fri Apr 09 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  9
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sat Apr 10 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  10
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="c11"
-          >
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sun Apr 11 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  11
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Mon Apr 12 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  12
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Tue Apr 13 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  13
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Wed Apr 14 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  14
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Thu Apr 15 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  15
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Fri Apr 16 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  16
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sat Apr 17 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  17
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="c11"
-          >
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sun Apr 18 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  18
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Mon Apr 19 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  19
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Tue Apr 20 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  20
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Wed Apr 21 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  21
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Thu Apr 22 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  22
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Fri Apr 23 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  23
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-            >
-              <button
-                aria-label="Sat Apr 24 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  24
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="c11"
-          >
-            <div
-              class="c12"
-            >
-              <button
                 aria-label="Sun Apr 25 2021"
                 class="c13"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c14"
                 >
                   25
                 </div>
@@ -1172,7 +708,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c14"
                 >
                   26
                 </div>
@@ -1188,7 +724,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c14"
                 >
                   27
                 </div>
@@ -1204,7 +740,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c14"
                 >
                   28
                 </div>
@@ -1220,7 +756,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c14"
                 >
                   29
                 </div>
@@ -1236,7 +772,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c14"
                 >
                   30
                 </div>
@@ -1252,7 +788,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   1
                 </div>
@@ -1272,7 +808,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   2
                 </div>
@@ -1288,7 +824,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   3
                 </div>
@@ -1304,7 +840,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   4
                 </div>
@@ -1320,7 +856,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   5
                 </div>
@@ -1336,7 +872,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   6
                 </div>
@@ -1352,7 +888,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   7
                 </div>
@@ -1368,9 +904,473 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   8
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+          >
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Sun May 09 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  9
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Mon May 10 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  10
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Tue May 11 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  11
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Wed May 12 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  12
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Thu May 13 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  13
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Fri May 14 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  14
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Sat May 15 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  15
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+          >
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Sun May 16 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  16
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Mon May 17 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  17
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Tue May 18 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  18
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Wed May 19 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  19
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Thu May 20 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  20
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Fri May 21 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  21
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Sat May 22 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  22
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+          >
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Sun May 23 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  23
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Mon May 24 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  24
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Tue May 25 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  25
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Wed May 26 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  26
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Thu May 27 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  27
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Fri May 28 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  28
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Sat May 29 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  29
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+          >
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Sun May 30 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  30
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Mon May 31 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  31
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Tue Jun 01 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  1
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Wed Jun 02 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  2
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Thu Jun 03 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  3
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Fri Jun 04 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  4
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+            >
+              <button
+                aria-label="Sat Jun 05 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  5
                 </div>
               </button>
             </div>
@@ -1402,14 +1402,14 @@ exports[`DateInput dates initialized with empty array 2`] = `
           <h3
             class="StyledHeading-sc-1rdh4aw-0 nltgZ"
           >
-            April 2021
+            May 2021
           </h3>
         </div>
         <div
           class="StyledBox-sc-13pk1d4-0 cYAyEW"
         >
           <button
-            aria-label="March 2021"
+            aria-label="April 2021"
             class="StyledButton-sc-323bzc-0 jLnPHV"
             type="button"
           >
@@ -1428,7 +1428,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
             </svg>
           </button>
           <button
-            aria-label="May 2021"
+            aria-label="June 2021"
             class="StyledButton-sc-323bzc-0 jLnPHV"
             type="button"
           >
@@ -1461,477 +1461,13 @@ exports[`DateInput dates initialized with empty array 2`] = `
               class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
             >
               <button
-                aria-label="Sun Mar 28 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
-                >
-                  28
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Mon Mar 29 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
-                >
-                  29
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Tue Mar 30 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
-                >
-                  30
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Wed Mar 31 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
-                >
-                  31
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Thu Apr 01 2021"
-                class="StyledButton-sc-323bzc-0 egeuHr"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  1
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Fri Apr 02 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  2
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Sat Apr 03 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  3
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
-          >
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Sun Apr 04 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  4
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Mon Apr 05 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  5
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Tue Apr 06 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  6
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Wed Apr 07 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  7
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Thu Apr 08 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  8
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Fri Apr 09 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  9
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Sat Apr 10 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  10
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
-          >
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Sun Apr 11 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  11
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Mon Apr 12 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  12
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Tue Apr 13 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  13
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Wed Apr 14 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  14
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Thu Apr 15 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  15
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Fri Apr 16 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  16
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Sat Apr 17 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  17
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
-          >
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Sun Apr 18 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  18
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Mon Apr 19 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  19
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Tue Apr 20 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dyzXnK"
-                >
-                  20
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Wed Apr 21 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  21
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Thu Apr 22 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  22
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Fri Apr 23 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  23
-                </div>
-              </button>
-            </div>
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
-                aria-label="Sat Apr 24 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
-                >
-                  24
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
-          >
-            <div
-              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
-            >
-              <button
                 aria-label="Sun Apr 25 2021"
                 class="StyledButton-sc-323bzc-0 dsmCNz"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
                 >
                   25
                 </div>
@@ -1947,7 +1483,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
                 >
                   26
                 </div>
@@ -1963,7 +1499,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
                 >
                   27
                 </div>
@@ -1979,7 +1515,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
                 >
                   28
                 </div>
@@ -1995,7 +1531,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
                 >
                   29
                 </div>
@@ -2011,7 +1547,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
                 >
                   30
                 </div>
@@ -2022,12 +1558,12 @@ exports[`DateInput dates initialized with empty array 2`] = `
             >
               <button
                 aria-label="Sat May 01 2021"
-                class="StyledButton-sc-323bzc-0 dsmCNz"
+                class="StyledButton-sc-323bzc-0 egeuHr"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
                 >
                   1
                 </div>
@@ -2047,7 +1583,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
                 >
                   2
                 </div>
@@ -2063,7 +1599,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
                 >
                   3
                 </div>
@@ -2079,7 +1615,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
                 >
                   4
                 </div>
@@ -2095,7 +1631,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
                 >
                   5
                 </div>
@@ -2111,7 +1647,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
                 >
                   6
                 </div>
@@ -2127,7 +1663,7 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
                 >
                   7
                 </div>
@@ -2143,9 +1679,473 @@ exports[`DateInput dates initialized with empty array 2`] = `
                 type="button"
               >
                 <div
-                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
                 >
                   8
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
+          >
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Sun May 09 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  9
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Mon May 10 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  10
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Tue May 11 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  11
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Wed May 12 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  12
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Thu May 13 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  13
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Fri May 14 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  14
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Sat May 15 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  15
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
+          >
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Sun May 16 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  16
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Mon May 17 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  17
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Tue May 18 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  18
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Wed May 19 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  19
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Thu May 20 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dyzXnK"
+                >
+                  20
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Fri May 21 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  21
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Sat May 22 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  22
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
+          >
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Sun May 23 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  23
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Mon May 24 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  24
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Tue May 25 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  25
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Wed May 26 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  26
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Thu May 27 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  27
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Fri May 28 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  28
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Sat May 29 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  29
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="StyledCalendar__StyledWeek-sc-1y4xhmp-3 kYtnmh"
+          >
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Sun May 30 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  30
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Mon May 31 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 dGMUSn"
+                >
+                  31
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Tue Jun 01 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                >
+                  1
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Wed Jun 02 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                >
+                  2
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Thu Jun 03 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                >
+                  3
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Fri Jun 04 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                >
+                  4
+                </div>
+              </button>
+            </div>
+            <div
+              class="StyledCalendar__StyledDayContainer-sc-1y4xhmp-4 jJnkzh"
+            >
+              <button
+                aria-label="Sat Jun 05 2021"
+                class="StyledButton-sc-323bzc-0 dsmCNz"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="StyledCalendar__StyledDay-sc-1y4xhmp-5 bqmutY"
+                >
+                  5
                 </div>
               </button>
             </div>

--- a/src/js/components/SkipLinks/SkipLinks.js
+++ b/src/js/components/SkipLinks/SkipLinks.js
@@ -1,4 +1,10 @@
-import React, { cloneElement, useContext, useRef, useState } from 'react';
+import React, {
+  Children,
+  cloneElement,
+  useContext,
+  useRef,
+  useState,
+} from 'react';
 import { ThemeContext } from 'styled-components';
 
 import { Box } from '../Box';
@@ -51,8 +57,8 @@ const SkipLinks = ({ children, id, messages }) => {
           <Text {...theme.skipLinks.label}>{messages.skipTo}</Text>
         )}
         <Box align="center" gap="medium">
-          {children.map((element, index) =>
-            cloneElement(element, {
+          {Children.map(children, (child, index) =>
+            cloneElement(child, {
               key: `skip-link-${index}`,
               onClick: removeLayer,
             }),

--- a/src/js/components/SkipLinks/__tests__/SkipLink-test.js
+++ b/src/js/components/SkipLinks/__tests__/SkipLink-test.js
@@ -45,4 +45,41 @@ describe('SkipLink', () => {
     });
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('should allow for single skip link', () => {
+    jest.useFakeTimers();
+    const { container } = render(
+      <Grommet>
+        <SkipLinks id="skip-links">
+          <SkipLink id="main" label="Main Content" />
+        </SkipLinks>
+        <div>
+          <SkipLinkTarget id="main" />
+          Main Content
+          <input type="text" value="main content" onChange={() => {}} />
+        </div>
+        <footer>
+          <input type="text" value="footer" onChange={() => {}} />
+        </footer>
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+
+    document
+      .getElementById('skip-links')
+      .querySelector('a')
+      .focus();
+    expect(container.firstChild).toMatchSnapshot();
+
+    fireEvent.click(document.activeElement);
+    document
+      .getElementById('skip-links')
+      .querySelector('a')
+      .blur();
+
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
+++ b/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
@@ -140,3 +140,122 @@ exports[`SkipLink basic 3`] = `
   </footer>
 </div>
 `;
+
+exports[`SkipLink should allow for single skip link 1`] = `
+.c1 {
+  box-sizing: border-box;
+  font-size: inherit;
+  line-height: inherit;
+  color: #7D4CDB;
+  font-weight: 600;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.c1:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<div
+  class="c0"
+>
+  <div>
+    <a
+      aria-hidden="true"
+      class="c1 c2"
+      id="main"
+      tabindex="-1"
+    />
+    Main Content
+    <input
+      type="text"
+      value="main content"
+    />
+  </div>
+  <footer>
+    <input
+      type="text"
+      value="footer"
+    />
+  </footer>
+</div>
+`;
+
+exports[`SkipLink should allow for single skip link 2`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
+>
+  <div>
+    <a
+      aria-hidden="true"
+      class="StyledAnchor-sc-1rp7lwl-0 eCyBYb SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 JifTi"
+      id="main"
+      tabindex="-1"
+    />
+    Main Content
+    <input
+      type="text"
+      value="main content"
+    />
+  </div>
+  <footer>
+    <input
+      type="text"
+      value="footer"
+    />
+  </footer>
+</div>
+`;
+
+exports[`SkipLink should allow for single skip link 3`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
+>
+  <div>
+    <a
+      aria-hidden="true"
+      class="StyledAnchor-sc-1rp7lwl-0 eCyBYb SkipLinkTarget__HiddenAnchor-sc-16wjfgk-0 JifTi"
+      id="main"
+      tabindex="-1"
+    />
+    Main Content
+    <input
+      type="text"
+      value="main content"
+    />
+  </div>
+  <footer>
+    <input
+      type="text"
+      value="footer"
+    />
+  </footer>
+</div>
+`;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Uses `React.Children` to map through children which allows SkipLinks to a have a single SkipLink child. Previously, just using `children.map` with a single child threw an error. Explanation can be found in link below, but essentially when `props.children` is a single child, `.map()` can't be performed. That is why we use `React.Children.map` which supports it regardless of if there is a single or multiple children: https://stackoverflow.com/questions/29464577/why-doesnt-this-props-children-map-work

#### Where should the reviewer start?
src/js/components/SkipLinks/SkipLinks.js

#### What testing has been done on this PR?
Tested in SkipLinks story book and created jest test.

BEFORE changes, jest test will fail:
<img width="949" alt="Screen Shot 2021-05-03 at 10 56 51 AM" src="https://user-images.githubusercontent.com/12522275/116916696-87038900-ac02-11eb-945d-ae499f33121b.png">

#### How should this be manually tested?
Create SkipLinks with single SkipLink child.

#### Any background context you want to provide?

#### What are the relevant issues?
Related to https://github.com/grommet/hpe-design-system/issues/1585 where we want to have a single "Main Content" SkipLink.

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Fixed SkipLinks to support single SkipLink child.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.