### PR TITLE
Refactor Heading tests to remove react-test-renderer

### DIFF
--- a/src/js/components/Heading/__tests__/Heading-test.js
+++ b/src/js/components/Heading/__tests__/Heading-test.js
@@ -1,35 +1,35 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
 import { Heading } from '..';
 
 test('Heading renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Heading />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('Heading accepts ref', () => {
   const ref = React.createRef();
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Heading ref={ref} />
     </Grommet>,
     { createNodeMock: el => el },
   );
+
   expect(ref.current).not.toBeNull();
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('Heading level renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Heading level={1} />
       <Heading level={2} />
@@ -41,12 +41,12 @@ test('Heading level renders', () => {
       <Heading level="4" />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('Heading size renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Heading level={1} size="small" />
       <Heading level={1} size="medium" />
@@ -67,24 +67,24 @@ test('Heading size renders', () => {
       <Heading level={1} size="77px" />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('Heading textAlign renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Heading textAlign="start" />
       <Heading textAlign="center" />
       <Heading textAlign="end" />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('Heading margin renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Heading margin="small" />
       <Heading margin="medium" />
@@ -96,42 +96,42 @@ test('Heading margin renders', () => {
       <Heading margin={{ top: 'none' }} />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('Heading color renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Heading color="brand" />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 const LONG = 'a b c d e f g h i j k l m n o p q r s t u v w x y z';
 
 test('Heading truncate renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Heading truncate={false}>{LONG}</Heading>
       <Heading truncate>{LONG}</Heading>
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('responsive renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Heading responsive />
       <Heading responsive={false} />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('Theme based font family renders', () => {
@@ -159,7 +159,7 @@ test('Theme based font family renders', () => {
       },
     },
   };
-  const component = renderer.create(
+  const { container } = render(
     <Grommet theme={customTheme}>
       <Heading level={1} />
       <Heading level={2} />
@@ -167,8 +167,8 @@ test('Theme based font family renders', () => {
       <Heading level={4} />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('Theme based font weight renders', () => {
@@ -194,7 +194,7 @@ test('Theme based font weight renders', () => {
       },
     },
   };
-  const component = renderer.create(
+  const { container } = render(
     <Grommet theme={customTheme}>
       <Heading level={1} />
       <Heading level={2} />
@@ -202,8 +202,8 @@ test('Theme based font weight renders', () => {
       <Heading level={4} />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('Theme color renders', () => {
@@ -212,7 +212,7 @@ test('Theme color renders', () => {
       color: 'text-strong',
     },
   };
-  const component = renderer.create(
+  const { container } = render(
     <Grommet theme={customTheme}>
       <Heading level={1} />
       <Heading level={2} />
@@ -220,8 +220,8 @@ test('Theme color renders', () => {
       <Heading level={4} />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('Throws a warning when heading.level is undefined in the theme.', () => {
@@ -237,7 +237,7 @@ test('Throws a warning when heading.level is undefined in the theme.', () => {
     },
   };
 
-  renderer.create(
+  render(
     <Grommet theme={customTheme}>
       <Heading level={6} />
     </Grommet>,
@@ -248,11 +248,11 @@ test('Throws a warning when heading.level is undefined in the theme.', () => {
 });
 
 test('Heading fill renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Heading fill />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -27,10 +27,10 @@ exports[`Heading accepts ref 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <h1
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -63,10 +63,10 @@ exports[`Heading color renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <h1
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -98,10 +98,10 @@ exports[`Heading fill renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <h1
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -178,31 +178,31 @@ exports[`Heading level renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <h1
-    className="c1"
+    class="c1"
   />
   <h2
-    className="c2"
+    class="c2"
   />
   <h3
-    className="c3"
+    class="c3"
   />
   <h4
-    className="c4"
+    class="c4"
   />
   <h1
-    className="c1"
+    class="c1"
   />
   <h2
-    className="c2"
+    class="c2"
   />
   <h3
-    className="c3"
+    class="c3"
   />
   <h4
-    className="c4"
+    class="c4"
   />
 </div>
 `;
@@ -395,31 +395,31 @@ exports[`Heading margin renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <h1
-    className="c1"
+    class="c1"
   />
   <h1
-    className="c2"
+    class="c2"
   />
   <h1
-    className="c3"
+    class="c3"
   />
   <h1
-    className="c4"
+    class="c4"
   />
   <h1
-    className="c5"
+    class="c5"
   />
   <h1
-    className="c6"
+    class="c6"
   />
   <h1
-    className="c7"
+    class="c7"
   />
   <h1
-    className="c8"
+    class="c8"
   />
 </div>
 `;
@@ -451,10 +451,10 @@ exports[`Heading renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <h1
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -643,75 +643,58 @@ exports[`Heading size renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <h1
-    className="c1"
-    size="small"
+    class="c1"
   />
   <h1
-    className="c2"
-    size="medium"
+    class="c2"
   />
   <h1
-    className="c3"
-    size="large"
+    class="c3"
   />
   <h1
-    className="c4"
-    size="xlarge"
+    class="c4"
   />
   <h2
-    className="c5"
-    size="small"
+    class="c5"
   />
   <h2
-    className="c1"
-    size="medium"
+    class="c1"
   />
   <h2
-    className="c2"
-    size="large"
+    class="c2"
   />
   <h2
-    className="c6"
-    size="xlarge"
+    class="c6"
   />
   <h3
-    className="c7"
-    size="small"
+    class="c7"
   />
   <h3
-    className="c8"
-    size="medium"
+    class="c8"
   />
   <h3
-    className="c9"
-    size="large"
+    class="c9"
   />
   <h3
-    className="c10"
-    size="xlarge"
+    class="c10"
   />
   <h4
-    className="c11"
-    size="small"
+    class="c11"
   />
   <h4
-    className="c11"
-    size="medium"
+    class="c11"
   />
   <h4
-    className="c11"
-    size="large"
+    class="c11"
   />
   <h4
-    className="c11"
-    size="xlarge"
+    class="c11"
   />
   <h1
-    className="c12"
-    size="77px"
+    class="c12"
   />
 </div>
 `;
@@ -776,16 +759,16 @@ exports[`Heading textAlign renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <h1
-    className="c1"
+    class="c1"
   />
   <h1
-    className="c2"
+    class="c2"
   />
   <h1
-    className="c3"
+    class="c3"
   />
 </div>
 `;
@@ -835,15 +818,15 @@ exports[`Heading truncate renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <h1
-    className="c1"
+    class="c1"
   >
     a b c d e f g h i j k l m n o p q r s t u v w x y z
   </h1>
   <h1
-    className="c2"
+    class="c2"
   >
     a b c d e f g h i j k l m n o p q r s t u v w x y z
   </h1>
@@ -926,19 +909,19 @@ exports[`Theme based font family renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <h1
-    className="c1"
+    class="c1"
   />
   <h2
-    className="c2"
+    class="c2"
   />
   <h3
-    className="c3"
+    class="c3"
   />
   <h4
-    className="c4"
+    class="c4"
   />
 </div>
 `;
@@ -1015,19 +998,19 @@ exports[`Theme based font weight renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <h1
-    className="c1"
+    class="c1"
   />
   <h2
-    className="c2"
+    class="c2"
   />
   <h3
-    className="c3"
+    class="c3"
   />
   <h4
-    className="c4"
+    class="c4"
   />
 </div>
 `;
@@ -1108,19 +1091,19 @@ exports[`Theme color renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <h1
-    className="c1"
+    class="c1"
   />
   <h2
-    className="c2"
+    class="c2"
   />
   <h3
-    className="c3"
+    class="c3"
   />
   <h4
-    className="c4"
+    class="c4"
   />
 </div>
 `;
@@ -1159,13 +1142,13 @@ exports[`responsive renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <h1
-    className="c1"
+    class="c1"
   />
   <h1
-    className="c2"
+    class="c2"
   />
 </div>
 `;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Heading/__tests__/Heading-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.