### PR TITLE
Refactor FormField tests to remove react-test-renderer

### DIFF
--- a/src/js/components/FormField/__tests__/FormField-test.js
+++ b/src/js/components/FormField/__tests__/FormField-test.js
@@ -1,12 +1,11 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { cleanup, render } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import styled from 'styled-components';
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
-import { axe } from 'jest-axe';
-import { cleanup, render } from '@testing-library/react';
 import { Alert, New, StatusInfo } from 'grommet-icons';
 import { Grommet } from '../../Grommet';
 import { Form } from '../../Form';
@@ -32,7 +31,7 @@ describe('FormField', () => {
   });
 
   test('default', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <FormField />
         <FormField>
@@ -40,101 +39,92 @@ describe('FormField', () => {
         </FormField>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('label', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <FormField label="test label" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('help', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <FormField help="test help" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('error', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <FormField error="test error" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('info', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <FormField info="test info" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('htmlFor', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <FormField htmlFor="test-id" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('margin', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <FormField margin="medium" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('empty margin', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <FormField margin="none" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('pad', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <FormField pad />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('abut', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet
         theme={{
           formField: {
@@ -157,13 +147,12 @@ describe('FormField', () => {
         <FormField htmlFor="test-id" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('abut with margin', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet
         theme={{
           formField: {
@@ -186,24 +175,22 @@ describe('FormField', () => {
         <FormField margin="medium" htmlFor="test-id" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('custom formfield', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <CustomFormField htmlFor="test-id" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('disabled', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <FormField disabled /> {/* don't use FormField without Form */}
         <Form>
@@ -211,13 +198,12 @@ describe('FormField', () => {
         </Form>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('required', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <FormField required /> {/* don't use FormField without Form */}
         <Form>
@@ -225,13 +211,12 @@ describe('FormField', () => {
         </Form>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('custom label', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet
         theme={{
           formField: {
@@ -249,13 +234,12 @@ describe('FormField', () => {
         </Form>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('disabled with custom label', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet
         theme={{
           formField: {
@@ -278,13 +262,12 @@ describe('FormField', () => {
         </Form>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('pad with border undefined', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet
         theme={{
           formField: {
@@ -300,13 +283,12 @@ describe('FormField', () => {
         </Form>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('custom input margin', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet
         theme={{
           formField: {
@@ -321,13 +303,12 @@ describe('FormField', () => {
         </Form>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('contentProps', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Form>
           <FormField
@@ -339,13 +320,12 @@ describe('FormField', () => {
         </Form>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('custom error and info icon and container', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet
         theme={{
           formField: {
@@ -378,9 +358,8 @@ describe('FormField', () => {
         </Form>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    component.unmount();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('should render asterisk when requiredIndicator === true', () => {
@@ -403,7 +382,7 @@ describe('FormField', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test(`should render custom indicator when requiredIndicator is 
+  test(`should render custom indicator when requiredIndicator is
   element`, () => {
     const { container } = render(
       <Grommet

--- a/src/js/components/FormField/__tests__/FormField-test.js
+++ b/src/js/components/FormField/__tests__/FormField-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import styled from 'styled-components';
 import 'jest-styled-components';
@@ -17,8 +17,6 @@ const CustomFormField = styled(FormField)`
 `;
 
 describe('FormField', () => {
-  afterEach(cleanup);
-
   test(`should have no accessibility violations`, async () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -54,15 +54,13 @@ exports[`FormField abut 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 "
-    onBlur={[Function]}
-    onFocus={[Function]}
+    class="c1 "
   >
     <div
-      className="c2 FormField__FormFieldContentBox-m9hood-1"
+      class="c2 FormField__FormFieldContentBox-m9hood-1"
     />
   </div>
 </div>
@@ -122,15 +120,13 @@ exports[`FormField abut with margin 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 "
-    onBlur={[Function]}
-    onFocus={[Function]}
+    class="c1 "
   >
     <div
-      className="c2 FormField__FormFieldContentBox-m9hood-1"
+      class="c2 FormField__FormFieldContentBox-m9hood-1"
     />
   </div>
 </div>
@@ -241,35 +237,27 @@ exports[`FormField contentProps 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
-  <form
-    onReset={[Function]}
-    onSubmit={[Function]}
-  >
+  <form>
     <div
-      className="c1 "
-      onBlur={[Function]}
-      onFocus={[Function]}
+      class="c1 "
     >
       <label
-        className="c2"
+        class="c2"
       >
         label
       </label>
       <div
-        className="c3 FormField__FormFieldContentBox-m9hood-1"
+        class="c3 FormField__FormFieldContentBox-m9hood-1"
       >
         <div
-          className="c4"
+          class="c4"
         >
           <input
-            autoComplete="off"
-            className="c5"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            autocomplete="off"
+            class="c5"
+            value=""
           />
         </div>
       </div>
@@ -493,85 +481,77 @@ exports[`FormField custom error and info icon and container 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
-  <form
-    onReset={[Function]}
-    onSubmit={[Function]}
-  >
+  <form>
     <div
-      className="c1 "
-      onBlur={[Function]}
-      onFocus={[Function]}
+      class="c1 "
     >
       <label
-        className="c2"
+        class="c2"
       >
         label
       </label>
       <div
-        className="c3 FormField__FormFieldContentBox-m9hood-1"
+        class="c3 FormField__FormFieldContentBox-m9hood-1"
       >
         <div
-          className="c4"
+          class="c4"
         >
           <input
-            aria-invalid={true}
-            autoComplete="off"
-            className="c5"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            aria-invalid="true"
+            autocomplete="off"
+            class="c5"
+            value=""
           />
         </div>
       </div>
       <div
-        className="c6 FormField__StyledMessageContainer-m9hood-2"
+        class="c6 FormField__StyledMessageContainer-m9hood-2"
       >
         <div
-          className="c7"
+          class="c7"
         >
           <svg
             aria-label="Alert"
-            className="c8"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
               d="M12,17 L12,19 M12,10 L12,16 M12,3 L2,22 L22,22 L12,3 Z"
               fill="none"
               stroke="#000"
-              strokeWidth="2"
+              stroke-width="2"
             />
           </svg>
         </div>
         <span
-          className="c9"
+          class="c9"
         >
           This is an error message.
         </span>
       </div>
       <div
-        className="c10 FormField__StyledMessageContainer-m9hood-2"
+        class="c10 FormField__StyledMessageContainer-m9hood-2"
       >
         <div
-          className="c7"
+          class="c7"
         >
           <svg
             aria-label="StatusInfo"
-            className="c8"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
               d="M2,3.99079514 C2,2.89130934 2.89821238,2 3.99079514,2 L20.0092049,2 C21.1086907,2 22,2.89821238 22,3.99079514 L22,20.0092049 C22,21.1086907 21.1017876,22 20.0092049,22 L3.99079514,22 C2.89130934,22 2,21.1017876 2,20.0092049 L2,3.99079514 Z M12,10 L12,18 M12,6 L12,8"
               fill="none"
               stroke="#000"
-              strokeWidth="2"
+              stroke-width="2"
             />
           </svg>
         </div>
         <span
-          className="c11"
+          class="c11"
         >
           Here is a little added info on FormField.
         </span>
@@ -639,15 +619,13 @@ exports[`FormField custom formfield 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 c2"
-    onBlur={[Function]}
-    onFocus={[Function]}
+    class="c1 c2"
   >
     <div
-      className="c3 FormField__FormFieldContentBox-m9hood-1"
+      class="c3 FormField__FormFieldContentBox-m9hood-1"
     />
   </div>
 </div>
@@ -774,35 +752,27 @@ exports[`FormField custom input margin 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
-  <form
-    onReset={[Function]}
-    onSubmit={[Function]}
-  >
+  <form>
     <div
-      className="c1 "
-      onBlur={[Function]}
-      onFocus={[Function]}
+      class="c1 "
     >
       <label
-        className="c2"
+        class="c2"
       >
         label
       </label>
       <div
-        className="c3 FormField__FormFieldContentBox-m9hood-1"
+        class="c3 FormField__FormFieldContentBox-m9hood-1"
       >
         <div
-          className="c4"
+          class="c4"
         >
           <input
-            autoComplete="off"
-            className="c5"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            autocomplete="off"
+            class="c5"
+            value=""
           />
         </div>
       </div>
@@ -922,35 +892,27 @@ exports[`FormField custom label 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
-  <form
-    onReset={[Function]}
-    onSubmit={[Function]}
-  >
+  <form>
     <div
-      className="c1 "
-      onBlur={[Function]}
-      onFocus={[Function]}
+      class="c1 "
     >
       <label
-        className="c2"
+        class="c2"
       >
         label
       </label>
       <div
-        className="c3 FormField__FormFieldContentBox-m9hood-1"
+        class="c3 FormField__FormFieldContentBox-m9hood-1"
       >
         <div
-          className="c4"
+          class="c4"
         >
           <input
-            autoComplete="off"
-            className="c5"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            autocomplete="off"
+            class="c5"
+            value=""
           />
         </div>
       </div>
@@ -1062,35 +1024,28 @@ exports[`FormField default 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 "
-    onBlur={[Function]}
-    onFocus={[Function]}
+    class="c1 "
   >
     <div
-      className="c2 FormField__FormFieldContentBox-m9hood-1"
+      class="c2 FormField__FormFieldContentBox-m9hood-1"
     />
   </div>
   <div
-    className="c1 "
-    onBlur={[Function]}
-    onFocus={[Function]}
+    class="c1 "
   >
     <div
-      className="c2 FormField__FormFieldContentBox-m9hood-1"
+      class="c2 FormField__FormFieldContentBox-m9hood-1"
     >
       <div
-        className="c3"
+        class="c3"
       >
         <input
-          autoComplete="off"
-          className="c4"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
+          autocomplete="off"
+          class="c4"
+          value=""
         />
       </div>
     </div>
@@ -1205,41 +1160,31 @@ exports[`FormField disabled 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 "
-    onBlur={[Function]}
-    onFocus={[Function]}
+    class="c1 "
   >
     <div
-      className="c2 FormField__FormFieldContentBox-m9hood-1"
+      class="c2 FormField__FormFieldContentBox-m9hood-1"
     />
   </div>
    
-  <form
-    onReset={[Function]}
-    onSubmit={[Function]}
-  >
+  <form>
     <div
-      className="c1 "
-      onBlur={[Function]}
-      onFocus={[Function]}
+      class="c1 "
     >
       <div
-        className="c2 FormField__FormFieldContentBox-m9hood-1"
+        class="c2 FormField__FormFieldContentBox-m9hood-1"
       >
         <div
-          className="c3"
+          class="c3"
         >
           <input
-            autoComplete="off"
-            className="c4"
-            disabled={true}
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            autocomplete="off"
+            class="c4"
+            disabled=""
+            value=""
           />
         </div>
       </div>
@@ -1363,36 +1308,28 @@ exports[`FormField disabled with custom label 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
-  <form
-    onReset={[Function]}
-    onSubmit={[Function]}
-  >
+  <form>
     <div
-      className="c1 "
-      onBlur={[Function]}
-      onFocus={[Function]}
+      class="c1 "
     >
       <label
-        className="c2"
+        class="c2"
       >
         label
       </label>
       <div
-        className="c3 FormField__FormFieldContentBox-m9hood-1"
+        class="c3 FormField__FormFieldContentBox-m9hood-1"
       >
         <div
-          className="c4"
+          class="c4"
         >
           <input
-            autoComplete="off"
-            className="c5"
-            disabled={true}
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            autocomplete="off"
+            class="c5"
+            disabled=""
+            value=""
           />
         </div>
       </div>
@@ -1455,15 +1392,13 @@ exports[`FormField empty margin 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 "
-    onBlur={[Function]}
-    onFocus={[Function]}
+    class="c1 "
   >
     <div
-      className="c2 FormField__FormFieldContentBox-m9hood-1"
+      class="c2 FormField__FormFieldContentBox-m9hood-1"
     />
   </div>
 </div>
@@ -1533,18 +1468,16 @@ exports[`FormField error 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 "
-    onBlur={[Function]}
-    onFocus={[Function]}
+    class="c1 "
   >
     <div
-      className="c2 FormField__FormFieldContentBox-m9hood-1"
+      class="c2 FormField__FormFieldContentBox-m9hood-1"
     />
     <span
-      className="c3"
+      class="c3"
     >
       test error
     </span>
@@ -1613,20 +1546,18 @@ exports[`FormField help 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 "
-    onBlur={[Function]}
-    onFocus={[Function]}
+    class="c1 "
   >
     <span
-      className="c2"
+      class="c2"
     >
       test help
     </span>
     <div
-      className="c3 FormField__FormFieldContentBox-m9hood-1"
+      class="c3 FormField__FormFieldContentBox-m9hood-1"
     />
   </div>
 </div>
@@ -1686,15 +1617,13 @@ exports[`FormField htmlFor 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 "
-    onBlur={[Function]}
-    onFocus={[Function]}
+    class="c1 "
   >
     <div
-      className="c2 FormField__FormFieldContentBox-m9hood-1"
+      class="c2 FormField__FormFieldContentBox-m9hood-1"
     />
   </div>
 </div>
@@ -1764,18 +1693,16 @@ exports[`FormField info 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 "
-    onBlur={[Function]}
-    onFocus={[Function]}
+    class="c1 "
   >
     <div
-      className="c2 FormField__FormFieldContentBox-m9hood-1"
+      class="c2 FormField__FormFieldContentBox-m9hood-1"
     />
     <span
-      className="c3"
+      class="c3"
     >
       test info
     </span>
@@ -1846,20 +1773,18 @@ exports[`FormField label 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 "
-    onBlur={[Function]}
-    onFocus={[Function]}
+    class="c1 "
   >
     <label
-      className="c2"
+      class="c2"
     >
       test label
     </label>
     <div
-      className="c3 FormField__FormFieldContentBox-m9hood-1"
+      class="c3 FormField__FormFieldContentBox-m9hood-1"
     />
   </div>
 </div>
@@ -1919,15 +1844,13 @@ exports[`FormField margin 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 "
-    onBlur={[Function]}
-    onFocus={[Function]}
+    class="c1 "
   >
     <div
-      className="c2 FormField__FormFieldContentBox-m9hood-1"
+      class="c2 FormField__FormFieldContentBox-m9hood-1"
     />
   </div>
 </div>
@@ -1994,15 +1917,13 @@ exports[`FormField pad 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 "
-    onBlur={[Function]}
-    onFocus={[Function]}
+    class="c1 "
   >
     <div
-      className="c2 FormField__FormFieldContentBox-m9hood-1"
+      class="c2 FormField__FormFieldContentBox-m9hood-1"
     />
   </div>
 </div>
@@ -2120,35 +2041,27 @@ exports[`FormField pad with border undefined 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
-  <form
-    onReset={[Function]}
-    onSubmit={[Function]}
-  >
+  <form>
     <div
-      className="c1 "
-      onBlur={[Function]}
-      onFocus={[Function]}
+      class="c1 "
     >
       <label
-        className="c2"
+        class="c2"
       >
         label
       </label>
       <div
-        className="c3"
+        class="c3"
       >
         <div
-          className="c4"
+          class="c4"
         >
           <input
-            autoComplete="off"
-            className="c5"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            autocomplete="off"
+            class="c5"
+            value=""
           />
         </div>
       </div>
@@ -2260,40 +2173,30 @@ exports[`FormField required 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 "
-    onBlur={[Function]}
-    onFocus={[Function]}
+    class="c1 "
   >
     <div
-      className="c2 FormField__FormFieldContentBox-m9hood-1"
+      class="c2 FormField__FormFieldContentBox-m9hood-1"
     />
   </div>
    
-  <form
-    onReset={[Function]}
-    onSubmit={[Function]}
-  >
+  <form>
     <div
-      className="c1 "
-      onBlur={[Function]}
-      onFocus={[Function]}
+      class="c1 "
     >
       <div
-        className="c2 FormField__FormFieldContentBox-m9hood-1"
+        class="c2 FormField__FormFieldContentBox-m9hood-1"
       >
         <div
-          className="c3"
+          class="c3"
         >
           <input
-            autoComplete="off"
-            className="c4"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            autocomplete="off"
+            class="c4"
+            value=""
           />
         </div>
       </div>
@@ -2520,7 +2423,7 @@ exports[`FormField should render asterisk when requiredIndicator === true 1`] = 
 </div>
 `;
 
-exports[`FormField should render custom indicator when requiredIndicator is 
+exports[`FormField should render custom indicator when requiredIndicator is
   element 1`] = `
 .c3 {
   display: inline-block;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/FormField/__tests__/FormField-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.