### PR TITLE
Changed Grid to add width and height

### DIFF
--- a/src/js/components/Box/README.md
+++ b/src/js/components/Box/README.md
@@ -478,6 +478,15 @@ xlarge
 xxlarge
 string
 {
+  height: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
   min: 
     xxsmall
     xsmall

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -11,9 +11,11 @@ import {
   focusStyle,
   genericStyles,
   getHoverIndicatorStyle,
+  heightStyle,
   overflowStyle,
   parseMetricToNum,
   responsiveBorderStyle,
+  widthStyle,
 } from '../../utils';
 
 import { getBreakpointStyle } from '../../utils/responsive';
@@ -347,47 +349,6 @@ const interactiveStyle = css`
   }
 `;
 
-const getSize = (props, size) => props.theme.global.size[size] || size;
-
-const heightObjectStyle = css`
-  ${props =>
-    props.heightProp.max &&
-    css`
-      max-height: ${getSize(props, props.heightProp.max)};
-    `};
-  ${props =>
-    props.heightProp.min &&
-    css`
-      min-height: ${getSize(props, props.heightProp.min)};
-    `};
-`;
-
-const heightStyle = css`
-  height: ${props => getSize(props, props.heightProp)};
-`;
-
-const widthObjectStyle = css`
-  ${props =>
-    props.widthProp.max &&
-    css`
-      max-width: ${getSize(props, props.widthProp.max)};
-    `};
-  ${props =>
-    props.widthProp.min &&
-    css`
-      min-width: ${getSize(props, props.widthProp.min)};
-    `};
-  ${props =>
-    props.widthProp.width &&
-    css`
-      width: ${getSize(props, props.widthProp.width)};
-    `};
-`;
-
-const widthStyle = css`
-  width: ${props => getSize(props, props.widthProp)};
-`;
-
 // NOTE: basis must be after flex! Otherwise, flex overrides basis
 const StyledBox = styled.div`
   display: flex;
@@ -407,12 +368,8 @@ const StyledBox = styled.div`
       : borderStyle(props.border, props.responsive, props.theme))}
   ${props =>
     props.directionProp && directionStyle(props.directionProp, props.theme)}
-  ${props =>
-    props.heightProp &&
-    (typeof props.heightProp === 'object' ? heightObjectStyle : heightStyle)}
-  ${props =>
-    props.widthProp &&
-    (typeof props.widthProp === 'object' ? widthObjectStyle : widthStyle)}
+  ${props => props.heightProp && heightStyle(props.heightProp, props.theme)}
+  ${props => props.widthProp && widthStyle(props.widthProp, props.theme)}
   ${props => props.flex !== undefined && flexStyle}
   ${props => props.basis && basisStyle}
   ${props => props.fillProp && fillStyle(props.fillProp)}

--- a/src/js/components/Box/doc.js
+++ b/src/js/components/Box/doc.js
@@ -5,9 +5,11 @@ import {
   elevationPropType,
   genericProps,
   getBorderPropType,
+  heightPropType,
   hoverIndicatorPropType,
   padPropType,
   roundPropType,
+  widthPropType,
 } from '../../utils/prop-types';
 import { getAvailableAtBadge } from '../../utils/mixins';
 import { themeDocUtils } from '../../utils/themeDocUtils';
@@ -179,44 +181,7 @@ export const doc = Box => {
         should not be used in conjunction with 'wrap' as the gap elements
         will not wrap gracefully. If a child is a Fragment,
         Box will not add a gap between the children of the Fragment.`),
-    height: PropTypes.oneOfType([
-      PropTypes.oneOf([
-        'xxsmall',
-        'xsmall',
-        'small',
-        'medium',
-        'large',
-        'xlarge',
-        'xxlarge',
-      ]),
-      PropTypes.string,
-      PropTypes.shape({
-        min: PropTypes.oneOfType([
-          PropTypes.oneOf([
-            'xxsmall',
-            'xsmall',
-            'small',
-            'medium',
-            'large',
-            'xlarge',
-            'xxlarge',
-          ]),
-          PropTypes.string,
-        ]),
-        max: PropTypes.oneOfType([
-          PropTypes.oneOf([
-            'xxsmall',
-            'xsmall',
-            'small',
-            'medium',
-            'large',
-            'xlarge',
-            'xxlarge',
-          ]),
-          PropTypes.string,
-        ]),
-      }),
-    ]).description('A fixed height.'),
+    height: heightPropType.description('A fixed height.'),
     hoverIndicator: hoverIndicatorPropType
       .description(
         `When 'onClick' has been specified, the hover indicator to apply
@@ -254,56 +219,7 @@ of indicating the DOM tag via the 'as' property.`,
     as: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
       .description('The DOM tag or react component to use for the element.')
       .defaultValue('div'),
-    width: PropTypes.oneOfType([
-      PropTypes.oneOf([
-        'xxsmall',
-        'xsmall',
-        'small',
-        'medium',
-        'large',
-        'xlarge',
-        'xxlarge',
-      ]),
-      PropTypes.string,
-      PropTypes.shape({
-        width: PropTypes.oneOfType([
-          PropTypes.oneOf([
-            'xxsmall',
-            'xsmall',
-            'small',
-            'medium',
-            'large',
-            'xlarge',
-            'xxlarge',
-          ]),
-          PropTypes.string,
-        ]),
-        min: PropTypes.oneOfType([
-          PropTypes.oneOf([
-            'xxsmall',
-            'xsmall',
-            'small',
-            'medium',
-            'large',
-            'xlarge',
-            'xxlarge',
-          ]),
-          PropTypes.string,
-        ]),
-        max: PropTypes.oneOfType([
-          PropTypes.oneOf([
-            'xxsmall',
-            'xsmall',
-            'small',
-            'medium',
-            'large',
-            'xlarge',
-            'xxlarge',
-          ]),
-          PropTypes.string,
-        ]),
-      }),
-    ]).description('A fixed width.'),
+    width: widthPropType.description('A fixed width.'),
     wrap: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['reverse'])])
       .description(`Whether children can wrap if they can't all fit.`)
       .defaultValue(false),

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -11,10 +11,12 @@ import {
   FillType,
   GapType,
   GridAreaType,
+  HeightType,
   MarginType,
   PadType,
   PolymorphicType,
   RoundType,
+  WidthType,
 } from '../../utils';
 
 export interface BoxProps {
@@ -92,35 +94,7 @@ export interface BoxProps {
   fill?: FillType;
   focusIndicator?: boolean;
   gap?: GapType;
-  height?:
-    | 'xxsmall'
-    | 'xsmall'
-    | 'small'
-    | 'medium'
-    | 'large'
-    | 'xlarge'
-    | 'xxlarge'
-    | string
-    | {
-        max?:
-          | 'xxsmall'
-          | 'xsmall'
-          | 'small'
-          | 'medium'
-          | 'large'
-          | 'xlarge'
-          | 'xxlarge'
-          | string;
-        min?:
-          | 'xxsmall'
-          | 'xsmall'
-          | 'small'
-          | 'medium'
-          | 'large'
-          | 'xlarge'
-          | 'xxlarge'
-          | string;
-      };
+  height?: HeightType;
   hoverIndicator?:
     | { background?: BackgroundType; elevation?: ElevationType }
     | BackgroundType
@@ -149,44 +123,7 @@ export interface BoxProps {
   round?: RoundType;
   tag?: PolymorphicType;
   as?: PolymorphicType;
-  width?:
-    | 'xxsmall'
-    | 'xsmall'
-    | 'small'
-    | 'medium'
-    | 'large'
-    | 'xlarge'
-    | 'xxlarge'
-    | string
-    | {
-        width?:
-          | 'xxsmall'
-          | 'xsmall'
-          | 'small'
-          | 'medium'
-          | 'large'
-          | 'xlarge'
-          | 'xxlarge'
-          | string;
-        max?:
-          | 'xxsmall'
-          | 'xsmall'
-          | 'small'
-          | 'medium'
-          | 'large'
-          | 'xlarge'
-          | 'xxlarge'
-          | string;
-        min?:
-          | 'xxsmall'
-          | 'xsmall'
-          | 'small'
-          | 'medium'
-          | 'large'
-          | 'xlarge'
-          | 'xxlarge'
-          | string;
-      };
+  width?: WidthType;
   wrap?: boolean | 'reverse';
 }
 

--- a/src/js/components/Grid/Grid.js
+++ b/src/js/components/Grid/Grid.js
@@ -7,10 +7,12 @@ const Grid = forwardRef((props, ref) => {
     a11yTitle,
     border,
     fill, // munged to avoid styled-components putting it in the DOM
+    height, // munged to avoid styled-components putting it in the DOM
     responsive = true,
     rows, // munged to avoid styled-components putting it in the DOM
     tag,
     as,
+    width, // munged to avoid styled-components putting it in the DOM
     ...rest
   } = props;
 
@@ -21,8 +23,10 @@ const Grid = forwardRef((props, ref) => {
       as={!as && tag ? tag : as}
       border={border}
       fillContainer={fill}
+      heightProp={height}
       responsive={responsive}
       rowsProp={rows}
+      widthProp={width}
       {...rest}
     />
   );

--- a/src/js/components/Grid/README.md
+++ b/src/js/components/Grid/README.md
@@ -384,6 +384,50 @@ none
 string
 ```
 
+**height**
+
+A fixed height.
+
+```
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+xxlarge
+string
+{
+  height: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  min: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  max: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string
+}
+```
+
 **justify**
 
 How to align the individual items inside the grid when there is extra
@@ -568,6 +612,50 @@ The DOM tag or react component to use for the element. Defaults to `div`.
 ```
 string
 function
+```
+
+**width**
+
+A fixed width.
+
+```
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+xxlarge
+string
+{
+  width: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  min: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  max: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string
+}
 ```
   
 ## Intrinsic element

--- a/src/js/components/Grid/StyledGrid.js
+++ b/src/js/components/Grid/StyledGrid.js
@@ -1,6 +1,12 @@
 import styled, { css } from 'styled-components';
 
-import { borderStyle, edgeStyle, genericStyles } from '../../utils';
+import {
+  borderStyle,
+  edgeStyle,
+  genericStyles,
+  heightStyle,
+  widthStyle,
+} from '../../utils';
 import { defaultProps } from '../../default-props';
 
 const fillStyle = fill => {
@@ -247,6 +253,8 @@ const StyledGrid = styled.div.attrs(props => ({
       props.theme,
     )}
   ${props => props.rowsProp && rowsStyle(props)}
+  ${props => props.heightProp && heightStyle(props.heightProp, props.theme)}
+  ${props => props.widthProp && widthStyle(props.widthProp, props.theme)}
   ${props => props.theme.grid && props.theme.grid.extend}
 `;
 

--- a/src/js/components/Grid/__tests__/Grid-test.js
+++ b/src/js/components/Grid/__tests__/Grid-test.js
@@ -311,7 +311,7 @@ describe('Grid', () => {
   });
 
   test('width', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid width="xsmall" />
         <Grid width="small" />
@@ -321,22 +321,20 @@ describe('Grid', () => {
         <Grid width="111px" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   test('width object', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid width={{ width: '100px', max: '100%' }} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   test('height', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid height="xsmall" />
         <Grid height="small" />
@@ -346,17 +344,15 @@ describe('Grid', () => {
         <Grid height="111px" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   test('height object', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid height={{ height: '100px', max: '100%' }} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 });

--- a/src/js/components/Grid/__tests__/Grid-test.js
+++ b/src/js/components/Grid/__tests__/Grid-test.js
@@ -309,4 +309,54 @@ describe('Grid', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  test('width', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid width="xsmall" />
+        <Grid width="small" />
+        <Grid width="medium" />
+        <Grid width="large" />
+        <Grid width="xlarge" />
+        <Grid width="111px" />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('width object', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid width={{ width: '100px', max: '100%' }} />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('height', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid height="xsmall" />
+        <Grid height="small" />
+        <Grid height="medium" />
+        <Grid height="large" />
+        <Grid height="xlarge" />
+        <Grid height="111px" />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('height object', () => {
+    const component = renderer.create(
+      <Grommet>
+        <Grid height={{ height: '100px', max: '100%' }} />
+      </Grommet>,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
+++ b/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
@@ -789,6 +789,103 @@ exports[`Grid gap renders 1`] = `
 </div>
 `;
 
+exports[`Grid height 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  height: 96px;
+}
+
+.c2 {
+  display: grid;
+  box-sizing: border-box;
+  height: 192px;
+}
+
+.c3 {
+  display: grid;
+  box-sizing: border-box;
+  height: 384px;
+}
+
+.c4 {
+  display: grid;
+  box-sizing: border-box;
+  height: 768px;
+}
+
+.c5 {
+  display: grid;
+  box-sizing: border-box;
+  height: 1152px;
+}
+
+.c6 {
+  display: grid;
+  box-sizing: border-box;
+  height: 111px;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  />
+  <div
+    className="c2"
+  />
+  <div
+    className="c3"
+  />
+  <div
+    className="c4"
+  />
+  <div
+    className="c5"
+  />
+  <div
+    className="c6"
+  />
+</div>
+`;
+
+exports[`Grid height object 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  max-height: 100%;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  />
+</div>
+`;
+
 exports[`Grid justify renders 1`] = `
 .c0 {
   font-size: 18px;
@@ -1229,6 +1326,104 @@ exports[`Grid rows renders with warning 1`] = `
   display: grid;
   box-sizing: border-box;
   grid-template-rows: 1fr;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  />
+</div>
+`;
+
+exports[`Grid width 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  width: 96px;
+}
+
+.c2 {
+  display: grid;
+  box-sizing: border-box;
+  width: 192px;
+}
+
+.c3 {
+  display: grid;
+  box-sizing: border-box;
+  width: 384px;
+}
+
+.c4 {
+  display: grid;
+  box-sizing: border-box;
+  width: 768px;
+}
+
+.c5 {
+  display: grid;
+  box-sizing: border-box;
+  width: 1152px;
+}
+
+.c6 {
+  display: grid;
+  box-sizing: border-box;
+  width: 111px;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  />
+  <div
+    className="c2"
+  />
+  <div
+    className="c3"
+  />
+  <div
+    className="c4"
+  />
+  <div
+    className="c5"
+  />
+  <div
+    className="c6"
+  />
+</div>
+`;
+
+exports[`Grid width object 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  max-width: 100%;
+  width: 100px;
 }
 
 <div

--- a/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
+++ b/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
@@ -836,27 +836,29 @@ exports[`Grid height 1`] = `
   height: 111px;
 }
 
-<div
-  className="c0"
->
+<div>
   <div
-    className="c1"
-  />
-  <div
-    className="c2"
-  />
-  <div
-    className="c3"
-  />
-  <div
-    className="c4"
-  />
-  <div
-    className="c5"
-  />
-  <div
-    className="c6"
-  />
+    class="c0"
+  >
+    <div
+      class="c1"
+    />
+    <div
+      class="c2"
+    />
+    <div
+      class="c3"
+    />
+    <div
+      class="c4"
+    />
+    <div
+      class="c5"
+    />
+    <div
+      class="c6"
+    />
+  </div>
 </div>
 `;
 
@@ -877,12 +879,14 @@ exports[`Grid height object 1`] = `
   max-height: 100%;
 }
 
-<div
-  className="c0"
->
+<div>
   <div
-    className="c1"
-  />
+    class="c0"
+  >
+    <div
+      class="c1"
+    />
+  </div>
 </div>
 `;
 
@@ -1384,27 +1388,29 @@ exports[`Grid width 1`] = `
   width: 111px;
 }
 
-<div
-  className="c0"
->
+<div>
   <div
-    className="c1"
-  />
-  <div
-    className="c2"
-  />
-  <div
-    className="c3"
-  />
-  <div
-    className="c4"
-  />
-  <div
-    className="c5"
-  />
-  <div
-    className="c6"
-  />
+    class="c0"
+  >
+    <div
+      class="c1"
+    />
+    <div
+      class="c2"
+    />
+    <div
+      class="c3"
+    />
+    <div
+      class="c4"
+    />
+    <div
+      class="c5"
+    />
+    <div
+      class="c6"
+    />
+  </div>
 </div>
 `;
 
@@ -1426,11 +1432,13 @@ exports[`Grid width object 1`] = `
   width: 100px;
 }
 
-<div
-  className="c0"
->
+<div>
   <div
-    className="c1"
-  />
+    class="c0"
+  >
+    <div
+      class="c1"
+    />
+  </div>
 </div>
 `;

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -3,7 +3,9 @@ import { describe, PropTypes } from 'react-desc';
 import {
   genericProps,
   getBorderPropType,
+  heightPropType,
   padPropType,
+  widthPropType,
 } from '../../utils/prop-types';
 import { getAvailableAtBadge } from '../../utils/mixins';
 import { themeDocUtils } from '../../utils/themeDocUtils';
@@ -154,6 +156,7 @@ space in the column axis.`,
       }),
       PropTypes.string,
     ]).description('Gap sizes between rows and/or columns.'),
+    height: heightPropType.description('A fixed height.'),
     justify: PropTypes.oneOf(['start', 'center', 'end', 'stretch'])
       .description(
         `How to align the individual items inside the grid when there is extra
@@ -200,6 +203,7 @@ space in the row axis.`,
     as: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
       .description('The DOM tag or react component to use for the element.')
       .defaultValue('div'),
+    width: widthPropType.description('A fixed width.'),
   };
 
   return DocumentedGrid;

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -7,10 +7,12 @@ import {
   FillType,
   GapType,
   GridAreaType,
+  HeightType,
   JustifyContentType,
   MarginType,
   PadType,
   PolymorphicType,
+  WidthType,
 } from '../../utils';
 
 export interface GridProps {
@@ -69,6 +71,7 @@ export interface GridProps {
   fill?: FillType;
   gap?: GapType | { row?: GapType; column?: GapType };
   gridArea?: GridAreaType;
+  height?: HeightType;
   justify?: 'start' | 'center' | 'end' | 'stretch';
   justifyContent?: JustifyContentType;
   margin?: MarginType;
@@ -100,6 +103,7 @@ export interface GridProps {
     | 'xlarge'
     | string;
   tag?: PolymorphicType;
+  width?: WidthType;
 }
 
 type divProps = JSX.IntrinsicElements['div'];

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -1478,6 +1478,15 @@ xlarge
 xxlarge
 string
 {
+  height: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
   min: 
     xxsmall
     xsmall
@@ -10430,6 +10439,50 @@ none
 string
 \`\`\`
 
+**height**
+
+A fixed height.
+
+\`\`\`
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+xxlarge
+string
+{
+  height: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  min: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  max: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string
+}
+\`\`\`
+
 **justify**
 
 How to align the individual items inside the grid when there is extra
@@ -10614,6 +10667,50 @@ The DOM tag or react component to use for the element. Defaults to \`div\`.
 \`\`\`
 string
 function
+\`\`\`
+
+**width**
+
+A fixed width.
+
+\`\`\`
+xxsmall
+xsmall
+small
+medium
+large
+xlarge
+xxlarge
+string
+{
+  width: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  min: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  max: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string
+}
 \`\`\`
   
 ## Intrinsic element

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -818,6 +818,15 @@ xlarge
 xxlarge
 string
 {
+  height: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
   min: 
     xxsmall
     xsmall
@@ -4705,6 +4714,47 @@ string",
         "name": "gap",
       },
       Object {
+        "description": "A fixed height.",
+        "format": "xxsmall
+xsmall
+small
+medium
+large
+xlarge
+xxlarge
+string
+{
+  height: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  min: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  max: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string
+}",
+        "name": "height",
+      },
+      Object {
         "defaultValue": "stretch",
         "description": "How to align the individual items inside the grid when there is extra
 space in the row axis.",
@@ -4872,6 +4922,47 @@ function",
         "format": "string
 function",
         "name": "as",
+      },
+      Object {
+        "description": "A fixed width.",
+        "format": "xxsmall
+xsmall
+small
+medium
+large
+xlarge
+xxlarge
+string
+{
+  width: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  min: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string,
+  max: 
+    xxsmall
+    xsmall
+    small
+    medium
+    large
+    xlarge
+    xxlarge
+    string
+}",
+        "name": "width",
       },
     ],
     "usage": "import { Grid } from 'grommet';

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -56,6 +56,15 @@ export type PropsOf<TComponent> = TComponent extends React.ComponentType<
   ? P
   : never;
 
+// the basic T-Shirt sizes xsmall through xlarge. Some places add on.
+type TShirtSizeType =
+  | 'xsmall'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'xlarge'
+  | string;
+
 // Extracting types for common properties among components
 type BoxSideType =
   | 'top'
@@ -261,3 +270,25 @@ declare const breakpointSize: {
   full?: string;
 };
 export type BreakpointSize = typeof breakpointSize;
+
+export type HeightType =
+  | 'xxsmall'
+  | 'xxlarge'
+  | TShirtSizeType
+  | '100%'
+  | {
+      height?: 'xxsmall' | 'xxlarge' | TShirtSizeType | '100%';
+      max?: 'xxsmall' | 'xxlarge' | TShirtSizeType | '100%';
+      min?: 'xxsmall' | 'xxlarge' | TShirtSizeType | '100%';
+    };
+
+export type WidthType =
+  | 'xxsmall'
+  | 'xxlarge'
+  | TShirtSizeType
+  | '100%'
+  | {
+      width?: 'xxsmall' | 'xxlarge' | TShirtSizeType | '100%';
+      max?: 'xxsmall' | 'xxlarge' | TShirtSizeType | '100%';
+      min?: 'xxsmall' | 'xxlarge' | TShirtSizeType | '100%';
+    };

--- a/src/js/utils/prop-types.js
+++ b/src/js/utils/prop-types.js
@@ -217,3 +217,33 @@ export const roundPropType = PropTypes.oneOfType([
 ])
   .description('How much to round the corners.')
   .defaultValue(undefined);
+
+const dimSizeType = PropTypes.oneOf([
+  'xxsmall',
+  'xsmall',
+  'small',
+  'medium',
+  'large',
+  'xlarge',
+  'xxlarge',
+]);
+
+export const heightPropType = PropTypes.oneOfType([
+  dimSizeType,
+  PropTypes.string,
+  PropTypes.shape({
+    height: PropTypes.oneOfType([dimSizeType, PropTypes.string]),
+    min: PropTypes.oneOfType([dimSizeType, PropTypes.string]),
+    max: PropTypes.oneOfType([dimSizeType, PropTypes.string]),
+  }),
+]);
+
+export const widthPropType = PropTypes.oneOfType([
+  dimSizeType,
+  PropTypes.string,
+  PropTypes.shape({
+    width: PropTypes.oneOfType([dimSizeType, PropTypes.string]),
+    min: PropTypes.oneOfType([dimSizeType, PropTypes.string]),
+    max: PropTypes.oneOfType([dimSizeType, PropTypes.string]),
+  }),
+]);

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -749,3 +749,71 @@ const TEXT_ALIGN_MAP = {
 export const textAlignStyle = css`
   text-align: ${props => TEXT_ALIGN_MAP[props.textAlign]};
 `;
+
+const getSize = (theme, size) => theme.global.size[size] || size;
+
+const widthObjectStyle = (width, theme) => {
+  const result = [];
+  if (width.max)
+    result.push(
+      css`
+        max-width: ${getSize(theme, width.max)};
+      `,
+    );
+  if (width.min)
+    result.push(
+      css`
+        min-width: ${getSize(theme, width.min)};
+      `,
+    );
+  if (width.width)
+    result.push(
+      css`
+        width: ${getSize(theme, width.width)};
+      `,
+    );
+  return result;
+};
+
+const widthStringStyle = (width, theme) =>
+  css`
+    width: ${getSize(theme, width)};
+  `;
+
+export const widthStyle = (width, theme) =>
+  typeof width === 'object'
+    ? widthObjectStyle(width, theme)
+    : widthStringStyle(width, theme);
+
+const heightObjectStyle = (height, theme) => {
+  const result = [];
+  if (height.max)
+    result.push(
+      css`
+        max-height: ${getSize(theme, height.max)};
+      `,
+    );
+  if (height.min)
+    result.push(
+      css`
+        min-height: ${getSize(theme, height.min)};
+      `,
+    );
+  if (height.width)
+    result.push(
+      css`
+        height: ${getSize(theme, height.height)};
+      `,
+    );
+  return result;
+};
+
+const heightStringStyle = (height, theme) =>
+  css`
+    height: ${getSize(theme, height)};
+  `;
+
+export const heightStyle = (height, theme) =>
+  typeof height === 'object'
+    ? heightObjectStyle(height, theme)
+    : heightStringStyle(height, theme);


### PR DESCRIPTION
#### What does this PR do?

Changed Grid to add width and height, same as Box.
This makes it easier to use Grid to drive layout without having to wrap with a Box to constrain its dimensions.

#### Where should the reviewer start?

anywhere

#### What testing has been done on this PR?

added unit tests
tested with grommet-designer locally

#### How should this be manually tested?

use it

#### Do the grommet docs need to be updated?

yes, automatic

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
