### PR TITLE
Refactor Markdown, SelectMultiple and ResponsiveContext tests to remove react-test-renderer

### DIFF
--- a/src/js/components/Markdown/__tests__/Markdown-test.js
+++ b/src/js/components/Markdown/__tests__/Markdown-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
@@ -29,11 +29,11 @@ Markdown | Less | Pretty
 `;
 
 test('Markdown renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Markdown>{CONTENT}</Markdown>
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });

--- a/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
+++ b/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
@@ -145,102 +145,97 @@ exports[`Markdown renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div>
     <h1
-      className="c1"
+      class="c1"
       id="h1"
     >
       H1
     </h1>
     <p
-      className="c2"
+      class="c2"
     >
       Paragraph
     </p>
     <h2
-      className="c3"
+      class="c3"
       id="h2"
     >
       H2
     </h2>
     <h3
-      className="c4"
+      class="c4"
       id="h3"
     >
       H3
     </h3>
     <h4
-      className="c5"
+      class="c5"
       id="h4"
     >
       H4
     </h4>
     <p
-      className="c2"
+      class="c2"
     >
       <a
-        className="c6"
+        class="c6"
         href="#"
-        onBlur={[Function]}
-        onFocus={[Function]}
       >
         a link
       </a>
     </p>
     <blockquote>
       <p
-        className="c2"
+        class="c2"
       >
         i carry your heart with me
       </p>
     </blockquote>
     <p
-      className="c2"
+      class="c2"
     >
       <img
         alt="alt text"
-        className=""
+        class=""
         src="//v2.grommet.io/assets/IMG_4245.jpg"
         title="Markdown Image"
       />
     </p>
     <table
-      className="c7"
+      class="c7"
     >
       <thead
-        className="StyledTable__StyledTableHeader-sc-1m3u5g-4"
+        class="StyledTable__StyledTableHeader-sc-1m3u5g-4"
       >
         <tr
-          className="StyledTable__StyledTableRow-sc-1m3u5g-2"
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2"
         >
           <td
-            className="c8"
+            class="c8"
           >
             <div
-              className="c9"
-              style={Object {}}
+              class="c9"
             >
               Markdown
             </div>
           </td>
           <td
-            className="c8"
+            class="c8"
           >
             <div
-              className="c9"
-              style={Object {}}
+              class="c9"
             >
               Less
             </div>
           </td>
           <td
-            className="c8"
+            class="c8"
           >
             <div
-              className="c9"
-              style={Object {}}
+              class="c9"
             >
               Pretty
             </div>
@@ -248,17 +243,16 @@ exports[`Markdown renders 1`] = `
         </tr>
       </thead>
       <tbody
-        className="StyledTable__StyledTableBody-sc-1m3u5g-3"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3"
       >
         <tr
-          className="StyledTable__StyledTableRow-sc-1m3u5g-2"
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2"
         >
           <td
-            className="c10"
+            class="c10"
           >
             <div
-              className="c9"
-              style={Object {}}
+              class="c9"
             >
               <em>
                 Still
@@ -266,11 +260,10 @@ exports[`Markdown renders 1`] = `
             </div>
           </td>
           <td
-            className="c10"
+            class="c10"
           >
             <div
-              className="c9"
-              style={Object {}}
+              class="c9"
             >
               <code>
                 renders
@@ -278,11 +271,10 @@ exports[`Markdown renders 1`] = `
             </div>
           </td>
           <td
-            className="c10"
+            class="c10"
           >
             <div
-              className="c9"
-              style={Object {}}
+              class="c9"
             >
               <strong>
                 nicely
@@ -291,34 +283,31 @@ exports[`Markdown renders 1`] = `
           </td>
         </tr>
         <tr
-          className="StyledTable__StyledTableRow-sc-1m3u5g-2"
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2"
         >
           <td
-            className="c10"
+            class="c10"
           >
             <div
-              className="c9"
-              style={Object {}}
+              class="c9"
             >
               1
             </div>
           </td>
           <td
-            className="c10"
+            class="c10"
           >
             <div
-              className="c9"
-              style={Object {}}
+              class="c9"
             >
               2
             </div>
           </td>
           <td
-            className="c10"
+            class="c10"
           >
             <div
-              className="c9"
-              style={Object {}}
+              class="c9"
             >
               3
             </div>

--- a/src/js/components/Select/__tests__/SelectMultiple-test.js
+++ b/src/js/components/Select/__tests__/SelectMultiple-test.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import 'jest-styled-components';
-import renderer from 'react-test-renderer';
 import { act, cleanup, render, fireEvent } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
+import 'jest-styled-components';
 
 import { createPortal, expectPortal } from '../../../utils/portal';
 
@@ -28,7 +27,7 @@ describe('Select Controlled', () => {
   });
 
   test('multiple', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Select
         id="test-select"
         multiple
@@ -37,7 +36,8 @@ describe('Select Controlled', () => {
         value={[]}
       />,
     );
-    expect(component.toJSON()).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('multiple values', () => {
@@ -418,7 +418,7 @@ describe('Select Controlled', () => {
     expect(onChange).toHaveBeenNthCalledWith(3, [{ id: 21, name: 'Value21' }]);
   });
 
-  test(`should allow multiple selections when options are 
+  test(`should allow multiple selections when options are
   loaded lazily`, () => {
     jest.useFakeTimers();
     const onChange = jest.fn();

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -486,57 +486,44 @@ exports[`Select Controlled multiple 1`] = `
 
 <button
   aria-label="Open Drop"
-  className="c0 c1"
+  class="c0 c1"
   id="test-select"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  onMouseOut={[Function]}
-  onMouseOver={[Function]}
   type="button"
 >
   <div
-    className="c2"
+    class="c2"
   >
     <div
-      className="c3"
+      class="c3"
     >
       <div
-        className="c4"
+        class="c4"
       >
         <input
-          autoComplete="off"
-          className="c5 c6"
+          autocomplete="off"
+          class="c5 c6"
           id="test-select__input"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          readOnly={true}
-          tabIndex="-1"
+          readonly=""
+          tabindex="-1"
           type="text"
           value=""
         />
       </div>
     </div>
     <div
-      className="c7"
-      style={
-        Object {
-          "minWidth": "auto",
-        }
-      }
+      class="c7"
+      style="min-width: auto;"
     >
       <svg
         aria-label="FormDown"
-        className="c8"
+        class="c8"
         viewBox="0 0 24 24"
       >
         <polyline
           fill="none"
           points="18 9 12 15 6 9"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>

--- a/src/js/contexts/ResponsiveContext/__tests__/ResponsiveContext-test.js
+++ b/src/js/contexts/ResponsiveContext/__tests__/ResponsiveContext-test.js
@@ -1,19 +1,73 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import 'jest-styled-components';
 import 'regenerator-runtime/runtime';
+import '@testing-library/jest-dom';
 
 import { Grommet } from '../../../components/Grommet';
 import { ResponsiveContext } from '..';
 
 describe('ResponsiveContext', () => {
-  test('basic', () => {
-    const { container } = render(
-      <Grommet>
-        <ResponsiveContext.Consumer>{size => size}</ResponsiveContext.Consumer>
-      </Grommet>,
-    );
+  describe('when viewport width is 768px', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(document.body, 'clientWidth', 'get')
+        .mockImplementation(() => 768);
+    });
 
-    expect(container.firstChild).toMatchSnapshot();
+    test('should return small', () => {
+      const { container } = render(
+        <Grommet>
+          <ResponsiveContext.Consumer>
+            {size => size}
+          </ResponsiveContext.Consumer>
+        </Grommet>,
+      );
+
+      expect(screen.getByText('small')).toBeInTheDocument();
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+
+  describe('when viewport width is 1536px', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(document.body, 'clientWidth', 'get')
+        .mockImplementation(() => 1536);
+    });
+
+    test('should return medium', () => {
+      const { container } = render(
+        <Grommet>
+          <ResponsiveContext.Consumer>
+            {size => size}
+          </ResponsiveContext.Consumer>
+        </Grommet>,
+      );
+
+      expect(screen.getByText('medium')).toBeInTheDocument();
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+
+  describe('when viewport width is 1537px', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(document.body, 'clientWidth', 'get')
+        .mockImplementation(() => 1537);
+    });
+
+    test('should return large', () => {
+      const { container } = render(
+        <Grommet>
+          <ResponsiveContext.Consumer>
+            {size => size}
+          </ResponsiveContext.Consumer>
+        </Grommet>,
+      );
+
+      expect(screen.getByText('large')).toBeInTheDocument();
+      expect(container.firstChild).toMatchSnapshot();
+    });
   });
 });

--- a/src/js/contexts/ResponsiveContext/__tests__/ResponsiveContext-test.js
+++ b/src/js/contexts/ResponsiveContext/__tests__/ResponsiveContext-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import 'jest-styled-components';
 import 'regenerator-runtime/runtime';
 
@@ -8,12 +8,12 @@ import { ResponsiveContext } from '..';
 
 describe('ResponsiveContext', () => {
   test('basic', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <ResponsiveContext.Consumer>{size => size}</ResponsiveContext.Consumer>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/contexts/ResponsiveContext/__tests__/__snapshots__/ResponsiveContext-test.js.snap
+++ b/src/js/contexts/ResponsiveContext/__tests__/__snapshots__/ResponsiveContext-test.js.snap
@@ -12,8 +12,8 @@ exports[`ResponsiveContext basic 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
-  medium
+  small
 </div>
 `;

--- a/src/js/contexts/ResponsiveContext/__tests__/__snapshots__/ResponsiveContext-test.js.snap
+++ b/src/js/contexts/ResponsiveContext/__tests__/__snapshots__/ResponsiveContext-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ResponsiveContext basic 1`] = `
+exports[`ResponsiveContext when viewport width is 768px should return small 1`] = `
 .c0 {
   font-size: 18px;
   line-height: 24px;
@@ -15,5 +15,41 @@ exports[`ResponsiveContext basic 1`] = `
   class="c0"
 >
   small
+</div>
+`;
+
+exports[`ResponsiveContext when viewport width is 1536px should return medium 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+  class="c0"
+>
+  medium
+</div>
+`;
+
+exports[`ResponsiveContext when viewport width is 1537px should return large 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+  class="c0"
+>
+  large
 </div>
 `;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Markdown/__tests__/Markdown-test.js`
`src/js/components/Select/__tests__/SelectMultiple-test.js`
`src/js/contexts/ResponsiveContext/__tests__/ResponsiveContext-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.