### PR TITLE
Refactor Menu tests to remove react-test-renderer

### DIFF
--- a/src/js/components/Menu/__tests__/Menu-test.js
+++ b/src/js/components/Menu/__tests__/Menu-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { getByText as getByTextDOM } from '@testing-library/dom';
 import { axe } from 'jest-axe';
 
@@ -42,8 +42,6 @@ const defaultButtonTheme = {
 
 describe('Menu', () => {
   beforeEach(createPortal);
-
-  afterEach(cleanup);
 
   test('should have no accessibility violations', async () => {
     const { container } = render(

--- a/src/js/components/Menu/__tests__/Menu-test.js
+++ b/src/js/components/Menu/__tests__/Menu-test.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import 'jest-styled-components';
-import renderer from 'react-test-renderer';
-import 'jest-axe/extend-expect';
-import 'regenerator-runtime/runtime';
-
-import { axe } from 'jest-axe';
 import { cleanup, fireEvent, render } from '@testing-library/react';
 import { getByText as getByTextDOM } from '@testing-library/dom';
+import { axe } from 'jest-axe';
+
+import 'jest-axe/extend-expect';
+import 'regenerator-runtime/runtime';
+import 'jest-styled-components';
 import '@testing-library/jest-dom/extend-expect';
+
 import { createPortal, expectPortal } from '../../../utils/portal';
 
 import { Grommet, Menu } from '../..';
@@ -58,7 +58,7 @@ describe('Menu', () => {
   });
 
   test('basic', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Menu
           icon={<svg />}
@@ -68,11 +68,12 @@ describe('Menu', () => {
         />
       </Grommet>,
     );
-    expect(component.toJSON()).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('custom message', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Menu
           label="Test Menu"
@@ -81,7 +82,8 @@ describe('Menu', () => {
         />
       </Grommet>,
     );
-    expect(component.toJSON()).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('custom a11yTitle', () => {
@@ -94,13 +96,15 @@ describe('Menu', () => {
         />
       </Grommet>,
     );
+
     const menuWithLabel = getByLabelText('My Menu');
     expect(menuWithLabel).toBeTruthy();
+
     expect(container).toMatchSnapshot();
   });
 
   test('justify content', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         {['start', 'center', 'end', 'between', 'around', 'stretch'].map(
           justifyContent => (
@@ -115,7 +119,8 @@ describe('Menu', () => {
         )}
       </Grommet>,
     );
-    expect(component.toJSON()).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('gap between icon and label', () => {
@@ -532,7 +537,7 @@ describe('Menu', () => {
   });
 
   test('custom theme icon color', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet theme={customTheme}>
         <Menu
           label="Test Menu"
@@ -540,11 +545,12 @@ describe('Menu', () => {
         />
       </Grommet>,
     );
-    expect(component.toJSON()).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('custom theme with default button', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet theme={defaultButtonTheme}>
         <Menu
           label="Test Menu"
@@ -552,18 +558,20 @@ describe('Menu', () => {
         />
       </Grommet>,
     );
-    expect(component.toJSON()).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('menu with children when custom theme has default button', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet theme={defaultButtonTheme}>
         <Menu items={[{ label: 'Item 1' }, { label: 'Item 2' }]}>
           {() => <>Test Menu</>}
         </Menu>
       </Grommet>,
     );
-    expect(component.toJSON()).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('should apply themed drop props', () => {
@@ -576,6 +584,7 @@ describe('Menu', () => {
         />
       </Grommet>,
     );
+
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -120,30 +120,24 @@ exports[`Menu basic 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
     aria-label="Open Menu"
-    className="c1"
+    class="c1"
     id="test-menu"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
     type="button"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <span
-        className="c3"
+        class="c3"
       >
         Test Menu
       </span>
       <div
-        className="c4"
+        class="c4"
       />
       <svg />
     </div>
@@ -1227,40 +1221,34 @@ exports[`Menu custom message 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
     aria-label="Abrir Menu"
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <span
-        className="c3"
+        class="c3"
       >
         Test Menu
       </span>
       <div
-        className="c4"
+        class="c4"
       />
       <svg
         aria-label="FormDown"
-        className="c5"
+        class="c5"
         viewBox="0 0 24 24"
       >
         <path
           d="m18 9-6 6-6-6"
           fill="none"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>
@@ -1422,40 +1410,34 @@ exports[`Menu custom theme icon color 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
     aria-label="Open Menu"
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <span
-        className="c3"
+        class="c3"
       >
         Test Menu
       </span>
       <div
-        className="c4"
+        class="c4"
       />
       <svg
         aria-label="FormDown"
-        className="c5"
+        class="c5"
         viewBox="0 0 24 24"
       >
         <path
           d="m18 9-6 6-6-6"
           fill="none"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>
@@ -1612,36 +1594,30 @@ exports[`Menu custom theme with default button 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
     aria-label="Open Menu"
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     <div
-      className="c2"
+      class="c2"
     >
       Test Menu
       <div
-        className="c3"
+        class="c3"
       />
       <svg
         aria-label="FormDown"
-        className="c4"
+        class="c4"
         viewBox="0 0 24 24"
       >
         <path
           d="m18 9-6 6-6-6"
           fill="none"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>
@@ -2344,220 +2320,184 @@ exports[`Menu justify content 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
     aria-label="Abrir Menu"
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <span
-        className="c3"
+        class="c3"
       >
         start Menu
       </span>
       <div
-        className="c4"
+        class="c4"
       />
       <svg
         aria-label="FormDown"
-        className="c5"
+        class="c5"
         viewBox="0 0 24 24"
       >
         <path
           d="m18 9-6 6-6-6"
           fill="none"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>
   </button>
   <button
     aria-label="Abrir Menu"
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     <div
-      className="c6"
+      class="c6"
     >
       <span
-        className="c3"
+        class="c3"
       >
         center Menu
       </span>
       <div
-        className="c4"
+        class="c4"
       />
       <svg
         aria-label="FormDown"
-        className="c5"
+        class="c5"
         viewBox="0 0 24 24"
       >
         <path
           d="m18 9-6 6-6-6"
           fill="none"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>
   </button>
   <button
     aria-label="Abrir Menu"
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     <div
-      className="c7"
+      class="c7"
     >
       <span
-        className="c3"
+        class="c3"
       >
         end Menu
       </span>
       <div
-        className="c4"
+        class="c4"
       />
       <svg
         aria-label="FormDown"
-        className="c5"
+        class="c5"
         viewBox="0 0 24 24"
       >
         <path
           d="m18 9-6 6-6-6"
           fill="none"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>
   </button>
   <button
     aria-label="Abrir Menu"
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     <div
-      className="c8"
+      class="c8"
     >
       <span
-        className="c3"
+        class="c3"
       >
         between Menu
       </span>
       <div
-        className="c4"
+        class="c4"
       />
       <svg
         aria-label="FormDown"
-        className="c5"
+        class="c5"
         viewBox="0 0 24 24"
       >
         <path
           d="m18 9-6 6-6-6"
           fill="none"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>
   </button>
   <button
     aria-label="Abrir Menu"
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     <div
-      className="c9"
+      class="c9"
     >
       <span
-        className="c3"
+        class="c3"
       >
         around Menu
       </span>
       <div
-        className="c4"
+        class="c4"
       />
       <svg
         aria-label="FormDown"
-        className="c5"
+        class="c5"
         viewBox="0 0 24 24"
       >
         <path
           d="m18 9-6 6-6-6"
           fill="none"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>
   </button>
   <button
     aria-label="Abrir Menu"
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     <div
-      className="c10"
+      class="c10"
     >
       <span
-        className="c3"
+        class="c3"
       >
         stretch Menu
       </span>
       <div
-        className="c4"
+        class="c4"
       />
       <svg
         aria-label="FormDown"
-        className="c5"
+        class="c5"
         viewBox="0 0 24 24"
       >
         <path
           d="m18 9-6 6-6-6"
           fill="none"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>
@@ -2648,17 +2588,11 @@ exports[`Menu menu with children when custom theme has default button 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
     aria-label="Open Menu"
-    className="c1"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     Test Menu


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Menu/__tests__/Menu-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.