### PR TITLE
Refactor Carousel, DropButton and FormUncontrolled tests to remove react-test-renderer 

### DIFF
--- a/src/js/components/Carousel/__tests__/Carousel-test.js
+++ b/src/js/components/Carousel/__tests__/Carousel-test.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
-import 'jest-styled-components';
 import { cleanup, render, fireEvent, act } from '@testing-library/react';
+import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
 import { Carousel } from '..';
@@ -11,7 +10,7 @@ describe('Carousel', () => {
   afterEach(cleanup);
 
   test('basic', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Carousel>
           <Image src="//v2.grommet.io/assets/IMG_4245.jpg" />
@@ -19,12 +18,12 @@ describe('Carousel', () => {
         </Carousel>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('basic with `initialChild: 1`', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Carousel initialChild={1}>
           <Image src="//v2.grommet.io/assets/IMG_4245.jpg" />
@@ -32,8 +31,8 @@ describe('Carousel', () => {
         </Carousel>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('navigate', () => {

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -386,159 +386,127 @@ exports[`Carousel basic 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
-    onKeyDown={[Function]}
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div
-        className="c3"
-        style={
-          Object {
-            "visibility": "visible",
-          }
-        }
+        class="c3"
+        style="visibility: visible;"
       >
         <div
-          className="c4"
+          class="c4"
         >
           <img
-            className=""
+            class=""
             src="//v2.grommet.io/assets/IMG_4245.jpg"
           />
         </div>
       </div>
     </div>
     <div
-      className="c5"
+      class="c5"
     >
       <div
-        className="c3"
-        style={
-          Object {
-            "visibility": "hidden",
-          }
-        }
+        class="c3"
+        style="visibility: hidden;"
       >
         <div
-          className="c6"
+          class="c6"
         >
           <img
-            className=""
+            class=""
             src="//v2.grommet.io/assets/IMG_4210.jpg"
           />
         </div>
       </div>
     </div>
     <div
-      className="c5"
+      class="c5"
     >
       <div
-        className="c7"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        tabIndex="0"
+        class="c7"
+        tabindex="0"
       >
         <button
-          className="c8"
-          disabled={true}
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
+          class="c8"
+          disabled=""
           type="button"
         >
           <svg
             aria-label="Previous"
-            className="c9"
+            class="c9"
             viewBox="0 0 24 24"
           >
             <polyline
               fill="none"
               points="7 2 17 12 7 22"
               stroke="#000"
-              strokeWidth="2"
+              stroke-width="2"
               transform="matrix(-1 0 0 1 24 0)"
             />
           </svg>
         </button>
         <div
-          className="c10"
+          class="c10"
         >
           <div
-            className="c11"
+            class="c11"
           >
             <button
-              className="c12"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
+              class="c12"
               type="button"
             >
               <svg
                 aria-label="Subtract"
-                className="c13"
+                class="c13"
                 viewBox="0 0 24 24"
               >
                 <path
                   d="M2,12 L22,12"
                   fill="none"
                   stroke="#000"
-                  strokeWidth="2"
+                  stroke-width="2"
                 />
               </svg>
             </button>
             <button
-              className="c12"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
+              class="c12"
               type="button"
             >
               <svg
                 aria-label="Subtract"
-                className="c9"
+                class="c9"
                 viewBox="0 0 24 24"
               >
                 <path
                   d="M2,12 L22,12"
                   fill="none"
                   stroke="#000"
-                  strokeWidth="2"
+                  stroke-width="2"
                 />
               </svg>
             </button>
           </div>
         </div>
         <button
-          className="c14"
-          disabled={false}
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
+          class="c14"
           type="button"
         >
           <svg
             aria-label="Next"
-            className="c9"
+            class="c9"
             viewBox="0 0 24 24"
           >
             <polyline
               fill="none"
               points="7 2 17 12 7 22"
               stroke="#000"
-              strokeWidth="2"
+              stroke-width="2"
             />
           </svg>
         </button>
@@ -934,159 +902,127 @@ exports[`Carousel basic with \`initialChild: 1\` 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
-    onKeyDown={[Function]}
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div
-        className="c3"
-        style={
-          Object {
-            "visibility": "hidden",
-          }
-        }
+        class="c3"
+        style="visibility: hidden;"
       >
         <div
-          className="c4"
+          class="c4"
         >
           <img
-            className=""
+            class=""
             src="//v2.grommet.io/assets/IMG_4245.jpg"
           />
         </div>
       </div>
     </div>
     <div
-      className="c5"
+      class="c5"
     >
       <div
-        className="c3"
-        style={
-          Object {
-            "visibility": "visible",
-          }
-        }
+        class="c3"
+        style="visibility: visible;"
       >
         <div
-          className="c6"
+          class="c6"
         >
           <img
-            className=""
+            class=""
             src="//v2.grommet.io/assets/IMG_4210.jpg"
           />
         </div>
       </div>
     </div>
     <div
-      className="c2"
+      class="c2"
     >
       <div
-        className="c7"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        tabIndex="0"
+        class="c7"
+        tabindex="0"
       >
         <button
-          className="c8"
-          disabled={false}
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
+          class="c8"
           type="button"
         >
           <svg
             aria-label="Previous"
-            className="c9"
+            class="c9"
             viewBox="0 0 24 24"
           >
             <polyline
               fill="none"
               points="7 2 17 12 7 22"
               stroke="#000"
-              strokeWidth="2"
+              stroke-width="2"
               transform="matrix(-1 0 0 1 24 0)"
             />
           </svg>
         </button>
         <div
-          className="c10"
+          class="c10"
         >
           <div
-            className="c11"
+            class="c11"
           >
             <button
-              className="c12"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
+              class="c12"
               type="button"
             >
               <svg
                 aria-label="Subtract"
-                className="c9"
+                class="c9"
                 viewBox="0 0 24 24"
               >
                 <path
                   d="M2,12 L22,12"
                   fill="none"
                   stroke="#000"
-                  strokeWidth="2"
+                  stroke-width="2"
                 />
               </svg>
             </button>
             <button
-              className="c12"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
+              class="c12"
               type="button"
             >
               <svg
                 aria-label="Subtract"
-                className="c13"
+                class="c13"
                 viewBox="0 0 24 24"
               >
                 <path
                   d="M2,12 L22,12"
                   fill="none"
                   stroke="#000"
-                  strokeWidth="2"
+                  stroke-width="2"
                 />
               </svg>
             </button>
           </div>
         </div>
         <button
-          className="c14"
-          disabled={true}
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
+          class="c14"
+          disabled=""
           type="button"
         >
           <svg
             aria-label="Next"
-            className="c9"
+            class="c9"
             viewBox="0 0 24 24"
           >
             <polyline
               fill="none"
               points="7 2 17 12 7 22"
               stroke="#000"
-              strokeWidth="2"
+              stroke-width="2"
             />
           </svg>
         </button>

--- a/src/js/components/DropButton/__tests__/DropButton-test.js
+++ b/src/js/components/DropButton/__tests__/DropButton-test.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import 'jest-styled-components';
-import renderer from 'react-test-renderer';
 import { cleanup, fireEvent, render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
+import 'jest-styled-components';
 
 import { createPortal, expectPortal } from '../../../utils/portal';
 
@@ -28,24 +27,28 @@ describe('DropButton', () => {
   });
 
   test('closed', () => {
-    const component = renderer.create(
+    window.scrollTo = jest.fn();
+
+    const { container } = render(
       <DropButton
         label="Dropper"
         dropContent={<div id="drop-contents">drop contents</div>}
       />,
     );
-    expect(component.toJSON()).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('opened', () => {
-    const component = renderer.create(
+    const { container } = render(
       <DropButton
         label="Dropper"
         open
         dropContent={<div id="drop-contents">drop contents</div>}
       />,
     );
-    expect(component.toJSON()).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('open and close', () => {

--- a/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
+++ b/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
@@ -165,12 +165,7 @@ exports[`DropButton closed 1`] = `
 
 <button
   aria-label="Open Drop"
-  className="c0"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onMouseOut={[Function]}
-  onMouseOver={[Function]}
+  class="c0"
   type="button"
 >
   Dropper
@@ -418,14 +413,13 @@ exports[`DropButton opened 1`] = `
   border: 0;
 }
 
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
 <button
   aria-label="Open Drop"
-  className="c0"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onMouseOut={[Function]}
-  onMouseOver={[Function]}
+  class="c0"
   type="button"
 >
   Dropper

--- a/src/js/components/Form/__tests__/Form-test-uncontrolled.js
+++ b/src/js/components/Form/__tests__/Form-test-uncontrolled.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
@@ -105,25 +104,25 @@ describe('Form uncontrolled', () => {
   afterEach(cleanup);
 
   test('empty', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Form />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('with field', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Form>
           <FormField name="test" />
         </Form>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('errors', () => {

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -1614,12 +1614,9 @@ exports[`Form uncontrolled empty 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
-  <form
-    onReset={[Function]}
-    onSubmit={[Function]}
-  />
+  <form />
 </div>
 `;
 
@@ -4661,31 +4658,23 @@ exports[`Form uncontrolled with field 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
-  <form
-    onReset={[Function]}
-    onSubmit={[Function]}
-  >
+  <form>
     <div
-      className="c1 "
-      onBlur={[Function]}
-      onFocus={[Function]}
+      class="c1 "
     >
       <div
-        className="c2 FormField__FormFieldContentBox-m9hood-1"
+        class="c2 FormField__FormFieldContentBox-m9hood-1"
       >
         <div
-          className="c3"
+          class="c3"
         >
           <input
-            autoComplete="off"
-            className="c4"
+            autocomplete="off"
+            class="c4"
             name="test"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            value=""
           />
         </div>
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Carousel/__tests__/Carousel-test.js`
`src/js/components/DropButton/__tests__/DropButton-test.js`
`src/js/components/Form/__tests__/Form-test-uncontrolled.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.