### PR TITLE
Refactor Card tests to remove react-test-renderer

### DIFF
--- a/src/js/components/Card/__tests__/Card-test.js
+++ b/src/js/components/Card/__tests__/Card-test.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { cleanup } from '@testing-library/react';
-import renderer from 'react-test-renderer';
+import { cleanup, render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Box } from '../../Box';
@@ -15,7 +14,7 @@ const customTheme = {
   global: {
     font: {
       family: `-apple-system,
-           BlinkMacSystemFont, 
+           BlinkMacSystemFont,
            "Segoe UI"`,
     },
   },
@@ -43,41 +42,41 @@ describe('Card', () => {
   afterEach(cleanup);
 
   test('renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Card />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('header', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Card>
           <CardHeader>header</CardHeader>
         </Card>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('footer', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Card>
           <CardFooter>footer</CardFooter>
         </Card>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('children', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Card>
           <Box>
@@ -86,12 +85,12 @@ describe('Card', () => {
         </Card>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('all', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Card>
           <CardHeader>header</CardHeader>
@@ -100,12 +99,12 @@ describe('Card', () => {
         </Card>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('Themed', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet theme={customTheme}>
         <Card width="small">
           <CardHeader>header</CardHeader>
@@ -114,7 +113,7 @@ describe('Card', () => {
         </Card>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/components/Card/__tests__/Card-test.js
+++ b/src/js/components/Card/__tests__/Card-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Box } from '../../Box';
@@ -39,8 +39,6 @@ const customTheme = {
 };
 
 describe('Card', () => {
-  afterEach(cleanup);
-
   test('renders', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Card/__tests__/__snapshots__/Card-test.js.snap
+++ b/src/js/components/Card/__tests__/__snapshots__/Card-test.js.snap
@@ -141,23 +141,23 @@ exports[`Card Themed 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <header
-      className="c2"
+      class="c2"
     >
       header
     </header>
     <div
-      className="c3"
+      class="c3"
     >
       body
     </div>
     <footer
-      className="c4"
+      class="c4"
     >
       footer
     </footer>
@@ -242,23 +242,23 @@ exports[`Card all 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <header
-      className="c2"
+      class="c2"
     >
       header
     </header>
     <div
-      className="c3"
+      class="c3"
     >
       body
     </div>
     <footer
-      className="c2"
+      class="c2"
     >
       footer
     </footer>
@@ -320,16 +320,16 @@ exports[`Card children 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <span
-        className="c3"
+        class="c3"
       >
         test
       </span>
@@ -398,13 +398,13 @@ exports[`Card footer 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <footer
-      className="c2"
+      class="c2"
     >
       footer
     </footer>
@@ -472,13 +472,13 @@ exports[`Card header 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <header
-      className="c2"
+      class="c2"
     >
       header
     </header>
@@ -521,10 +521,10 @@ exports[`Card renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
 </div>
 `;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Card/__tests__/Card-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.