### PR TITLE
Refactor RangeSelector tests to remove react-test-renderer

### DIFF
--- a/src/js/components/RangeSelector/__tests__/RangeSelector-test.js
+++ b/src/js/components/RangeSelector/__tests__/RangeSelector-test.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
-import 'jest-styled-components';
 import { cleanup, render, fireEvent } from '@testing-library/react';
 import { axe } from 'jest-axe';
+import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
@@ -18,99 +17,101 @@ describe('RangeSelector', () => {
         <RangeSelector values={[20, 30]} />
       </Grommet>,
     );
+
     const results = await axe(container);
-    expect(container.firstChild).toMatchSnapshot();
     expect(results).toHaveNoViolations();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('basic', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <RangeSelector values={[20, 30]} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('color', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <RangeSelector color="accent-1" values={[20, 30]} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('direction', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <RangeSelector direction="horizontal" values={[20, 30]} />
         <RangeSelector direction="vertical" values={[20, 30]} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('invert', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <RangeSelector invert values={[20, 30]} />
         <RangeSelector invert={false} values={[20, 30]} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('max', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <RangeSelector max={50} values={[20, 30]} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('min', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <RangeSelector min={10} values={[20, 30]} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('opacity', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         {['weak', 'medium', 'strong'].map(opacity => (
           <RangeSelector key={opacity} opacity={opacity} values={[20, 30]} />
         ))}
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('round', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         {['xsmall', 'small', 'medium', 'large', 'full'].map(round => (
           <RangeSelector key={round} round={round} values={[20, 30]} />
         ))}
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('size', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         {[
           'xxsmall',
@@ -125,8 +126,8 @@ describe('RangeSelector', () => {
         ))}
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('step renders correct values', () => {

--- a/src/js/components/RangeSelector/__tests__/RangeSelector-test.js
+++ b/src/js/components/RangeSelector/__tests__/RangeSelector-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, render, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
@@ -9,8 +9,6 @@ import { Grommet } from '../../Grommet';
 import { RangeSelector } from '..';
 
 describe('RangeSelector', () => {
-  afterEach(cleanup);
-
   test('should not have accessibility violations', async () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
+++ b/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
@@ -143,96 +143,53 @@ exports[`RangeSelector basic 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c7"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c7"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 70 0 0px;"
     />
   </div>
 </div>
@@ -381,96 +338,53 @@ exports[`RangeSelector color 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c7"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c7"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 70 0 0px;"
     />
   </div>
 </div>
@@ -724,186 +638,100 @@ exports[`RangeSelector direction 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c7"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c7"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 70 0 0px;"
     />
   </div>
   <div
-    className="c8 c2"
-    tabIndex="-1"
+    class="c8 c2"
+    tabindex="-1"
   >
     <div
-      className="c9"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c9"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c10"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c10"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c11"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "row-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c11"
+        style="cursor: row-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c12"
-      style={
-        Object {
-          "cursor": "ns-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c12"
+      style="flex: 11 0 0px; cursor: ns-resize;"
     />
     <div
-      className="c10"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c10"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c11"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "row-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c11"
+        style="cursor: row-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c9"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c9"
+      style="flex: 70 0 0px;"
     />
   </div>
 </div>
@@ -1658,186 +1486,100 @@ exports[`RangeSelector invert 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c7"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c7"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 70 0 0px;"
     />
   </div>
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c7"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c7"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c8"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c8"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c7"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c7"
+      style="flex: 70 0 0px;"
     />
   </div>
 </div>
@@ -1986,96 +1728,53 @@ exports[`RangeSelector max 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c7"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c7"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 20 0 0px;"
     />
   </div>
 </div>
@@ -2224,96 +1923,53 @@ exports[`RangeSelector min 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "10 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 10 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c7"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c7"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 70 0 0px;"
     />
   </div>
 </div>
@@ -2497,276 +2153,147 @@ exports[`RangeSelector opacity 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c7"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c7"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 70 0 0px;"
     />
   </div>
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c8"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c8"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 70 0 0px;"
     />
   </div>
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c9"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c9"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 70 0 0px;"
     />
   </div>
 </div>
@@ -3109,456 +2636,241 @@ exports[`RangeSelector round 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c7"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c7"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 70 0 0px;"
     />
   </div>
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c8"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c8"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c9"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c9"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c8"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c8"
+      style="flex: 70 0 0px;"
     />
   </div>
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c10"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c10"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c11"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c11"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c10"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c10"
+      style="flex: 70 0 0px;"
     />
   </div>
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c12"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c12"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c13"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c13"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c12"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c12"
+      style="flex: 70 0 0px;"
     />
   </div>
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c14"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c14"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c15"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c15"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c14"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c14"
+      style="flex: 70 0 0px;"
     />
   </div>
 </div>
@@ -4110,636 +3422,335 @@ exports[`RangeSelector size 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c7"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c7"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c3"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c3"
+      style="flex: 70 0 0px;"
     />
   </div>
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c8"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c8"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c9"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c9"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c8"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c8"
+      style="flex: 70 0 0px;"
     />
   </div>
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c10"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c10"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c11"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c11"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c10"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c10"
+      style="flex: 70 0 0px;"
     />
   </div>
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c12"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c12"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c13"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c13"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c12"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c12"
+      style="flex: 70 0 0px;"
     />
   </div>
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c14"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c14"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c15"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c15"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c14"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c14"
+      style="flex: 70 0 0px;"
     />
   </div>
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c16"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c16"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c17"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c17"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c16"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c16"
+      style="flex: 70 0 0px;"
     />
   </div>
   <div
-    className="c1 c2"
-    tabIndex="-1"
+    class="c1 c2"
+    tabindex="-1"
   >
     <div
-      className="c18"
-      style={
-        Object {
-          "flex": "20 0 0",
-        }
-      }
+      class="c18"
+      style="flex: 20 0 0px;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Lower Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c19"
-      style={
-        Object {
-          "cursor": "ew-resize",
-          "flex": "11 0 0",
-        }
-      }
+      class="c19"
+      style="flex: 11 0 0px; cursor: ew-resize;"
     />
     <div
-      className="c4"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "flex": "0 0 1px",
-        }
-      }
+      class="c4"
+      style="flex: 0 0 1px;"
     >
       <div
         aria-label="Upper Bounds"
-        className="c5"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "cursor": "col-resize",
-            "minHeight": 12,
-            "minWidth": 12,
-            "outline": "none",
-            "zIndex": 10,
-          }
-        }
-        tabIndex={0}
+        class="c5"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 10;"
+        tabindex="0"
       >
         <div
-          className="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
         />
       </div>
     </div>
     <div
-      className="c18"
-      style={
-        Object {
-          "flex": "70 0 0",
-        }
-      }
+      class="c18"
+      style="flex: 70 0 0px;"
     />
   </div>
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/RangeSelector/__tests__/RangeSelector-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.