### PR TITLE
Changed Grid to enhance columns capabilities

### DIFF
--- a/src/js/components/Grid/README.md
+++ b/src/js/components/Grid/README.md
@@ -306,6 +306,15 @@ small
 medium
 large
 xlarge
+full
+1/2
+1/3
+2/3
+1/4
+2/4
+3/4
+flex
+auto
 {
   count: 
     fit
@@ -317,6 +326,15 @@ xlarge
     medium
     large
     xlarge
+    full
+    1/2
+    1/3
+    2/3
+    1/4
+    2/4
+    3/4
+    flex
+    auto
     [
       xsmall
       small

--- a/src/js/components/Grid/StyledGrid.js
+++ b/src/js/components/Grid/StyledGrid.js
@@ -125,8 +125,10 @@ const getRepeatSize = (size, props) => {
   const gaps = gapSizes(props);
   let min;
   let max;
+  let minFill;
   if (Array.isArray(size)) {
     min = normalizeSize(size[0], props);
+    if (min.search(/px/) !== -1) minFill = true;
     max = normalizeSize(size[1], props);
     if (gaps[1] !== undefined) {
       // account for the column gap when using fractional sizes, e.g. 1/3
@@ -137,6 +139,7 @@ const getRepeatSize = (size, props) => {
     }
   } else {
     min = normalizeSize(size, props);
+    if (min.search(/px/) !== -1) minFill = true;
     max = '1fr';
     if (gaps[1] !== undefined) {
       // account for column gap with fractional sizes, e.g. 1/3
@@ -144,7 +147,7 @@ const getRepeatSize = (size, props) => {
         min = `calc(${min} - (${gaps[1]} * (1 - ${size})))`;
     }
   }
-  if (min.indexOf('%') === -1) {
+  if (minFill) {
     // ensure we never go beyond the container width,
     // for mobile/narrow situations
     min = `min(${min}, 100%)`;

--- a/src/js/components/Grid/StyledGrid.js
+++ b/src/js/components/Grid/StyledGrid.js
@@ -73,30 +73,32 @@ const justifyContentStyle = css`
   justify-content: ${props => JUSTIFY_CONTENT_MAP[props.justifyContent]};
 `;
 
-const gapStyle = props => {
+const gapSizes = props => {
+  const result = [];
   if (typeof props.gap === 'string') {
-    const gapSize = props.theme.global.edgeSize[props.gap] || props.gap;
-    return `grid-gap: ${gapSize} ${gapSize};`;
+    const size = props.theme.global.edgeSize[props.gap] || props.gap;
+    result[0] = size;
+    result[1] = size;
+  } else if (props.gap) {
+    if (props.gap.row)
+      result[0] = props.theme.global.edgeSize[props.gap.row] || props.gap.row;
+    if (props.gap.column)
+      result[1] =
+        props.theme.global.edgeSize[props.gap.column] || props.gap.column;
   }
-  if (props.gap.row && props.gap.column) {
-    return `
-      grid-row-gap: ${props.theme.global.edgeSize[props.gap.row] ||
-        props.gap.row};
-      grid-column-gap: ${props.theme.global.edgeSize[props.gap.column] ||
-        props.gap.column};
-    `;
+  return result;
+};
+
+const gapStyle = props => {
+  const sizes = gapSizes(props);
+  if (sizes[0] !== undefined && sizes[1] !== undefined) {
+    return `grid-gap: ${sizes[0]} ${sizes[1]};`;
   }
-  if (props.gap.row) {
-    return `
-      grid-row-gap: ${props.theme.global.edgeSize[props.gap.row] ||
-        props.gap.row};
-    `;
+  if (sizes[0] !== undefined) {
+    return `grid-row-gap: ${sizes[0]};`;
   }
-  if (props.gap.column) {
-    return `
-      grid-column-gap: ${props.theme.global.edgeSize[props.gap.column] ||
-        props.gap.column};
-    `;
+  if (sizes[1] !== undefined) {
+    return `grid-column-gap: ${sizes[1]};`;
   }
   return '';
 };
@@ -112,36 +114,42 @@ const SIZE_MAP = {
   '2/3': '66.66%',
 };
 
-const getRepeatCount = count =>
-  typeof count === 'number' ? count : `auto-${count}`;
+const normalizeSize = (size, props) =>
+  SIZE_MAP[size] || props.theme.global.size[size] || size;
 
-const getRepeatSize = (size, theme) => {
+const getRepeatCount = count =>
+  typeof count === 'number' ? count : `auto-${count || 'fit'}`;
+
+const getRepeatSize = (size, props) => {
   if (size === 'flex') return '1fr';
+  const gaps = gapSizes(props);
   let min;
   let max;
   if (Array.isArray(size)) {
-    min = theme.global.size[size[0]] || size[0];
-    max = theme.global.size[size[1]] || size[1];
+    min = normalizeSize(size[0], props);
+    max = normalizeSize(size[1], props);
+    if (gaps[1] !== undefined) {
+      // account for the column gap when using fractional sizes, e.g. 1/3
+      if (size[0].indexOf('/') !== -1)
+        min = `calc(${min} - (${gaps[1]} * (1 - ${size[0]})))`;
+      if (size[1].indexOf('/') !== -1)
+        max = `calc(${max} - (${gaps[1]} * (1 - ${size[1]})))`;
+    }
   } else {
-    min = theme.global.size[size] || size;
+    min = normalizeSize(size, props);
     max = '1fr';
+    if (gaps[1] !== undefined) {
+      // account for column gap with fractional sizes, e.g. 1/3
+      if (size.indexOf('/') !== -1)
+        min = `calc(${min} - (${gaps[1]} * (1 - ${size})))`;
+    }
   }
-  if (min.search(/\d/) !== -1) {
+  if (min.indexOf('%') === -1) {
+    // ensure we never go beyond the container width,
+    // for mobile/narrow situations
     min = `min(${min}, 100%)`;
   }
   return `minmax(${min}, ${max})`;
-};
-
-const sizeFor = (size, props, isRow) => {
-  const mapped = SIZE_MAP[size];
-  if (
-    isRow &&
-    mapped &&
-    (!props.fillContainer || props.fillContainer === 'horizontal')
-  ) {
-    console.warn('Grid needs `fill` when using fractional row sizes');
-  }
-  return mapped || props.theme.global.size[size] || size;
 };
 
 const columnsStyle = props => {
@@ -150,9 +158,12 @@ const columnsStyle = props => {
       grid-template-columns: ${props.columns
         .map(s => {
           if (Array.isArray(s)) {
-            return `minmax(${sizeFor(s[0], props)}, ${sizeFor(s[1], props)})`;
+            return `minmax(${normalizeSize(s[0], props)}, ${normalizeSize(
+              s[1],
+              props,
+            )})`;
           }
-          return sizeFor(s, props);
+          return normalizeSize(s, props);
         })
         .join(' ')};
     `;
@@ -161,14 +172,14 @@ const columnsStyle = props => {
     return css`
       grid-template-columns: repeat(
         ${getRepeatCount(props.columns.count)},
-        ${getRepeatSize(props.columns.size, props.theme)}
+        ${getRepeatSize(props.columns.size, props)}
       );
     `;
   }
   return css`
     grid-template-columns: repeat(
       auto-fill,
-      ${getRepeatSize(props.columns, props.theme)}
+      ${getRepeatSize(props.columns, props)}
     );
   `;
 };
@@ -179,13 +190,12 @@ const rowsStyle = props => {
       grid-template-rows: ${props.rowsProp
         .map(s => {
           if (Array.isArray(s)) {
-            return `minmax(${sizeFor(s[0], props, true)}, ${sizeFor(
+            return `minmax(${normalizeSize(s[0], props)}, ${normalizeSize(
               s[1],
               props,
-              true,
             )})`;
           }
-          return sizeFor(s, props, true);
+          return normalizeSize(s, props);
         })
         .join(' ')};
     `;

--- a/src/js/components/Grid/__tests__/Grid-test.js
+++ b/src/js/components/Grid/__tests__/Grid-test.js
@@ -40,21 +40,6 @@ describe('Grid', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  test('rows renders with warning', () => {
-    console.warn = jest.fn();
-    const warnSpy = jest.spyOn(console, 'warn');
-    const component = renderer.create(
-      <Grommet>
-        <Grid rows={['flex']} fill={false} />
-      </Grommet>,
-    );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    expect(warnSpy).toHaveBeenCalledWith(
-      'Grid needs `fill` when using fractional row sizes',
-    );
-  });
-
   test('columns renders', () => {
     const component = renderer.create(
       <Grommet>
@@ -63,9 +48,12 @@ describe('Grid', () => {
         <Grid columns={['1/4', '3/4']} />
         <Grid columns={[['1/2', '2/4'], '1/4', '3/4']} />
         <Grid columns="small" />
+        <Grid columns="1/3" />
         <Grid columns="flex" />
         <Grid columns={{ count: 'fit', size: 'small' }} />
         <Grid columns={{ count: 'fill', size: ['small', 'medium'] }} />
+        <Grid columns={{ count: 'fit', size: ['small', '1/2'] }} />
+        <Grid columns={{ count: 'fit', size: ['1/4', 'medium'] }} />
       </Grommet>,
     );
     const tree = component.toJSON();

--- a/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
+++ b/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
@@ -575,19 +575,37 @@ exports[`Grid columns renders 1`] = `
 .c6 {
   display: grid;
   box-sizing: border-box;
-  grid-template-columns: repeat( auto-fill,1fr );
+  grid-template-columns: repeat( auto-fill,minmax(33.33%,1fr) );
 }
 
 .c7 {
   display: grid;
   box-sizing: border-box;
-  grid-template-columns: repeat( auto-fit,minmax(min(192px,100%),1fr) );
+  grid-template-columns: repeat( auto-fill,1fr );
 }
 
 .c8 {
   display: grid;
   box-sizing: border-box;
+  grid-template-columns: repeat( auto-fit,minmax(min(192px,100%),1fr) );
+}
+
+.c9 {
+  display: grid;
+  box-sizing: border-box;
   grid-template-columns: repeat( auto-fill,minmax(min(192px,100%),384px) );
+}
+
+.c10 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-columns: repeat( auto-fit,minmax(min(192px,100%),50%) );
+}
+
+.c11 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-columns: repeat( auto-fit,minmax(25%,384px) );
 }
 
 <div
@@ -616,6 +634,15 @@ exports[`Grid columns renders 1`] = `
   />
   <div
     className="c8"
+  />
+  <div
+    className="c9"
+  />
+  <div
+    className="c10"
+  />
+  <div
+    className="c11"
   />
 </div>
 `;
@@ -741,8 +768,7 @@ exports[`Grid gap renders 1`] = `
 .c10 {
   display: grid;
   box-sizing: border-box;
-  grid-row-gap: 12px;
-  grid-column-gap: 24px;
+  grid-gap: 12px 24px;
 }
 
 .c11 {
@@ -1311,32 +1337,6 @@ exports[`Grid rows renders 1`] = `
   />
   <div
     className="c3"
-  />
-</div>
-`;
-
-exports[`Grid rows renders with warning 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: grid;
-  box-sizing: border-box;
-  grid-template-rows: 1fr;
-}
-
-<div
-  className="c0"
->
-  <div
-    className="c1"
   />
 </div>
 `;

--- a/src/js/components/Grid/doc.js
+++ b/src/js/components/Grid/doc.js
@@ -112,14 +112,14 @@ space in the column axis.`,
           PropTypes.string,
         ]),
       ),
-      PropTypes.oneOf(fixedSizes),
+      PropTypes.oneOf(sizes),
       PropTypes.shape({
         count: PropTypes.oneOfType([
           PropTypes.oneOf(['fit', 'fill']),
           PropTypes.number,
         ]),
         size: PropTypes.oneOfType([
-          PropTypes.oneOf(fixedSizes),
+          PropTypes.oneOf(sizes),
           PropTypes.arrayOf(
             PropTypes.oneOfType([PropTypes.oneOf(sizes), PropTypes.string]),
           ),

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -15,6 +15,24 @@ import {
   WidthType,
 } from '../../utils';
 
+export type GridSizeType =
+  | 'xsmall'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'xlarge'
+  | 'full'
+  | '1/2'
+  | '1/3'
+  | '2/3'
+  | '1/4'
+  | '2/4'
+  | '3/4'
+  | 'flex'
+  | 'auto'
+  | string
+  | string[];
+
 export interface GridProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
@@ -24,50 +42,12 @@ export interface GridProps {
   as?: PolymorphicType;
   border?: BorderType;
   columns?:
-    | (
-        | 'xsmall'
-        | 'small'
-        | 'medium'
-        | 'large'
-        | 'xlarge'
-        | 'full'
-        | '1/2'
-        | '1/3'
-        | '2/3'
-        | '1/4'
-        | '2/4'
-        | '3/4'
-        | 'flex'
-        | 'auto'
-        | string
-        | string[]
-      )[]
-    | 'xsmall'
-    | 'small'
-    | 'medium'
-    | 'large'
-    | 'xlarge'
+    | GridSizeType
+    | GridSizeType[]
     | {
         count?: 'fit' | 'fill' | number;
-        size?:
-          | 'xsmall'
-          | 'small'
-          | 'medium'
-          | 'large'
-          | 'xlarge'
-          | 'full'
-          | '1/2'
-          | '1/3'
-          | '2/3'
-          | '1/4'
-          | '2/4'
-          | '3/4'
-          | 'flex'
-          | 'auto'
-          | string
-          | string[];
-      }
-    | string;
+        size?: GridSizeType;
+      };
   fill?: FillType;
   gap?: GapType | { row?: GapType; column?: GapType };
   gridArea?: GridAreaType;
@@ -77,31 +57,7 @@ export interface GridProps {
   margin?: MarginType;
   pad?: PadType;
   responsive?: boolean;
-  rows?:
-    | (
-        | 'xsmall'
-        | 'small'
-        | 'medium'
-        | 'large'
-        | 'xlarge'
-        | 'full'
-        | '1/2'
-        | '1/3'
-        | '2/3'
-        | '1/4'
-        | '2/4'
-        | '3/4'
-        | 'flex'
-        | 'auto'
-        | string
-        | string[]
-      )[]
-    | 'xsmall'
-    | 'small'
-    | 'medium'
-    | 'large'
-    | 'xlarge'
-    | string;
+  rows?: GridSizeType | GridSizeType[];
   tag?: PolymorphicType;
   width?: WidthType;
 }

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -10381,6 +10381,15 @@ small
 medium
 large
 xlarge
+full
+1/2
+1/3
+2/3
+1/4
+2/4
+3/4
+flex
+auto
 {
   count: 
     fit
@@ -10392,6 +10401,15 @@ xlarge
     medium
     large
     xlarge
+    full
+    1/2
+    1/3
+    2/3
+    1/4
+    2/4
+    3/4
+    flex
+    auto
     [
       xsmall
       small

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -4641,6 +4641,15 @@ small
 medium
 large
 xlarge
+full
+1/2
+1/3
+2/3
+1/4
+2/4
+3/4
+flex
+auto
 {
   count: 
     fit
@@ -4652,6 +4661,15 @@ xlarge
     medium
     large
     xlarge
+    full
+    1/2
+    1/3
+    2/3
+    1/4
+    2/4
+    3/4
+    flex
+    auto
     [
       xsmall
       small


### PR DESCRIPTION
#### What does this PR do?

Changed Grid to enhance columns capabilities.

Particularly, this change allows single fractional column sizes or min/max fractional sizes. For instance, you can now do `columns={{ size: ['small', '1/3'] }}` which says the columns should at least be small but not more than 1/3 of the available space. 

It also takes care of automatically accounting for any gap. So, if you have columns="1/3" gap="medium", you will actually get three columns. Before, you would get two, since the gap space would prevent three columns from being shown.

#### Where should the reviewer start?

index.d.ts

#### What testing has been done on this PR?

added unit tests
custom stories with a variety of columns
grommet designer

#### How should this be manually tested?

Ideally, try it out with a variety of `columns` values.

#### Do the grommet docs need to be updated?

yes, additional custom example syntaxes should be added, once this goes in.

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
