### PR TITLE
carousel: Fix carousel showing the wrong image initially.

### DIFF
--- a/src/js/components/Carousel/Carousel.js
+++ b/src/js/components/Carousel/Carousel.js
@@ -140,6 +140,7 @@ const Carousel = ({
     );
 
     let animation;
+    let visibility = 'visible';
     if (index === activeIndex) {
       if (priorActiveIndex !== undefined) {
         animation = {
@@ -155,10 +156,11 @@ const Carousel = ({
       };
     } else {
       animation = { type: 'fadeOut', duration: 0 };
+      visibility = 'hidden';
     }
 
     return (
-      <Box fill={fill} overflow="hidden">
+      <Box fill={fill} style={{ visibility }} overflow="hidden">
         <Box fill={fill} animation={animation}>
           {child}
         </Box>

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -397,6 +397,11 @@ exports[`Carousel basic 1`] = `
     >
       <div
         className="c3"
+        style={
+          Object {
+            "visibility": "visible",
+          }
+        }
       >
         <div
           className="c4"
@@ -413,6 +418,11 @@ exports[`Carousel basic 1`] = `
     >
       <div
         className="c3"
+        style={
+          Object {
+            "visibility": "hidden",
+          }
+        }
       >
         <div
           className="c6"
@@ -935,6 +945,11 @@ exports[`Carousel basic with \`initialChild: 1\` 1`] = `
     >
       <div
         className="c3"
+        style={
+          Object {
+            "visibility": "hidden",
+          }
+        }
       >
         <div
           className="c4"
@@ -951,6 +966,11 @@ exports[`Carousel basic with \`initialChild: 1\` 1`] = `
     >
       <div
         className="c3"
+        style={
+          Object {
+            "visibility": "visible",
+          }
+        }
       >
         <div
           className="c6"
@@ -1473,6 +1493,7 @@ exports[`Carousel navigate 1`] = `
     >
       <div
         class="c3"
+        style="visibility: visible;"
       >
         <div
           class="c4"
@@ -1489,6 +1510,7 @@ exports[`Carousel navigate 1`] = `
     >
       <div
         class="c3"
+        style="visibility: hidden;"
       >
         <div
           class="c6"
@@ -1604,6 +1626,7 @@ exports[`Carousel navigate 2`] = `
     >
       <div
         class="StyledBox-sc-13pk1d4-0 ceQwbc"
+        style="visibility: visible;"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 csgqhr"
@@ -1620,6 +1643,7 @@ exports[`Carousel navigate 2`] = `
     >
       <div
         class="StyledBox-sc-13pk1d4-0 ceQwbc"
+        style="visibility: visible;"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 hggYQt"
@@ -1735,6 +1759,7 @@ exports[`Carousel navigate 3`] = `
     >
       <div
         class="StyledBox-sc-13pk1d4-0 ceQwbc"
+        style="visibility: visible;"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 gWwFrB"
@@ -1751,6 +1776,7 @@ exports[`Carousel navigate 3`] = `
     >
       <div
         class="StyledBox-sc-13pk1d4-0 ceQwbc"
+        style="visibility: visible;"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 csgqhr"
@@ -2249,6 +2275,7 @@ exports[`Carousel play 1`] = `
     >
       <div
         class="c3"
+        style="visibility: visible;"
       >
         <div
           class="c4"
@@ -2265,6 +2292,7 @@ exports[`Carousel play 1`] = `
     >
       <div
         class="c3"
+        style="visibility: hidden;"
       >
         <div
           class="c6"
@@ -2379,6 +2407,7 @@ exports[`Carousel play 2`] = `
     >
       <div
         class="StyledBox-sc-13pk1d4-0 ceQwbc"
+        style="visibility: visible;"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 csgqhr"
@@ -2395,6 +2424,7 @@ exports[`Carousel play 2`] = `
     >
       <div
         class="StyledBox-sc-13pk1d4-0 ceQwbc"
+        style="visibility: visible;"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 hggYQt"
@@ -2828,6 +2858,7 @@ exports[`Carousel should trigger events of focus, blur and click 1`] = `
     >
       <div
         class="c3"
+        style="visibility: visible;"
       >
         <div
           class="c4"
@@ -2844,6 +2875,7 @@ exports[`Carousel should trigger events of focus, blur and click 1`] = `
     >
       <div
         class="c3"
+        style="visibility: hidden;"
       >
         <div
           class="c6"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This fixes the issue by explicitly hiding every other child except for
the initial child on mount (and the previously visible child for
animation purposes after the initial child has changed) so that only the
desired image will be visible on mount.

#### Where should the reviewer start?

#5093 is a bug where a wrong image is shown in the carousel on mount. This PR fixes that bug.

#### What testing has been done on this PR?

Storyboard works and my local site which uses the carousel works.

#### How should this be manually tested?

On master, open the storyboard carousel and watch the wrong image initially be visible. Pull in this commit and then watch how the initial child doesn't change when the page loads.

#### Any background context you want to provide?

#5093

#### What are the relevant issues?

#5093

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
It is a bug fix, so sure.
#### Is this change backwards compatible or is it a breaking change?
It is backwards compatible.