### PR TITLE
Refactor WorldMap tests to remove react-test-renderer

### DIFF
--- a/src/js/components/WorldMap/__tests__/WorldMap-test.js
+++ b/src/js/components/WorldMap/__tests__/WorldMap-test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 import { cleanup, render, fireEvent } from '@testing-library/react';
 import 'jest-styled-components';
 
@@ -10,23 +9,23 @@ describe('WorldMap', () => {
   afterEach(cleanup);
 
   test('default', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <WorldMap />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('color', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <WorldMap color="brand" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('continents', () => {
@@ -132,7 +131,7 @@ describe('WorldMap', () => {
   });
 
   test('fill', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <WorldMap fill />
         <WorldMap fill={false} />
@@ -140,8 +139,8 @@ describe('WorldMap', () => {
         <WorldMap fill="vertical" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('onClick handlers', () => {

--- a/src/js/components/WorldMap/__tests__/WorldMap-test.js
+++ b/src/js/components/WorldMap/__tests__/WorldMap-test.js
@@ -1,13 +1,11 @@
 import React from 'react';
-import { cleanup, render, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
 import { WorldMap } from '..';
 
 describe('WorldMap', () => {
-  afterEach(cleanup);
-
   test('default', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/WorldMap/__tests__/__snapshots__/WorldMap-test.js.snap
+++ b/src/js/components/WorldMap/__tests__/__snapshots__/WorldMap-test.js.snap
@@ -16,102 +16,102 @@ exports[`WorldMap color 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <svg
-    className="c1"
-    height={460}
+    class="c1"
+    height="460"
     preserveAspectRatio="xMinYMin meet"
     viewBox="0 0 940 460"
-    width={940}
+    width="940"
   >
     <g
       fill="none"
-      fillRule="evenodd"
+      fill-rule="evenodd"
       stroke="none"
     >
       <g>
         <path
           d="M790,330 L820,340 L900,400 L880,420 L830,410 L750,390 L750,350 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M790,330 h0 M770,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,370 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,380 h0 m10,0 h0 m10,0 h0 M800,380 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M800,390 h0 m10,0 h0 m10,0 h0 m10,0 h0 M830,410 h0 M900,400 h0 M890,410 h0 M880,420 h0"
           stroke="#7D4CDB"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M690,20 L910,70 L930,90 L810,190 L770,270 L820,310 L720,310 L640,260 L560,250 L530,220 L530,210 L590,150 L600,80 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M690,20 h0 M700,30 h0 m10,0 h0 M710,40 h0 m10,0 h0 M680,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M810,50 h0 M830,50 h0 M630,60 h0 m10,0 h0 M660,60 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M770,60 h0 M620,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,70 h0 M910,70 h0 M600,80 h0 m10,0 h0 M630,80 h0 M650,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M870,110 h0 m10,0 h0 m10,0 h0 M600,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M840,120 h0 M860,120 h0 M600,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,130 h0 m10,0 h0 M600,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,140 h0 M590,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,150 h0 M590,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M580,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,180 h0 m10,0 h0 M590,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,190 h0 m10,0 h0 m10,0 h0 M590,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M770,190 h0 M810,190 h0 M540,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M790,200 h0 m10,0 h0 M530,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M530,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M590,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M630,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M640,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 M690,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,250 h0 m10,0 h0 m10,0 h0 M640,250 h0 m10,0 h0 M700,250 h0 m10,0 h0 m10,0 h0 M760,250 h0 M640,260 h0 m10,0 h0 M710,260 h0 m10,0 h0 M760,260 h0 M770,270 h0 M710,280 h0 M750,280 h0 M710,290 h0 M730,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 M710,300 h0 M740,300 h0 M760,300 h0 M790,300 h0 m10,0 h0 m10,0 h0 M720,310 h0 M810,310 h0 m10,0 h0"
           stroke="#7D4CDB"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M440,200 L470,200 L520,220 L570,270 L570,350 L520,380 L500,380 L410,260 L410,230 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M440,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M500,210 h0 m10,0 h0 M420,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,250 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,260 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M420,270 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,280 h0 m10,0 h0 M470,280 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,300 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,310 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M490,320 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,330 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M570,340 h0 M490,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,350 h0 m10,0 h0 M490,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M500,370 h0 m10,0 h0 m10,0 h0 M500,380 h0 m10,0 h0 m10,0 h0"
           stroke="#7D4CDB"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M480,30 L500,30 L600,50 L590,140 L580,160 L540,190 L430,190 L400,100 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M480,30 h0 m10,0 h0 m10,0 h0 M490,40 h0 M600,50 h0 M590,60 h0 M520,70 h0 M590,70 h0 M490,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M490,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M570,90 h0 m10,0 h0 m10,0 h0 M400,100 h0 M480,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M470,110 h0 m10,0 h0 m10,0 h0 M510,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M470,120 h0 m10,0 h0 m10,0 h0 M510,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,130 h0 M470,130 h0 M490,130 h0 M510,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,140 h0 m10,0 h0 M470,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,150 h0 M460,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M450,170 h0 m10,0 h0 m10,0 h0 M490,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,170 h0 m10,0 h0 M430,180 h0 m10,0 h0 m10,0 h0 M480,180 h0 M500,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M460,180 h0 m10,0 h0 M430,190 h0 m10,0 h0 M500,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0"
           stroke="#7D4CDB"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M250,270 L280,270 L340,310 L340,350 L260,450 L250,440 L230,310 L230,300 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M250,270 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,280 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M230,300 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M230,310 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,320 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,330 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,370 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,380 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,390 h0 m10,0 h0 m10,0 h0 M250,400 h0 m10,0 h0 m10,0 h0 M250,410 h0 m10,0 h0 m10,0 h0 M250,420 h0 m10,0 h0 M250,430 h0 m10,0 h0 M250,440 h0 m10,0 h0 M260,450 h0"
           stroke="#7D4CDB"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M220,10 L400,10 L400,70 L230,270 L170,240 L30,130 L10,80 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M230,10 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M300,10 h0 M320,10 h0 M340,10 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M210,20 h0 M230,20 h0 M250,20 h0 m10,0 h0 M280,20 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M180,30 h0 M210,30 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M270,30 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M140,40 h0 M200,40 h0 M220,40 h0 m10,0 h0 m10,0 h0 M270,40 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M150,50 h0 M170,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 M220,50 h0 m10,0 h0 m10,0 h0 M300,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,60 h0 m10,0 h0 m10,0 h0 M170,60 h0 M190,60 h0 M210,60 h0 m10,0 h0 m10,0 h0 M250,60 h0 M310,60 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M150,70 h0 m10,0 h0 m10,0 h0 M200,70 h0 M230,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 M320,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M10,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M170,80 h0 M190,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,80 h0 m10,0 h0 M310,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M30,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,90 h0 m10,0 h0 m10,0 h0 M300,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M30,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,100 h0 m10,0 h0 M310,100 h0 m10,0 h0 m10,0 h0 M20,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,110 h0 m10,0 h0 M320,110 h0 M30,120 h0 m10,0 h0 M90,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,120 h0 m10,0 h0 M270,120 h0 M30,130 h0 M90,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,130 h0 m10,0 h0 m10,0 h0 M110,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M220,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M290,160 h0 m10,0 h0 M120,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M140,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M160,220 h0 m10,0 h0 m10,0 h0 M230,220 h0 M170,230 h0 m10,0 h0 M170,240 h0 m10,0 h0 M210,240 h0 M240,240 h0 M190,250 h0 m10,0 h0 m10,0 h0 M220,260 h0 M230,270 h0"
           stroke="#7D4CDB"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
     </g>
@@ -259,102 +259,102 @@ exports[`WorldMap default 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <svg
-    className="c1"
-    height={460}
+    class="c1"
+    height="460"
     preserveAspectRatio="xMinYMin meet"
     viewBox="0 0 940 460"
-    width={940}
+    width="940"
   >
     <g
       fill="none"
-      fillRule="evenodd"
+      fill-rule="evenodd"
       stroke="none"
     >
       <g>
         <path
           d="M790,330 L820,340 L900,400 L880,420 L830,410 L750,390 L750,350 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M790,330 h0 M770,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,370 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,380 h0 m10,0 h0 m10,0 h0 M800,380 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M800,390 h0 m10,0 h0 m10,0 h0 m10,0 h0 M830,410 h0 M900,400 h0 M890,410 h0 M880,420 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M690,20 L910,70 L930,90 L810,190 L770,270 L820,310 L720,310 L640,260 L560,250 L530,220 L530,210 L590,150 L600,80 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M690,20 h0 M700,30 h0 m10,0 h0 M710,40 h0 m10,0 h0 M680,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M810,50 h0 M830,50 h0 M630,60 h0 m10,0 h0 M660,60 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M770,60 h0 M620,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,70 h0 M910,70 h0 M600,80 h0 m10,0 h0 M630,80 h0 M650,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M870,110 h0 m10,0 h0 m10,0 h0 M600,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M840,120 h0 M860,120 h0 M600,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,130 h0 m10,0 h0 M600,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,140 h0 M590,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,150 h0 M590,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M580,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,180 h0 m10,0 h0 M590,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,190 h0 m10,0 h0 m10,0 h0 M590,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M770,190 h0 M810,190 h0 M540,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M790,200 h0 m10,0 h0 M530,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M530,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M590,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M630,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M640,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 M690,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,250 h0 m10,0 h0 m10,0 h0 M640,250 h0 m10,0 h0 M700,250 h0 m10,0 h0 m10,0 h0 M760,250 h0 M640,260 h0 m10,0 h0 M710,260 h0 m10,0 h0 M760,260 h0 M770,270 h0 M710,280 h0 M750,280 h0 M710,290 h0 M730,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 M710,300 h0 M740,300 h0 M760,300 h0 M790,300 h0 m10,0 h0 m10,0 h0 M720,310 h0 M810,310 h0 m10,0 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M440,200 L470,200 L520,220 L570,270 L570,350 L520,380 L500,380 L410,260 L410,230 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M440,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M500,210 h0 m10,0 h0 M420,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,250 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,260 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M420,270 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,280 h0 m10,0 h0 M470,280 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,300 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,310 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M490,320 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,330 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M570,340 h0 M490,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,350 h0 m10,0 h0 M490,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M500,370 h0 m10,0 h0 m10,0 h0 M500,380 h0 m10,0 h0 m10,0 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M480,30 L500,30 L600,50 L590,140 L580,160 L540,190 L430,190 L400,100 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M480,30 h0 m10,0 h0 m10,0 h0 M490,40 h0 M600,50 h0 M590,60 h0 M520,70 h0 M590,70 h0 M490,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M490,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M570,90 h0 m10,0 h0 m10,0 h0 M400,100 h0 M480,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M470,110 h0 m10,0 h0 m10,0 h0 M510,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M470,120 h0 m10,0 h0 m10,0 h0 M510,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,130 h0 M470,130 h0 M490,130 h0 M510,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,140 h0 m10,0 h0 M470,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,150 h0 M460,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M450,170 h0 m10,0 h0 m10,0 h0 M490,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,170 h0 m10,0 h0 M430,180 h0 m10,0 h0 m10,0 h0 M480,180 h0 M500,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M460,180 h0 m10,0 h0 M430,190 h0 m10,0 h0 M500,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M250,270 L280,270 L340,310 L340,350 L260,450 L250,440 L230,310 L230,300 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M250,270 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,280 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M230,300 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M230,310 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,320 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,330 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,370 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,380 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,390 h0 m10,0 h0 m10,0 h0 M250,400 h0 m10,0 h0 m10,0 h0 M250,410 h0 m10,0 h0 m10,0 h0 M250,420 h0 m10,0 h0 M250,430 h0 m10,0 h0 M250,440 h0 m10,0 h0 M260,450 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M220,10 L400,10 L400,70 L230,270 L170,240 L30,130 L10,80 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M230,10 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M300,10 h0 M320,10 h0 M340,10 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M210,20 h0 M230,20 h0 M250,20 h0 m10,0 h0 M280,20 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M180,30 h0 M210,30 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M270,30 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M140,40 h0 M200,40 h0 M220,40 h0 m10,0 h0 m10,0 h0 M270,40 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M150,50 h0 M170,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 M220,50 h0 m10,0 h0 m10,0 h0 M300,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,60 h0 m10,0 h0 m10,0 h0 M170,60 h0 M190,60 h0 M210,60 h0 m10,0 h0 m10,0 h0 M250,60 h0 M310,60 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M150,70 h0 m10,0 h0 m10,0 h0 M200,70 h0 M230,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 M320,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M10,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M170,80 h0 M190,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,80 h0 m10,0 h0 M310,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M30,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,90 h0 m10,0 h0 m10,0 h0 M300,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M30,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,100 h0 m10,0 h0 M310,100 h0 m10,0 h0 m10,0 h0 M20,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,110 h0 m10,0 h0 M320,110 h0 M30,120 h0 m10,0 h0 M90,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,120 h0 m10,0 h0 M270,120 h0 M30,130 h0 M90,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,130 h0 m10,0 h0 m10,0 h0 M110,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M220,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M290,160 h0 m10,0 h0 M120,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M140,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M160,220 h0 m10,0 h0 m10,0 h0 M230,220 h0 M170,230 h0 m10,0 h0 M170,240 h0 m10,0 h0 M210,240 h0 M240,240 h0 M190,250 h0 m10,0 h0 m10,0 h0 M220,260 h0 M230,270 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
     </g>
@@ -736,396 +736,396 @@ exports[`WorldMap fill 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <svg
-    className="c1"
-    height={460}
+    class="c1"
+    height="460"
     preserveAspectRatio="xMinYMin meet"
     viewBox="0 0 940 460"
-    width={940}
+    width="940"
   >
     <g
       fill="none"
-      fillRule="evenodd"
+      fill-rule="evenodd"
       stroke="none"
     >
       <g>
         <path
           d="M790,330 L820,340 L900,400 L880,420 L830,410 L750,390 L750,350 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M790,330 h0 M770,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,370 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,380 h0 m10,0 h0 m10,0 h0 M800,380 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M800,390 h0 m10,0 h0 m10,0 h0 m10,0 h0 M830,410 h0 M900,400 h0 M890,410 h0 M880,420 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M690,20 L910,70 L930,90 L810,190 L770,270 L820,310 L720,310 L640,260 L560,250 L530,220 L530,210 L590,150 L600,80 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M690,20 h0 M700,30 h0 m10,0 h0 M710,40 h0 m10,0 h0 M680,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M810,50 h0 M830,50 h0 M630,60 h0 m10,0 h0 M660,60 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M770,60 h0 M620,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,70 h0 M910,70 h0 M600,80 h0 m10,0 h0 M630,80 h0 M650,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M870,110 h0 m10,0 h0 m10,0 h0 M600,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M840,120 h0 M860,120 h0 M600,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,130 h0 m10,0 h0 M600,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,140 h0 M590,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,150 h0 M590,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M580,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,180 h0 m10,0 h0 M590,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,190 h0 m10,0 h0 m10,0 h0 M590,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M770,190 h0 M810,190 h0 M540,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M790,200 h0 m10,0 h0 M530,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M530,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M590,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M630,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M640,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 M690,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,250 h0 m10,0 h0 m10,0 h0 M640,250 h0 m10,0 h0 M700,250 h0 m10,0 h0 m10,0 h0 M760,250 h0 M640,260 h0 m10,0 h0 M710,260 h0 m10,0 h0 M760,260 h0 M770,270 h0 M710,280 h0 M750,280 h0 M710,290 h0 M730,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 M710,300 h0 M740,300 h0 M760,300 h0 M790,300 h0 m10,0 h0 m10,0 h0 M720,310 h0 M810,310 h0 m10,0 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M440,200 L470,200 L520,220 L570,270 L570,350 L520,380 L500,380 L410,260 L410,230 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M440,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M500,210 h0 m10,0 h0 M420,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,250 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,260 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M420,270 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,280 h0 m10,0 h0 M470,280 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,300 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,310 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M490,320 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,330 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M570,340 h0 M490,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,350 h0 m10,0 h0 M490,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M500,370 h0 m10,0 h0 m10,0 h0 M500,380 h0 m10,0 h0 m10,0 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M480,30 L500,30 L600,50 L590,140 L580,160 L540,190 L430,190 L400,100 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M480,30 h0 m10,0 h0 m10,0 h0 M490,40 h0 M600,50 h0 M590,60 h0 M520,70 h0 M590,70 h0 M490,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M490,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M570,90 h0 m10,0 h0 m10,0 h0 M400,100 h0 M480,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M470,110 h0 m10,0 h0 m10,0 h0 M510,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M470,120 h0 m10,0 h0 m10,0 h0 M510,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,130 h0 M470,130 h0 M490,130 h0 M510,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,140 h0 m10,0 h0 M470,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,150 h0 M460,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M450,170 h0 m10,0 h0 m10,0 h0 M490,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,170 h0 m10,0 h0 M430,180 h0 m10,0 h0 m10,0 h0 M480,180 h0 M500,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M460,180 h0 m10,0 h0 M430,190 h0 m10,0 h0 M500,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M250,270 L280,270 L340,310 L340,350 L260,450 L250,440 L230,310 L230,300 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M250,270 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,280 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M230,300 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M230,310 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,320 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,330 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,370 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,380 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,390 h0 m10,0 h0 m10,0 h0 M250,400 h0 m10,0 h0 m10,0 h0 M250,410 h0 m10,0 h0 m10,0 h0 M250,420 h0 m10,0 h0 M250,430 h0 m10,0 h0 M250,440 h0 m10,0 h0 M260,450 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M220,10 L400,10 L400,70 L230,270 L170,240 L30,130 L10,80 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M230,10 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M300,10 h0 M320,10 h0 M340,10 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M210,20 h0 M230,20 h0 M250,20 h0 m10,0 h0 M280,20 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M180,30 h0 M210,30 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M270,30 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M140,40 h0 M200,40 h0 M220,40 h0 m10,0 h0 m10,0 h0 M270,40 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M150,50 h0 M170,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 M220,50 h0 m10,0 h0 m10,0 h0 M300,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,60 h0 m10,0 h0 m10,0 h0 M170,60 h0 M190,60 h0 M210,60 h0 m10,0 h0 m10,0 h0 M250,60 h0 M310,60 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M150,70 h0 m10,0 h0 m10,0 h0 M200,70 h0 M230,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 M320,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M10,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M170,80 h0 M190,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,80 h0 m10,0 h0 M310,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M30,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,90 h0 m10,0 h0 m10,0 h0 M300,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M30,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,100 h0 m10,0 h0 M310,100 h0 m10,0 h0 m10,0 h0 M20,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,110 h0 m10,0 h0 M320,110 h0 M30,120 h0 m10,0 h0 M90,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,120 h0 m10,0 h0 M270,120 h0 M30,130 h0 M90,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,130 h0 m10,0 h0 m10,0 h0 M110,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M220,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M290,160 h0 m10,0 h0 M120,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M140,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M160,220 h0 m10,0 h0 m10,0 h0 M230,220 h0 M170,230 h0 m10,0 h0 M170,240 h0 m10,0 h0 M210,240 h0 M240,240 h0 M190,250 h0 m10,0 h0 m10,0 h0 M220,260 h0 M230,270 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
     </g>
   </svg>
   <svg
-    className=""
-    height={460}
+    class=""
+    height="460"
     preserveAspectRatio="xMinYMin meet"
     viewBox="0 0 940 460"
-    width={940}
+    width="940"
   >
     <g
       fill="none"
-      fillRule="evenodd"
+      fill-rule="evenodd"
       stroke="none"
     >
       <g>
         <path
           d="M790,330 L820,340 L900,400 L880,420 L830,410 L750,390 L750,350 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M790,330 h0 M770,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,370 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,380 h0 m10,0 h0 m10,0 h0 M800,380 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M800,390 h0 m10,0 h0 m10,0 h0 m10,0 h0 M830,410 h0 M900,400 h0 M890,410 h0 M880,420 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M690,20 L910,70 L930,90 L810,190 L770,270 L820,310 L720,310 L640,260 L560,250 L530,220 L530,210 L590,150 L600,80 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M690,20 h0 M700,30 h0 m10,0 h0 M710,40 h0 m10,0 h0 M680,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M810,50 h0 M830,50 h0 M630,60 h0 m10,0 h0 M660,60 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M770,60 h0 M620,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,70 h0 M910,70 h0 M600,80 h0 m10,0 h0 M630,80 h0 M650,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M870,110 h0 m10,0 h0 m10,0 h0 M600,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M840,120 h0 M860,120 h0 M600,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,130 h0 m10,0 h0 M600,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,140 h0 M590,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,150 h0 M590,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M580,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,180 h0 m10,0 h0 M590,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,190 h0 m10,0 h0 m10,0 h0 M590,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M770,190 h0 M810,190 h0 M540,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M790,200 h0 m10,0 h0 M530,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M530,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M590,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M630,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M640,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 M690,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,250 h0 m10,0 h0 m10,0 h0 M640,250 h0 m10,0 h0 M700,250 h0 m10,0 h0 m10,0 h0 M760,250 h0 M640,260 h0 m10,0 h0 M710,260 h0 m10,0 h0 M760,260 h0 M770,270 h0 M710,280 h0 M750,280 h0 M710,290 h0 M730,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 M710,300 h0 M740,300 h0 M760,300 h0 M790,300 h0 m10,0 h0 m10,0 h0 M720,310 h0 M810,310 h0 m10,0 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M440,200 L470,200 L520,220 L570,270 L570,350 L520,380 L500,380 L410,260 L410,230 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M440,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M500,210 h0 m10,0 h0 M420,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,250 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,260 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M420,270 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,280 h0 m10,0 h0 M470,280 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,300 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,310 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M490,320 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,330 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M570,340 h0 M490,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,350 h0 m10,0 h0 M490,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M500,370 h0 m10,0 h0 m10,0 h0 M500,380 h0 m10,0 h0 m10,0 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M480,30 L500,30 L600,50 L590,140 L580,160 L540,190 L430,190 L400,100 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M480,30 h0 m10,0 h0 m10,0 h0 M490,40 h0 M600,50 h0 M590,60 h0 M520,70 h0 M590,70 h0 M490,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M490,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M570,90 h0 m10,0 h0 m10,0 h0 M400,100 h0 M480,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M470,110 h0 m10,0 h0 m10,0 h0 M510,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M470,120 h0 m10,0 h0 m10,0 h0 M510,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,130 h0 M470,130 h0 M490,130 h0 M510,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,140 h0 m10,0 h0 M470,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,150 h0 M460,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M450,170 h0 m10,0 h0 m10,0 h0 M490,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,170 h0 m10,0 h0 M430,180 h0 m10,0 h0 m10,0 h0 M480,180 h0 M500,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M460,180 h0 m10,0 h0 M430,190 h0 m10,0 h0 M500,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M250,270 L280,270 L340,310 L340,350 L260,450 L250,440 L230,310 L230,300 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M250,270 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,280 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M230,300 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M230,310 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,320 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,330 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,370 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,380 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,390 h0 m10,0 h0 m10,0 h0 M250,400 h0 m10,0 h0 m10,0 h0 M250,410 h0 m10,0 h0 m10,0 h0 M250,420 h0 m10,0 h0 M250,430 h0 m10,0 h0 M250,440 h0 m10,0 h0 M260,450 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M220,10 L400,10 L400,70 L230,270 L170,240 L30,130 L10,80 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M230,10 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M300,10 h0 M320,10 h0 M340,10 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M210,20 h0 M230,20 h0 M250,20 h0 m10,0 h0 M280,20 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M180,30 h0 M210,30 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M270,30 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M140,40 h0 M200,40 h0 M220,40 h0 m10,0 h0 m10,0 h0 M270,40 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M150,50 h0 M170,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 M220,50 h0 m10,0 h0 m10,0 h0 M300,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,60 h0 m10,0 h0 m10,0 h0 M170,60 h0 M190,60 h0 M210,60 h0 m10,0 h0 m10,0 h0 M250,60 h0 M310,60 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M150,70 h0 m10,0 h0 m10,0 h0 M200,70 h0 M230,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 M320,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M10,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M170,80 h0 M190,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,80 h0 m10,0 h0 M310,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M30,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,90 h0 m10,0 h0 m10,0 h0 M300,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M30,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,100 h0 m10,0 h0 M310,100 h0 m10,0 h0 m10,0 h0 M20,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,110 h0 m10,0 h0 M320,110 h0 M30,120 h0 m10,0 h0 M90,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,120 h0 m10,0 h0 M270,120 h0 M30,130 h0 M90,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,130 h0 m10,0 h0 m10,0 h0 M110,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M220,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M290,160 h0 m10,0 h0 M120,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M140,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M160,220 h0 m10,0 h0 m10,0 h0 M230,220 h0 M170,230 h0 m10,0 h0 M170,240 h0 m10,0 h0 M210,240 h0 M240,240 h0 M190,250 h0 m10,0 h0 m10,0 h0 M220,260 h0 M230,270 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
     </g>
   </svg>
   <svg
-    className="c2"
-    height={460}
+    class="c2"
+    height="460"
     preserveAspectRatio="xMinYMin meet"
     viewBox="0 0 940 460"
-    width={940}
+    width="940"
   >
     <g
       fill="none"
-      fillRule="evenodd"
+      fill-rule="evenodd"
       stroke="none"
     >
       <g>
         <path
           d="M790,330 L820,340 L900,400 L880,420 L830,410 L750,390 L750,350 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M790,330 h0 M770,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,370 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,380 h0 m10,0 h0 m10,0 h0 M800,380 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M800,390 h0 m10,0 h0 m10,0 h0 m10,0 h0 M830,410 h0 M900,400 h0 M890,410 h0 M880,420 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M690,20 L910,70 L930,90 L810,190 L770,270 L820,310 L720,310 L640,260 L560,250 L530,220 L530,210 L590,150 L600,80 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M690,20 h0 M700,30 h0 m10,0 h0 M710,40 h0 m10,0 h0 M680,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M810,50 h0 M830,50 h0 M630,60 h0 m10,0 h0 M660,60 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M770,60 h0 M620,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,70 h0 M910,70 h0 M600,80 h0 m10,0 h0 M630,80 h0 M650,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M870,110 h0 m10,0 h0 m10,0 h0 M600,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M840,120 h0 M860,120 h0 M600,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,130 h0 m10,0 h0 M600,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,140 h0 M590,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,150 h0 M590,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M580,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,180 h0 m10,0 h0 M590,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,190 h0 m10,0 h0 m10,0 h0 M590,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M770,190 h0 M810,190 h0 M540,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M790,200 h0 m10,0 h0 M530,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M530,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M590,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M630,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M640,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 M690,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,250 h0 m10,0 h0 m10,0 h0 M640,250 h0 m10,0 h0 M700,250 h0 m10,0 h0 m10,0 h0 M760,250 h0 M640,260 h0 m10,0 h0 M710,260 h0 m10,0 h0 M760,260 h0 M770,270 h0 M710,280 h0 M750,280 h0 M710,290 h0 M730,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 M710,300 h0 M740,300 h0 M760,300 h0 M790,300 h0 m10,0 h0 m10,0 h0 M720,310 h0 M810,310 h0 m10,0 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M440,200 L470,200 L520,220 L570,270 L570,350 L520,380 L500,380 L410,260 L410,230 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M440,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M500,210 h0 m10,0 h0 M420,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,250 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,260 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M420,270 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,280 h0 m10,0 h0 M470,280 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,300 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,310 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M490,320 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,330 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M570,340 h0 M490,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,350 h0 m10,0 h0 M490,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M500,370 h0 m10,0 h0 m10,0 h0 M500,380 h0 m10,0 h0 m10,0 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M480,30 L500,30 L600,50 L590,140 L580,160 L540,190 L430,190 L400,100 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M480,30 h0 m10,0 h0 m10,0 h0 M490,40 h0 M600,50 h0 M590,60 h0 M520,70 h0 M590,70 h0 M490,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M490,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M570,90 h0 m10,0 h0 m10,0 h0 M400,100 h0 M480,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M470,110 h0 m10,0 h0 m10,0 h0 M510,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M470,120 h0 m10,0 h0 m10,0 h0 M510,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,130 h0 M470,130 h0 M490,130 h0 M510,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,140 h0 m10,0 h0 M470,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,150 h0 M460,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M450,170 h0 m10,0 h0 m10,0 h0 M490,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,170 h0 m10,0 h0 M430,180 h0 m10,0 h0 m10,0 h0 M480,180 h0 M500,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M460,180 h0 m10,0 h0 M430,190 h0 m10,0 h0 M500,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M250,270 L280,270 L340,310 L340,350 L260,450 L250,440 L230,310 L230,300 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M250,270 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,280 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M230,300 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M230,310 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,320 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,330 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,370 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,380 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,390 h0 m10,0 h0 m10,0 h0 M250,400 h0 m10,0 h0 m10,0 h0 M250,410 h0 m10,0 h0 m10,0 h0 M250,420 h0 m10,0 h0 M250,430 h0 m10,0 h0 M250,440 h0 m10,0 h0 M260,450 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M220,10 L400,10 L400,70 L230,270 L170,240 L30,130 L10,80 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M230,10 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M300,10 h0 M320,10 h0 M340,10 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M210,20 h0 M230,20 h0 M250,20 h0 m10,0 h0 M280,20 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M180,30 h0 M210,30 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M270,30 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M140,40 h0 M200,40 h0 M220,40 h0 m10,0 h0 m10,0 h0 M270,40 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M150,50 h0 M170,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 M220,50 h0 m10,0 h0 m10,0 h0 M300,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,60 h0 m10,0 h0 m10,0 h0 M170,60 h0 M190,60 h0 M210,60 h0 m10,0 h0 m10,0 h0 M250,60 h0 M310,60 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M150,70 h0 m10,0 h0 m10,0 h0 M200,70 h0 M230,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 M320,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M10,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M170,80 h0 M190,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,80 h0 m10,0 h0 M310,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M30,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,90 h0 m10,0 h0 m10,0 h0 M300,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M30,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,100 h0 m10,0 h0 M310,100 h0 m10,0 h0 m10,0 h0 M20,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,110 h0 m10,0 h0 M320,110 h0 M30,120 h0 m10,0 h0 M90,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,120 h0 m10,0 h0 M270,120 h0 M30,130 h0 M90,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,130 h0 m10,0 h0 m10,0 h0 M110,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M220,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M290,160 h0 m10,0 h0 M120,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M140,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M160,220 h0 m10,0 h0 m10,0 h0 M230,220 h0 M170,230 h0 m10,0 h0 M170,240 h0 m10,0 h0 M210,240 h0 M240,240 h0 M190,250 h0 m10,0 h0 m10,0 h0 M220,260 h0 M230,270 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
     </g>
   </svg>
   <svg
-    className="c3"
-    height={460}
+    class="c3"
+    height="460"
     preserveAspectRatio="xMinYMin meet"
     viewBox="0 0 940 460"
-    width={940}
+    width="940"
   >
     <g
       fill="none"
-      fillRule="evenodd"
+      fill-rule="evenodd"
       stroke="none"
     >
       <g>
         <path
           d="M790,330 L820,340 L900,400 L880,420 L830,410 L750,390 L750,350 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M790,330 h0 M770,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,370 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,380 h0 m10,0 h0 m10,0 h0 M800,380 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M800,390 h0 m10,0 h0 m10,0 h0 m10,0 h0 M830,410 h0 M900,400 h0 M890,410 h0 M880,420 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M690,20 L910,70 L930,90 L810,190 L770,270 L820,310 L720,310 L640,260 L560,250 L530,220 L530,210 L590,150 L600,80 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M690,20 h0 M700,30 h0 m10,0 h0 M710,40 h0 m10,0 h0 M680,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M810,50 h0 M830,50 h0 M630,60 h0 m10,0 h0 M660,60 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M770,60 h0 M620,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,70 h0 M910,70 h0 M600,80 h0 m10,0 h0 M630,80 h0 M650,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M870,110 h0 m10,0 h0 m10,0 h0 M600,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M840,120 h0 M860,120 h0 M600,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,130 h0 m10,0 h0 M600,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,140 h0 M590,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,150 h0 M590,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M580,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,180 h0 m10,0 h0 M590,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,190 h0 m10,0 h0 m10,0 h0 M590,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M770,190 h0 M810,190 h0 M540,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M790,200 h0 m10,0 h0 M530,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M530,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M590,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M630,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M640,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 M690,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,250 h0 m10,0 h0 m10,0 h0 M640,250 h0 m10,0 h0 M700,250 h0 m10,0 h0 m10,0 h0 M760,250 h0 M640,260 h0 m10,0 h0 M710,260 h0 m10,0 h0 M760,260 h0 M770,270 h0 M710,280 h0 M750,280 h0 M710,290 h0 M730,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 M710,300 h0 M740,300 h0 M760,300 h0 M790,300 h0 m10,0 h0 m10,0 h0 M720,310 h0 M810,310 h0 m10,0 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M440,200 L470,200 L520,220 L570,270 L570,350 L520,380 L500,380 L410,260 L410,230 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M440,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M500,210 h0 m10,0 h0 M420,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,250 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,260 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M420,270 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,280 h0 m10,0 h0 M470,280 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,300 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,310 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M490,320 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,330 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M570,340 h0 M490,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,350 h0 m10,0 h0 M490,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M500,370 h0 m10,0 h0 m10,0 h0 M500,380 h0 m10,0 h0 m10,0 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M480,30 L500,30 L600,50 L590,140 L580,160 L540,190 L430,190 L400,100 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M480,30 h0 m10,0 h0 m10,0 h0 M490,40 h0 M600,50 h0 M590,60 h0 M520,70 h0 M590,70 h0 M490,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M490,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M570,90 h0 m10,0 h0 m10,0 h0 M400,100 h0 M480,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M470,110 h0 m10,0 h0 m10,0 h0 M510,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M470,120 h0 m10,0 h0 m10,0 h0 M510,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,130 h0 M470,130 h0 M490,130 h0 M510,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,140 h0 m10,0 h0 M470,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,150 h0 M460,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M450,170 h0 m10,0 h0 m10,0 h0 M490,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,170 h0 m10,0 h0 M430,180 h0 m10,0 h0 m10,0 h0 M480,180 h0 M500,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M460,180 h0 m10,0 h0 M430,190 h0 m10,0 h0 M500,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M250,270 L280,270 L340,310 L340,350 L260,450 L250,440 L230,310 L230,300 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M250,270 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,280 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M230,300 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M230,310 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,320 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,330 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,370 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,380 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,390 h0 m10,0 h0 m10,0 h0 M250,400 h0 m10,0 h0 m10,0 h0 M250,410 h0 m10,0 h0 m10,0 h0 M250,420 h0 m10,0 h0 M250,430 h0 m10,0 h0 M250,440 h0 m10,0 h0 M260,450 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
       <g>
         <path
           d="M220,10 L400,10 L400,70 L230,270 L170,240 L30,130 L10,80 Z"
           fill="#fff"
-          fillOpacity="0.01"
+          fill-opacity="0.01"
           stroke="none"
         />
         <path
           d="M230,10 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M300,10 h0 M320,10 h0 M340,10 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M210,20 h0 M230,20 h0 M250,20 h0 m10,0 h0 M280,20 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M180,30 h0 M210,30 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M270,30 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M140,40 h0 M200,40 h0 M220,40 h0 m10,0 h0 m10,0 h0 M270,40 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M150,50 h0 M170,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 M220,50 h0 m10,0 h0 m10,0 h0 M300,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,60 h0 m10,0 h0 m10,0 h0 M170,60 h0 M190,60 h0 M210,60 h0 m10,0 h0 m10,0 h0 M250,60 h0 M310,60 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M150,70 h0 m10,0 h0 m10,0 h0 M200,70 h0 M230,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 M320,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M10,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M170,80 h0 M190,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,80 h0 m10,0 h0 M310,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M30,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,90 h0 m10,0 h0 m10,0 h0 M300,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M30,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,100 h0 m10,0 h0 M310,100 h0 m10,0 h0 m10,0 h0 M20,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,110 h0 m10,0 h0 M320,110 h0 M30,120 h0 m10,0 h0 M90,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,120 h0 m10,0 h0 M270,120 h0 M30,130 h0 M90,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,130 h0 m10,0 h0 m10,0 h0 M110,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M220,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M290,160 h0 m10,0 h0 M120,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M140,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M160,220 h0 m10,0 h0 m10,0 h0 M230,220 h0 M170,230 h0 m10,0 h0 M170,240 h0 m10,0 h0 M210,240 h0 M240,240 h0 M190,250 h0 m10,0 h0 m10,0 h0 M220,260 h0 M230,270 h0"
           stroke="#EDEDED"
-          strokeLinecap="round"
-          strokeWidth={6}
+          stroke-linecap="round"
+          stroke-width="6"
         />
       </g>
     </g>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update WorldMap tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/WorldMap/__tests__/WorldMap-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.