### PR TITLE
Fix Carousel showed slide when mounted

### DIFF
--- a/src/js/components/Carousel/Carousel.js
+++ b/src/js/components/Carousel/Carousel.js
@@ -127,7 +127,8 @@ const Carousel = ({
   );
 
   const selectors = [];
-  const wrappedChildren = Children.map(children, (child, index) => {
+  const wrappedChildren = [];
+  Children.map(children, (child, index) => {
     selectors.push(
       <Button
         // eslint-disable-next-line react/no-array-index-key
@@ -157,13 +158,29 @@ const Carousel = ({
       animation = { type: 'fadeOut', duration: 0 };
     }
 
-    return (
-      <Box fill={fill} overflow="hidden">
-        <Box fill={fill} animation={animation}>
-          {child}
-        </Box>
-      </Box>
-    );
+    if (index === activeIndex) {
+      wrappedChildren.push(
+        // eslint-disable-next-line react/no-array-index-key
+        <Box key={index} fill={fill} overflow="hidden">
+          <Box fill={fill} animation={animation}>
+            {child}
+          </Box>
+        </Box>,
+      );
+    } else {
+      wrappedChildren.unshift(
+        <Box
+          // eslint-disable-next-line react/no-array-index-key
+          key={index}
+          fill={fill}
+          overflow="hidden"
+        >
+          <Box fill={fill} animation={animation}>
+            {child}
+          </Box>
+        </Box>,
+      );
+    }
   });
 
   const NextIcon = theme.carousel.icons.next;

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -106,6 +106,9 @@ exports[`Carousel basic 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  opacity: 1;
+  -webkit-animation: hftlBD 1s 0s forwards;
+  animation: hftlBD 1s 0s forwards;
 }
 
 .c6 {
@@ -120,9 +123,6 @@ exports[`Carousel basic 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  opacity: 1;
-  -webkit-animation: hftlBD 1s 0s forwards;
-  animation: hftlBD 1s 0s forwards;
 }
 
 .c7 {
@@ -403,7 +403,7 @@ exports[`Carousel basic 1`] = `
         >
           <img
             className=""
-            src="//v2.grommet.io/assets/IMG_4245.jpg"
+            src="//v2.grommet.io/assets/IMG_4210.jpg"
           />
         </div>
       </div>
@@ -419,7 +419,7 @@ exports[`Carousel basic 1`] = `
         >
           <img
             className=""
-            src="//v2.grommet.io/assets/IMG_4210.jpg"
+            src="//v2.grommet.io/assets/IMG_4245.jpg"
           />
         </div>
       </div>
@@ -1182,6 +1182,9 @@ exports[`Carousel navigate 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  opacity: 1;
+  -webkit-animation: hftlBD 1s 0s forwards;
+  animation: hftlBD 1s 0s forwards;
 }
 
 .c6 {
@@ -1196,9 +1199,6 @@ exports[`Carousel navigate 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  opacity: 1;
-  -webkit-animation: hftlBD 1s 0s forwards;
-  animation: hftlBD 1s 0s forwards;
 }
 
 .c7 {
@@ -1479,7 +1479,7 @@ exports[`Carousel navigate 1`] = `
         >
           <img
             class=""
-            src="//v2.grommet.io/assets/IMG_4245.jpg"
+            src="//v2.grommet.io/assets/IMG_4210.jpg"
           />
         </div>
       </div>
@@ -1495,7 +1495,7 @@ exports[`Carousel navigate 1`] = `
         >
           <img
             class=""
-            src="//v2.grommet.io/assets/IMG_4210.jpg"
+            src="//v2.grommet.io/assets/IMG_4245.jpg"
           />
         </div>
       </div>
@@ -1602,14 +1602,46 @@ exports[`Carousel navigate 2`] = `
     <div
       class="StyledStack__StyledStackLayer-ajspsk-1 gBThXn"
     >
-      <div
-        class="StyledBox-sc-13pk1d4-0 ceQwbc"
+      .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  opacity: 1;
+  -webkit-animation: hftlBD 1s 0s forwards;
+  animation: hftlBD 1s 0s forwards;
+}
+
+<div
+        class="c0"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 csgqhr"
+          class="c1"
         >
           <img
-            class="StyledImage-ey4zx9-0 paVDt"
+            class=""
             src="//v2.grommet.io/assets/IMG_4245.jpg"
           />
         </div>
@@ -1618,14 +1650,48 @@ exports[`Carousel navigate 2`] = `
     <div
       class="StyledStack__StyledStackLayer-ajspsk-1 jeVJjk"
     >
-      <div
-        class="StyledBox-sc-13pk1d4-0 ceQwbc"
+      .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-transform: translateX(200%);
+  -ms-transform: translateX(200%);
+  transform: translateX(200%);
+  -webkit-animation: cCLHuk 1s 0s forwards;
+  animation: cCLHuk 1s 0s forwards;
+}
+
+<div
+        class="c0"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 hggYQt"
+          class="c1"
         >
           <img
-            class="StyledImage-ey4zx9-0 paVDt"
+            class=""
             src="//v2.grommet.io/assets/IMG_4210.jpg"
           />
         </div>
@@ -1733,15 +1799,47 @@ exports[`Carousel navigate 3`] = `
     <div
       class="StyledStack__StyledStackLayer-ajspsk-1 jeVJjk"
     >
-      <div
-        class="StyledBox-sc-13pk1d4-0 ceQwbc"
+      .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  opacity: 1;
+  -webkit-animation: hftlBD 1s 0s forwards;
+  animation: hftlBD 1s 0s forwards;
+}
+
+<div
+        class="c0"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 gWwFrB"
+          class="c1"
         >
           <img
-            class="StyledImage-ey4zx9-0 paVDt"
-            src="//v2.grommet.io/assets/IMG_4245.jpg"
+            class=""
+            src="//v2.grommet.io/assets/IMG_4210.jpg"
           />
         </div>
       </div>
@@ -1749,15 +1847,49 @@ exports[`Carousel navigate 3`] = `
     <div
       class="StyledStack__StyledStackLayer-ajspsk-1 gBThXn"
     >
-      <div
-        class="StyledBox-sc-13pk1d4-0 ceQwbc"
+      .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-transform: translateX(-200%);
+  -ms-transform: translateX(-200%);
+  transform: translateX(-200%);
+  -webkit-animation: cowwqN 1s 0s forwards;
+  animation: cowwqN 1s 0s forwards;
+}
+
+<div
+        class="c0"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 csgqhr"
+          class="c1"
         >
           <img
-            class="StyledImage-ey4zx9-0 paVDt"
-            src="//v2.grommet.io/assets/IMG_4210.jpg"
+            class=""
+            src="//v2.grommet.io/assets/IMG_4245.jpg"
           />
         </div>
       </div>
@@ -1959,6 +2091,9 @@ exports[`Carousel play 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  opacity: 1;
+  -webkit-animation: hftlBD 1s 0s forwards;
+  animation: hftlBD 1s 0s forwards;
 }
 
 .c6 {
@@ -1973,9 +2108,6 @@ exports[`Carousel play 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  opacity: 1;
-  -webkit-animation: hftlBD 1s 0s forwards;
-  animation: hftlBD 1s 0s forwards;
 }
 
 .c7 {
@@ -2255,7 +2387,7 @@ exports[`Carousel play 1`] = `
         >
           <img
             class=""
-            src="//v2.grommet.io/assets/IMG_4245.jpg"
+            src="//v2.grommet.io/assets/IMG_4210.jpg"
           />
         </div>
       </div>
@@ -2271,7 +2403,7 @@ exports[`Carousel play 1`] = `
         >
           <img
             class=""
-            src="//v2.grommet.io/assets/IMG_4210.jpg"
+            src="//v2.grommet.io/assets/IMG_4245.jpg"
           />
         </div>
       </div>
@@ -2377,14 +2509,46 @@ exports[`Carousel play 2`] = `
     <div
       class="StyledStack__StyledStackLayer-ajspsk-1 gBThXn"
     >
-      <div
-        class="StyledBox-sc-13pk1d4-0 ceQwbc"
+      .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  opacity: 1;
+  -webkit-animation: hftlBD 1s 0s forwards;
+  animation: hftlBD 1s 0s forwards;
+}
+
+<div
+        class="c0"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 csgqhr"
+          class="c1"
         >
           <img
-            class="StyledImage-ey4zx9-0 paVDt"
+            class=""
             src="//v2.grommet.io/assets/IMG_4245.jpg"
           />
         </div>
@@ -2393,14 +2557,48 @@ exports[`Carousel play 2`] = `
     <div
       class="StyledStack__StyledStackLayer-ajspsk-1 jeVJjk"
     >
-      <div
-        class="StyledBox-sc-13pk1d4-0 ceQwbc"
+      .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-transform: translateX(200%);
+  -ms-transform: translateX(200%);
+  transform: translateX(200%);
+  -webkit-animation: cCLHuk 1s 0s forwards;
+  animation: cCLHuk 1s 0s forwards;
+}
+
+<div
+        class="c0"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 hggYQt"
+          class="c1"
         >
           <img
-            class="StyledImage-ey4zx9-0 paVDt"
+            class=""
             src="//v2.grommet.io/assets/IMG_4210.jpg"
           />
         </div>
@@ -2603,6 +2801,9 @@ exports[`Carousel should trigger events of focus, blur and click 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  opacity: 1;
+  -webkit-animation: hftlBD 1s 0s forwards;
+  animation: hftlBD 1s 0s forwards;
 }
 
 .c6 {
@@ -2617,9 +2818,6 @@ exports[`Carousel should trigger events of focus, blur and click 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  opacity: 1;
-  -webkit-animation: hftlBD 1s 0s forwards;
-  animation: hftlBD 1s 0s forwards;
 }
 
 .c7 {
@@ -2834,7 +3032,7 @@ exports[`Carousel should trigger events of focus, blur and click 1`] = `
         >
           <img
             class=""
-            src="//v2.grommet.io/assets/IMG_4245.jpg"
+            src="//v2.grommet.io/assets/IMG_4210.jpg"
           />
         </div>
       </div>
@@ -2850,7 +3048,7 @@ exports[`Carousel should trigger events of focus, blur and click 1`] = `
         >
           <img
             class=""
-            src="//v2.grommet.io/assets/IMG_4210.jpg"
+            src="//v2.grommet.io/assets/IMG_4245.jpg"
           />
         </div>
       </div>


### PR DESCRIPTION
#### What does this PR do?
Provides a fix for #5093 by building on #5115, which seems abandoned.

Following the insights of the issue reporter, reversing the Carousel children fixes the behavior for some cases (initialChild = 0). However, passing any other value as initialChild results in the same problem.

The problem itself is related to children animations. That's how Carousel navigation is handled, by changing their visibility. This fix solves the problem by reordering the children based on which one is the activeIndex, and also changing z-Index and opacity for the other children.

#### Where should the reviewer start?

src/js/components/Carousel/Carousel.js

#### What testing has been done on this PR?

Manual testing and the existing tests (that were updated)

#### How should this be manually tested?

```
const CarouselModal = ({ close }) => (
  <Layer onClickOutside={close}>
    <Carousel controls="arrows" initialChild={0}>
      <Image fit="cover" src="//v2.grommet.io/assets/Wilderpeople_Ricky.jpg" />
      <Image fit="cover" src="//v2.grommet.io/assets/IMG_4245.jpg" />
      <Image fit="cover" src="//v2.grommet.io/assets/IMG_4210.jpg" />
    </Carousel>
  </Layer>
);

export const Simple = () => {
  const [showModal, setShowModal] = useState(false);

  return (
    <Grommet theme={grommet}>
      <Button label="Show Modal Carousel" onClick={() => setShowModal(true)} />

      {showModal && <CarouselModal close={() => setShowModal(false)} />}
    </Grommet>
  );
};
```


#### Any background context you want to provide?

#### What are the relevant issues?

Closes #5093

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible, but it might break some snapshots as children's order might differ a little bit.
