### PR TITLE
Update DateInput TextValue on Value prop change

### DIFF
--- a/src/js/components/DateInput/DateInput.js
+++ b/src/js/components/DateInput/DateInput.js
@@ -68,6 +68,16 @@ const DateInput = forwardRef(
     const [textValue, setTextValue] = useState(
       schema ? valueToText(value, schema) : undefined,
     );
+
+    // updates the text value if the value prop changes
+    useEffect(() => {
+      if (schema) {
+        setTextValue(valueToText(value, schema));
+      } else {
+        setTextValue(undefined);
+      }
+    }, [value, schema]);
+
     // We need to distinguish between the caller changing a Form value
     // and the user typing a date that he isn't finished with yet.
     // To track this, we keep track of the internalValue from interacting


### PR DESCRIPTION
This PR fixes the behaviour described in the current open issue: https://github.com/grommet/grommet/issues/5247

The display value of the `DateInput` component should update when the value prop of the component changes. 

#### What does this PR do?

Adds a `useEffect` hook in `DateInput.js` to update the `textValue` which is the displayed value of the text iput.

#### Where should the reviewer start?

View file `src/js/components/DateInput/DateInput.js`

#### What testing has been done on this PR?

NA

#### How should this be manually tested?

This could be manually tested by creating a storybook story that updates the passed in date value similar to the codesandbox presented in the issue above.

#### Any background context you want to provide?

NA

#### What are the relevant issues?

NA

#### Screenshots (if appropriate)

fixes the issues found here: https://codesandbox.io/s/grommet-v2-template-forked-8yrp8?file=/index.js

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

Backwards
