### PR TITLE
Fix keyboard behavior of RadioButtonGroup

### DIFF
--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -3022,7 +3022,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
           role="radiogroup"
         >
           <label
-            class="StyledRadioButton__StyledRadioButtonContainer-g1f6ld-0 hnWETW"
+            class="StyledRadioButton__StyledRadioButtonContainer-g1f6ld-0 hHFdON"
             for="test-radiobuttongroup-one"
           >
             <div
@@ -3049,7 +3049,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
             class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
           />
           <label
-            class="StyledRadioButton__StyledRadioButtonContainer-g1f6ld-0 hnWETW"
+            class="StyledRadioButton__StyledRadioButtonContainer-g1f6ld-0 hHFdON"
             for="test-radiobuttongroup-two"
           >
             <div
@@ -3076,7 +3076,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
             class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
           />
           <label
-            class="StyledRadioButton__StyledRadioButtonContainer-g1f6ld-0 hnWETW"
+            class="StyledRadioButton__StyledRadioButtonContainer-g1f6ld-0 hHFdON"
             for="test-radiobuttongroup-three"
           >
             <div

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -2811,6 +2811,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
                 class="c22"
                 id="test-radiobuttongroup-one"
                 name="test-radiobuttongroup"
+                tabindex="-1"
                 type="radio"
                 value="one"
               />
@@ -2838,6 +2839,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
                 class="c22"
                 id="test-radiobuttongroup-two"
                 name="test-radiobuttongroup"
+                tabindex="0"
                 type="radio"
                 value="two"
               />
@@ -2877,6 +2879,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
                 class="c22"
                 id="test-radiobuttongroup-three"
                 name="test-radiobuttongroup"
+                tabindex="-1"
                 type="radio"
                 value="three"
               />
@@ -3032,6 +3035,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
                 class="StyledRadioButton__StyledRadioButtonInput-g1f6ld-1 hIKMbD"
                 id="test-radiobuttongroup-one"
                 name="test-radiobuttongroup"
+                tabindex="0"
                 type="radio"
                 value="one"
               />
@@ -3059,6 +3063,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
                 class="StyledRadioButton__StyledRadioButtonInput-g1f6ld-1 hIKMbD"
                 id="test-radiobuttongroup-two"
                 name="test-radiobuttongroup"
+                tabindex="-1"
                 type="radio"
                 value="two"
               />
@@ -3086,6 +3091,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
                 class="StyledRadioButton__StyledRadioButtonInput-g1f6ld-1 hIKMbD"
                 id="test-radiobuttongroup-three"
                 name="test-radiobuttongroup"
+                tabindex="-1"
                 type="radio"
                 value="three"
               />

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -27,6 +27,7 @@ const grommetInputNames = [
   'TextArea',
   'DateInput',
   'FileInput',
+  'RadioButtonGroup',
 ];
 const grommetInputPadNames = [
   'CheckBox',

--- a/src/js/components/RadioButton/RadioButton.js
+++ b/src/js/components/RadioButton/RadioButton.js
@@ -22,6 +22,7 @@ const RadioButton = forwardRef(
       children,
       disabled,
       focus,
+      focusIndicator,
       id,
       label,
       name,
@@ -55,6 +56,8 @@ const RadioButton = forwardRef(
             event.stopPropagation();
           }
         }}
+        focus={focus}
+        focusIndicator={focusIndicator}
         onMouseEnter={() => setHover(true)}
         onMouseLeave={() => setHover(false)}
       >
@@ -82,7 +85,7 @@ const RadioButton = forwardRef(
             children({ checked, hover })
           ) : (
             <StyledRadioButtonBox
-              focus={focus}
+              focus={focus && focusIndicator}
               as={Box}
               align="center"
               justify="center"

--- a/src/js/components/RadioButton/StyledRadioButton.js
+++ b/src/js/components/RadioButton/StyledRadioButton.js
@@ -33,8 +33,9 @@ const StyledRadioButtonContainer = styled.label`
         props.theme,
       )};
   }
-  // when the radiobutton has focus but there is no focusIndicator,
-  // apply the hover styling instead
+  // when the RadioButton has focus but there is no focusIndicator,
+  // apply the hover styling instead so that keyboard users know
+  // which RadioButton is active
   ${props =>
     props.focus &&
     !props.focusIndicator &&

--- a/src/js/components/RadioButton/StyledRadioButton.js
+++ b/src/js/components/RadioButton/StyledRadioButton.js
@@ -33,6 +33,27 @@ const StyledRadioButtonContainer = styled.label`
         props.theme,
       )};
   }
+  // when the radiobutton has focus but there is no focusIndicator,
+  // apply the hover styling instead
+  ${props =>
+    props.focus &&
+    !props.focusIndicator &&
+    `
+      input:not([disabled]) + div,
+      input:not([disabled]) + span {
+      border-color: ${normalizeColor(
+        props.theme.radioButton.hover.border.color,
+        props.theme,
+      )};
+    }
+    background-color: ${normalizeColor(
+      !props.disabled &&
+        props.theme.radioButton.hover &&
+        props.theme.radioButton.hover.background &&
+        props.theme.radioButton.hover.background.color,
+      props.theme,
+    )};
+    `}
   ${props => props.theme.radioButton.container.extend};
 `;
 

--- a/src/js/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/js/components/RadioButtonGroup/RadioButtonGroup.js
@@ -50,6 +50,7 @@ const RadioButtonGroup = forwardRef(
       defaultValue || '',
     );
 
+    // track if focus is on one of the radio buttons
     const [focus, setFocus] = useState();
 
     const optionRefs = useRef([]);
@@ -67,8 +68,8 @@ const RadioButtonGroup = forwardRef(
     }, [options, value]);
 
     useEffect(() => {
-      // if tab comes back to radiobuttongroup when there still is no selection,
-      // we want focus to be on the first radiobutton
+      // if tab comes back to RadioButtonGroup when there still is no selection,
+      // we want focus to be on the first RadioButton
       if (focus && !valueIndex) {
         optionRefs.current[0].focus();
       }
@@ -132,10 +133,12 @@ const RadioButtonGroup = forwardRef(
               },
               index,
             ) => {
+              // if focus is within the RadioButtonGroup, determine
+              // which radio button should be the active one
               const focusable =
                 optionValue === value ||
                 (value === undefined && !index) ||
-                // when nothing has been selected, focus
+                // when nothing has been selected, show focus
                 // on the first radiobutton
                 (value === '' && index === 0);
               return (
@@ -149,6 +152,11 @@ const RadioButtonGroup = forwardRef(
                   disabled={optionDisabled}
                   checked={optionValue === value}
                   focus={focus && focusable}
+                  // when contained in a FormField, focusIndicator = false,
+                  // so that the FormField has focus style. However, we still
+                  // need to visually indicate when a RadioButton is active.
+                  // In RadioButton, if focus = true but focusIndicator = false,
+                  // we will apply the hover treament.
                   focusIndicator={focusIndicator}
                   id={id}
                   value={optionValue}

--- a/src/js/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/js/components/RadioButtonGroup/RadioButtonGroup.js
@@ -1,4 +1,10 @@
-import React, { forwardRef, useContext, useRef, useState } from 'react';
+import React, {
+  forwardRef,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import { ThemeContext } from 'styled-components';
 import { FormContext } from '../Form/FormContext';
@@ -60,6 +66,14 @@ const RadioButtonGroup = forwardRef(
       return result;
     }, [options, value]);
 
+    useEffect(() => {
+      // if tab comes back to radiobuttongroup when there still is no selection,
+      // we want focus to be on the first radiobutton
+      if (focus && !valueIndex) {
+        optionRefs.current[0].focus();
+      }
+    }, [focus, valueIndex]);
+
     const onNext = () => {
       if (valueIndex !== undefined && valueIndex < options.length - 1) {
         const nextIndex = valueIndex + 1;
@@ -117,38 +131,42 @@ const RadioButtonGroup = forwardRef(
                 ...optionRest
               },
               index,
-            ) => (
-              <RadioButton
-                ref={aRef => {
-                  optionRefs.current[index] = aRef;
-                }}
-                key={optionValue}
-                name={name}
-                label={!children ? label : undefined}
-                disabled={optionDisabled}
-                checked={optionValue === value}
-                focus={
-                  focus &&
-                  (optionValue === value ||
-                    (value === undefined && !index) ||
-                    // when nothing has been selected, focus
-                    // on the first radiobutton
-                    (value === '' && index === 0))
-                }
-                focusIndicator={focusIndicator}
-                id={id}
-                value={optionValue}
-                onFocus={onFocus}
-                onBlur={onBlur}
-                onChange={event => {
-                  setValue(optionValue);
-                  if (onChange) onChange(event);
-                }}
-                {...optionRest}
-              >
-                {children ? state => children(optionsProp[index], state) : null}
-              </RadioButton>
-            ),
+            ) => {
+              const focusable =
+                optionValue === value ||
+                (value === undefined && !index) ||
+                // when nothing has been selected, focus
+                // on the first radiobutton
+                (value === '' && index === 0);
+              return (
+                <RadioButton
+                  ref={aRef => {
+                    optionRefs.current[index] = aRef;
+                  }}
+                  key={optionValue}
+                  name={name}
+                  label={!children ? label : undefined}
+                  disabled={optionDisabled}
+                  checked={optionValue === value}
+                  focus={focus && focusable}
+                  focusIndicator={focusIndicator}
+                  id={id}
+                  value={optionValue}
+                  onFocus={onFocus}
+                  onBlur={onBlur}
+                  onChange={event => {
+                    setValue(optionValue);
+                    if (onChange) onChange(event);
+                  }}
+                  tabIndex={focusable ? '0' : '-1'} // necessary for Firefox
+                  {...optionRest}
+                >
+                  {children
+                    ? state => children(optionsProp[index], state)
+                    : null}
+                </RadioButton>
+              );
+            },
           )}
         </Box>
       </Keyboard>

--- a/src/js/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/js/components/RadioButtonGroup/RadioButtonGroup.js
@@ -1,10 +1,4 @@
-import React, {
-  forwardRef,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { forwardRef, useContext, useRef, useState } from 'react';
 
 import { ThemeContext } from 'styled-components';
 import { FormContext } from '../Form/FormContext';
@@ -19,6 +13,7 @@ const RadioButtonGroup = forwardRef(
       children,
       defaultValue,
       disabled,
+      focusIndicator = true,
       name,
       onChange,
       options: optionsProp,
@@ -65,25 +60,19 @@ const RadioButtonGroup = forwardRef(
       return result;
     }, [options, value]);
 
-    useEffect(() => {
-      if (focus && valueIndex >= 0) optionRefs.current[valueIndex].focus();
-    }, [focus, valueIndex]);
-
     const onNext = () => {
       if (valueIndex !== undefined && valueIndex < options.length - 1) {
         const nextIndex = valueIndex + 1;
-        const nextValue = options[nextIndex].value;
-        setValue(nextValue);
-        if (onChange) onChange({ target: { value: nextValue } });
+        // ensure change event occurs
+        optionRefs.current[nextIndex].click();
       }
     };
 
     const onPrevious = () => {
       if (valueIndex > 0) {
         const nextIndex = valueIndex - 1;
-        const nextValue = options[nextIndex].value;
-        setValue(nextValue);
-        if (onChange) onChange({ target: { value: nextValue } });
+        // ensure change event occurs
+        optionRefs.current[nextIndex].click();
       }
     };
 
@@ -91,10 +80,12 @@ const RadioButtonGroup = forwardRef(
       // Delay just a wee bit so Chrome doesn't missing turning the button on.
       // Chrome behaves differently in that focus is given to radio buttons
       // when the user selects one, unlike Safari and Firefox.
-      setTimeout(() => !focus && setFocus(true), 1);
+      setTimeout(() => {
+        setFocus(true);
+      }, 1);
     };
 
-    const onBlur = () => focus && setFocus(false);
+    const onBlur = () => setFocus(false);
     return (
       <Keyboard
         target="document"
@@ -138,8 +129,13 @@ const RadioButtonGroup = forwardRef(
                 checked={optionValue === value}
                 focus={
                   focus &&
-                  (optionValue === value || (value === undefined && !index))
+                  (optionValue === value ||
+                    (value === undefined && !index) ||
+                    // when nothing has been selected, focus
+                    // on the first radiobutton
+                    (value === '' && index === 0))
                 }
+                focusIndicator={focusIndicator}
                 id={id}
                 value={optionValue}
                 onFocus={onFocus}

--- a/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
+++ b/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
@@ -152,6 +152,7 @@ exports[`RadioButtonGroup adding additional props 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          tabIndex="0"
           type="radio"
           value="1"
         />
@@ -182,6 +183,7 @@ exports[`RadioButtonGroup adding additional props 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          tabIndex="-1"
           type="radio"
           value="2"
         />
@@ -391,6 +393,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          tabIndex="0"
           type="radio"
           value={true}
         />
@@ -437,6 +440,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          tabIndex="-1"
           type="radio"
           value={false}
         />
@@ -596,6 +600,7 @@ exports[`RadioButtonGroup children 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          tabIndex="0"
           type="radio"
           value="one"
         />
@@ -625,6 +630,7 @@ exports[`RadioButtonGroup children 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          tabIndex="-1"
           type="radio"
           value="two"
         />
@@ -829,6 +835,7 @@ exports[`RadioButtonGroup defaultValue 1`] = `
             class="c4"
             id="one"
             name="test"
+            tabindex="0"
             type="radio"
             value="one"
           />
@@ -868,6 +875,7 @@ exports[`RadioButtonGroup defaultValue 1`] = `
             class="c4"
             id="two"
             name="test"
+            tabindex="-1"
             type="radio"
             value="two"
           />
@@ -1083,6 +1091,7 @@ exports[`RadioButtonGroup number options 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          tabIndex="0"
           type="radio"
           value={1}
         />
@@ -1129,6 +1138,7 @@ exports[`RadioButtonGroup number options 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          tabIndex="-1"
           type="radio"
           value={2}
         />
@@ -1304,6 +1314,7 @@ exports[`RadioButtonGroup object options 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          tabIndex="0"
           type="radio"
           value="one"
         />
@@ -1338,6 +1349,7 @@ exports[`RadioButtonGroup object options 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          tabIndex="-1"
           type="radio"
           value="two"
         />
@@ -1542,6 +1554,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          tabIndex="0"
           type="radio"
           value="one"
         />
@@ -1569,6 +1582,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          tabIndex="-1"
           type="radio"
           value="two"
         />
@@ -1769,6 +1783,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          tabIndex="-1"
           type="radio"
           value="one"
         />
@@ -1796,6 +1811,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          tabIndex="0"
           type="radio"
           value="two"
         />
@@ -1956,6 +1972,7 @@ exports[`RadioButtonGroup should have no accessibility violations 1`] = `
             class="c4"
             id="option1"
             name="test"
+            tabindex="0"
             type="radio"
             value="option1"
           />
@@ -2171,6 +2188,7 @@ exports[`RadioButtonGroup string options 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          tabIndex="0"
           type="radio"
           value="one"
         />
@@ -2217,6 +2235,7 @@ exports[`RadioButtonGroup string options 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          tabIndex="-1"
           type="radio"
           value="two"
         />


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes the keyboard behavior for RadioButtonGroup and ensures that the onChange event is always called when the checked radio button changes.

The keyboard event handlers were adjusted to ensure that the native `onChange` event is always called, since it is called every time a user clicks with mouse. Previously, the event was not always called with keyboard navigation.

When in a FormField, the formfield receives focus indicator and the radiobuttons receive hover treatment so it is clear which is active.

In order for the interaction to work correctly on Firefox, a tabindex is toggled between the active radiobutton vs the others to ensure that pressing tab will leave the radiobuttongroup as opposed to navigating between them.

The expected behavior is that (view WCAG demo: https://www.w3.org/TR/2017/WD-wai-aria-practices-1.1-20170628/examples/radio/radio-1/radio-1.html)
- When the RadioButtonGroup receives focus, if nothing has been selected, the first radiobutton should receive focus.
- Pressing space would select the first radiobutton, pressing down arrow should select the second option.
- Using up/now arrows should navigate within the radiobuttons
- Pressing tab should leave the radiobuttongroup

#### Where should the reviewer start?
src/js/components/RadioButtonGroup/RadioButtonGroup.js

#### What testing has been done on this PR?
Tested on Safari, Chrome, and Firefox on Mac with mouse and keyboard.

#### How should this be manually tested?
Navigate through radiobuttons in both the standalone radiobuttongroup and in a form:

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/hpe-design-system/issues/899

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Fixed RadioButtonGroup keyboard interaction to align with WCAG standards.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.