### PR TITLE
Add text align justify

### DIFF
--- a/src/js/components/Heading/README.md
+++ b/src/js/components/Heading/README.md
@@ -197,6 +197,7 @@ How to align the text inside the heading. Defaults to `start`.
 start
 center
 end
+justify
 ```
 
 **truncate**

--- a/src/js/components/Heading/__tests__/Heading-test.js
+++ b/src/js/components/Heading/__tests__/Heading-test.js
@@ -77,6 +77,7 @@ test('Heading textAlign renders', () => {
       <Heading textAlign="start" />
       <Heading textAlign="center" />
       <Heading textAlign="end" />
+      <Heading textAlign="justify" />
     </Grommet>,
   );
   const tree = component.toJSON();

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -751,6 +751,14 @@ exports[`Heading textAlign renders 1`] = `
   text-align: right;
 }
 
+.c4 {
+  font-size: 50px;
+  line-height: 56px;
+  max-width: 1200px;
+  font-weight: 600;
+  text-align: justify;
+}
+
 @media only screen and (max-width:768px) {
   .c1 {
     font-size: 34px;
@@ -775,6 +783,14 @@ exports[`Heading textAlign renders 1`] = `
   }
 }
 
+@media only screen and (max-width:768px) {
+  .c4 {
+    font-size: 34px;
+    line-height: 40px;
+    max-width: 816px;
+  }
+}
+
 <div
   className="c0"
 >
@@ -786,6 +802,9 @@ exports[`Heading textAlign renders 1`] = `
   />
   <h1
     className="c3"
+  />
+  <h1
+    className="c4"
   />
 </div>
 `;

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -787,7 +787,7 @@ exports[`Heading textAlign renders 1`] = `
     class="c3"
   />
   <h1
-    className="c4"
+    class="c4"
   />
 </div>
 `;

--- a/src/js/components/Heading/doc.js
+++ b/src/js/components/Heading/doc.js
@@ -46,7 +46,7 @@ correctness and accessibility. This size property allows for stylistic
 adjustments.`,
       )
       .defaultValue('medium'),
-    textAlign: PropTypes.oneOf(['start', 'center', 'end'])
+    textAlign: PropTypes.oneOf(['start', 'center', 'end', 'justify'])
       .description('How to align the text inside the heading.')
       .defaultValue('start'),
     truncate: PropTypes.bool

--- a/src/js/components/Paragraph/README.md
+++ b/src/js/components/Paragraph/README.md
@@ -173,6 +173,7 @@ How to align the text inside the paragraph. Defaults to `start`.
 start
 center
 end
+justify
 ```
   
 ## Intrinsic element

--- a/src/js/components/Paragraph/__tests__/Paragraph-test.js
+++ b/src/js/components/Paragraph/__tests__/Paragraph-test.js
@@ -52,6 +52,7 @@ test('Paragraph textAlign renders', () => {
       <Paragraph textAlign="start" />
       <Paragraph textAlign="center" />
       <Paragraph textAlign="end" />
+      <Paragraph textAlign="justify" />
     </Grommet>,
   );
   const tree = component.toJSON();

--- a/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.js.snap
+++ b/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.js.snap
@@ -229,7 +229,7 @@ exports[`Paragraph textAlign renders 1`] = `
     class="c3"
   />
   <p
-    className="c4"
+    class="c4"
   />
 </div>
 `;

--- a/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.js.snap
+++ b/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.js.snap
@@ -214,6 +214,13 @@ exports[`Paragraph textAlign renders 1`] = `
   text-align: right;
 }
 
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  text-align: justify;
+}
+
 <div
   className="c0"
 >
@@ -225,6 +232,9 @@ exports[`Paragraph textAlign renders 1`] = `
   />
   <p
     className="c3"
+  />
+  <p
+    className="c4"
   />
 </div>
 `;

--- a/src/js/components/Paragraph/doc.js
+++ b/src/js/components/Paragraph/doc.js
@@ -31,7 +31,7 @@ export const doc = Paragraph => {
     ])
       .description('The size of the Paragraph text.')
       .defaultValue('medium'),
-    textAlign: PropTypes.oneOf(['start', 'center', 'end'])
+    textAlign: PropTypes.oneOf(['start', 'center', 'end', 'justify'])
       .description('How to align the text inside the paragraph.')
       .defaultValue('start'),
   };

--- a/src/js/components/Text/README.md
+++ b/src/js/components/Text/README.md
@@ -186,6 +186,7 @@ How to align the text inside the component. Defaults to `start`.
 start
 center
 end
+justify
 ```
 
 **tip**

--- a/src/js/components/Text/__tests__/Text-test.js
+++ b/src/js/components/Text/__tests__/Text-test.js
@@ -70,6 +70,7 @@ test('renders textAlign', () => {
       <Text textAlign="start" />
       <Text textAlign="center" />
       <Text textAlign="end" />
+      <Text textAlign="justify" />
     </Grommet>,
   );
   const tree = component.toJSON();

--- a/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
+++ b/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
@@ -343,6 +343,12 @@ exports[`renders textAlign 1`] = `
   text-align: right;
 }
 
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+  text-align: justify;
+}
+
 <div
   className="c0"
 >
@@ -354,6 +360,9 @@ exports[`renders textAlign 1`] = `
   />
   <span
     className="c3"
+  />
+  <span
+    className="c4"
   />
 </div>
 `;

--- a/src/js/components/Text/doc.js
+++ b/src/js/components/Text/doc.js
@@ -95,7 +95,7 @@ export const doc = Text => {
     ])
       .description(`The DOM tag or react component to use for the element.`)
       .defaultValue('span'),
-    textAlign: PropTypes.oneOf(['start', 'center', 'end'])
+    textAlign: PropTypes.oneOf(['start', 'center', 'end', 'justify'])
       .description('How to align the text inside the component.')
       .defaultValue('start'),
     tip: PropTypes.oneOfType([

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -14431,6 +14431,7 @@ How to align the text inside the paragraph. Defaults to \`start\`.
 start
 center
 end
+justify
 \`\`\`
   
 ## Intrinsic element

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -17886,6 +17886,7 @@ How to align the text inside the component. Defaults to \`start\`.
 start
 center
 end
+justify
 \`\`\`
 
 **tip**

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -11216,6 +11216,7 @@ How to align the text inside the heading. Defaults to \`start\`.
 start
 center
 end
+justify
 \`\`\`
 
 **truncate**

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -5296,7 +5296,8 @@ string",
         "description": "How to align the text inside the heading.",
         "format": "start
 center
-end",
+end
+justify",
         "name": "textAlign",
       },
       Object {

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -8446,7 +8446,8 @@ element",
         "description": "How to align the text inside the component.",
         "format": "start
 center
-end",
+end
+justify",
         "name": "textAlign",
       },
       Object {

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -6986,7 +6986,8 @@ string",
         "description": "How to align the text inside the paragraph.",
         "format": "start
 center
-end",
+end
+justify",
         "name": "textAlign",
       },
     ],

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -227,7 +227,7 @@ export type RoundType =
         | 'bottom-right';
       size?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | string;
     };
-export type TextAlignType = 'start' | 'center' | 'end';
+export type TextAlignType = 'start' | 'center' | 'end' | 'justify';
 export type ThicknessType =
   | 'hair'
   | 'xsmall'

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -743,6 +743,7 @@ export const roundStyle = (data, responsive, theme) => {
 const TEXT_ALIGN_MAP = {
   center: 'center',
   end: 'right',
+  justify: 'justify',
   start: 'left',
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
* Adds 'justify' to Text Align styles
* Update doc.js of tested components

#### Where should the reviewer start?
Minor change at styles.js at the utils directory and TextAlignType

#### What testing has been done on this PR?
Tests if the Text, Heading, Paragraph components renders with the textAlign="justify" prop

#### How should this be manually tested?
Test the main components that uses the textAlign prop

#### What are the relevant issues?
'Justify' text-alignment #5368
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/24925816/123485609-ce920a00-d5e0-11eb-9f50-36274ba0900a.png)

#### Do the grommet docs need to be updated?
No, the changes already includes docs update

#### Should this PR be mentioned in the release notes?
#### Is this change backwards compatible or is it a breaking change?
No