### PR TITLE
Refactor Box tests to remove react-test-renderer

### DIFF
--- a/src/js/components/Box/__tests__/Box-test.js
+++ b/src/js/components/Box/__tests__/Box-test.js
@@ -1,13 +1,11 @@
 import React from 'react';
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
 import { Box } from '..';
 
 describe('Box', () => {
-  afterEach(cleanup);
-
   test('default', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Box/__tests__/Box-test.js
+++ b/src/js/components/Box/__tests__/Box-test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 import { cleanup, fireEvent, render } from '@testing-library/react';
 import 'jest-styled-components';
 
@@ -10,17 +9,17 @@ describe('Box', () => {
   afterEach(cleanup);
 
   test('default', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('direction', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box direction="row" />
         <Box direction="row-responsive" />
@@ -29,35 +28,35 @@ describe('Box', () => {
         <Box direction="row-reverse" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('responsive', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box responsive />
         <Box responsive={false} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('wrap', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         {[true, false, 'reverse'].map(wrap => (
           <Box key={`${wrap}`} wrap={wrap} />
         ))}
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('justify', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box justify="start" />
         <Box justify="center" />
@@ -67,12 +66,12 @@ describe('Box', () => {
         <Box justify="end" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('align', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box align="start" />
         <Box align="center" />
@@ -81,12 +80,12 @@ describe('Box', () => {
         <Box align="end" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('alignContent', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box alignContent="start" />
         <Box alignContent="center" />
@@ -96,12 +95,12 @@ describe('Box', () => {
         <Box alignContent="end" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('alignSelf', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box alignSelf="start" />
         <Box alignSelf="center" />
@@ -109,13 +108,13 @@ describe('Box', () => {
         <Box alignSelf="end" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   /* eslint-disable max-len */
   test('background', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box background="brand" />
         <Box background="accent-1" />
@@ -188,13 +187,13 @@ describe('Box', () => {
         />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
   /* eslint-enable max-len */
 
   test('basis', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box>
           <Box basis="xsmall" />
@@ -220,12 +219,12 @@ describe('Box', () => {
         </Box>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('flex', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box>
           <Box flex />
@@ -238,12 +237,12 @@ describe('Box', () => {
         </Box>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('fill', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box>
           <Box fill />
@@ -253,12 +252,12 @@ describe('Box', () => {
         </Box>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('gap', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         {['xsmall', 'small', 'medium', 'large', '80px', 'none'].map(gap => (
           <Box key={gap} gap={gap} direction="row">
@@ -271,12 +270,12 @@ describe('Box', () => {
         </Box>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('margin', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box margin="small" />
         <Box margin="medium" />
@@ -318,12 +317,12 @@ describe('Box', () => {
         />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('pad', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box pad="small" />
         <Box pad="medium" />
@@ -367,22 +366,22 @@ describe('Box', () => {
         />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('gridArea', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box gridArea="header" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('round', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box round />
         <Box round="xsmall" />
@@ -405,12 +404,12 @@ describe('Box', () => {
         <Box round={{ size: 'xlarge' }} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('border', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box border="all" />
         <Box border="horizontal" />
@@ -441,12 +440,12 @@ describe('Box', () => {
         </Box>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('elevation', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box elevation="none" />
         <Box elevation="xsmall" />
@@ -459,36 +458,37 @@ describe('Box', () => {
         </Box>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('as', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box as="header" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('tag proxied', () => {
-    const tagComponent = renderer.create(
+    const { container: tagComponent } = render(
       <Grommet>
         <Box tag="header" />
       </Grommet>,
     );
-    const asComponent = renderer.create(
+    const { container: asComponent } = render(
       <Grommet>
         <Box as="header" />
       </Grommet>,
     );
-    expect(tagComponent.toJSON()).toEqual(asComponent.toJSON());
+
+    expect(tagComponent).toEqual(asComponent);
   });
 
   test('animation', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         {[
           'fadeIn',
@@ -516,12 +516,12 @@ describe('Box', () => {
         />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('width', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box width="xsmall" />
         <Box width="small" />
@@ -531,22 +531,22 @@ describe('Box', () => {
         <Box width="111px" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('width object', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box width={{ width: '100px' }} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('height', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box height="xsmall" />
         <Box height="small" />
@@ -556,8 +556,8 @@ describe('Box', () => {
         <Box height="111px" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('onClick', () => {
@@ -575,7 +575,7 @@ describe('Box', () => {
   });
 
   test('hoverIndicator', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box>
           <Box onClick={() => {}} hoverIndicator />
@@ -594,7 +594,7 @@ describe('Box', () => {
         </Box>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -102,22 +102,22 @@ exports[`Box align 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
 </div>
 `;
@@ -236,25 +236,25 @@ exports[`Box alignContent 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
 </div>
 `;
@@ -339,19 +339,19 @@ exports[`Box alignSelf 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
 </div>
 `;
@@ -649,52 +649,52 @@ exports[`Box animation 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
   <div
-    className="c7"
+    class="c7"
   />
   <div
-    className="c8"
+    class="c8"
   />
   <div
-    className="c9"
+    class="c9"
   />
   <div
-    className="c10"
+    class="c10"
   />
   <div
-    className="c11"
+    class="c11"
   />
   <div
-    className="c12"
+    class="c12"
   />
   <div
-    className="c13"
+    class="c13"
   />
   <div
-    className="c14"
+    class="c14"
   />
   <div
-    className="c15"
+    class="c15"
   />
 </div>
 `;
@@ -725,10 +725,10 @@ exports[`Box as 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <header
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -1127,70 +1127,70 @@ exports[`Box background 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
   <div
-    className="c7"
+    class="c7"
   />
   <div
-    className="c8"
+    class="c8"
   />
   <div
-    className="c9"
+    class="c9"
   />
   <div
-    className="c10"
+    class="c10"
   />
   <div
-    className="c11"
+    class="c11"
   />
   <div
-    className="c12"
+    class="c12"
   />
   <div
-    className="c13"
+    class="c13"
   />
   <div
-    className="c14"
+    class="c14"
   />
   <div
-    className="c15"
+    class="c15"
   />
   <div
-    className="c16"
+    class="c16"
   />
   <div
-    className="c17"
+    class="c17"
   />
   <div
-    className="c18"
+    class="c18"
   />
   <div
-    className="c19"
+    class="c19"
   />
   <div
-    className="c20"
+    class="c20"
   />
   <div
-    className="c21"
+    class="c21"
   />
 </div>
 `;
@@ -1411,62 +1411,62 @@ exports[`Box basis 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     />
     <div
-      className="c3"
+      class="c3"
     />
     <div
-      className="c4"
+      class="c4"
     />
     <div
-      className="c5"
+      class="c5"
     />
     <div
-      className="c6"
+      class="c6"
     />
   </div>
   <div
-    className="c7"
+    class="c7"
   >
     <div
-      className="c8"
+      class="c8"
     />
   </div>
   <div
-    className="c7"
+    class="c7"
   >
     <div
-      className="c9"
+      class="c9"
     />
     <div
-      className="c9"
+      class="c9"
     />
   </div>
   <div
-    className="c7"
+    class="c7"
   >
     <div
-      className="c10"
+      class="c10"
     />
     <div
-      className="c11"
+      class="c11"
     />
   </div>
   <div
-    className="c7"
+    class="c7"
   >
     <div
-      className="c12"
+      class="c12"
     />
     <div
-      className="c13"
+      class="c13"
     />
   </div>
 </div>
@@ -1883,75 +1883,75 @@ exports[`Box border 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
   <div
-    className="c7"
+    class="c7"
   />
   <div
-    className="c8"
+    class="c8"
   />
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c9"
+    class="c9"
   />
   <div
-    className="c10"
+    class="c10"
   />
   <div
-    className="c11"
+    class="c11"
   />
   <div
-    className="c12"
+    class="c12"
   />
   <div
-    className="c13"
+    class="c13"
   />
   <div
-    className="c14"
+    class="c14"
   />
   <div
-    className="c15"
+    class="c15"
   />
   <div
-    className="c16"
+    class="c16"
   />
   <div
-    className="c17"
+    class="c17"
   >
     <div
-      className="c17"
+      class="c17"
     >
       one
     </div>
     <div
-      className="c18"
+      class="c18"
     />
     <div
-      className="c17"
+      class="c17"
     >
       two
     </div>
@@ -1985,10 +1985,10 @@ exports[`Box default 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -2094,22 +2094,22 @@ exports[`Box direction 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
 </div>
 `;
@@ -2248,31 +2248,31 @@ exports[`Box elevation 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
   <div
-    className="c7"
+    class="c7"
   >
     <div
-      className="c8"
+      class="c8"
     />
   </div>
 </div>
@@ -2350,22 +2350,22 @@ exports[`Box fill 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     />
     <div
-      className="c1"
+      class="c1"
     />
     <div
-      className="c3"
+      class="c3"
     />
     <div
-      className="c4"
+      class="c4"
     />
   </div>
 </div>
@@ -2516,31 +2516,31 @@ exports[`Box flex 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     />
     <div
-      className="c3"
+      class="c3"
     />
     <div
-      className="c4"
+      class="c4"
     />
     <div
-      className="c5"
+      class="c5"
     />
     <div
-      className="c6"
+      class="c6"
     />
     <div
-      className="c7"
+      class="c7"
     />
     <div
-      className="c8"
+      class="c8"
     />
   </div>
 </div>
@@ -2602,58 +2602,58 @@ exports[`Box gap 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     />
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     />
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     />
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     />
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     />
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     />
   </div>
   <span
-    className="c2"
+    class="c2"
   >
     <span>
       first
     </span>
     <span
-      className="c3"
+      class="c3"
     />
     <span>
       second
@@ -2689,10 +2689,10 @@ exports[`Box gridArea 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -2799,25 +2799,25 @@ exports[`Box height 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
 </div>
 `;
@@ -2928,43 +2928,27 @@ exports[`Box hoverIndicator 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      tabIndex={0}
+      class="c2"
+      tabindex="0"
     />
     <div
-      className="c3"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      tabIndex={0}
+      class="c3"
+      tabindex="0"
     />
     \\
     <div
-      className="c4"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      tabIndex={0}
+      class="c4"
+      tabindex="0"
     />
     <div
-      className="c5"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      tabIndex={0}
+      class="c5"
+      tabindex="0"
     />
   </div>
 </div>
@@ -3090,25 +3074,25 @@ exports[`Box justify 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
 </div>
 `;
@@ -3529,55 +3513,55 @@ exports[`Box margin 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
   <div
-    className="c7"
+    class="c7"
   />
   <div
-    className="c8"
+    class="c8"
   />
   <div
-    className="c9"
+    class="c9"
   />
   <div
-    className="c10"
+    class="c10"
   />
   <div
-    className="c11"
+    class="c11"
   />
   <div
-    className="c12"
+    class="c12"
   />
   <div
-    className="c13"
+    class="c13"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c14"
+    class="c14"
   />
   <div
-    className="c15"
+    class="c15"
   />
 </div>
 `;
@@ -4061,55 +4045,55 @@ exports[`Box pad 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
   <div
-    className="c7"
+    class="c7"
   />
   <div
-    className="c8"
+    class="c8"
   />
   <div
-    className="c9"
+    class="c9"
   />
   <div
-    className="c10"
+    class="c10"
   />
   <div
-    className="c11"
+    class="c11"
   />
   <div
-    className="c12"
+    class="c12"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c13"
+    class="c13"
   />
   <div
-    className="c14"
+    class="c14"
   />
   <div
-    className="c15"
+    class="c15"
   />
 </div>
 `;
@@ -4140,13 +4124,13 @@ exports[`Box responsive 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -4491,64 +4475,64 @@ exports[`Box round 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
   <div
-    className="c7"
+    class="c7"
   />
   <div
-    className="c8"
+    class="c8"
   />
   <div
-    className="c9"
+    class="c9"
   />
   <div
-    className="c10"
+    class="c10"
   />
   <div
-    className="c11"
+    class="c11"
   />
   <div
-    className="c12"
+    class="c12"
   />
   <div
-    className="c13"
+    class="c13"
   />
   <div
-    className="c14"
+    class="c14"
   />
   <div
-    className="c15"
+    class="c15"
   />
   <div
-    className="c16"
+    class="c16"
   />
   <div
-    className="c17"
+    class="c17"
   />
   <div
-    className="c18"
+    class="c18"
   />
 </div>
 `;
@@ -4655,25 +4639,25 @@ exports[`Box width 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
 </div>
 `;
@@ -4705,10 +4689,10 @@ exports[`Box width object 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -4773,16 +4757,16 @@ exports[`Box wrap 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
 </div>
 `;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Box/__tests__/Box-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.