### PR TITLE
Refactor Meter tests to remove react-test-renderer

### DIFF
--- a/src/js/components/Meter/__tests__/Meter-test.js
+++ b/src/js/components/Meter/__tests__/Meter-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
@@ -9,37 +9,37 @@ const VALUES = [{ value: 20, label: 'twenty', onHover: () => {} }];
 
 describe('Meter', () => {
   test('default', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Meter />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('single', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Meter value={25} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('basic', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Meter values={VALUES} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('many values', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Meter
           values={[
@@ -55,24 +55,24 @@ describe('Meter', () => {
         />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('type', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Meter type="bar" values={VALUES} />
         <Meter type="circle" values={VALUES} />
         <Meter type="pie" values={VALUES} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('size', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Meter size="xsmall" values={VALUES} />
         <Meter size="small" values={VALUES} />
@@ -94,12 +94,12 @@ describe('Meter', () => {
         <Meter type="pie" size="55px" values={VALUES} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('thickness', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Meter thickness="xsmall" values={VALUES} />
         <Meter thickness="small" values={VALUES} />
@@ -115,23 +115,23 @@ describe('Meter', () => {
         <Meter type="circle" thickness="55px" values={VALUES} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('round', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Meter round values={VALUES} />
         <Meter type="circle" round values={VALUES} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('background', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Meter background="light-3" values={VALUES} />
         <Meter
@@ -150,17 +150,17 @@ describe('Meter', () => {
         />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('vertical', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Meter direction="vertical" values={VALUES} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
+++ b/src/js/components/Meter/__tests__/__snapshots__/Meter-test.js.snap
@@ -22,131 +22,121 @@ exports[`Meter background 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <svg
-    className="c1"
-    height={24}
+    class="c1"
+    height="24"
     preserveAspectRatio="none"
     viewBox="0 0 384 24"
-    width={384}
+    width="384"
   >
     <path
       d="M 0,12 L 384,12"
       fill="none"
       stroke="#EDEDED"
-      strokeLinecap="square"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-width="24"
     />
     <path
       d="M 0,12 L 76.8,12"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={24}
+    class="c1"
+    height="24"
     preserveAspectRatio="none"
     viewBox="0 0 384 24"
-    width={384}
+    width="384"
   >
     <path
       d="M 0,12 L 384,12"
       fill="none"
       stroke="#EDEDED"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 0,12 L 76.8,12"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={384}
+    class="c1"
+    height="384"
     viewBox="0 0 384 384"
-    width={384}
+    width="384"
   >
     <circle
-      cx={192}
-      cy={192}
+      cx="192"
+      cy="192"
       fill="none"
-      r={180}
+      r="180"
       stroke="#EDEDED"
-      strokeLinecap="square"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-width="24"
     />
     <path
       d="M 363.1901729331 136.3769410125 A 180.0000000000 180.0000000000 0 0 0 192.0000000000 12.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={384}
+    class="c1"
+    height="384"
     viewBox="0 0 384 384"
-    width={384}
+    width="384"
   >
     <circle
-      cx={192}
-      cy={192}
+      cx="192"
+      cy="192"
       fill="none"
-      r={180}
+      r="180"
       stroke="#EDEDED"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 363.1901729331 136.3769410125 A 180.0000000000 180.0000000000 0 0 0 192.0000000000 12.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={24}
+    class="c1"
+    height="24"
     preserveAspectRatio="none"
     viewBox="0 0 384 24"
-    width={384}
+    width="384"
   >
     <path
       d="M 0,12 L 384,12"
       fill="none"
       stroke="#EDEDED"
-      strokeLinecap="square"
-      strokeOpacity="0.2"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.2"
+      stroke-width="24"
     />
     <path
       d="M 0,12 L 76.8,12"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
 </div>
@@ -174,31 +164,29 @@ exports[`Meter basic 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <svg
-    className="c1"
-    height={24}
+    class="c1"
+    height="24"
     preserveAspectRatio="none"
     viewBox="0 0 384 24"
-    width={384}
+    width="384"
   >
     <path
       d="M 0,12 L 384,12"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 0,12 L 76.8,12"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
 </div>
@@ -226,22 +214,22 @@ exports[`Meter default 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <svg
-    className="c1"
-    height={24}
+    class="c1"
+    height="24"
     preserveAspectRatio="none"
     viewBox="0 0 384 24"
-    width={384}
+    width="384"
   >
     <path
       d="M 0,12 L 384,12"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
   </svg>
 </div>
@@ -269,78 +257,78 @@ exports[`Meter many values 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <svg
-    className="c1"
-    height={24}
+    class="c1"
+    height="24"
     preserveAspectRatio="none"
     viewBox="0 0 384 24"
-    width={384}
+    width="384"
   >
     <path
       d="M 0,12 L 384,12"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 336,12 L 384,12"
       fill="none"
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
     <path
       d="M 288,12 L 336,12"
       fill="none"
       stroke="#00873D"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
     <path
       d="M 240,12 L 288,12"
       fill="none"
       stroke="#3D138D"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
     <path
       d="M 192,12 L 240,12"
       fill="none"
       stroke="#00739D"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
     <path
       d="M 144,12 L 192,12"
       fill="none"
       stroke="#A2423D"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
     <path
       d="M 96,12 L 144,12"
       fill="none"
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
     <path
       d="M 48,12 L 96,12"
       fill="none"
       stroke="#00873D"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
     <path
       d="M 0,12 L 48,12"
       fill="none"
       stroke="#3D138D"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
 </div>
@@ -379,66 +367,60 @@ exports[`Meter round 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <svg
-    className="c1"
-    height={24}
+    class="c1"
+    height="24"
     preserveAspectRatio="none"
     viewBox="0 0 384 24"
-    width={384}
+    width="384"
   >
     <path
       d="M 12,12 L 372,12"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="round"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="round"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 12,12 L 84,12"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="round"
-      strokeWidth={24}
+      stroke-linecap="round"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c2"
-    height={384}
+    class="c2"
+    height="384"
     viewBox="0 0 384 384"
-    width={384}
+    width="384"
   >
     <circle
-      cx={192}
-      cy={192}
+      cx="192"
+      cy="192"
       fill="none"
-      r={180}
+      r="180"
       stroke="#F2F2F2"
-      strokeLinecap="round"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="round"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 363.1901729331 136.3769410125 A 180.0000000000 180.0000000000 0 0 0 192.0000000000 12.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="round"
-      strokeWidth={24}
+      stroke-linecap="round"
+      stroke-width="24"
     />
     <path
       d="M 363.1901729331 136.3769410125 A 180.0000000000 180.0000000000 0 0 0 362.6982579371 134.8851618471"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="round"
-      strokeWidth={24}
+      stroke-linecap="round"
+      stroke-width="24"
     />
   </svg>
 </div>
@@ -466,29 +448,29 @@ exports[`Meter single 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <svg
-    className="c1"
-    height={24}
+    class="c1"
+    height="24"
     preserveAspectRatio="none"
     viewBox="0 0 384 24"
-    width={384}
+    width="384"
   >
     <path
       d="M 0,12 L 384,12"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 0,12 L 96,12"
       fill="none"
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
 </div>
@@ -516,468 +498,432 @@ exports[`Meter size 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <svg
-    className="c1"
-    height={24}
+    class="c1"
+    height="24"
     preserveAspectRatio="none"
     viewBox="0 0 96 24"
-    width={96}
+    width="96"
   >
     <path
       d="M 0,12 L 96,12"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 0,12 L 19.2,12"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={24}
+    class="c1"
+    height="24"
     preserveAspectRatio="none"
     viewBox="0 0 192 24"
-    width={192}
+    width="192"
   >
     <path
       d="M 0,12 L 192,12"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 0,12 L 38.4,12"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={24}
+    class="c1"
+    height="24"
     preserveAspectRatio="none"
     viewBox="0 0 384 24"
-    width={384}
+    width="384"
   >
     <path
       d="M 0,12 L 384,12"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 0,12 L 76.8,12"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={24}
+    class="c1"
+    height="24"
     preserveAspectRatio="none"
     viewBox="0 0 768 24"
-    width={768}
+    width="768"
   >
     <path
       d="M 0,12 L 768,12"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 0,12 L 153.6,12"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={24}
+    class="c1"
+    height="24"
     preserveAspectRatio="none"
     viewBox="0 0 1152 24"
-    width={1152}
+    width="1152"
   >
     <path
       d="M 0,12 L 1152,12"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 0,12 L 230.4,12"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={24}
+    class="c1"
+    height="24"
     preserveAspectRatio="none"
     viewBox="0 0 24 24"
-    width={24}
+    width="24"
   >
     <path
       d="M 0,12 L 24,12"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 0,12 L 4.8,12"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={96}
+    class="c1"
+    height="96"
     viewBox="0 0 96 96"
-    width={96}
+    width="96"
   >
     <circle
-      cx={48}
-      cy={48}
+      cx="48"
+      cy="48"
       fill="none"
-      r={36}
+      r="36"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 82.2380345866 36.8753882025 A 36.0000000000 36.0000000000 0 0 0 48.0000000000 12.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={192}
+    class="c1"
+    height="192"
     viewBox="0 0 192 192"
-    width={192}
+    width="192"
   >
     <circle
-      cx={96}
-      cy={96}
+      cx="96"
+      cy="96"
       fill="none"
-      r={84}
+      r="84"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 175.8887473688 70.0425724725 A 84.0000000000 84.0000000000 0 0 0 96.0000000000 12.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={384}
+    class="c1"
+    height="384"
     viewBox="0 0 384 384"
-    width={384}
+    width="384"
   >
     <circle
-      cx={192}
-      cy={192}
+      cx="192"
+      cy="192"
       fill="none"
-      r={180}
+      r="180"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 363.1901729331 136.3769410125 A 180.0000000000 180.0000000000 0 0 0 192.0000000000 12.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={768}
+    class="c1"
+    height="768"
     viewBox="0 0 768 768"
-    width={768}
+    width="768"
   >
     <circle
-      cx={384}
-      cy={384}
+      cx="384"
+      cy="384"
       fill="none"
-      r={372}
+      r="372"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 737.7930240618 269.0456780925 A 372.0000000000 372.0000000000 0 0 0 384.0000000000 12.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={1152}
+    class="c1"
+    height="1152"
     viewBox="0 0 1152 1152"
-    width={1152}
+    width="1152"
   >
     <circle
-      cx={576}
-      cy={576}
+      cx="576"
+      cy="576"
       fill="none"
-      r={564}
+      r="564"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 1112.3958751905 401.7144151725 A 564.0000000000 564.0000000000 0 0 0 576.0000000000 12.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={55}
+    class="c1"
+    height="55"
     viewBox="0 0 55 55"
-    width={55}
+    width="55"
   >
     <circle
-      cx={27.5}
-      cy={27.5}
+      cx="27.5"
+      cy="27.5"
       fill="none"
-      r={15.5}
+      r="15.5"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 42.2413760026 22.7102365872 A 15.5000000000 15.5000000000 0 0 0 27.5000000000 12.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={96}
+    class="c1"
+    height="96"
     viewBox="0 0 96 96"
-    width={96}
+    width="96"
   >
     <circle
-      cx={48}
-      cy={48}
+      cx="48"
+      cy="48"
       fill="none"
-      r={24}
+      r="24"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={48}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="48"
     />
     <path
       d="M 70.8253563911 40.5835921350 A 24.0000000000 24.0000000000 0 0 0 48.0000000000 24.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={48}
+      stroke-linecap="butt"
+      stroke-width="48"
     />
   </svg>
   <svg
-    className="c1"
-    height={192}
+    class="c1"
+    height="192"
     viewBox="0 0 192 192"
-    width={192}
+    width="192"
   >
     <circle
-      cx={96}
-      cy={96}
+      cx="96"
+      cy="96"
       fill="none"
-      r={48}
+      r="48"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={96}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="96"
     />
     <path
       d="M 141.6507127822 81.1671842700 A 48.0000000000 48.0000000000 0 0 0 96.0000000000 48.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={96}
+      stroke-linecap="butt"
+      stroke-width="96"
     />
   </svg>
   <svg
-    className="c1"
-    height={384}
+    class="c1"
+    height="384"
     viewBox="0 0 384 384"
-    width={384}
+    width="384"
   >
     <circle
-      cx={192}
-      cy={192}
+      cx="192"
+      cy="192"
       fill="none"
-      r={96}
+      r="96"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={192}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="192"
     />
     <path
       d="M 283.3014255643 162.3343685400 A 96.0000000000 96.0000000000 0 0 0 192.0000000000 96.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={192}
+      stroke-linecap="butt"
+      stroke-width="192"
     />
   </svg>
   <svg
-    className="c1"
-    height={768}
+    class="c1"
+    height="768"
     viewBox="0 0 768 768"
-    width={768}
+    width="768"
   >
     <circle
-      cx={384}
-      cy={384}
+      cx="384"
+      cy="384"
       fill="none"
-      r={192}
+      r="192"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={384}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="384"
     />
     <path
       d="M 566.6028511287 324.6687370800 A 192.0000000000 192.0000000000 0 0 0 384.0000000000 192.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={384}
+      stroke-linecap="butt"
+      stroke-width="384"
     />
   </svg>
   <svg
-    className="c1"
-    height={1152}
+    class="c1"
+    height="1152"
     viewBox="0 0 1152 1152"
-    width={1152}
+    width="1152"
   >
     <circle
-      cx={576}
-      cy={576}
+      cx="576"
+      cy="576"
       fill="none"
-      r={288}
+      r="288"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={576}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="576"
     />
     <path
       d="M 849.9042766930 487.0031056200 A 288.0000000000 288.0000000000 0 0 0 576.0000000000 288.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={576}
+      stroke-linecap="butt"
+      stroke-width="576"
     />
   </svg>
   <svg
-    className="c1"
-    height={55}
+    class="c1"
+    height="55"
     viewBox="0 0 55 55"
-    width={55}
+    width="55"
   >
     <circle
-      cx={27.5}
-      cy={27.5}
+      cx="27.5"
+      cy="27.5"
       fill="none"
-      r={13.75}
+      r="13.75"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={27.5}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="27.5"
     />
     <path
       d="M 40.5770270991 23.2510163273 A 13.7500000000 13.7500000000 0 0 0 27.5000000000 13.7500000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={27.5}
+      stroke-linecap="butt"
+      stroke-width="27.5"
     />
   </svg>
 </div>
@@ -1005,312 +951,288 @@ exports[`Meter thickness 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <svg
-    className="c1"
-    height={6}
+    class="c1"
+    height="6"
     preserveAspectRatio="none"
     viewBox="0 0 384 6"
-    width={384}
+    width="384"
   >
     <path
       d="M 0,3 L 384,3"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={6}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="6"
     />
     <path
       d="M 0,3 L 76.8,3"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={6}
+      stroke-linecap="butt"
+      stroke-width="6"
     />
   </svg>
   <svg
-    className="c1"
-    height={12}
+    class="c1"
+    height="12"
     preserveAspectRatio="none"
     viewBox="0 0 384 12"
-    width={384}
+    width="384"
   >
     <path
       d="M 0,6 L 384,6"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={12}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="12"
     />
     <path
       d="M 0,6 L 76.8,6"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={12}
+      stroke-linecap="butt"
+      stroke-width="12"
     />
   </svg>
   <svg
-    className="c1"
-    height={24}
+    class="c1"
+    height="24"
     preserveAspectRatio="none"
     viewBox="0 0 384 24"
-    width={384}
+    width="384"
   >
     <path
       d="M 0,12 L 384,12"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 0,12 L 76.8,12"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={48}
+    class="c1"
+    height="48"
     preserveAspectRatio="none"
     viewBox="0 0 384 48"
-    width={384}
+    width="384"
   >
     <path
       d="M 0,24 L 384,24"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={48}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="48"
     />
     <path
       d="M 0,24 L 76.8,24"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={48}
+      stroke-linecap="butt"
+      stroke-width="48"
     />
   </svg>
   <svg
-    className="c1"
-    height={96}
+    class="c1"
+    height="96"
     preserveAspectRatio="none"
     viewBox="0 0 384 96"
-    width={384}
+    width="384"
   >
     <path
       d="M 0,48 L 384,48"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={96}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="96"
     />
     <path
       d="M 0,48 L 76.8,48"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={96}
+      stroke-linecap="butt"
+      stroke-width="96"
     />
   </svg>
   <svg
-    className="c1"
-    height={55}
+    class="c1"
+    height="55"
     preserveAspectRatio="none"
     viewBox="0 0 384 55"
-    width={384}
+    width="384"
   >
     <path
       d="M 0,27.5 L 384,27.5"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={55}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="55"
     />
     <path
       d="M 0,27.5 L 76.8,27.5"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={55}
+      stroke-linecap="butt"
+      stroke-width="55"
     />
   </svg>
   <svg
-    className="c1"
-    height={384}
+    class="c1"
+    height="384"
     viewBox="0 0 384 384"
-    width={384}
+    width="384"
   >
     <circle
-      cx={192}
-      cy={192}
+      cx="192"
+      cy="192"
       fill="none"
-      r={189}
+      r="189"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={6}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="6"
     />
     <path
       d="M 371.7496815798 133.5957880631 A 189.0000000000 189.0000000000 0 0 0 192.0000000000 3.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={6}
+      stroke-linecap="butt"
+      stroke-width="6"
     />
   </svg>
   <svg
-    className="c1"
-    height={384}
+    class="c1"
+    height="384"
     viewBox="0 0 384 384"
-    width={384}
+    width="384"
   >
     <circle
-      cx={192}
-      cy={192}
+      cx="192"
+      cy="192"
       fill="none"
-      r={186}
+      r="186"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={12}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="12"
     />
     <path
       d="M 368.8965120309 134.5228390463 A 186.0000000000 186.0000000000 0 0 0 192.0000000000 6.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={12}
+      stroke-linecap="butt"
+      stroke-width="12"
     />
   </svg>
   <svg
-    className="c1"
-    height={384}
+    class="c1"
+    height="384"
     viewBox="0 0 384 384"
-    width={384}
+    width="384"
   >
     <circle
-      cx={192}
-      cy={192}
+      cx="192"
+      cy="192"
       fill="none"
-      r={180}
+      r="180"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 363.1901729331 136.3769410125 A 180.0000000000 180.0000000000 0 0 0 192.0000000000 12.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={384}
+    class="c1"
+    height="384"
     viewBox="0 0 384 384"
-    width={384}
+    width="384"
   >
     <circle
-      cx={192}
-      cy={192}
+      cx="192"
+      cy="192"
       fill="none"
-      r={168}
+      r="168"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={48}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="48"
     />
     <path
       d="M 351.7774947376 140.0851449450 A 168.0000000000 168.0000000000 0 0 0 192.0000000000 24.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={48}
+      stroke-linecap="butt"
+      stroke-width="48"
     />
   </svg>
   <svg
-    className="c1"
-    height={384}
+    class="c1"
+    height="384"
     viewBox="0 0 384 384"
-    width={384}
+    width="384"
   >
     <circle
-      cx={192}
-      cy={192}
+      cx="192"
+      cy="192"
       fill="none"
-      r={144}
+      r="144"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={96}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="96"
     />
     <path
       d="M 328.9521383465 147.5015528100 A 144.0000000000 144.0000000000 0 0 0 192.0000000000 48.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={96}
+      stroke-linecap="butt"
+      stroke-width="96"
     />
   </svg>
   <svg
-    className="c1"
-    height={384}
+    class="c1"
+    height="384"
     viewBox="0 0 384 384"
-    width={384}
+    width="384"
   >
     <circle
-      cx={192}
-      cy={192}
+      cx="192"
+      cy="192"
       fill="none"
-      r={164.5}
+      r="164.5"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={55}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="55"
     />
     <path
       d="M 348.4487969306 141.1667044253 A 164.5000000000 164.5000000000 0 0 0 192.0000000000 27.5000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={55}
+      stroke-linecap="butt"
+      stroke-width="55"
     />
   </svg>
 </div>
@@ -1338,83 +1260,77 @@ exports[`Meter type 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <svg
-    className="c1"
-    height={24}
+    class="c1"
+    height="24"
     preserveAspectRatio="none"
     viewBox="0 0 384 24"
-    width={384}
+    width="384"
   >
     <path
       d="M 0,12 L 384,12"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 0,12 L 76.8,12"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={384}
+    class="c1"
+    height="384"
     viewBox="0 0 384 384"
-    width={384}
+    width="384"
   >
     <circle
-      cx={192}
-      cy={192}
+      cx="192"
+      cy="192"
       fill="none"
-      r={180}
+      r="180"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 363.1901729331 136.3769410125 A 180.0000000000 180.0000000000 0 0 0 192.0000000000 12.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={24}
+      stroke-linecap="butt"
+      stroke-width="24"
     />
   </svg>
   <svg
-    className="c1"
-    height={384}
+    class="c1"
+    height="384"
     viewBox="0 0 384 384"
-    width={384}
+    width="384"
   >
     <circle
-      cx={192}
-      cy={192}
+      cx="192"
+      cy="192"
       fill="none"
-      r={96}
+      r="96"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={192}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="192"
     />
     <path
       d="M 283.3014255643 162.3343685400 A 96.0000000000 96.0000000000 0 0 0 192.0000000000 96.0000000000"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={192}
+      stroke-linecap="butt"
+      stroke-width="192"
     />
   </svg>
 </div>
@@ -1442,31 +1358,29 @@ exports[`Meter vertical 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <svg
-    className="c1"
-    height={384}
+    class="c1"
+    height="384"
     preserveAspectRatio="none"
     viewBox="0 0 24 384"
-    width={24}
+    width="24"
   >
     <path
       d="M 12,0 L 12,384"
       fill="none"
       stroke="#F2F2F2"
-      strokeLinecap="square"
-      strokeOpacity="0.4"
-      strokeWidth={24}
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
     />
     <path
       d="M 12,384 L 12,307.2"
       fill="none"
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
       stroke="#6FFFB0"
-      strokeLinecap="butt"
-      strokeWidth={384}
+      stroke-linecap="butt"
+      stroke-width="384"
     />
   </svg>
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Meter/__tests__/Meter-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.