### PR TITLE
adds import for defaultProps to DataTable

### DIFF
--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -9,6 +9,8 @@ import React, {
 } from 'react';
 import { ThemeContext } from 'styled-components';
 
+import { defaultProps } from '../../default-props';
+
 import { useLayoutEffect } from '../../utils/use-isomorphic-layout-effect';
 import { Box } from '../Box';
 import { Text } from '../Text';


### PR DESCRIPTION
Signed-off-by: Daniel Baird <daniel.baird@jcu.edu.au>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Like other Grommet components, DataTable will default to `defaultProps.theme` if there's no Theme context available. However defaultProps isn't imported. This PR adds that missing import.

#### Where should the reviewer start?
Line 12 is the change; line 104 is the reference to defaultProps

#### What testing has been done on this PR?
I ran the standard tests, which passed (except for a date-related one because the test doesn't allow for my +10 timezone. I'll PR a fix for that later)

#### How should this be manually tested?
You could use a DataTable outside of a ThemeContext -- it will fail without this change.

#### Any background context you want to provide?
I hit this bug while updating all my dependencies, when I accidentally included multiple instances of styled-components in my app. That broke ThemeContext enough that my DataTable tried to fall back to (the non-existent) defaultProps.

#### Do the grommet docs need to be updated?
Nope

#### Should this PR be mentioned in the release notes?
Not unless you list every bugfix.

#### Is this change backwards compatible or is it a breaking change?
Compatible.
