### PR TITLE
Refactor Avatar tests to remove react-test-renderer

### DIFF
--- a/src/js/components/Avatar/__tests__/Avatar-test.js
+++ b/src/js/components/Avatar/__tests__/Avatar-test.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { cleanup } from '@testing-library/react';
-import renderer from 'react-test-renderer';
+import { cleanup, render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Favorite } from 'grommet-icons';
@@ -16,18 +15,18 @@ describe('Avatar', () => {
   afterEach(cleanup);
 
   test('renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Avatar />
         <Avatar id="test id" name="test name" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('size', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Avatar size="xsmall" src={src} />
         <Avatar size="small" src={src} />
@@ -49,12 +48,12 @@ describe('Avatar', () => {
         <Avatar size="5xl">S</Avatar>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('round renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Avatar src={src} round={false} />
         <Avatar src={src} round="xsmall" />
@@ -64,12 +63,12 @@ describe('Avatar', () => {
         <Avatar src={src} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('text renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Avatar background="dark-2">
           <Text alignSelf="center" size="xlarge">
@@ -83,22 +82,22 @@ describe('Avatar', () => {
         </Avatar>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('icon renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Avatar src={<Favorite color="accent-2" />} background="accent-4" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('stack renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Stack anchor="bottom-right">
           <Box>
@@ -112,8 +111,8 @@ describe('Avatar', () => {
         </Stack>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('text size changes according to theme', () => {
@@ -129,7 +128,7 @@ describe('Avatar', () => {
       },
     };
 
-    const component = renderer.create(
+    const { container } = render(
       <Grommet theme={theme}>
         <Box>
           <Avatar>T1</Avatar>
@@ -139,7 +138,7 @@ describe('Avatar', () => {
         </Box>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/components/Avatar/__tests__/Avatar-test.js
+++ b/src/js/components/Avatar/__tests__/Avatar-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Favorite } from 'grommet-icons';
@@ -12,8 +12,6 @@ import { Avatar } from '..';
 const src = '';
 
 describe('Avatar', () => {
-  afterEach(cleanup);
-
   test('renders', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Avatar/__tests__/__snapshots__/Avatar-test.js.snap
+++ b/src/js/components/Avatar/__tests__/__snapshots__/Avatar-test.js.snap
@@ -40,10 +40,10 @@ exports[`Avatar icon renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 StyledAvatar-sc-1suyamb-1"
+    class="c1 StyledAvatar-sc-1suyamb-1"
   />
 </div>
 `;
@@ -86,13 +86,13 @@ exports[`Avatar renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 StyledAvatar-sc-1suyamb-1"
+    class="c1 StyledAvatar-sc-1suyamb-1"
   />
   <div
-    className="c1 StyledAvatar-sc-1suyamb-1"
+    class="c1 StyledAvatar-sc-1suyamb-1"
     id="test id"
     name="test name"
   />
@@ -302,25 +302,25 @@ exports[`Avatar round renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 StyledAvatar-sc-1suyamb-1"
+    class="c1 StyledAvatar-sc-1suyamb-1"
   />
   <div
-    className="c2 StyledAvatar-sc-1suyamb-1"
+    class="c2 StyledAvatar-sc-1suyamb-1"
   />
   <div
-    className="c3 StyledAvatar-sc-1suyamb-1"
+    class="c3 StyledAvatar-sc-1suyamb-1"
   />
   <div
-    className="c4 StyledAvatar-sc-1suyamb-1"
+    class="c4 StyledAvatar-sc-1suyamb-1"
   />
   <div
-    className="c5 StyledAvatar-sc-1suyamb-1"
+    class="c5 StyledAvatar-sc-1suyamb-1"
   />
   <div
-    className="c6 StyledAvatar-sc-1suyamb-1"
+    class="c6 StyledAvatar-sc-1suyamb-1"
   />
 </div>
 `;
@@ -861,103 +861,103 @@ exports[`Avatar size 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 StyledAvatar-sc-1suyamb-1"
+    class="c1 StyledAvatar-sc-1suyamb-1"
   />
   <div
-    className="c2 StyledAvatar-sc-1suyamb-1"
+    class="c2 StyledAvatar-sc-1suyamb-1"
   />
   <div
-    className="c3 StyledAvatar-sc-1suyamb-1"
+    class="c3 StyledAvatar-sc-1suyamb-1"
   />
   <div
-    className="c4 StyledAvatar-sc-1suyamb-1"
+    class="c4 StyledAvatar-sc-1suyamb-1"
   />
   <div
-    className="c5 StyledAvatar-sc-1suyamb-1"
+    class="c5 StyledAvatar-sc-1suyamb-1"
   />
   <div
-    className="c6 StyledAvatar-sc-1suyamb-1"
+    class="c6 StyledAvatar-sc-1suyamb-1"
   />
   <div
-    className="c7 StyledAvatar-sc-1suyamb-1"
+    class="c7 StyledAvatar-sc-1suyamb-1"
   />
   <div
-    className="c8 StyledAvatar-sc-1suyamb-1"
+    class="c8 StyledAvatar-sc-1suyamb-1"
   />
   <div
-    className="c9 StyledAvatar-sc-1suyamb-1"
+    class="c9 StyledAvatar-sc-1suyamb-1"
   />
   <div
-    className="c10 StyledAvatar-sc-1suyamb-1"
+    class="c10 StyledAvatar-sc-1suyamb-1"
   >
     <span
-      className="c11 "
+      class="c11 "
     >
       S
     </span>
   </div>
   <div
-    className="c12 StyledAvatar-sc-1suyamb-1"
+    class="c12 StyledAvatar-sc-1suyamb-1"
   >
     <span
-      className="c13 "
+      class="c13 "
     >
       S
     </span>
   </div>
   <div
-    className="c14 StyledAvatar-sc-1suyamb-1"
+    class="c14 StyledAvatar-sc-1suyamb-1"
   >
     <span
-      className="c15 "
+      class="c15 "
     >
       S
     </span>
   </div>
   <div
-    className="c16 StyledAvatar-sc-1suyamb-1"
+    class="c16 StyledAvatar-sc-1suyamb-1"
   >
     <span
-      className="c17 "
+      class="c17 "
     >
       S
     </span>
   </div>
   <div
-    className="c18 StyledAvatar-sc-1suyamb-1"
+    class="c18 StyledAvatar-sc-1suyamb-1"
   >
     <span
-      className="c19 "
+      class="c19 "
     >
       S
     </span>
   </div>
   <div
-    className="c20 StyledAvatar-sc-1suyamb-1"
+    class="c20 StyledAvatar-sc-1suyamb-1"
   >
     <span
-      className="c21 "
+      class="c21 "
     >
       S
     </span>
   </div>
   <div
-    className="c22 StyledAvatar-sc-1suyamb-1"
+    class="c22 StyledAvatar-sc-1suyamb-1"
   >
     <span
-      className="c23 "
+      class="c23 "
     >
       S
     </span>
   </div>
   <div
-    className="c24 StyledAvatar-sc-1suyamb-1"
+    class="c24 StyledAvatar-sc-1suyamb-1"
   >
     <span
-      className="c25 "
+      class="c25 "
     >
       S
     </span>
@@ -1097,37 +1097,37 @@ exports[`Avatar stack renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div
-        className="c3"
+        class="c3"
       >
         <div
-          className="c4"
+          class="c4"
         >
           <div
-            className="c5 StyledAvatar-sc-1suyamb-1"
+            class="c5 StyledAvatar-sc-1suyamb-1"
           />
           <div
-            className="c6"
+            class="c6"
           />
         </div>
         <div
-          className="c6"
+          class="c6"
         />
       </div>
     </div>
     <div
-      className="c7"
+      class="c7"
     >
       <div
-        className="c8 StyledAvatar-sc-1suyamb-1"
+        class="c8 StyledAvatar-sc-1suyamb-1"
       />
     </div>
   </div>
@@ -1210,22 +1210,22 @@ exports[`Avatar text renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 StyledAvatar-sc-1suyamb-1"
+    class="c1 StyledAvatar-sc-1suyamb-1"
   >
     <span
-      className="c2"
+      class="c2"
     >
       R
     </span>
   </div>
   <div
-    className="c3 StyledAvatar-sc-1suyamb-1"
+    class="c3 StyledAvatar-sc-1suyamb-1"
   >
     <span
-      className="c2"
+      class="c2"
     >
       SY
     </span>
@@ -1395,43 +1395,43 @@ exports[`Avatar text size changes according to theme 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2 StyledAvatar-sc-1suyamb-1"
+      class="c2 StyledAvatar-sc-1suyamb-1"
     >
       <span
-        className="c3 "
+        class="c3 "
       >
         T1
       </span>
     </div>
     <div
-      className="c4 StyledAvatar-sc-1suyamb-1"
+      class="c4 StyledAvatar-sc-1suyamb-1"
     >
       <span
-        className="c5 "
+        class="c5 "
       >
         T2
       </span>
     </div>
     <div
-      className="c6 StyledAvatar-sc-1suyamb-1"
+      class="c6 StyledAvatar-sc-1suyamb-1"
     >
       <span
-        className="c7 "
+        class="c7 "
       >
         T3
       </span>
     </div>
     <div
-      className="c8 StyledAvatar-sc-1suyamb-1"
+      class="c8 StyledAvatar-sc-1suyamb-1"
     >
       <span
-        className="c9 "
+        class="c9 "
       >
         T4
       </span>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Avatar/__tests__/Avatar-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.