### PR TITLE
Allow className to table row

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -42,6 +42,7 @@ const Row = memo(
   }) => (
     <>
       <StyledDataTableRow
+        className={rowProps && rowProps[primaryValue]?.className}
         ref={rowRef}
         size={size}
         active={active}

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -642,7 +642,12 @@ describe('DataTable', () => {
             { a: 'two', b: 2 },
           ]}
           rowProps={{
-            one: { background: 'accent-1', border: 'bottom', pad: 'large' },
+            one: {
+              background: 'accent-1',
+              border: 'bottom',
+              pad: 'large',
+              className: 'custom-table-row',
+            },
           }}
         />
       </Grommet>,

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -17479,7 +17479,7 @@ exports[`DataTable rowProps 1`] = `
       class="StyledTable__StyledTableBody-sc-1m3u5g-3 c6"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 custom-table-row"
       >
         <th
           class="c7 "


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR allows to add a class name to table row via `rowProps`

#### Where should the reviewer start?
Can start by looking at how className is added to rowProps.

#### What testing has been done on this PR?
Snapshot test.

#### How should this be manually tested?
Pass className to rowProps

#### Any background context you want to provide?
This enables custom styling to table rows with greater flexibility.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
