### PR TITLE
Refactor Grid tests to remove react-test-renderer

### DIFF
--- a/src/js/components/Grid/__tests__/Grid-test.js
+++ b/src/js/components/Grid/__tests__/Grid-test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 import { render } from '@testing-library/react';
 import 'jest-styled-components';
 
@@ -8,13 +7,13 @@ import { Grid } from '..';
 
 describe('Grid', () => {
   test('renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('a11yTitle renders', () => {
@@ -29,19 +28,19 @@ describe('Grid', () => {
   });
 
   test('rows renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid rows={[['small', 'medium'], 'large', 'medium']} />
         <Grid rows={['small', 'large', 'medium']} />
         <Grid rows="small" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('columns renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid columns={['1/2', '2/4']} />
         <Grid columns={['1/3', '2/3']} />
@@ -58,12 +57,12 @@ describe('Grid', () => {
         <Grid columns={{ count: 'fill', size: [] }} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('areas renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid
           rows={['xxsmall', 'medium', 'xsmall']}
@@ -77,8 +76,8 @@ describe('Grid', () => {
         />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('areas renders with warning and throws error', () => {
@@ -86,7 +85,7 @@ describe('Grid', () => {
     console.warn = jest.fn();
     const warnSpy = jest.spyOn(console, 'warn');
     expect(() => {
-      renderer.create(
+      render(
         <Grommet>
           <Grid
             rows={['xxsmall', 'medium', 'xsmall']}
@@ -107,7 +106,7 @@ describe('Grid', () => {
   });
 
   test('areas renders when given an array of string arrays', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid
           rows={['xxsmall', 'medium', 'xsmall']}
@@ -120,12 +119,12 @@ describe('Grid', () => {
         />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('justify renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid justify="start" />
         <Grid justify="center" />
@@ -133,12 +132,12 @@ describe('Grid', () => {
         <Grid justify="stretch" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('align renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid align="start" />
         <Grid align="center" />
@@ -146,12 +145,12 @@ describe('Grid', () => {
         <Grid align="stretch" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('justifyContent renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid justifyContent="start" />
         <Grid justifyContent="center" />
@@ -161,12 +160,12 @@ describe('Grid', () => {
         <Grid justifyContent="stretch" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('alignContent renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid alignContent="start" />
         <Grid alignContent="center" />
@@ -176,12 +175,12 @@ describe('Grid', () => {
         <Grid alignContent="stretch" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('gap renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid gap="small" />
         <Grid gap="medium" />
@@ -196,12 +195,12 @@ describe('Grid', () => {
         <Grid gap={{ test: 'test' }} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('fill renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid fill />
         <Grid fill={false} />
@@ -209,47 +208,48 @@ describe('Grid', () => {
         <Grid fill="vertical" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('responsive', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid responsive />
         <Grid responsive={false} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('as renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid as="article" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('proxies tag', () => {
-    const tagComponent = renderer.create(
+    const { container: tagComponent } = render(
       <Grommet>
         <Grid tag="article" />
       </Grommet>,
     );
-    const asComponent = renderer.create(
+    const { container: asComponent } = render(
       <Grommet>
         <Grid as="article" />
       </Grommet>,
     );
-    expect(tagComponent.toJSON()).toEqual(asComponent.toJSON());
+
+    expect(tagComponent).toEqual(asComponent);
   });
 
   test('pad', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid pad="small" />
         <Grid pad="medium" />
@@ -264,12 +264,12 @@ describe('Grid', () => {
         <Grid pad={{ top: 'small' }} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('border', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Grid border="all" />
         <Grid border="horizontal" />
@@ -296,8 +296,8 @@ describe('Grid', () => {
         />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('width', () => {

--- a/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
+++ b/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
@@ -76,19 +76,19 @@ exports[`Grid align renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
 </div>
 `;
@@ -153,25 +153,25 @@ exports[`Grid alignContent renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
 </div>
 `;
@@ -196,10 +196,10 @@ exports[`Grid areas renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -224,10 +224,10 @@ exports[`Grid areas renders when given an array of string arrays 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -249,10 +249,10 @@ exports[`Grid as renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <article
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -472,61 +472,61 @@ exports[`Grid border 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
   <div
-    className="c7"
+    class="c7"
   />
   <div
-    className="c8"
+    class="c8"
   />
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c9"
+    class="c9"
   />
   <div
-    className="c10"
+    class="c10"
   />
   <div
-    className="c11"
+    class="c11"
   />
   <div
-    className="c12"
+    class="c12"
   />
   <div
-    className="c13"
+    class="c13"
   />
   <div
-    className="c14"
+    class="c14"
   />
   <div
-    className="c15"
+    class="c15"
   />
   <div
-    className="c16"
+    class="c16"
   />
 </div>
 `;
@@ -615,43 +615,43 @@ exports[`Grid columns renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
   <div
-    className="c7"
+    class="c7"
   />
   <div
-    className="c8"
+    class="c8"
   />
   <div
-    className="c9"
+    class="c9"
   />
   <div
-    className="c10"
+    class="c10"
   />
   <div
-    className="c11"
+    class="c11"
   />
   <div
-    className="c12"
+    class="c12"
   />
 </div>
 `;
@@ -692,19 +692,19 @@ exports[`Grid fill renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
 </div>
 `;
@@ -786,40 +786,40 @@ exports[`Grid gap renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
   <div
-    className="c7"
+    class="c7"
   />
   <div
-    className="c8"
+    class="c8"
   />
   <div
-    className="c9"
+    class="c9"
   />
   <div
-    className="c10"
+    class="c10"
   />
   <div
-    className="c11"
+    class="c11"
   />
 </div>
 `;
@@ -961,19 +961,19 @@ exports[`Grid justify renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
 </div>
 `;
@@ -1044,25 +1044,25 @@ exports[`Grid justifyContent renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
 </div>
 `;
@@ -1215,40 +1215,40 @@ exports[`Grid pad 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="c6"
+    class="c6"
   />
   <div
-    className="c7"
+    class="c7"
   />
   <div
-    className="c8"
+    class="c8"
   />
   <div
-    className="c9"
+    class="c9"
   />
   <div
-    className="c10"
+    class="c10"
   />
   <div
-    className="c11"
+    class="c11"
   />
 </div>
 `;
@@ -1270,10 +1270,10 @@ exports[`Grid renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -1295,13 +1295,13 @@ exports[`Grid responsive 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -1336,16 +1336,16 @@ exports[`Grid rows renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
 </div>
 `;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Grid/__tests__/Grid-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.