### PR TITLE
Refactor RadioButton tests to remove react-test-renderer

### DIFF
--- a/src/js/components/RadioButton/__tests__/RadioButton-test.js
+++ b/src/js/components/RadioButton/__tests__/RadioButton-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
@@ -10,8 +10,6 @@ import { Box } from '../../Box';
 import { RadioButton } from '..';
 
 describe('RadioButton', () => {
-  afterEach(cleanup);
-
   test('should have no accessibility violations', async () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/RadioButton/__tests__/RadioButton-test.js
+++ b/src/js/components/RadioButton/__tests__/RadioButton-test.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { cleanup, render } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
-import { axe } from 'jest-axe';
-import { cleanup, render } from '@testing-library/react';
 import { Grommet } from '../../Grommet';
 import { Box } from '../../Box';
 import { RadioButton } from '..';
@@ -22,68 +21,69 @@ describe('RadioButton', () => {
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
-    expect(container).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('basic', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <RadioButton name="test" value="1" />
         <RadioButton id="test id" name="test" value="2" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('label', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <RadioButton label="test label" name="test" value="1" />
         <RadioButton label={<div>test label</div>} name="test" value="2" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('checked', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
-        <RadioButton checked name="test" value="1" />
+        <RadioButton checked name="test" value="1" onChange={jest.fn()} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('disabled', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <RadioButton disabled name="test" value="1" />
         <RadioButton disabled checked name="test" value="2" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('children', () => {
     const child = ({ checked }) => (
       <Box pad="small" background={checked ? 'accent-1' : 'control'} />
     );
-    const component = renderer.create(
+
+    const { container } = render(
       <Grommet>
         <RadioButton name="test" value="1">
           {child}
         </RadioButton>
-        <RadioButton checked name="test" value="2">
+        <RadioButton checked name="test" value="2" onChange={jest.fn()}>
           {child}
         </RadioButton>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('label themed', () => {
@@ -94,13 +94,13 @@ describe('RadioButton', () => {
         },
       },
     };
-    const component = renderer.create(
+    const { container } = render(
       <Grommet theme={customTheme}>
         <RadioButton label="test" name="test" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('background-color themed', () => {
@@ -114,13 +114,12 @@ describe('RadioButton', () => {
       },
     };
 
-    const component = renderer.create(
+    const { container } = render(
       <Grommet theme={customTheme}>
         <RadioButton name="test" />
       </Grommet>,
     );
 
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
+++ b/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.js.snap
@@ -101,24 +101,21 @@ exports[`RadioButton background-color themed 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <label
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+    class="c1"
   >
     <div
-      className="c2 "
+      class="c2 "
     >
       <input
-        className="c3"
+        class="c3"
         name="test"
         type="radio"
       />
       <div
-        className="c4 c5"
+        class="c4 c5"
       />
     </div>
   </label>
@@ -222,47 +219,41 @@ exports[`RadioButton basic 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <label
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+    class="c1"
   >
     <div
-      className="c2 "
+      class="c2 "
     >
       <input
-        className="c3"
+        class="c3"
         name="test"
         type="radio"
         value="1"
       />
       <div
-        className="c4 "
+        class="c4 "
       />
     </div>
   </label>
   <label
-    className="c1"
-    htmlFor="test id"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+    class="c1"
+    for="test id"
   >
     <div
-      className="c2 "
+      class="c2 "
     >
       <input
-        className="c3"
+        class="c3"
         id="test id"
         name="test"
         type="radio"
         value="2"
       />
       <div
-        className="c4 "
+        class="c4 "
       />
     </div>
   </label>
@@ -373,36 +364,33 @@ exports[`RadioButton checked 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <label
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+    class="c1"
   >
     <div
-      className="c2 "
+      class="c2 "
     >
       <input
-        checked={true}
-        className="c3"
+        checked=""
+        class="c3"
         name="test"
         type="radio"
         value="1"
       />
       <div
-        className="c4 "
+        class="c4 "
       >
         <svg
-          className="c5"
+          class="c5"
           preserveAspectRatio="xMidYMid meet"
           viewBox="0 0 24 24"
         >
           <circle
-            cx={12}
-            cy={12}
-            r={6}
+            cx="12"
+            cy="12"
+            r="6"
           />
         </svg>
       </div>
@@ -522,46 +510,40 @@ exports[`RadioButton children 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <label
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+    class="c1"
   >
     <div
-      className="c2 "
+      class="c2 "
     >
       <input
-        className="c3"
+        class="c3"
         name="test"
         type="radio"
         value="1"
       />
       <div
-        className="c4"
+        class="c4"
       />
     </div>
   </label>
   <label
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+    class="c1"
   >
     <div
-      className="c2 "
+      class="c2 "
     >
       <input
-        checked={true}
-        className="c3"
+        checked=""
+        class="c3"
         name="test"
         type="radio"
         value="2"
       />
       <div
-        className="c5"
+        class="c5"
       />
     </div>
   </label>
@@ -704,60 +686,54 @@ exports[`RadioButton disabled 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <label
-    className="c1"
-    disabled={true}
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+    class="c1"
+    disabled=""
   >
     <div
-      className="c2 "
+      class="c2 "
     >
       <input
-        className="c3"
-        disabled={true}
+        class="c3"
+        disabled=""
         name="test"
         type="radio"
         value="1"
       />
       <div
-        className="c4 "
+        class="c4 "
       />
     </div>
   </label>
   <label
-    className="c1"
-    disabled={true}
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+    class="c1"
+    disabled=""
   >
     <div
-      className="c2 "
+      class="c2 "
     >
       <input
-        checked={true}
-        className="c3"
-        disabled={true}
+        checked=""
+        class="c3"
+        disabled=""
         name="test"
         type="radio"
         value="2"
       />
       <div
-        className="c5 "
+        class="c5 "
       >
         <svg
-          className="c6"
+          class="c6"
           preserveAspectRatio="xMidYMid meet"
           viewBox="0 0 24 24"
         >
           <circle
-            cx={12}
-            cy={12}
-            r={6}
+            cx="12"
+            cy="12"
+            r="6"
           />
         </svg>
       </div>
@@ -870,50 +846,44 @@ exports[`RadioButton label 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <label
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+    class="c1"
   >
     <div
-      className="c2 "
+      class="c2 "
     >
       <input
-        className="c3"
+        class="c3"
         name="test"
         type="radio"
         value="1"
       />
       <div
-        className="c4 "
+        class="c4 "
       />
     </div>
     <span
-      className="StyledRadioButton__StyledRadioButtonLabel-g1f6ld-2"
+      class="StyledRadioButton__StyledRadioButtonLabel-g1f6ld-2"
     >
       test label
     </span>
   </label>
   <label
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+    class="c1"
   >
     <div
-      className="c2 "
+      class="c2 "
     >
       <input
-        className="c3"
+        class="c3"
         name="test"
         type="radio"
         value="2"
       />
       <div
-        className="c4 "
+        class="c4 "
       />
     </div>
     <div>
@@ -1031,28 +1001,25 @@ exports[`RadioButton label themed 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <label
-    className="c1"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+    class="c1"
   >
     <div
-      className="c2 "
+      class="c2 "
     >
       <input
-        className="c3"
+        class="c3"
         name="test"
         type="radio"
       />
       <div
-        className="c4 "
+        class="c4 "
       />
     </div>
     <span
-      className="c5"
+      class="c5"
     >
       test
     </span>
@@ -1156,27 +1123,25 @@ exports[`RadioButton should have no accessibility violations 1`] = `
   }
 }
 
-<div>
-  <div
-    class="c0"
+<div
+  class="c0"
+>
+  <label
+    class="c1"
   >
-    <label
-      class="c1"
+    <div
+      class="c2 "
     >
+      <input
+        aria-label="test"
+        class="c3"
+        name="test"
+        type="radio"
+      />
       <div
-        class="c2 "
-      >
-        <input
-          aria-label="test"
-          class="c3"
-          name="test"
-          type="radio"
-        />
-        <div
-          class="c4 "
-        />
-      </div>
-    </label>
-  </div>
+        class="c4 "
+      />
+    </div>
+  </label>
 </div>
 `;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/RadioButton/__tests__/RadioButton-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.