### PR TITLE
Changed MaskedInput to add textAlign

### DIFF
--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
@@ -10346,7 +10346,7 @@ exports[`DateInput select format 2`] = `
     </div>
     <input
       autocomplete="off"
-      class="StyledMaskedInput-sc-99vkfa-0 eVBatt"
+      class="StyledMaskedInput-sc-99vkfa-0 jiFKVa"
       id="item"
       name="item"
       placeholder="mm/dd/yyyy"
@@ -12807,7 +12807,7 @@ exports[`DateInput select format inline 2`] = `
       </div>
       <input
         autocomplete="off"
-        class="StyledMaskedInput-sc-99vkfa-0 eVBatt"
+        class="StyledMaskedInput-sc-99vkfa-0 jiFKVa"
         id="item"
         name="item"
         placeholder="mm/dd/yyyy"
@@ -14877,7 +14877,7 @@ exports[`DateInput select format inline range 2`] = `
       </div>
       <input
         autocomplete="off"
-        class="StyledMaskedInput-sc-99vkfa-0 eVBatt"
+        class="StyledMaskedInput-sc-99vkfa-0 jiFKVa"
         id="item"
         name="item"
         placeholder="mm/dd/yyyy-mm/dd/yyyy"
@@ -18058,7 +18058,7 @@ exports[`DateInput type format inline 2`] = `
       </div>
       <input
         autocomplete="off"
-        class="StyledMaskedInput-sc-99vkfa-0 eVBatt"
+        class="StyledMaskedInput-sc-99vkfa-0 jiFKVa"
         id="item"
         name="item"
         placeholder="mm/dd/yyyy"
@@ -20110,7 +20110,7 @@ exports[`DateInput type format inline short 2`] = `
       </div>
       <input
         autocomplete="off"
-        class="StyledMaskedInput-sc-99vkfa-0 eVBatt"
+        class="StyledMaskedInput-sc-99vkfa-0 jiFKVa"
         id="item"
         name="item"
         placeholder="m/d/yy"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -223,7 +223,7 @@ exports[`Form controlled controlled 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="test"
             placeholder="test input"
             value="v"
@@ -257,7 +257,7 @@ exports[`Form controlled controlled 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="test"
             placeholder="test input"
             value="v"
@@ -519,7 +519,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             id="test"
             name="test"
             value="v"
@@ -559,7 +559,7 @@ exports[`Form controlled controlled FormField deprecated 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             id="test"
             name="test"
             value="v"
@@ -800,7 +800,7 @@ exports[`Form controlled controlled input 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="test"
             placeholder="test input"
             value="v"
@@ -834,7 +834,7 @@ exports[`Form controlled controlled input 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="test"
             placeholder="test input"
             value="v"
@@ -1075,7 +1075,7 @@ exports[`Form controlled controlled input lazy 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="test"
             placeholder="test input"
             value="v"
@@ -1109,7 +1109,7 @@ exports[`Form controlled controlled input lazy 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="test"
             placeholder="test input"
             value="v"
@@ -1350,7 +1350,7 @@ exports[`Form controlled controlled lazy 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="test"
             placeholder="test input"
             value="v"
@@ -1384,7 +1384,7 @@ exports[`Form controlled controlled lazy 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="test"
             placeholder="test input"
             value="v"
@@ -1832,7 +1832,7 @@ exports[`Form controlled controlled onValidate 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="test"
             placeholder="test input"
             value=""
@@ -2100,7 +2100,7 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="test"
             placeholder="test input"
             value=""
@@ -2368,7 +2368,7 @@ exports[`Form controlled controlled onValidate custom info 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="test"
             placeholder="test input"
             value=""
@@ -2797,7 +2797,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="name"
             placeholder="test name"
             value=""
@@ -3036,7 +3036,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="name"
             placeholder="test name"
             value=""

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -1318,7 +1318,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="name"
             placeholder="test name"
             value=""
@@ -1557,7 +1557,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="name"
             placeholder="test name"
             value=""
@@ -2937,7 +2937,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
               >
                 <input
                   autocomplete="off"
-                  class="StyledTextInput-sc-1x30a0s-0 laYMFW Select__SelectTextInput-sc-17idtfo-0 bIurki"
+                  class="StyledTextInput-sc-1x30a0s-0 duVzSE Select__SelectTextInput-sc-17idtfo-0 bIurki"
                   id="test-select__input"
                   name="test-select"
                   placeholder="test select"
@@ -3335,7 +3335,7 @@ exports[`Form uncontrolled uncontrolled 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="test"
             placeholder="test input"
             value=""
@@ -3369,7 +3369,7 @@ exports[`Form uncontrolled uncontrolled 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="test"
             placeholder="test input"
             value=""
@@ -3610,7 +3610,7 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="test"
             placeholder="test input"
             value=""
@@ -3878,7 +3878,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="test"
             placeholder="test input"
             value=""
@@ -4146,7 +4146,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE"
             name="test"
             placeholder="test input"
             value=""

--- a/src/js/components/MaskedInput/MaskedInput.js
+++ b/src/js/components/MaskedInput/MaskedInput.js
@@ -176,6 +176,7 @@ const MaskedInput = forwardRef(
       placeholder,
       plain,
       reverse,
+      textAlign,
       value: valueProp,
       ...rest
     },
@@ -372,6 +373,7 @@ const MaskedInput = forwardRef(
             icon={icon}
             reverse={reverse}
             focus={focus}
+            textAlign={textAlign}
             {...rest}
             value={value}
             theme={theme}

--- a/src/js/components/MaskedInput/README.md
+++ b/src/js/components/MaskedInput/README.md
@@ -135,6 +135,16 @@ xlarge
 string
 ```
 
+**textAlign**
+
+How to align the text inside the input. Defaults to `start`.
+
+```
+start
+center
+end
+```
+
 **value**
 
 What text to put in the input. The caller should ensure that it

--- a/src/js/components/MaskedInput/StyledMaskedInput.js
+++ b/src/js/components/MaskedInput/StyledMaskedInput.js
@@ -5,6 +5,7 @@ import {
   getInputPadBySide,
   inputStyle,
   plainInputStyle,
+  textAlignStyle,
 } from '../../utils';
 
 export const StyledMaskedInput = styled.input`
@@ -21,6 +22,7 @@ export const StyledMaskedInput = styled.input`
       props.theme.maskedInput.disabled &&
         props.theme.maskedInput.disabled.opacity,
     )}
+  ${props => props.textAlign && textAlignStyle}
   ${props => props.theme.maskedInput && props.theme.maskedInput.extend};
 `;
 

--- a/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
+++ b/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
@@ -428,4 +428,14 @@ describe('MaskedInput', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('textAlign end', () => {
+    const { container } = render(
+      <Grommet>
+        <MaskedInput value="1234" textAlign="end" />
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -973,7 +973,7 @@ exports[`MaskedInput event target props are available option via mouse 4`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 hBxWhl"
+    class="StyledMaskedInput-sc-99vkfa-0 ffKOGu"
     data-testid="test-input"
     id="item"
     name="item"
@@ -1775,7 +1775,7 @@ exports[`MaskedInput next and previous without options 2`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 llmgUE"
+    class="StyledMaskedInput-sc-99vkfa-0 ejMspP"
     data-testid="test-input"
     id="item"
     name="item"
@@ -2198,13 +2198,108 @@ exports[`MaskedInput option via mouse 4`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 hBxWhl"
+    class="StyledMaskedInput-sc-99vkfa-0 ffKOGu"
     data-testid="test-input"
     id="item"
     name="item"
     placeholder="!"
     value=""
   />
+</div>
+`;
+
+exports[`MaskedInput textAlign end 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  text-align: right;
+}
+
+.c2:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus > circle,
+.c2:focus > ellipse,
+.c2:focus > line,
+.c2:focus > path,
+.c2:focus > polygon,
+.c2:focus > polyline,
+.c2:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c2::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c2::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c2:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c2::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c2::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c2:-moz-placeholder,
+.c2::-moz-placeholder {
+  opacity: 1;
+}
+
+.c1 {
+  position: relative;
+  width: 100%;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <input
+      autocomplete="off"
+      class="c2"
+      placeholder=""
+      value="1234"
+    />
+  </div>
 </div>
 `;
 

--- a/src/js/components/MaskedInput/doc.js
+++ b/src/js/components/MaskedInput/doc.js
@@ -64,6 +64,9 @@ export const doc = MaskedInput => {
       PropTypes.oneOf(['small', 'medium', 'large', 'xlarge']),
       PropTypes.string,
     ]).description('The size of the text.'),
+    textAlign: PropTypes.oneOf(['start', 'center', 'end'])
+      .description('How to align the text inside the input.')
+      .defaultValue('start'),
     value: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,

--- a/src/js/components/MaskedInput/index.d.ts
+++ b/src/js/components/MaskedInput/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Omit, TextAlignType } from '../../utils';
 import { DropProps } from '../Drop';
 
 export interface MaskedInputProps {
@@ -19,6 +20,7 @@ export interface MaskedInputProps {
   plain?: boolean;
   reverse?: boolean;
   size?: 'small' | 'medium' | 'large' | 'xlarge' | string;
+  textAlign?: TextAlignType;
   value?: string | number;
 }
 

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -2756,7 +2756,7 @@ exports[`Select complex options and children 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 laYMFW Select__SelectTextInput-sc-17idtfo-0 bIurki"
+          class="StyledTextInput-sc-1x30a0s-0 duVzSE Select__SelectTextInput-sc-17idtfo-0 bIurki"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -4570,7 +4570,7 @@ exports[`Select disabled 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 laYMFW Select__SelectTextInput-sc-17idtfo-0 cANsmG"
+          class="StyledTextInput-sc-1x30a0s-0 duVzSE Select__SelectTextInput-sc-17idtfo-0 cANsmG"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -9206,7 +9206,7 @@ exports[`Select prop: onOpen 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 laYMFW Select__SelectTextInput-sc-17idtfo-0 bIurki"
+          class="StyledTextInput-sc-1x30a0s-0 duVzSE Select__SelectTextInput-sc-17idtfo-0 bIurki"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -10131,7 +10131,7 @@ exports[`Select renders custom up and down icons 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW Select__SelectTextInput-sc-17idtfo-0 bIurki"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE Select__SelectTextInput-sc-17idtfo-0 bIurki"
             placeholder="Select..."
             readonly=""
             tabindex="-1"
@@ -12189,7 +12189,7 @@ exports[`Select search 3`] = `
 exports[`Select search 4`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 CGMPz"
+  class="StyledTextInput-sc-1x30a0s-0 gZAijB"
   type="search"
   value=""
 />
@@ -12198,7 +12198,7 @@ exports[`Select search 4`] = `
 exports[`Select search 5`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 CGMPz"
+  class="StyledTextInput-sc-1x30a0s-0 gZAijB"
   type="search"
   value="o"
 />
@@ -12854,7 +12854,7 @@ exports[`Select search and select 3`] = `
 exports[`Select search and select 4`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 CGMPz"
+  class="StyledTextInput-sc-1x30a0s-0 gZAijB"
   type="search"
   value=""
 />
@@ -12863,7 +12863,7 @@ exports[`Select search and select 4`] = `
 exports[`Select search and select 5`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 CGMPz"
+  class="StyledTextInput-sc-1x30a0s-0 gZAijB"
   type="search"
   value="t"
 />
@@ -14708,7 +14708,7 @@ exports[`Select select option by typing should not break if caller passes JSX 2`
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 laYMFW Select__SelectTextInput-sc-17idtfo-0 bIurki"
+            class="StyledTextInput-sc-1x30a0s-0 duVzSE Select__SelectTextInput-sc-17idtfo-0 bIurki"
             id="test-select__input"
             placeholder="test select"
             readonly=""

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -3115,7 +3115,7 @@ exports[`Select Controlled multiple values 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 laYMFW Select__SelectTextInput-sc-17idtfo-0 bIurki"
+          class="StyledTextInput-sc-1x30a0s-0 duVzSE Select__SelectTextInput-sc-17idtfo-0 bIurki"
           id="test-select__input"
           placeholder="test select"
           readonly=""

--- a/src/js/components/TextInput/StyledTextInput.js
+++ b/src/js/components/TextInput/StyledTextInput.js
@@ -32,8 +32,8 @@ const StyledTextInput = styled.input`
     disabledStyle(
       props.theme.textInput.disabled && props.theme.textInput.disabled.opacity,
     )}
-  ${props => props.theme.textInput && props.theme.textInput.extend};
   ${props => props.textAlign && textAlignStyle}
+  ${props => props.theme.textInput && props.theme.textInput.extend};
 `;
 
 StyledTextInput.defaultProps = {};

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -486,7 +486,7 @@ exports[`TextInput calls onSuggestionsClose 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 dqjEjz"
+      class="StyledTextInput-sc-1x30a0s-0 lnZjZd"
       data-testid="test-input"
       id="item"
       name="item"
@@ -1041,7 +1041,7 @@ exports[`TextInput close suggestion drop 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 dqjEjz"
+      class="StyledTextInput-sc-1x30a0s-0 lnZjZd"
       data-testid="test-input"
       id="item"
       name="item"
@@ -1555,7 +1555,7 @@ exports[`TextInput handles next and previous without suggestion 2`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 dqjEjz"
+      class="StyledTextInput-sc-1x30a0s-0 lnZjZd"
       data-testid="test-input"
       id="item"
       name="item"
@@ -2824,7 +2824,7 @@ exports[`TextInput select suggestion 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 fOWkK"
+      class="StyledTextInput-sc-1x30a0s-0 bzNjNY"
       data-testid="test-input"
       id="item"
       name="item"
@@ -3424,7 +3424,7 @@ exports[`TextInput should only show default placeholder when placeholder is a
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 dqjEjz"
+      class="StyledTextInput-sc-1x30a0s-0 lnZjZd"
       data-testid="placeholder"
       id="placeholder"
       name="placeholder"

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -12888,6 +12888,16 @@ xlarge
 string
 \`\`\`
 
+**textAlign**
+
+How to align the text inside the input. Defaults to \`start\`.
+
+\`\`\`
+start
+center
+end
+\`\`\`
+
 **value**
 
 What text to put in the input. The caller should ensure that it

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -6129,6 +6129,14 @@ string",
         "name": "size",
       },
       Object {
+        "defaultValue": "start",
+        "description": "How to align the text inside the input.",
+        "format": "start
+center
+end",
+        "name": "textAlign",
+      },
+      Object {
         "description": "What text to put in the input. The caller should ensure that it
       is initially valid with respect to the mask.",
         "format": "string


### PR DESCRIPTION
#### What does this PR do?

Changed MaskedInput to add textAlign. This is the same property as with TextInput.

Also fixed TextInput to style textAlign before `extend`.

#### Where should the reviewer start?

doc.js

#### What testing has been done on this PR?

added a unit test
tested with grommet-designer

#### Do the grommet docs need to be updated?

automatic

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
