### PR TITLE
Changed DataChart to allow detail to work for more data points.

### DIFF
--- a/src/js/components/DataChart/Detail.js
+++ b/src/js/components/DataChart/Detail.js
@@ -21,10 +21,10 @@ const Detail = ({
   activeProperty,
   axis,
   data,
-  pad,
   series,
   seriesStyles,
   renderValue,
+  thickness,
 }) => {
   const [detailIndex, setDetailIndex] = useState();
   const activeIndex = useRef();
@@ -75,7 +75,7 @@ const Detail = ({
               key={i}
               align="center"
               responsive={false}
-              pad={{ horizontal: pad.horizontal }}
+              width={thickness}
               onMouseOver={event => {
                 activeIndex.current = event.currentTarget;
                 setDetailIndex(i);

--- a/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
+++ b/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
@@ -4383,8 +4383,7 @@ exports[`DataChart detail 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  padding-left: 48px;
-  padding-right: 48px;
+  width: 96px;
 }
 
 .c13 {


### PR DESCRIPTION
#### What does this PR do?

Changed DataChart to allow detail to work for more data points.

The old way was using the outer `pad` to drive the thickness of the detail segments. This sort of worked, as long as half the pad could be determined. But, when the thickness of the Chart elements was `hair`, the half size of that became 0, which meant there was no pad, but then no width to the Detail segments. This new approach separates the outer `pad` from the thickness of the detail segments.

#### Where should the reviewer start?

Detail.js

#### What testing has been done on this PR?

Changed the Detail story to have 130 data points.

#### What are the relevant issues?

#5312 

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
