### PR TITLE
Added selected styling to custom child in Select

### DIFF
--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -199,7 +199,7 @@ const StyledButton = styled.button`
   ${props => !props.plain && basicStyle(props)}
   ${props => props.primary && primaryStyle(props)}
 
-  ${props => !props.disabled && !props.focus && hoverStyle}
+  ${props => !props.disabled && !props.selected && !props.focus && hoverStyle}
 
   ${props => !props.disabled && props.active && activeButtonStyle(props)}
   ${props =>

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -382,11 +382,15 @@ const SelectContainer = forwardRef(
                   // as an option Button kind property.
                   let child;
                   if (children)
-                    child = children(option, index, options, {
-                      active: optionActive,
-                      disabled: optionDisabled,
-                      selected: optionSelected,
-                    });
+                    child = (
+                      <OptionBox selected={optionSelected}>
+                        {children(option, index, options, {
+                          active: optionActive,
+                          disabled: optionDisabled,
+                          selected: optionSelected,
+                        })}
+                      </OptionBox>
+                    );
                   else if (theme.select.options)
                     child = (
                       <OptionBox
@@ -398,6 +402,7 @@ const SelectContainer = forwardRef(
                         </Text>
                       </OptionBox>
                     );
+
                   // if we have a child, turn on plain, and hoverIndicator
 
                   return (

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -30,11 +30,8 @@ const OptionsBox = styled.div`
   outline: none;
 `;
 
-const OptionBox = styled(Box)`
-  ${props => props.selected && selectedStyle}
-`;
-
 const SelectOption = styled(Button)`
+  ${props => props.selected && props.textComponent && selectedStyle}
   display: block;
   width: 100%;
 `;
@@ -381,27 +378,30 @@ const SelectContainer = forwardRef(
                   // Determine whether the label is done as a child or
                   // as an option Button kind property.
                   let child;
-                  if (children)
+                  let textComponent = false;
+                  if (children) {
+                    child = children(option, index, options, {
+                      active: optionActive,
+                      disabled: optionDisabled,
+                      selected: optionSelected,
+                    });
+                    if (
+                      typeof child === 'string' ||
+                      (child.props &&
+                        child.props.children &&
+                        typeof child.props.children === 'string')
+                    )
+                      textComponent = true;
+                  } else if (theme.select.options) {
                     child = (
-                      <OptionBox selected={optionSelected}>
-                        {children(option, index, options, {
-                          active: optionActive,
-                          disabled: optionDisabled,
-                          selected: optionSelected,
-                        })}
-                      </OptionBox>
-                    );
-                  else if (theme.select.options)
-                    child = (
-                      <OptionBox
-                        {...selectOptionsStyle}
-                        selected={optionSelected}
-                      >
+                      <Box {...selectOptionsStyle}>
                         <Text {...theme.select.options.text}>
                           {optionLabel(index)}
                         </Text>
-                      </OptionBox>
+                      </Box>
                     );
+                    textComponent = true;
+                  }
 
                   // if we have a child, turn on plain, and hoverIndicator
 
@@ -427,6 +427,7 @@ const SelectContainer = forwardRef(
                       onClick={
                         !optionDisabled ? selectOption(index) : undefined
                       }
+                      textComponent={textComponent}
                     >
                       {child}
                     </SelectOption>
@@ -442,11 +443,11 @@ const SelectContainer = forwardRef(
                 disabled
                 option={emptySearchMessage}
               >
-                <OptionBox {...selectOptionsStyle}>
+                <Box {...selectOptionsStyle}>
                   <Text {...theme.select.container.text}>
                     {emptySearchMessage}
                   </Text>
-                </OptionBox>
+                </Box>
               </SelectOption>
             )}
           </OptionsBox>

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -511,7 +511,7 @@ exports[`Select Clear option renders - bottom 1`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -527,7 +527,7 @@ exports[`Select Clear option renders - bottom 1`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -795,7 +795,7 @@ exports[`Select Clear option renders correct label when wrapped in FormField 1`]
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -811,7 +811,7 @@ exports[`Select Clear option renders correct label when wrapped in FormField 1`]
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -1070,7 +1070,7 @@ exports[`Select Clear option renders custom label 1`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -1086,7 +1086,7 @@ exports[`Select Clear option renders custom label 1`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -1345,7 +1345,7 @@ exports[`Select Clear option renders- top 1`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -1361,7 +1361,7 @@ exports[`Select Clear option renders- top 1`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -2182,7 +2182,7 @@ exports[`Select applies custom global.hover theme to options 2`] = `
   type="button"
 >
   <div
-    class="c2 SelectContainer__OptionBox-sc-1wi0ul8-1"
+    class="c2"
   >
     <span
       class="c3"
@@ -2987,13 +2987,9 @@ exports[`Select complex options and children 3`] = `
         tabindex="-1"
         type="button"
       >
-        <div
-          class="c2 SelectContainer__OptionBox-sc-1wi0ul8-1"
-        >
-          <span>
-            one
-          </span>
-        </div>
+        <span>
+          one
+        </span>
       </button>
       <button
         class="c5 c6"
@@ -3001,13 +2997,9 @@ exports[`Select complex options and children 3`] = `
         tabindex="-1"
         type="button"
       >
-        <div
-          class="c2 SelectContainer__OptionBox-sc-1wi0ul8-1"
-        >
-          <span>
-            two
-          </span>
-        </div>
+        <span>
+          two
+        </span>
       </button>
       <div
         class="c7"
@@ -3697,7 +3689,7 @@ exports[`Select default value clear 1`] = `
   padding: 12px;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3872,6 +3864,64 @@ exports[`Select default value clear 1`] = `
   border: 0;
 }
 
+.c12 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c12:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus > circle,
+.c12:focus > ellipse,
+.c12:focus > line,
+.c12:focus > path,
+.c12:focus > polygon,
+.c12:focus > polyline,
+.c12:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c12:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible) > circle,
+.c12:focus:not(:focus-visible) > ellipse,
+.c12:focus:not(:focus-visible) > line,
+.c12:focus:not(:focus-visible) > path,
+.c12:focus:not(:focus-visible) > polygon,
+.c12:focus:not(:focus-visible) > polyline,
+.c12:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
 .c3 {
   max-height: inherit;
 }
@@ -3886,12 +3936,14 @@ exports[`Select default value clear 1`] = `
   outline: none;
 }
 
-.c12 {
-  background-color: #7D4CDB;
-  color: #FFFFFF;
+.c9 {
+  display: block;
+  width: 100%;
 }
 
-.c9 {
+.c13 {
+  background-color: #7D4CDB;
+  color: #FFFFFF;
   display: block;
   width: 100%;
 }
@@ -3968,7 +4020,7 @@ exports[`Select default value clear 1`] = `
         type="button"
       >
         <div
-          class="c10 "
+          class="c10"
         >
           <span
             class="c11"
@@ -3978,13 +4030,13 @@ exports[`Select default value clear 1`] = `
         </div>
       </button>
       <button
-        class="c8 c9"
+        class="c12 c13"
         role="menuitem"
         tabindex="-1"
         type="button"
       >
         <div
-          class="c10 c12"
+          class="c10"
         >
           <span
             class="c11"
@@ -3994,7 +4046,7 @@ exports[`Select default value clear 1`] = `
         </div>
       </button>
       <div
-        class="c13"
+        class="c14"
       />
     </div>
   </div>
@@ -5182,7 +5234,7 @@ exports[`Select disabled key 2`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -5198,7 +5250,7 @@ exports[`Select disabled key 2`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -5517,7 +5569,7 @@ exports[`Select disabled option value 1`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -5533,7 +5585,7 @@ exports[`Select disabled option value 1`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -6180,7 +6232,7 @@ exports[`Select large drop container height 1`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -6196,7 +6248,7 @@ exports[`Select large drop container height 1`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -6445,7 +6497,7 @@ exports[`Select medium drop container height 1`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -6461,7 +6513,7 @@ exports[`Select medium drop container height 1`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -7272,7 +7324,7 @@ exports[`Select onChange with valueKey string 2`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -7288,7 +7340,7 @@ exports[`Select onChange with valueKey string 2`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -7773,7 +7825,7 @@ exports[`Select onChange with valueLabel 2`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -7789,7 +7841,7 @@ exports[`Select onChange with valueLabel 2`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -8327,7 +8379,7 @@ exports[`Select onChange without valueKey 2`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -8343,7 +8395,7 @@ exports[`Select onChange without valueKey 2`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -9477,7 +9529,7 @@ exports[`Select prop: onOpen 3`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -9493,7 +9545,7 @@ exports[`Select prop: onOpen 3`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -9526,13 +9578,13 @@ exports[`Select prop: onOpen 5`] = `
   tabindex="-1"
 >
   <button
-    class="StyledButton-sc-323bzc-0 ksFFvX SelectContainer__SelectOption-sc-1wi0ul8-2 kNOKDt"
+    class="StyledButton-sc-323bzc-0 ksFFvX SelectContainer__SelectOption-sc-1wi0ul8-1 etFdtz"
     role="menuitem"
     tabindex="-1"
     type="button"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kNEzzP SelectContainer__OptionBox-sc-1wi0ul8-1"
+      class="StyledBox-sc-13pk1d4-0 kNEzzP"
     >
       <span
         class="StyledText-sc-1sadyjn-0 fEvqji"
@@ -9542,13 +9594,13 @@ exports[`Select prop: onOpen 5`] = `
     </div>
   </button>
   <button
-    class="StyledButton-sc-323bzc-0 ksFFvX SelectContainer__SelectOption-sc-1wi0ul8-2 kNOKDt"
+    class="StyledButton-sc-323bzc-0 ksFFvX SelectContainer__SelectOption-sc-1wi0ul8-1 etFdtz"
     role="menuitem"
     tabindex="-1"
     type="button"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kNEzzP SelectContainer__OptionBox-sc-1wi0ul8-1"
+      class="StyledBox-sc-13pk1d4-0 kNEzzP"
     >
       <span
         class="StyledText-sc-1sadyjn-0 fEvqji"
@@ -11876,7 +11928,7 @@ exports[`Select search 2`] = `
   padding: 12px;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11987,6 +12039,64 @@ exports[`Select search 2`] = `
   border: 0;
 }
 
+.c12 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c12:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus > circle,
+.c12:focus > ellipse,
+.c12:focus > line,
+.c12:focus > path,
+.c12:focus > polygon,
+.c12:focus > polyline,
+.c12:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c12:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible) > circle,
+.c12:focus:not(:focus-visible) > ellipse,
+.c12:focus:not(:focus-visible) > line,
+.c12:focus:not(:focus-visible) > path,
+.c12:focus:not(:focus-visible) > polygon,
+.c12:focus:not(:focus-visible) > polyline,
+.c12:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
 .c6 {
   box-sizing: border-box;
   font-size: inherit;
@@ -12070,12 +12180,14 @@ exports[`Select search 2`] = `
   outline: none;
 }
 
-.c12 {
-  background-color: #7D4CDB;
-  color: #FFFFFF;
+.c9 {
+  display: block;
+  width: 100%;
 }
 
-.c9 {
+.c13 {
+  background-color: #7D4CDB;
+  color: #FFFFFF;
   display: block;
   width: 100%;
 }
@@ -12152,7 +12264,7 @@ exports[`Select search 2`] = `
         type="button"
       >
         <div
-          class="c10 "
+          class="c10"
         >
           <span
             class="c11"
@@ -12162,13 +12274,13 @@ exports[`Select search 2`] = `
         </div>
       </button>
       <button
-        class="c8 c9"
+        class="c12 c13"
         role="menuitem"
         tabindex="-1"
         type="button"
       >
         <div
-          class="c10 c12"
+          class="c10"
         >
           <span
             class="c11"
@@ -12178,7 +12290,7 @@ exports[`Select search 2`] = `
         </div>
       </button>
       <div
-        class="c13"
+        class="c14"
       />
     </div>
   </div>
@@ -12817,7 +12929,7 @@ exports[`Select search and select 2`] = `
         type="button"
       >
         <div
-          class="c10 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c10"
         >
           <span
             class="c11"
@@ -12833,7 +12945,7 @@ exports[`Select search and select 2`] = `
         type="button"
       >
         <div
-          class="c10 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c10"
         >
           <span
             class="c11"
@@ -15819,7 +15931,7 @@ exports[`Select small drop container height 1`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -15835,7 +15947,7 @@ exports[`Select small drop container height 1`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -2987,9 +2987,13 @@ exports[`Select complex options and children 3`] = `
         tabindex="-1"
         type="button"
       >
-        <span>
-          one
-        </span>
+        <div
+          class="c2 SelectContainer__OptionBox-sc-1wi0ul8-1"
+        >
+          <span>
+            one
+          </span>
+        </div>
       </button>
       <button
         class="c5 c6"
@@ -2997,9 +3001,13 @@ exports[`Select complex options and children 3`] = `
         tabindex="-1"
         type="button"
       >
-        <span>
-          two
-        </span>
+        <div
+          class="c2 SelectContainer__OptionBox-sc-1wi0ul8-1"
+        >
+          <span>
+            two
+          </span>
+        </div>
       </button>
       <div
         class="c7"

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -874,7 +874,7 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
   padding: 12px;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -916,7 +916,7 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
   animation-delay: 0.01s;
 }
 
-.c9 {
+.c8 {
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
@@ -938,11 +938,6 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
   border: none;
   padding: 0;
   text-align: inherit;
-}
-
-.c5:hover {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 .c5:focus {
@@ -985,6 +980,69 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
   border: 0;
 }
 
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c9:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
 .c3 {
   max-height: inherit;
 }
@@ -999,12 +1057,14 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
   outline: none;
 }
 
-.c8 {
+.c6 {
   background-color: #7D4CDB;
   color: #FFFFFF;
+  display: block;
+  width: 100%;
 }
 
-.c6 {
+.c10 {
   display: block;
   width: 100%;
 }
@@ -1061,33 +1121,33 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
         type="button"
       >
         <div
-          class="c7 c8"
+          class="c7"
         >
           <span
-            class="c9"
+            class="c8"
           >
             Value1
           </span>
         </div>
       </button>
       <button
-        class="c5 c6"
+        class="c9 c10"
         role="menuitem"
         tabindex="-1"
         type="button"
       >
         <div
-          class="c7 "
+          class="c7"
         >
           <span
-            class="c9"
+            class="c8"
           >
             Value2
           </span>
         </div>
       </button>
       <div
-        class="c10"
+        class="c11"
       />
     </div>
   </div>
@@ -1615,7 +1675,7 @@ exports[`Select Controlled multiple onChange with valueKey reduce 2`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -1631,7 +1691,7 @@ exports[`Select Controlled multiple onChange with valueKey reduce 2`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -2169,7 +2229,7 @@ exports[`Select Controlled multiple onChange with valueKey string 2`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -2185,7 +2245,7 @@ exports[`Select Controlled multiple onChange with valueKey string 2`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -2723,7 +2783,7 @@ exports[`Select Controlled multiple onChange without valueKey 2`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -2739,7 +2799,7 @@ exports[`Select Controlled multiple onChange without valueKey 2`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -2783,13 +2843,13 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
       tabindex="-1"
     >
       <button
-        class="StyledButton-sc-323bzc-0 ksFFvX SelectContainer__SelectOption-sc-1wi0ul8-2 kNOKDt"
+        class="StyledButton-sc-323bzc-0 ksFFvX SelectContainer__SelectOption-sc-1wi0ul8-1 etFdtz"
         role="menuitem"
         tabindex="-1"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kNEzzP SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="StyledBox-sc-13pk1d4-0 kNEzzP"
         >
           <span
             class="StyledText-sc-1sadyjn-0 fEvqji"
@@ -2799,13 +2859,13 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
         </div>
       </button>
       <button
-        class="StyledButton-sc-323bzc-0 ksFFvX SelectContainer__SelectOption-sc-1wi0ul8-2 kNOKDt"
+        class="StyledButton-sc-323bzc-0 ksFFvX SelectContainer__SelectOption-sc-1wi0ul8-1 etFdtz"
         role="menuitem"
         tabindex="-1"
         type="button"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 kNEzzP SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="StyledBox-sc-13pk1d4-0 kNEzzP"
         >
           <span
             class="StyledText-sc-1sadyjn-0 fEvqji"
@@ -3196,7 +3256,7 @@ exports[`Select Controlled multiple values 3`] = `
   padding: 12px;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3238,7 +3298,7 @@ exports[`Select Controlled multiple values 3`] = `
   animation-delay: 0.01s;
 }
 
-.c9 {
+.c8 {
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
@@ -3260,11 +3320,6 @@ exports[`Select Controlled multiple values 3`] = `
   border: none;
   padding: 0;
   text-align: inherit;
-}
-
-.c5:hover {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 .c5:focus {
@@ -3321,12 +3376,9 @@ exports[`Select Controlled multiple values 3`] = `
   outline: none;
 }
 
-.c8 {
+.c6 {
   background-color: #7D4CDB;
   color: #FFFFFF;
-}
-
-.c6 {
   display: block;
   width: 100%;
 }
@@ -3383,10 +3435,10 @@ exports[`Select Controlled multiple values 3`] = `
         type="button"
       >
         <div
-          class="c7 c8"
+          class="c7"
         >
           <span
-            class="c9"
+            class="c8"
           >
             one
           </span>
@@ -3399,17 +3451,17 @@ exports[`Select Controlled multiple values 3`] = `
         type="button"
       >
         <div
-          class="c7 c8"
+          class="c7"
         >
           <span
-            class="c9"
+            class="c8"
           >
             two
           </span>
         </div>
       </button>
       <div
-        class="c10"
+        class="c9"
       />
     </div>
   </div>
@@ -3937,7 +3989,7 @@ exports[`Select Controlled multiple with empty results 2`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"
@@ -3953,7 +4005,7 @@ exports[`Select Controlled multiple with empty results 2`] = `
         type="button"
       >
         <div
-          class="c7 SelectContainer__OptionBox-sc-1wi0ul8-1"
+          class="c7"
         >
           <span
             class="c8"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
When you have custom children in Select the hover styling is applied but the selected styling is not applied. This PR adds the selected styling to custom children when they are selected.

#### Where should the reviewer start?
SelectContainer.js

#### What testing has been done on this PR?
Tested with this storybook story
```javascript
import React from 'react';

import { Box, Grommet, Select, Text, Paragraph } from 'grommet';
import { grommet } from 'grommet/themes';

export const TEST = () => {
  const options = ['one', 'two'];
  return (
    <Grommet full theme={grommet}>
        <Box gap="small" width="small">
            <Select options={options} />
            <Select options={options}>{(option) => <Text>{option}</Text>}</Select>
            <Select options={options}>{(option) => option}</Select>
            <Select options={options}>{(option) => <Paragraph>{option}</Paragraph>}</Select>
        </Box>
    </Grommet>
  );
};

export default {
  title: 'Input/Select/TEST',
};
```

#### How should this be manually tested?
See above

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #5154 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible