### PR TITLE
Refactor Image tests to remove react-test-renderer

### DIFF
--- a/src/js/components/Image/__tests__/Image-test.js
+++ b/src/js/components/Image/__tests__/Image-test.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
-import { act, cleanup, fireEvent, render } from '@testing-library/react';
-import { axe } from 'jest-axe';
 import { Grommet } from '../../Grommet';
 import { Image } from '..';
 
@@ -27,50 +26,50 @@ test('image should have no violations', async () => {
 });
 
 test('Image renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Image src={SRC} />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('Image renders with aria-label', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Image a11yTitle="aria-label-text" src={SRC} />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('Image fit renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Image fit="cover" src={SRC} />
       <Image fit="contain" src={SRC} />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 opacityTypes.forEach(opacity => {
   test(`Image opacity of ${opacity} renders`, () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Image opacity={opacity} src={SRC} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 });
 
 test('Image fillProp renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Image fill src={SRC} />
       <Image fill={false} src={SRC} />
@@ -78,8 +77,8 @@ test('Image fillProp renders', () => {
       <Image fill="vertical" src={SRC} />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('Image onError', () => {

--- a/src/js/components/Image/__tests__/__snapshots__/Image-test.js.snap
+++ b/src/js/components/Image/__tests__/__snapshots__/Image-test.js.snap
@@ -25,22 +25,22 @@ exports[`Image fillProp renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <img
-    className="c1"
+    class="c1"
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
   <img
-    className=""
+    class=""
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
   <img
-    className="c2"
+    class="c2"
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
   <img
-    className="c3"
+    class="c3"
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
 </div>
@@ -74,14 +74,14 @@ exports[`Image fit renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <img
-    className="c1"
+    class="c1"
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
   <img
-    className="c2"
+    class="c2"
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
 </div>
@@ -103,10 +103,10 @@ exports[`Image opacity of 0.3 renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <img
-    className="c1"
+    class="c1"
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
 </div>
@@ -124,10 +124,10 @@ exports[`Image opacity of false renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <img
-    className=""
+    class=""
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
 </div>
@@ -149,10 +149,10 @@ exports[`Image opacity of medium renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <img
-    className="c1"
+    class="c1"
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
 </div>
@@ -174,10 +174,10 @@ exports[`Image opacity of strong renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <img
-    className="c1"
+    class="c1"
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
 </div>
@@ -199,10 +199,10 @@ exports[`Image opacity of true renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <img
-    className="c1"
+    class="c1"
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
 </div>
@@ -224,10 +224,10 @@ exports[`Image opacity of weak renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <img
-    className="c1"
+    class="c1"
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
 </div>
@@ -245,10 +245,10 @@ exports[`Image renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <img
-    className=""
+    class=""
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
 </div>
@@ -266,11 +266,11 @@ exports[`Image renders with aria-label 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <img
     aria-label="aria-label-text"
-    className=""
+    class=""
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGPC/xhBQAAAA1JREFUCB1jYGBg+A8AAQQBAB5znEAAAAAASUVORK5CYII="
   />
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Image/__tests__/Image-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.