### PR TITLE
Refactor Button tests to use `render` @testing-library function

### DIFF
--- a/src/js/components/Button/__tests__/Button-test.js
+++ b/src/js/components/Button/__tests__/Button-test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
@@ -8,7 +7,6 @@ import 'regenerator-runtime/runtime';
 import { axe } from 'jest-axe';
 import { Add, Next } from 'grommet-icons';
 import { cleanup, fireEvent, render } from '@testing-library/react';
-import { findAllByType } from '../../../utils';
 import { Grommet, Button, Text } from '../..';
 
 describe('Button', () => {
@@ -43,27 +41,26 @@ describe('Button', () => {
   });
 
   test('basic', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button label="Test" onClick={() => {}} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('children function', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button onClick={() => {}}>{() => <Text>Test</Text>}</Button>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('children function with disabled prop', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button onClick={() => {}} disabled>
           {({ disabled }) => <Text>{disabled ? 'Disabled' : 'Test'}</Text>}
@@ -73,8 +70,8 @@ describe('Button', () => {
         </Button>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('warns about invalid label', () => {
@@ -116,17 +113,17 @@ describe('Button', () => {
   });
 
   test('primary', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button primary label="Test" onClick={() => {}} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('color', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button color="accent-1" label="Test" onClick={() => {}} />
         <Button color="accent-1" primary label="Test" onClick={() => {}} />
@@ -134,23 +131,21 @@ describe('Button', () => {
         <Button color="#123" primary label="Test" onClick={() => {}} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('fill', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
-        <Button>
-          <Button fill />
-          <Button fill={false} />
-          <Button fill="horizontal" />
-          <Button fill="vertical" />
-        </Button>
+        <Button fill />
+        <Button fill={false} />
+        <Button fill="horizontal" />
+        <Button fill="vertical" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('focus', () => {
@@ -176,7 +171,7 @@ describe('Button', () => {
   });
 
   test('disabled', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button disabled />
         <Button disabled primary label="Button" />
@@ -191,124 +186,122 @@ describe('Button', () => {
         <Button disabled icon={<svg />} label="Button" primary />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('active', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button active label="Button" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('active + primary', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button active primary label="Button" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('icon label', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button icon={<svg />} label="Test" onClick={() => {}} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('reverse icon label', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button reverse icon={<svg />} label="Test" onClick={() => {}} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('href', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button href="test" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('hoverIndicator background', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button onClick={() => {}} hoverIndicator="background">
           hoverIndicator
         </Button>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('hoverIndicator as object with color', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button onClick={() => {}} hoverIndicator={{ color: 'brand' }}>
           hoverIndicator
         </Button>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('hoverIndicator as object with invalid color', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button onClick={() => {}} hoverIndicator={{ color: 'invalid' }}>
           hoverIndicator
         </Button>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('hoverIndicator color', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button onClick={() => {}} hoverIndicator="dark-3">
           hoverIndicator
         </Button>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('onClick', () => {
     const onClick = jest.fn();
-    const component = renderer.create(
+    const { getByRole } = render(
       <Grommet>
         <Button label="Test" onClick={onClick} />
       </Grommet>,
     );
-    const tree = component.toJSON();
 
-    const button = findAllByType(tree, 'button');
-    button[0].props.onClick();
+    fireEvent.click(getByRole('button'));
     expect(onClick).toBeCalled();
   });
 
   test('size', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button size="small" label="Small" />
         <Button size="medium" label="Medium" />
@@ -329,29 +322,28 @@ describe('Button', () => {
       </Grommet>,
     );
 
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('as', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button as="span" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('a11yTitle', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Button a11yTitle="Title" />
         <Button aria-label="Title" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test(`disabled state cursor should indicate the button cannot be
@@ -434,7 +426,7 @@ describe('Button', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test(`badge should render relative to contents when button has no 
+  test(`badge should render relative to contents when button has no
   border or background`, () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.js.snap
@@ -81,24 +81,16 @@ exports[`Button a11yTitle 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
     aria-label="Title"
-    className="c1"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   />
   <button
     aria-label="Title"
-    className="c1"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   />
 </div>
@@ -190,14 +182,10 @@ exports[`Button active + primary 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     Button
@@ -288,14 +276,10 @@ exports[`Button active 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     Button
@@ -384,14 +368,10 @@ exports[`Button as 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <span
-    className="c1"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   />
 </div>
@@ -1261,7 +1241,7 @@ exports[`Button badge should render custom element 1`] = `
 </div>
 `;
 
-exports[`Button badge should render relative to contents when button has no 
+exports[`Button badge should render relative to contents when button has no
   border or background 1`] = `
 .c4 {
   display: inline-block;
@@ -1539,15 +1519,10 @@ exports[`Button basic 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     Test
@@ -1641,19 +1616,14 @@ exports[`Button children function 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     <span
-      className="c2"
+      class="c2"
     >
       Test
     </span>
@@ -1814,35 +1784,25 @@ exports[`Button children function with disabled prop 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    disabled={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
+    disabled=""
     type="button"
   >
     <span
-      className="c2"
+      class="c2"
     >
       Disabled
     </span>
   </button>
   <button
-    className="c3"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c3"
     type="button"
   >
     <span
-      className="c2"
+      class="c2"
     >
       Test
     </span>
@@ -2147,48 +2107,28 @@ exports[`Button color 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     Test
   </button>
   <button
-    className="c2"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c2"
     type="button"
   >
     Test
   </button>
   <button
-    className="c3"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c3"
     type="button"
   >
     Test
   </button>
   <button
-    className="c4"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c4"
     type="button"
   >
     Test
@@ -2629,149 +2569,105 @@ exports[`Button disabled 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    disabled={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
+    disabled=""
     type="button"
   />
   <button
-    className="c2"
-    disabled={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c2"
+    disabled=""
     type="button"
   >
     Button
   </button>
   <button
-    className="c1"
-    disabled={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
+    disabled=""
     type="button"
   >
     Button
   </button>
   <button
-    className="c3"
-    disabled={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c3"
+    disabled=""
     type="button"
   >
     Button
   </button>
   <button
-    className="c1"
-    disabled={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
+    disabled=""
     type="button"
   >
     Button
   </button>
   <button
-    className="c4"
-    disabled={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c4"
+    disabled=""
     type="button"
   >
     <svg />
   </button>
   <button
-    className="c5"
-    disabled={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c5"
+    disabled=""
     type="button"
   >
     <svg />
   </button>
   <button
-    className="c6"
-    disabled={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c6"
+    disabled=""
     type="button"
   >
     <svg />
   </button>
   <button
-    className="c1"
-    disabled={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
+    disabled=""
     type="button"
   >
     <div
-      className="c7"
+      class="c7"
     >
       <svg />
       <div
-        className="c8"
+        class="c8"
       />
       Button
     </div>
   </button>
   <button
-    className="c3"
-    disabled={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c3"
+    disabled=""
     type="button"
   >
     <div
-      className="c7"
+      class="c7"
     >
       <svg />
       <div
-        className="c8"
+        class="c8"
       />
       Button
     </div>
   </button>
   <button
-    className="c2"
-    disabled={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c2"
+    disabled=""
     type="button"
   >
     <div
-      className="c7"
+      class="c7"
     >
       <svg
         color="#f8f8f8"
       />
       <div
-        className="c8"
+        class="c8"
       />
       Button
     </div>
@@ -2791,11 +2687,28 @@ exports[`Button fill 1`] = `
   background: transparent;
   overflow: visible;
   text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c1:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
 .c1:focus {
@@ -2861,12 +2774,6 @@ exports[`Button fill 1`] = `
   transition-duration: 0.1s;
   -webkit-transition-timing-function: ease-in-out;
   transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
 }
 
 .c2:hover {
@@ -2936,6 +2843,7 @@ exports[`Button fill 1`] = `
   transition-duration: 0.1s;
   -webkit-transition-timing-function: ease-in-out;
   transition-timing-function: ease-in-out;
+  width: 100%;
 }
 
 .c3:hover {
@@ -3005,7 +2913,7 @@ exports[`Button fill 1`] = `
   transition-duration: 0.1s;
   -webkit-transition-timing-function: ease-in-out;
   transition-timing-function: ease-in-out;
-  width: 100%;
+  height: 100%;
 }
 
 .c4:hover {
@@ -3052,76 +2960,6 @@ exports[`Button fill 1`] = `
   border: 0;
 }
 
-.c5 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: 2px solid #7D4CDB;
-  border-radius: 18px;
-  color: #444444;
-  padding: 4px 22px;
-  font-size: 18px;
-  line-height: 24px;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  height: 100%;
-}
-
-.c5:hover {
-  box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c5:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
 .c0 {
   font-size: 18px;
   line-height: 24px;
@@ -3133,49 +2971,24 @@ exports[`Button fill 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
-  >
-    <button
-      className="c2"
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
-      type="button"
-    />
-    <button
-      className="c3"
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
-      type="button"
-    />
-    <button
-      className="c4"
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
-      type="button"
-    />
-    <button
-      className="c5"
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
-      type="button"
-    />
-  </button>
+  />
+  <button
+    class="c2"
+    type="button"
+  />
+  <button
+    class="c3"
+    type="button"
+  />
+  <button
+    class="c4"
+    type="button"
+  />
 </div>
 `;
 
@@ -3342,15 +3155,10 @@ exports[`Button hoverIndicator as object with color 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     hoverIndicator
@@ -3433,15 +3241,10 @@ exports[`Button hoverIndicator as object with invalid color 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     hoverIndicator
@@ -3524,15 +3327,10 @@ exports[`Button hoverIndicator background 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     hoverIndicator
@@ -3615,15 +3413,10 @@ exports[`Button hoverIndicator color 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     hoverIndicator
@@ -3712,15 +3505,11 @@ exports[`Button href 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <a
-    className="c1"
+    class="c1"
     href="test"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
   />
 </div>
 `;
@@ -3838,23 +3627,18 @@ exports[`Button icon label 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <svg />
       <div
-        className="c3"
+        class="c3"
       />
       Test
     </div>
@@ -3946,15 +3730,10 @@ exports[`Button primary 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     Test
@@ -4075,23 +3854,18 @@ exports[`Button reverse icon label 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     <div
-      className="c2"
+      class="c2"
     >
       Test
       <div
-        className="c3"
+        class="c3"
       />
       <svg />
     </div>
@@ -4697,284 +4471,220 @@ exports[`Button size 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     Small
   </button>
   <button
-    className="c2"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c2"
     type="button"
   >
     Medium
   </button>
   <button
-    className="c2"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c2"
     type="button"
   >
     Default
   </button>
   <button
-    className="c3"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c3"
     type="button"
   >
     Large
   </button>
   <button
-    className="c4"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c4"
     type="button"
   >
     Small
   </button>
   <button
-    className="c5"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c5"
     type="button"
   >
     Medium
   </button>
   <button
-    className="c5"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c5"
     type="button"
   >
     Default
   </button>
   <button
-    className="c6"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c6"
     type="button"
   >
     Large
   </button>
   <button
-    className="c7"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c7"
     type="button"
   >
     <svg
       aria-label="Add"
-      className="c8"
+      class="c8"
       viewBox="0 0 24 24"
     >
       <path
         d="M12,22 L12,2 M2,12 L22,12"
         fill="none"
         stroke="#000"
-        strokeWidth="2"
+        stroke-width="2"
       />
     </svg>
   </button>
   <button
-    className="c7"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c7"
     type="button"
   >
     <svg
       aria-label="Add"
-      className="c8"
+      class="c8"
       viewBox="0 0 24 24"
     >
       <path
         d="M12,22 L12,2 M2,12 L22,12"
         fill="none"
         stroke="#000"
-        strokeWidth="2"
+        stroke-width="2"
       />
     </svg>
   </button>
   <button
-    className="c7"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c7"
     type="button"
   >
     <svg
       aria-label="Add"
-      className="c8"
+      class="c8"
       viewBox="0 0 24 24"
     >
       <path
         d="M12,22 L12,2 M2,12 L22,12"
         fill="none"
         stroke="#000"
-        strokeWidth="2"
+        stroke-width="2"
       />
     </svg>
   </button>
   <button
-    className="c7"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c7"
     type="button"
   >
     <svg
       aria-label="Add"
-      className="c8"
+      class="c8"
       viewBox="0 0 24 24"
     >
       <path
         d="M12,22 L12,2 M2,12 L22,12"
         fill="none"
         stroke="#000"
-        strokeWidth="2"
+        stroke-width="2"
       />
     </svg>
   </button>
   <button
-    className="c1"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     <div
-      className="c9"
+      class="c9"
     >
       Small
       <div
-        className="c10"
+        class="c10"
       />
       <svg
         aria-label="Next"
-        className="c11"
+        class="c11"
         viewBox="0 0 24 24"
       >
         <polyline
           fill="none"
           points="7 2 17 12 7 22"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>
   </button>
   <button
-    className="c2"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c2"
     type="button"
   >
     <div
-      className="c9"
+      class="c9"
     >
       Medium
       <div
-        className="c10"
+        class="c10"
       />
       <svg
         aria-label="Next"
-        className="c11"
+        class="c11"
         viewBox="0 0 24 24"
       >
         <polyline
           fill="none"
           points="7 2 17 12 7 22"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>
   </button>
   <button
-    className="c2"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c2"
     type="button"
   >
     <div
-      className="c9"
+      class="c9"
     >
       Default
       <div
-        className="c10"
+        class="c10"
       />
       <svg
         aria-label="Next"
-        className="c11"
+        class="c11"
         viewBox="0 0 24 24"
       >
         <polyline
           fill="none"
           points="7 2 17 12 7 22"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>
   </button>
   <button
-    className="c3"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c3"
     type="button"
   >
     <div
-      className="c9"
+      class="c9"
     >
       Large
       <div
-        className="c10"
+        class="c10"
       />
       <svg
         aria-label="Next"
-        className="c11"
+        class="c11"
         viewBox="0 0 24 24"
       >
         <polyline
           fill="none"
           points="7 2 17 12 7 22"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Button/__tests__/Button-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.