### PR TITLE
Refactor CheckBox tests to remove react-test-renderer

### DIFF
--- a/src/js/components/CheckBox/__tests__/CheckBox-test.js
+++ b/src/js/components/CheckBox/__tests__/CheckBox-test.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { cleanup, render, fireEvent } from '@testing-library/react';
-import renderer from 'react-test-renderer';
-import 'jest-styled-components';
 import { axe } from 'jest-axe';
+import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
@@ -35,100 +34,100 @@ describe('CheckBox', () => {
   });
 
   test('renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <CheckBox />
         <CheckBox id="test id" name="test name" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('label renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <CheckBox label="test label" />
         <CheckBox label={<div>test label</div>} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('checked renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <CheckBox checked />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('defaultChecked', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <CheckBox defaultChecked />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('disabled renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <CheckBox disabled />
         <CheckBox disabled checked />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('reverse renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <CheckBox reverse label="test label" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('toggle renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <CheckBox toggle />
         <CheckBox toggle checked />
         <CheckBox toggle label="test label" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('reverse toggle fill', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <CheckBox label="test label" reverse fill toggle />
         <CheckBox fill toggle label="test label" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('indeterminate renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <CheckBox indeterminate />
         <CheckBox indeterminate label="test label" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('indeterminate checked warns', () => {

--- a/src/js/components/CheckBox/__tests__/CheckBox-test.js
+++ b/src/js/components/CheckBox/__tests__/CheckBox-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, render, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
@@ -9,8 +9,6 @@ import { Grommet } from '../../Grommet';
 import { CheckBox } from '..';
 
 describe('CheckBox', () => {
-  afterEach(cleanup);
-
   test('should not have accessibility violations', async () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.js.snap
@@ -121,36 +121,24 @@ exports[`CheckBox checked renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <label
-    checked={true}
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
   >
     <div
-      checked={true}
-      className="c2 c3"
+      class="c2 c3"
     >
       <input
-        checked={true}
-        className="c4"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
+        checked=""
+        class="c4"
         type="checkbox"
       />
       <div
-        checked={true}
-        className="c5 "
+        class="c5 "
       >
         <svg
-          checked={true}
-          className="c6"
+          class="c6"
           preserveAspectRatio="xMidYMid meet"
           viewBox="0 0 24 24"
         >
@@ -633,36 +621,24 @@ exports[`CheckBox defaultChecked 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <label
-    checked={true}
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
   >
     <div
-      checked={true}
-      className="c2 c3"
+      class="c2 c3"
     >
       <input
-        checked={true}
-        className="c4"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
+        checked=""
+        class="c4"
         type="checkbox"
       />
       <div
-        checked={true}
-        className="c5 "
+        class="c5 "
       >
         <svg
-          checked={true}
-          className="c6"
+          class="c6"
           preserveAspectRatio="xMidYMid meet"
           viewBox="0 0 24 24"
         >
@@ -830,72 +806,48 @@ exports[`CheckBox disabled renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <label
-    checked={false}
-    className="c1"
-    disabled={true}
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
+    disabled=""
   >
     <div
-      checked={false}
-      className="c2 c3"
-      disabled={true}
+      class="c2 c3"
+      disabled=""
     >
       <input
-        checked={false}
-        className="c4"
-        disabled={true}
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
+        class="c4"
+        disabled=""
         type="checkbox"
       />
       <div
-        checked={false}
-        className="c5 "
-        disabled={true}
+        class="c5 "
+        disabled=""
       />
     </div>
   </label>
   <label
-    checked={true}
-    className="c1"
-    disabled={true}
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
+    disabled=""
   >
     <div
-      checked={true}
-      className="c2 c3"
-      disabled={true}
+      class="c2 c3"
+      disabled=""
     >
       <input
-        checked={true}
-        className="c4"
-        disabled={true}
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
+        checked=""
+        class="c4"
+        disabled=""
         type="checkbox"
       />
       <div
-        checked={true}
-        className="c6 "
-        disabled={true}
+        class="c6 "
+        disabled=""
       >
         <svg
-          checked={true}
-          className="c7"
-          disabled={true}
+          class="c7"
+          disabled=""
           preserveAspectRatio="xMidYMid meet"
           viewBox="0 0 24 24"
         >
@@ -1064,36 +1016,23 @@ exports[`CheckBox indeterminate renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <label
-    checked={false}
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
   >
     <div
-      checked={false}
-      className="c2 c3"
+      class="c2 c3"
     >
       <input
-        checked={false}
-        className="c4"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
+        class="c4"
         type="checkbox"
       />
       <div
-        checked={false}
-        className="c5 "
+        class="c5 "
       >
         <svg
-          checked={false}
-          className="c6"
+          class="c6"
           preserveAspectRatio="xMidYMid meet"
           viewBox="0 0 24 24"
         >
@@ -1106,33 +1045,20 @@ exports[`CheckBox indeterminate renders 1`] = `
     </div>
   </label>
   <label
-    checked={false}
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
   >
     <div
-      checked={false}
-      className="c7 c3"
+      class="c7 c3"
     >
       <input
-        checked={false}
-        className="c4"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
+        class="c4"
         type="checkbox"
       />
       <div
-        checked={false}
-        className="c5 "
+        class="c5 "
       >
         <svg
-          checked={false}
-          className="c6"
+          class="c6"
           preserveAspectRatio="xMidYMid meet"
           viewBox="0 0 24 24"
         >
@@ -1270,32 +1196,20 @@ exports[`CheckBox label renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <label
-    checked={false}
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
   >
     <div
-      checked={false}
-      className="c2 c3"
+      class="c2 c3"
     >
       <input
-        checked={false}
-        className="c4"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
+        class="c4"
         type="checkbox"
       />
       <div
-        checked={false}
-        className="c5 "
+        class="c5 "
       />
     </div>
     <span>
@@ -1303,29 +1217,17 @@ exports[`CheckBox label renders 1`] = `
     </span>
   </label>
   <label
-    checked={false}
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
   >
     <div
-      checked={false}
-      className="c2 c3"
+      class="c2 c3"
     >
       <input
-        checked={false}
-        className="c4"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
+        class="c4"
         type="checkbox"
       />
       <div
-        checked={false}
-        className="c5 "
+        class="c5 "
       />
     </div>
     <div>
@@ -1591,62 +1493,38 @@ exports[`CheckBox renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <label
-    checked={false}
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
   >
     <div
-      checked={false}
-      className="c2 c3"
+      class="c2 c3"
     >
       <input
-        checked={false}
-        className="c4"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
+        class="c4"
         type="checkbox"
       />
       <div
-        checked={false}
-        className="c5 "
+        class="c5 "
       />
     </div>
   </label>
   <label
-    checked={false}
-    className="c1"
-    htmlFor="test id"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
+    for="test id"
   >
     <div
-      checked={false}
-      className="c2 c3"
+      class="c2 c3"
     >
       <input
-        checked={false}
-        className="c4"
+        class="c4"
         id="test id"
         name="test name"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
         type="checkbox"
       />
       <div
-        checked={false}
-        className="c5 "
+        class="c5 "
       />
     </div>
   </label>
@@ -1773,35 +1651,23 @@ exports[`CheckBox reverse renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <label
-    checked={false}
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
   >
     <span>
       test label
     </span>
     <div
-      checked={false}
-      className="c2 c3"
+      class="c2 c3"
     >
       <input
-        checked={false}
-        className="c4"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
+        class="c4"
         type="checkbox"
       />
       <div
-        checked={false}
-        className="c5 "
+        class="c5 "
       />
     </div>
   </label>
@@ -1958,71 +1824,45 @@ exports[`CheckBox reverse toggle fill 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <label
-    checked={false}
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
   >
     <span>
       test label
     </span>
     <div
-      checked={false}
-      className="c2 c3"
+      class="c2 c3"
     >
       <input
-        checked={false}
-        className="c4"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
+        class="c4"
         type="checkbox"
       />
       <span
-        checked={false}
-        className="c5"
+        class="c5"
       >
         <span
-          checked={false}
-          className="c6"
+          class="c6"
         />
       </span>
     </div>
   </label>
   <label
-    checked={false}
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
   >
     <div
-      checked={false}
-      className="c7 c3"
+      class="c7 c3"
     >
       <input
-        checked={false}
-        className="c4"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
+        class="c4"
         type="checkbox"
       />
       <span
-        checked={false}
-        className="c5"
+        class="c5"
       >
         <span
-          checked={false}
-          className="c6"
+          class="c6"
         />
       </span>
     </div>
@@ -2303,100 +2143,62 @@ exports[`CheckBox toggle renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <label
-    checked={false}
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
   >
     <div
-      checked={false}
-      className="c2 c3"
+      class="c2 c3"
     >
       <input
-        checked={false}
-        className="c4"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
+        class="c4"
         type="checkbox"
       />
       <span
-        checked={false}
-        className="c5"
+        class="c5"
       >
         <span
-          checked={false}
-          className="c6"
+          class="c6"
         />
       </span>
     </div>
   </label>
   <label
-    checked={true}
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
   >
     <div
-      checked={true}
-      className="c2 c3"
+      class="c2 c3"
     >
       <input
-        checked={true}
-        className="c4"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
+        checked=""
+        class="c4"
         type="checkbox"
       />
       <span
-        checked={true}
-        className="c5"
+        class="c5"
       >
         <span
-          checked={true}
-          className="c6"
+          class="c6"
         />
       </span>
     </div>
   </label>
   <label
-    checked={false}
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
   >
     <div
-      checked={false}
-      className="c7 c3"
+      class="c7 c3"
     >
       <input
-        checked={false}
-        className="c4"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
+        class="c4"
         type="checkbox"
       />
       <span
-        checked={false}
-        className="c5"
+        class="c5"
       >
         <span
-          checked={false}
-          className="c6"
+          class="c6"
         />
       </span>
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/CheckBox/__tests__/CheckBox-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.