### PR TITLE
Fix/hover indicator button

### DIFF
--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -178,7 +178,11 @@ const hoverIndicatorStyle = ({ hoverIndicator, theme }) => {
   const themishObj = {};
   if (hoverIndicator === true || hoverIndicator === 'background')
     themishObj.background = theme.global.hover.background;
-  else themishObj.background = hoverIndicator;
+  else if (hoverIndicator.color || hoverIndicator.background) {
+    if (hoverIndicator.background)
+      themishObj.background = hoverIndicator.background;
+    if (hoverIndicator.color) themishObj.color = hoverIndicator.color;
+  } else themishObj.background = hoverIndicator;
   const styles = kindPartStyles(themishObj, theme);
   if (styles.length > 0)
     return css`

--- a/src/js/components/Button/__tests__/Button-kind-test.js
+++ b/src/js/components/Button/__tests__/Button-kind-test.js
@@ -565,4 +565,60 @@ describe('Button kind', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test(`hoverIndicator with color and background`, () => {
+    const { container, getByText } = render(
+      <Grommet
+        theme={{
+          button: { default: {} },
+        }}
+      >
+        <Button
+          hoverIndicator={{
+            background: {
+              color: 'pink',
+            },
+            color: 'white',
+          }}
+          label="Button"
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+
+    fireEvent.mouseOver(getByText('Button'));
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test(`hover secondary with color and background`, () => {
+    const { container, getByText } = render(
+      <Grommet
+        theme={{
+          button: {
+            default: {},
+            secondary: {
+              color: 'white',
+              background: {
+                color: 'skyblue',
+              },
+            },
+            hover: {
+              secondary: {
+                color: 'green',
+                background: {
+                  color: 'orange',
+                },
+              },
+            },
+          },
+        }}
+      >
+        <Button secondary label="Button" />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+
+    fireEvent.mouseOver(getByText('Button'));
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -2288,6 +2288,228 @@ exports[`Button kind hover on default button 1`] = `
 </div>
 `;
 
+exports[`Button kind hover secondary with color and background 1`] = `
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 18px;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: skyblue;
+  color: #FFFFFF;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c1 > svg {
+  vertical-align: bottom;
+}
+
+.c1:hover {
+  background-color: orange;
+  color: green;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus > circle,
+.c1:focus > ellipse,
+.c1:focus > line,
+.c1:focus > path,
+.c1:focus > polygon,
+.c1:focus > polyline,
+.c1:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c1:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible) > circle,
+.c1:focus:not(:focus-visible) > ellipse,
+.c1:focus:not(:focus-visible) > line,
+.c1:focus:not(:focus-visible) > path,
+.c1:focus:not(:focus-visible) > polygon,
+.c1:focus:not(:focus-visible) > polyline,
+.c1:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+  class="c0"
+>
+  <button
+    class="c1"
+    type="button"
+  >
+    Button
+  </button>
+</div>
+`;
+
+exports[`Button kind hover secondary with color and background 2`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
+>
+  <button
+    class="StyledButtonKind-sc-1vhfpnt-0 chxxCr"
+    type="button"
+  >
+    Button
+  </button>
+</div>
+`;
+
+exports[`Button kind hoverIndicator with color and background 1`] = `
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 18px;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c1 > svg {
+  vertical-align: bottom;
+}
+
+.c1:hover {
+  background-color: pink;
+  color: #FFFFFF;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus > circle,
+.c1:focus > ellipse,
+.c1:focus > line,
+.c1:focus > path,
+.c1:focus > polygon,
+.c1:focus > polyline,
+.c1:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c1:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible) > circle,
+.c1:focus:not(:focus-visible) > ellipse,
+.c1:focus:not(:focus-visible) > line,
+.c1:focus:not(:focus-visible) > path,
+.c1:focus:not(:focus-visible) > polygon,
+.c1:focus:not(:focus-visible) > polyline,
+.c1:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+  class="c0"
+>
+  <button
+    class="c1"
+    type="button"
+  >
+    Button
+  </button>
+</div>
+`;
+
+exports[`Button kind hoverIndicator with color and background 2`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
+>
+  <button
+    class="StyledButtonKind-sc-1vhfpnt-0 kvbRIc"
+    type="button"
+  >
+    Button
+  </button>
+</div>
+`;
+
 exports[`Button kind mouseOver and mouseOut events 1`] = `
 .c3 {
   display: inline-block;


### PR DESCRIPTION
#### What does this PR do?
Fix Button hovering style to apply both background and color hover styles

#### Where should the reviewer start?
StyledButtonKind.js

#### What testing has been done on this PR?
Added jest tests and tested with this storybook story:
```javascript
import React from 'react';

import { Box, Button, Grommet } from "grommet";

const theme = {
  button: {
    default: {
    },
    secondary: {
      color: "white",
      background: {
        color: "skyblue"
      }
    },
    hover: {
      secondary: {
        color: "green",
        background: {
            color: "orange"
        }
      }
    }
  }
};

export const TEST = () => (
  <Grommet theme={theme} full={true}>
    <Box pad="small" gap="medium">
      <Button
        secondary
        label="hover"
      />
      <Button
        plain
        label="hoverIndicator={false}"
        hoverIndicator={false}
      />
      <Button
        plain
        label="hoverIndicator={true}"
        hoverIndicator={true}
      />
      <Button
        plain
        label="hoverIndicator background='pink' color='white'"
        hoverIndicator={{
            background: {
                color: 'pink',
            },
            color: 'white'
        }}
      />
      <Button
        plain
        label="hoverIndicator='grey'"
        hoverIndicator="grey"
      />
    </Box>
  </Grommet>
);

export default {
  title: 'Controls/Button/TEST',
};
```

#### How should this be manually tested?
See above

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #5262 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes "Fixed styling for Button hover"

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible