### PR TITLE
Refactor Paragraph tests to remove react-test-renderer

### DIFF
--- a/src/js/components/Paragraph/__tests__/Paragraph-test.js
+++ b/src/js/components/Paragraph/__tests__/Paragraph-test.js
@@ -1,22 +1,22 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
 import { Paragraph } from '..';
 
 test('Paragraph renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Paragraph />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('Paragraph size renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Paragraph size="small" />
       <Paragraph size="medium" />
@@ -27,12 +27,12 @@ test('Paragraph size renders', () => {
       <Paragraph fill={false} />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('Paragraph margin renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Paragraph margin="small" />
       <Paragraph margin="medium" />
@@ -42,18 +42,18 @@ test('Paragraph margin renders', () => {
       <Paragraph margin={{ top: 'small' }} />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('Paragraph textAlign renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Paragraph textAlign="start" />
       <Paragraph textAlign="center" />
       <Paragraph textAlign="end" />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });

--- a/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.js.snap
+++ b/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.js.snap
@@ -54,25 +54,25 @@ exports[`Paragraph margin renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <p
-    className="c1"
+    class="c1"
   />
   <p
-    className="c2"
+    class="c2"
   />
   <p
-    className="c3"
+    class="c3"
   />
   <p
-    className="c4"
+    class="c4"
   />
   <p
-    className="c5"
+    class="c5"
   />
   <p
-    className="c6"
+    class="c6"
   />
 </div>
 `;
@@ -95,10 +95,10 @@ exports[`Paragraph renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <p
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -151,33 +151,28 @@ exports[`Paragraph size renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <p
-    className="c1"
-    size="small"
+    class="c1"
   />
   <p
-    className="c2"
-    size="medium"
+    class="c2"
   />
   <p
-    className="c3"
-    size="large"
+    class="c3"
   />
   <p
-    className="c4"
-    size="xlarge"
+    class="c4"
   />
   <p
-    className="c5"
-    size="xxlarge"
+    class="c5"
   />
   <p
-    className="c6"
+    class="c6"
   />
   <p
-    className="c2"
+    class="c2"
   />
 </div>
 `;
@@ -215,16 +210,16 @@ exports[`Paragraph textAlign renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <p
-    className="c1"
+    class="c1"
   />
   <p
-    className="c2"
+    class="c2"
   />
   <p
-    className="c3"
+    class="c3"
   />
 </div>
 `;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Paragraph/__tests__/Paragraph-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.