### PR TITLE
Refactor Tip, extendDefaultTheme and CheckBoxGroup tests to remove react-test-renderer

### DIFF
--- a/src/js/__tests__/__snapshots__/default-props-test.js.snap
+++ b/src/js/__tests__/__snapshots__/default-props-test.js.snap
@@ -18,7 +18,7 @@ exports[`default theme is used 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 />
 `;
 
@@ -40,7 +40,7 @@ exports[`extends default theme 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 />
 `;
 
@@ -62,7 +62,7 @@ exports[`extends default theme twice 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 />
 `;
 
@@ -84,7 +84,7 @@ exports[`extends default theme twice 2`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 />
 `;
 
@@ -94,7 +94,7 @@ exports[`leverages default theme 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 />
 `;
 
@@ -129,10 +129,10 @@ exports[`uses Grommet theme instead of default 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
 </div>
 `;

--- a/src/js/__tests__/default-props-test.js
+++ b/src/js/__tests__/default-props-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import styled from 'styled-components';
 
 import 'jest-styled-components';
@@ -13,50 +13,45 @@ CustomBox.defaultProps = {};
 Object.setPrototypeOf(CustomBox.defaultProps, defaultProps);
 
 test('default theme is used', () => {
-  const component = renderer.create(<Box background="brand" />);
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-  component.unmount();
+  const { container } = render(<Box background="brand" />);
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('extends default theme', () => {
   extendDefaultTheme({ global: { colors: { brand: '#ff0000' } } });
-  const component = renderer.create(<Box background="brand" />);
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-  component.unmount();
+  const { container } = render(<Box background="brand" />);
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('extends default theme twice', () => {
   extendDefaultTheme({ global: { colors: { brand: '#ff0000' } } });
-  let component = renderer.create(<Box background="brand" />);
-  let tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+  const { container, rerender, unmount } = render(<Box background="brand" />);
+
+  expect(container.firstChild).toMatchSnapshot();
+  unmount();
 
   extendDefaultTheme({ global: { colors: { brand: '#0000ff' } } });
+  rerender(<Box background="brand" />);
 
-  component = renderer.create(<Box background="brand" />);
-  tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-  component.unmount();
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('uses Grommet theme instead of default', () => {
   extendDefaultTheme({ global: { colors: { brand: 'red' } } });
-  const component = renderer.create(
+  const { container } = render(
     <Grommet theme={grommet}>
       <Box background="brand" />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-  component.unmount();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('leverages default theme', () => {
   extendDefaultTheme({ global: { colors: { brand: 'red' } } });
-  const component = renderer.create(<CustomBox />);
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-  component.unmount();
+  const { container } = render(<CustomBox />);
+
+  expect(container.firstChild).toMatchSnapshot();
 });

--- a/src/js/components/CheckBoxGroup/__tests__/CheckBoxGroup-test.js
+++ b/src/js/components/CheckBoxGroup/__tests__/CheckBoxGroup-test.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { cleanup, render, fireEvent } from '@testing-library/react';
+import { axe } from 'jest-axe';
 
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
-import { cleanup, render, fireEvent } from '@testing-library/react';
-import { axe } from 'jest-axe';
 import { Grommet } from '../../Grommet';
 import { CheckBoxGroup } from '..';
 
@@ -24,27 +23,27 @@ describe('CheckBoxGroup', () => {
   });
 
   test('options renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <CheckBoxGroup options={['First', 'Second']} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('value renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <CheckBoxGroup value={['First']} options={['First', 'Second']} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('initial value renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <CheckBoxGroup
           value={['Wuhan', 'Jerusalem']}
@@ -56,20 +55,20 @@ describe('CheckBoxGroup', () => {
         />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('disabled renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <CheckBoxGroup disabled options={['First', 'Second']} />
         <CheckBoxGroup options={[{ label: 'First', disabled: true }]} />
         <CheckBoxGroup options={[{ label: 'First', disabled: true }]} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('onChange', () => {

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.js.snap
@@ -53,40 +53,28 @@ exports[`CheckBoxGroup custom theme 1`] = `
 
 exports[`CheckBoxGroup disabled renders 1`] = `
 <div
-  className="StyledGrommet-sc-19lkkz7-0 djOnwZ"
+  class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <div
-    className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
+    class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
     role="group"
   >
     <label
-      checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hQyqlg"
-      disabled={true}
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hQyqlg"
+      disabled=""
     >
       <div
-        checked={false}
-        className="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
-        disabled={true}
+        class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
+        disabled=""
       >
         <input
-          checked={false}
-          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 bIiinc"
-          disabled={true}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 bIiinc"
+          disabled=""
           type="checkbox"
         />
         <div
-          checked={false}
-          className="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
-          disabled={true}
+          class="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
+          disabled=""
         />
       </div>
       <span>
@@ -94,36 +82,24 @@ exports[`CheckBoxGroup disabled renders 1`] = `
       </span>
     </label>
     <div
-      className="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hQyqlg"
-      disabled={true}
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hQyqlg"
+      disabled=""
     >
       <div
-        checked={false}
-        className="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
-        disabled={true}
+        class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
+        disabled=""
       >
         <input
-          checked={false}
-          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 bIiinc"
-          disabled={true}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 bIiinc"
+          disabled=""
           type="checkbox"
         />
         <div
-          checked={false}
-          className="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
-          disabled={true}
+          class="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
+          disabled=""
         />
       </div>
       <span>
@@ -132,37 +108,25 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     </label>
   </div>
   <div
-    className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
+    class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
     role="group"
   >
     <label
-      checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hQyqlg"
-      disabled={true}
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hQyqlg"
+      disabled=""
     >
       <div
-        checked={false}
-        className="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
-        disabled={true}
+        class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
+        disabled=""
       >
         <input
-          checked={false}
-          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 bIiinc"
-          disabled={true}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 bIiinc"
+          disabled=""
           type="checkbox"
         />
         <div
-          checked={false}
-          className="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
-          disabled={true}
+          class="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
+          disabled=""
         />
       </div>
       <span>
@@ -171,37 +135,25 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     </label>
   </div>
   <div
-    className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
+    class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
     role="group"
   >
     <label
-      checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hQyqlg"
-      disabled={true}
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hQyqlg"
+      disabled=""
     >
       <div
-        checked={false}
-        className="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
-        disabled={true}
+        class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
+        disabled=""
       >
         <input
-          checked={false}
-          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 bIiinc"
-          disabled={true}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 bIiinc"
+          disabled=""
           type="checkbox"
         />
         <div
-          checked={false}
-          className="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
-          disabled={true}
+          class="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
+          disabled=""
         />
       </div>
       <span>
@@ -214,36 +166,24 @@ exports[`CheckBoxGroup disabled renders 1`] = `
 
 exports[`CheckBoxGroup initial value renders 1`] = `
 <div
-  className="StyledGrommet-sc-19lkkz7-0 djOnwZ"
+  class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <div
-    className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
+    class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
     role="group"
   >
     <label
-      checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
-        checked={false}
-        className="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
+        class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
       >
         <input
-          checked={false}
-          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fYuA-Ds"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fYuA-Ds"
           type="checkbox"
         />
         <div
-          checked={false}
-          className="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
+          class="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
         />
       </div>
       <span>
@@ -251,36 +191,24 @@ exports[`CheckBoxGroup initial value renders 1`] = `
       </span>
     </label>
     <div
-      className="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
-        checked={true}
-        className="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
+        class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
       >
         <input
-          checked={true}
-          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fYuA-Ds"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
+          checked=""
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fYuA-Ds"
           type="checkbox"
         />
         <div
-          checked={true}
-          className="StyledBox-sc-13pk1d4-0 icgjqF StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
+          class="StyledBox-sc-13pk1d4-0 icgjqF StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
         >
           <svg
-            checked={true}
-            className="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 uDaMI"
+            class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 uDaMI"
             preserveAspectRatio="xMidYMid meet"
             viewBox="0 0 24 24"
           >
@@ -296,36 +224,24 @@ exports[`CheckBoxGroup initial value renders 1`] = `
       </span>
     </label>
     <div
-      className="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
-        checked={true}
-        className="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
+        class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
       >
         <input
-          checked={true}
-          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fYuA-Ds"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
+          checked=""
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fYuA-Ds"
           type="checkbox"
         />
         <div
-          checked={true}
-          className="StyledBox-sc-13pk1d4-0 icgjqF StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
+          class="StyledBox-sc-13pk1d4-0 icgjqF StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
         >
           <svg
-            checked={true}
-            className="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 uDaMI"
+            class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 uDaMI"
             preserveAspectRatio="xMidYMid meet"
             viewBox="0 0 24 24"
           >
@@ -574,36 +490,24 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
 
 exports[`CheckBoxGroup options renders 1`] = `
 <div
-  className="StyledGrommet-sc-19lkkz7-0 djOnwZ"
+  class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <div
-    className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
+    class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
     role="group"
   >
     <label
-      checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
-        checked={false}
-        className="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
+        class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
       >
         <input
-          checked={false}
-          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fYuA-Ds"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fYuA-Ds"
           type="checkbox"
         />
         <div
-          checked={false}
-          className="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
+          class="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
         />
       </div>
       <span>
@@ -611,32 +515,20 @@ exports[`CheckBoxGroup options renders 1`] = `
       </span>
     </label>
     <div
-      className="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
-        checked={false}
-        className="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
+        class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
       >
         <input
-          checked={false}
-          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fYuA-Ds"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fYuA-Ds"
           type="checkbox"
         />
         <div
-          checked={false}
-          className="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
+          class="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
         />
       </div>
       <span>
@@ -649,40 +541,28 @@ exports[`CheckBoxGroup options renders 1`] = `
 
 exports[`CheckBoxGroup value renders 1`] = `
 <div
-  className="StyledGrommet-sc-19lkkz7-0 djOnwZ"
+  class="StyledGrommet-sc-19lkkz7-0 djOnwZ"
 >
   <div
-    className="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
+    class="StyledBox-sc-13pk1d4-0 dYebPD StyledCheckBoxGroup-sc-2nhc5d-0"
     role="group"
   >
     <label
-      checked={true}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
-        checked={true}
-        className="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
+        class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
       >
         <input
-          checked={true}
-          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fYuA-Ds"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
+          checked=""
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fYuA-Ds"
           type="checkbox"
         />
         <div
-          checked={true}
-          className="StyledBox-sc-13pk1d4-0 icgjqF StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
+          class="StyledBox-sc-13pk1d4-0 icgjqF StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
         >
           <svg
-            checked={true}
-            className="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 uDaMI"
+            class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 uDaMI"
             preserveAspectRatio="xMidYMid meet"
             viewBox="0 0 24 24"
           >
@@ -698,32 +578,20 @@ exports[`CheckBoxGroup value renders 1`] = `
       </span>
     </label>
     <div
-      className="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 ggstca"
     />
     <label
-      checked={false}
-      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 cBQiTh"
     >
       <div
-        checked={false}
-        className="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
+        class="StyledBox-sc-13pk1d4-0 jbIyUK StyledCheckBox-sc-1dbk5ju-6 hOFfoi"
       >
         <input
-          checked={false}
-          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fYuA-Ds"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fYuA-Ds"
           type="checkbox"
         />
         <div
-          checked={false}
-          className="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
+          class="StyledBox-sc-13pk1d4-0 jYPXhZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 kRWCTA"
         />
       </div>
       <span>

--- a/src/js/components/Tip/__tests__/Tip-test.js
+++ b/src/js/components/Tip/__tests__/Tip-test.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
-import 'jest-styled-components';
 import { axe } from 'jest-axe';
+import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
@@ -122,20 +121,19 @@ describe('Tip', () => {
   });
 
   test(`should work with a child that isn't a React Element`, () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Tip content="Hello">Not React Element</Tip>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test(`throw error with more than one child`, () => {
     console.error = jest.fn();
     expect(() => {
-      renderer.create(
+      render(
         <Grommet>
           <Tip>
             <Box>1</Box>
@@ -151,7 +149,7 @@ describe('Tip', () => {
   test(`throw error with more than one non React Element`, () => {
     console.error = jest.fn();
     expect(() => {
-      renderer.create(
+      render(
         <Grommet>
           <Tip>123 {false}</Tip>
         </Grommet>,

--- a/src/js/components/Tip/__tests__/__snapshots__/Tip-test.js.snap
+++ b/src/js/components/Tip/__tests__/__snapshots__/Tip-test.js.snap
@@ -507,14 +507,9 @@ exports[`Tip should work with a child that isn't a React Element 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
-  <span
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-  >
+  <span>
     Not React Element
   </span>
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Tip/__tests__/Tip-test.js`
`src/js/__tests__/default-props-test.js`
`src/js/components/CheckBoxGroup/__tests__/CheckBoxGroup-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.