### PR TITLE
Fix required FormField validation when value is an empty array

### DIFF
--- a/src/js/components/Form/Form.js
+++ b/src/js/components/Form/Form.js
@@ -339,11 +339,7 @@ const Form = forwardRef(
           let result;
           if (
             required &&
-            // false is for CheckBox
-            (value2 === undefined ||
-              value2 === '' ||
-              value2 === false ||
-              (Array.isArray(value2) && !value2.length))
+            (!value2 || (Array.isArray(value2) && !value2.length))
           ) {
             result = messages.required;
           } else if (validateArg) {

--- a/src/js/components/Form/Form.js
+++ b/src/js/components/Form/Form.js
@@ -339,7 +339,11 @@ const Form = forwardRef(
           let result;
           if (
             required &&
-            (!value2 || (Array.isArray(value2) && !value2.length))
+            // false is for CheckBox
+            (value2 === undefined ||
+              value2 === '' ||
+              value2 === false ||
+              (Array.isArray(value2) && !value2.length))
           ) {
             result = messages.required;
           } else if (validateArg) {

--- a/src/js/components/Form/Form.js
+++ b/src/js/components/Form/Form.js
@@ -340,7 +340,10 @@ const Form = forwardRef(
           if (
             required &&
             // false is for CheckBox
-            (value2 === undefined || value2 === '' || value2 === false)
+            (value2 === undefined ||
+              value2 === '' ||
+              value2 === false ||
+              (Array.isArray(value2) && !value2.length))
           ) {
             result = messages.required;
           } else if (validateArg) {

--- a/src/js/components/Form/__tests__/Form-test-uncontrolled.js
+++ b/src/js/components/Form/__tests__/Form-test-uncontrolled.js
@@ -3,8 +3,15 @@ import React from 'react';
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
+import '@testing-library/jest-dom';
 
-import { act, cleanup, render, fireEvent } from '@testing-library/react';
+import {
+  act,
+  cleanup,
+  render,
+  fireEvent,
+  screen,
+} from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { Grommet } from '../../Grommet';
@@ -17,6 +24,7 @@ import { Select } from '../../Select';
 import { CheckBox } from '../../CheckBox';
 import { RadioButtonGroup } from '../../RadioButtonGroup';
 import { Box } from '../../Box';
+import { DateInput } from '../../DateInput';
 
 describe('Form accessibility', () => {
   afterEach(cleanup);
@@ -418,6 +426,35 @@ describe('Form uncontrolled', () => {
       target: { value: '1' },
     });
     expect(queryByText('required')).toBeNull();
+  });
+
+  test('should not submit when field is required and value is "[]"', () => {
+    const onSubmit = jest.fn();
+    render(
+      <Grommet>
+        <Form onSubmit={onSubmit}>
+          <FormField
+            label="Date Range"
+            htmlFor="date-range"
+            name="date-range"
+            required
+          >
+            <DateInput
+              name="date-range"
+              value={[]}
+              format="mm/dd/yyyy-mm/dd/yyyy"
+            />
+          </FormField>
+          <Button type="submit" label="Submit" />
+        </Form>
+      </Grommet>,
+    );
+
+    expect(screen.queryByText('required')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText('required')).toBeInTheDocument();
   });
 
   test('reset clears form', () => {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fix/Add required FormField validation when value is an empty array (`[]`).

Closes #5333

#### Where should the reviewer start?

`src/js/components/Form/Form.js` and on `DateInput` storybook.

#### What testing has been done on this PR?

I created a test case on `src/js/components/Form/__tests__/Form-test-uncontrolled.js` to cover the bug described in #5333

#### How should this be manually tested?

Manual running: 

```bash
yarn test
```

#### Any background context you want to provide?

I also simplified a validation on the same file: instead of doing `value2 === undefined || value2 === '' || value2 === false` we can simply do `!value2` that means the same thing and also validates when the value is `null`.

#### What are the relevant issues?

#5333

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

Yes.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.