### PR TITLE
Remove duplicate focus styling on CheckBox/CheckBoxGroup inside FormField

### DIFF
--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -35,6 +35,7 @@ const CheckBox = forwardRef(
       disabled,
       fill,
       focus: focusProp,
+      focusIndicator = true,
       id,
       label,
       name,
@@ -83,6 +84,12 @@ const CheckBox = forwardRef(
       checked,
       disabled,
       focus,
+      // when contained in a FormField, focusIndicator = false,
+      // so that the FormField has focus style. However, we still
+      // need to visually indicate when a CheckBox is active.
+      // If focus = true but focusIndicator = false,
+      // we will apply the hover treament.
+      focusIndicator,
       reverse,
       toggle,
       indeterminate,

--- a/src/js/components/CheckBox/README.md
+++ b/src/js/components/CheckBox/README.md
@@ -288,10 +288,10 @@ Defaults to
 { dark: 'white', light: 'black' }
 ```
 
-**checkBox.hover.label.background.color**
+**checkBox.hover.background.color**
 
-The hover background color for the box surrounding CheckBox 
-    and its label. Expects `string | { 'dark': string, 'light': string }`.
+The background color of the Box surrounding the RadioButton 
+    when hovered over. Expects `string | { 'dark': string, 'light': string }`.
 
 Defaults to
 

--- a/src/js/components/CheckBox/README.md
+++ b/src/js/components/CheckBox/README.md
@@ -288,6 +288,17 @@ Defaults to
 { dark: 'white', light: 'black' }
 ```
 
+**checkBox.hover.label.background.color**
+
+The hover background color for the box surrounding CheckBox 
+    and its label. Expects `string | { 'dark': string, 'light': string }`.
+
+Defaults to
+
+```
+undefined
+```
+
 **checkBox.icon.size**
 
 The size of the checked icon. Expects `string`.

--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -35,9 +35,8 @@ const hoverStyle = css`
       normalizeColor(
         !props.disabled &&
           props.theme.checkBox.hover &&
-          props.theme.checkBox.hover.label &&
-          props.theme.checkBox.hover.label.background &&
-          props.theme.checkBox.hover.label.background.color,
+          props.theme.checkBox.hover.background &&
+          props.theme.checkBox.hover.background.color,
         props.theme,
       )};
   }
@@ -96,9 +95,8 @@ const StyledCheckBoxContainer = styled.label`
     background-color: ${normalizeColor(
       !props.disabled &&
         props.theme.checkBox.hover &&
-        props.theme.checkBox.hover.label &&
-        props.theme.checkBox.hover.label.background &&
-        props.theme.checkBox.hover.label.background.color,
+        props.theme.checkBox.hover.background &&
+        props.theme.checkBox.hover.background.color,
       props.theme,
     )};`}
   ${props => props.theme.checkBox.extend}

--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -23,7 +23,23 @@ const hoverStyle = css`
   :hover input:not([disabled]) + div,
   :hover input:not([disabled]) + span {
     border-color: ${props =>
-      normalizeColor(props.theme.checkBox.hover.border.color, props.theme)};
+      normalizeColor(
+        props.theme.checkBox.hover &&
+          props.theme.checkBox.hover.border &&
+          props.theme.checkBox.hover.border.color,
+        props.theme,
+      )};
+  }
+  :hover {
+    background-color: ${props =>
+      normalizeColor(
+        !props.disabled &&
+          props.theme.checkBox.hover &&
+          props.theme.checkBox.hover.label &&
+          props.theme.checkBox.hover.label.background &&
+          props.theme.checkBox.hover.label.background.color,
+        props.theme,
+      )};
   }
 `;
 
@@ -59,7 +75,32 @@ const StyledCheckBoxContainer = styled.label`
     )}
   ${props => props.disabled && disabledStyle}
   ${props => !props.disabled && 'cursor: pointer;'}
-  ${props => props.theme.checkBox.hover.border.color && hoverStyle}
+  ${hoverStyle}
+  // when the CheckBox has focus but there is no focusIndicator,
+  // apply the hover styling instead so that keyboard users know
+  // which CheckBox is active
+  ${props =>
+    props.focus &&
+    !props.focusIndicator &&
+    `
+    input:not([disabled]) + div,
+    input:not([disabled]) + span {
+      border-color: ${normalizeColor(
+        props.theme.checkBox.hover &&
+          props.theme.checkBox.hover.border &&
+          props.theme.checkBox.hover.border.color,
+        props.theme,
+      )};
+    }
+     
+    background-color: ${normalizeColor(
+      !props.disabled &&
+        props.theme.checkBox.hover &&
+        props.theme.checkBox.hover.label &&
+        props.theme.checkBox.hover.label.background &&
+        props.theme.checkBox.hover.label.background.color,
+      props.theme,
+    )};`}
   ${props => props.theme.checkBox.extend}
 `;
 
@@ -87,7 +128,7 @@ StyledCheckBoxInput.defaultProps = {};
 Object.setPrototypeOf(StyledCheckBoxInput.defaultProps, defaultProps);
 
 const StyledCheckBoxBox = styled.div`
-  ${props => props.focus && focusStyle()};
+  ${props => props.focus && props.focusIndicator && focusStyle()};
   ${props => props.theme.checkBox.check.extend};
 `;
 
@@ -109,7 +150,7 @@ const StyledCheckBoxToggle = styled.span`
       ? normalizeColor(props.theme.checkBox.toggle.background, props.theme)
       : 'transparent'};
 
-  ${props => props.focus && focusStyle()};
+  ${props => props.focus && props.focusIndicator && focusStyle()};
   ${props => props.theme.checkBox.toggle.extend};
 `;
 

--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -23,20 +23,12 @@ const hoverStyle = css`
   :hover input:not([disabled]) + div,
   :hover input:not([disabled]) + span {
     border-color: ${props =>
-      normalizeColor(
-        props.theme.checkBox.hover &&
-          props.theme.checkBox.hover.border &&
-          props.theme.checkBox.hover.border.color,
-        props.theme,
-      )};
+      normalizeColor(props.theme.checkBox.hover?.border?.color, props.theme)};
   }
   :hover {
     background-color: ${props =>
       normalizeColor(
-        !props.disabled &&
-          props.theme.checkBox.hover &&
-          props.theme.checkBox.hover.background &&
-          props.theme.checkBox.hover.background.color,
+        !props.disabled && props.theme.checkBox.hover?.background?.color,
         props.theme,
       )};
   }
@@ -85,18 +77,13 @@ const StyledCheckBoxContainer = styled.label`
     input:not([disabled]) + div,
     input:not([disabled]) + span {
       border-color: ${normalizeColor(
-        props.theme.checkBox.hover &&
-          props.theme.checkBox.hover.border &&
-          props.theme.checkBox.hover.border.color,
+        props.theme.checkBox.hover?.border?.color,
         props.theme,
       )};
     }
      
     background-color: ${normalizeColor(
-      !props.disabled &&
-        props.theme.checkBox.hover &&
-        props.theme.checkBox.hover.background &&
-        props.theme.checkBox.hover.background.color,
+      !props.disabled && props.theme.checkBox.hover?.background?.color,
       props.theme,
     )};`}
   ${props => props.theme.checkBox.extend}

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -333,7 +333,7 @@ exports[`CheckBox controlled 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <label
-    class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+    class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"

--- a/src/js/components/CheckBox/doc.js
+++ b/src/js/components/CheckBox/doc.js
@@ -120,9 +120,9 @@ export const themeDoc = {
     type: "string | { 'dark': string, 'light': string }",
     defaultValue: "{ dark: 'white', light: 'black' }",
   },
-  'checkBox.hover.label.background.color': {
-    description: `The hover background color for the box surrounding CheckBox 
-    and its label.`,
+  'checkBox.hover.background.color': {
+    description: `The background color of the Box surrounding the RadioButton 
+    when hovered over.`,
     type: "string | { 'dark': string, 'light': string }",
     defaultValue: undefined,
   },

--- a/src/js/components/CheckBox/doc.js
+++ b/src/js/components/CheckBox/doc.js
@@ -120,6 +120,12 @@ export const themeDoc = {
     type: "string | { 'dark': string, 'light': string }",
     defaultValue: "{ dark: 'white', light: 'black' }",
   },
+  'checkBox.hover.label.background.color': {
+    description: `The hover background color for the box surrounding CheckBox 
+    and its label.`,
+    type: "string | { 'dark': string, 'light': string }",
+    defaultValue: undefined,
+  },
   'checkBox.icon.size': {
     description: 'The size of the checked icon.',
     type: 'string',

--- a/src/js/components/CheckBoxGroup/CheckBoxGroup.js
+++ b/src/js/components/CheckBoxGroup/CheckBoxGroup.js
@@ -10,6 +10,7 @@ export const CheckBoxGroup = forwardRef(
     {
       value: valueProp,
       disabled: disabledProp,
+      focusIndicator = true,
       gap,
       labelKey,
       valueKey,
@@ -92,6 +93,12 @@ export const CheckBoxGroup = forwardRef(
               {...optionProps}
               disabled={disabled}
               checked={checked}
+              // when contained in a FormField, focusIndicator = false,
+              // so that the FormField has focus style. However, we still
+              // need to visually indicate when a CheckBox is active.
+              // In CheckBox, if focus = true but focusIndicator = false,
+              // we will apply the hover treament.
+              focusIndicator={focusIndicator}
               label={label}
               onChange={event =>
                 onCheckBoxChange(event, valueOption, optionProps)

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
@@ -9,7 +9,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
     role="group"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -30,7 +30,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 dLcqZl"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -61,7 +61,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hPWSvI"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hQyqlg"
       disabled={true}
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -98,7 +98,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     />
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hPWSvI"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hQyqlg"
       disabled={true}
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -137,7 +137,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hPWSvI"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hQyqlg"
       disabled={true}
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -176,7 +176,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hPWSvI"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hQyqlg"
       disabled={true}
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -222,7 +222,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -255,7 +255,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
     />
     <label
       checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -300,7 +300,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
     />
     <label
       checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -353,7 +353,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
     role="group"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -374,7 +374,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -404,7 +404,7 @@ exports[`CheckBoxGroup onChange 1`] = `
     role="group"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -436,7 +436,7 @@ exports[`CheckBoxGroup onChange 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -467,7 +467,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
     tabindex="0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -499,7 +499,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -530,7 +530,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
     tabindex="0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -551,7 +551,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -582,7 +582,7 @@ exports[`CheckBoxGroup options renders 1`] = `
   >
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -615,7 +615,7 @@ exports[`CheckBoxGroup options renders 1`] = `
     />
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -657,7 +657,7 @@ exports[`CheckBoxGroup value renders 1`] = `
   >
     <label
       checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -702,7 +702,7 @@ exports[`CheckBoxGroup value renders 1`] = `
     />
     <label
       checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -743,7 +743,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
     role="group"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -764,7 +764,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -3511,7 +3511,7 @@ exports[`DataTable custom theme 2`] = `
           >
             <label
               aria-label="unselect alpha"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dSsJRT"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 eJitRX"
               disabled=""
             >
               <div
@@ -3575,7 +3575,7 @@ exports[`DataTable custom theme 2`] = `
           >
             <label
               aria-label="select beta"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dSsJRT"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 eJitRX"
               disabled=""
             >
               <div
@@ -10219,7 +10219,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           >
             <label
               aria-label="unselect all"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 jGrNxy"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -10341,7 +10341,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           >
             <label
               aria-label="unselect one"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 jGrNxy"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -10452,7 +10452,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           >
             <label
               aria-label="unselect two"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 jGrNxy"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -10579,7 +10579,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           >
             <label
               aria-label="select all"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 jGrNxy"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -10666,7 +10666,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           >
             <label
               aria-label="select one"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 jGrNxy"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -10742,7 +10742,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           >
             <label
               aria-label="select two"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 jGrNxy"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -18593,7 +18593,7 @@ exports[`DataTable select 2`] = `
           >
             <label
               aria-label="unselect all"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 jGrNxy"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -18671,7 +18671,7 @@ exports[`DataTable select 2`] = `
           >
             <label
               aria-label="unselect alpha"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 jGrNxy"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -18726,7 +18726,7 @@ exports[`DataTable select 2`] = `
           >
             <label
               aria-label="unselect beta"
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hfCcYi"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 jGrNxy"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kDZMxH StyledCheckBox-sc-1dbk5ju-6 hOFfoi"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -2812,7 +2812,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 fYhoox FormField__FormFieldContentBox-m9hood-1"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -3051,7 +3051,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 fYhoox FormField__FormFieldContentBox-m9hood-1 iUyYoX"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 khDdKn"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -3062,7 +3062,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
               type="checkbox"
             />
             <div
-              class="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 cSDzSd"
+              class="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
             />
           </div>
           <span>

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -1333,7 +1333,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 fYhoox FormField__FormFieldContentBox-m9hood-1"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -1572,7 +1572,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 fYhoox FormField__FormFieldContentBox-m9hood-1 iUyYoX"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 khDdKn"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
@@ -1583,7 +1583,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
               type="checkbox"
             />
             <div
-              class="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 cSDzSd"
+              class="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
             />
           </div>
           <span>
@@ -2985,7 +2985,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
         class="StyledBox-sc-13pk1d4-0 fYhoox FormField__FormFieldContentBox-m9hood-1"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 koQNld"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
           for="test-checkbox"
         >
           <div

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -21,6 +21,8 @@ import { TextInput } from '../TextInput';
 import { FormContext } from '../Form/FormContext';
 
 const grommetInputNames = [
+  'CheckBox',
+  'CheckBoxGroup',
   'TextInput',
   'Select',
   'MaskedInput',

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5332,10 +5332,10 @@ Defaults to
 { dark: 'white', light: 'black' }
 \`\`\`
 
-**checkBox.hover.label.background.color**
+**checkBox.hover.background.color**
 
-The hover background color for the box surrounding CheckBox 
-    and its label. Expects \`string | { 'dark': string, 'light': string }\`.
+The background color of the Box surrounding the RadioButton 
+    when hovered over. Expects \`string | { 'dark': string, 'light': string }\`.
 
 Defaults to
 

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -5332,6 +5332,17 @@ Defaults to
 { dark: 'white', light: 'black' }
 \`\`\`
 
+**checkBox.hover.label.background.color**
+
+The hover background color for the box surrounding CheckBox 
+    and its label. Expects \`string | { 'dark': string, 'light': string }\`.
+
+Defaults to
+
+\`\`\`
+undefined
+\`\`\`
+
 **checkBox.icon.size**
 
 The size of the checked icon. Expects \`string\`.

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -544,10 +544,8 @@ export interface ThemeType {
       border?: {
         color?: ColorType;
       };
-      label?: {
-        background?: {
-          color?: ColorType;
-        };
+      background?: {
+        color?: ColorType;
       };
     };
     icon?: {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -544,6 +544,11 @@ export interface ThemeType {
       border?: {
         color?: ColorType;
       };
+      label?: {
+        background?: {
+          color?: ColorType;
+        };
+      };
     };
     icon?: {
       size?: string;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -617,9 +617,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
             light: 'black',
           },
         },
-        // label: {
-        //   background: undefined,
-        // }
+        // background: undefined,
       },
       icon: {
         // size: undefined,

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -617,6 +617,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
             light: 'black',
           },
         },
+        // label: {
+        //   background: undefined,
+        // }
       },
       icon: {
         // size: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
When CheckBox or CheckBoxGroup is within a FormField, the focus styling should appear on the formfield. When rendered outside of a FormField, the focus styling should appear on the CheckBox itself. However, a keyboard user still needs to be aware that an element is active inside the FormField, especially in a CheckBoxGroup. When in a FormField, the formfield receives focus indicator and the CheckBoxes receive hover treatment so it is clear which is active.

Additionally, the theme was enhanced to support `checkBox.hover.background.color` which mirrors the behavior of `radioButton.hover.background.color`. Once merged, we will leverage this new theme object in grommet-theme-hpe as opposed to `extend` like we have to do now and will remove where we manually remove box-shadow from checkbox (which is causing issues for the stand alone checkbox outside of form field.)

This leverages similar logic to what was recently applied to RadioButton Group: https://github.com/grommet/grommet/pull/5284.

There has been discussion about if arrow keys should be able to navigate within the CheckBoxGroup as opposed to tab. However, this PR does not address any changes to keyboard behaviors. It purely address the styling that should occur when a checkbox or Checkboxgroup is contained in a FormField. That being said, if keyboard interaction is adjusted in the future, this styling would still be able to be leveraged there.

#### Where should the reviewer start?
src/js/components/CheckBoxGroup/CheckBoxGroup.js

#### What testing has been done on this PR?
Test in storybook Custom Form story, standalone checkbox/checkboxgroup stories, and checkboxes in DataTable.

#### How should this be manually tested?
Same as above.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet-theme-hpe/issues/151

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, updated here.

#### Should this PR be mentioned in the release notes?
Fixed duplicate focus styling that occurred when CheckBox/CheckBoxGroup was contained in FormField.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.