### PR TITLE
Refactor RangeInput tests to remove react-test-renderer

### DIFF
--- a/src/js/components/RangeInput/__tests__/RangeInput-test.js
+++ b/src/js/components/RangeInput/__tests__/RangeInput-test.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { cleanup, render, fireEvent } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
-import { axe } from 'jest-axe';
-import { cleanup, render, fireEvent } from '@testing-library/react';
 import { Grommet } from '../../Grommet';
 import { RangeInput } from '..';
 
@@ -21,49 +20,49 @@ describe('RangeInput', () => {
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
-    expect(container).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <RangeInput value="50" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('track themed', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet theme={{ rangeInput: { track: { color: 'brand' } } }}>
         <RangeInput value="10" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('track themed with color and opacity', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet
         theme={{ rangeInput: { track: { color: 'brand', opacity: 0.3 } } }}
       >
         <RangeInput value="10" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('with min and max offset', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <RangeInput min={10} max={20} step={1} value={15} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('onFocus', () => {
@@ -73,9 +72,11 @@ describe('RangeInput', () => {
         <RangeInput min={0} max={10} step={1} value={5} onFocus={onFocus} />
       </Grommet>,
     );
+
     fireEvent.focus(getByDisplayValue('5'));
-    expect(container.firstChild).toMatchSnapshot();
     expect(onFocus).toHaveBeenCalledTimes(1);
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('onBlur', () => {
@@ -85,9 +86,11 @@ describe('RangeInput', () => {
         <RangeInput min={0} max={10} step={1} value={5} onBlur={onBlur} />
       </Grommet>,
     );
+
     fireEvent.blur(getByDisplayValue('5'));
-    expect(container.firstChild).toMatchSnapshot();
     expect(onBlur).toHaveBeenCalledTimes(1);
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('onChange', () => {
@@ -97,12 +100,14 @@ describe('RangeInput', () => {
         <RangeInput min={0} max={10} step={1} value={5} onChange={onChange} />
       </Grommet>,
     );
+
     fireEvent.change(getByDisplayValue('5'), {
       target: {
         value: '10',
       },
     });
-    expect(container.firstChild).toMatchSnapshot();
     expect(onChange).toBeCalledTimes(1);
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/components/RangeInput/__tests__/RangeInput-test.js
+++ b/src/js/components/RangeInput/__tests__/RangeInput-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, render, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
@@ -9,8 +9,6 @@ import { Grommet } from '../../Grommet';
 import { RangeInput } from '..';
 
 describe('RangeInput', () => {
-  afterEach(cleanup);
-
   test('should have no accessibility violations', async () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/RangeInput/__tests__/__snapshots__/RangeInput-test.js.snap
+++ b/src/js/components/RangeInput/__tests__/__snapshots__/RangeInput-test.js.snap
@@ -536,13 +536,10 @@ exports[`RangeInput renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <input
-    className="c1"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
+    class="c1"
     type="range"
     value="50"
   />
@@ -668,17 +665,15 @@ exports[`RangeInput should have no accessibility violations 1`] = `
   border-color: transparent;
 }
 
-<div>
-  <div
-    class="c0"
-  >
-    <input
-      aria-label="test"
-      class="c1"
-      type="range"
-      value="50"
-    />
-  </div>
+<div
+  class="c0"
+>
+  <input
+    aria-label="test"
+    class="c1"
+    type="range"
+    value="50"
+  />
 </div>
 `;
 
@@ -802,13 +797,10 @@ exports[`RangeInput track themed 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <input
-    className="c1"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
+    class="c1"
     type="range"
     value="10"
   />
@@ -935,13 +927,10 @@ exports[`RangeInput track themed with color and opacity 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <input
-    className="c1"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
+    class="c1"
     type="range"
     value="10"
   />
@@ -1068,18 +1057,15 @@ exports[`RangeInput with min and max offset 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <input
-    className="c1"
-    max={20}
-    min={10}
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    step={1}
+    class="c1"
+    max="20"
+    min="10"
+    step="1"
     type="range"
-    value={15}
+    value="15"
   />
 </div>
 `;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/RangeInput/__tests__/RangeInput-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.