### PR TITLE
Refactor RoutedAnchor tests to remove react-test-renderer

### DIFF
--- a/src/js/components/RoutedAnchor/__tests__/RoutedAnchor-test.js
+++ b/src/js/components/RoutedAnchor/__tests__/RoutedAnchor-test.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import renderer from 'react-test-renderer';
-import 'jest-styled-components';
+import { render, screen, fireEvent, createEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
-import { findAllByType } from '../../../utils';
+import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
 import { RoutedAnchor } from '..';
@@ -42,37 +42,42 @@ describe('RoutedAnchor', () => {
   const push = jest.fn();
   test('renders', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <FakeRouter push={push} replace={replace}>
           <RoutedAnchor label="Test" path="/" />
         </FakeRouter>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('is clickable', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const preventDefault = jest.fn();
     const onClick = jest.fn();
-    const component = renderer.create(
+    render(
       <Grommet>
         <FakeRouter push={push} replace={replace}>
           <RoutedAnchor label="Test" onClick={onClick} path="/" />
         </FakeRouter>
       </Grommet>,
     );
-    const tree = component.toJSON();
 
-    const anchor = findAllByType(tree, 'a');
-    anchor[0].props.onClick({ preventDefault });
-    expect(onClick).toBeCalled();
-    expect(push).toBeCalled();
-    expect(preventDefault).toBeCalled();
+    const anchor = screen.getByRole('link');
+
+    const clickEvent = createEvent.click(anchor);
+    clickEvent.preventDefault = preventDefault;
+    fireEvent(anchor, clickEvent);
+
+    expect(onClick).toBeCalledTimes(1);
+    expect(push).toBeCalledTimes(1);
+    expect(preventDefault).toBeCalledTimes(1);
+
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
   });
@@ -80,23 +85,21 @@ describe('RoutedAnchor', () => {
   test('skips onClick if right clicked', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const onClick = jest.fn();
-    const component = renderer.create(
+    render(
       <Grommet>
         <FakeRouter push={push} replace={replace}>
           <RoutedAnchor label="Test" onClick={onClick} path="/" />
         </FakeRouter>
       </Grommet>,
     );
-    const tree = component.toJSON();
 
-    const anchor = findAllByType(tree, 'a');
-    anchor[0].props.onClick({
-      ctrlKey: true,
-    });
-    anchor[0].props.onClick({
-      metaKey: true,
-    });
-    expect(onClick).not.toBeCalled();
+    const anchor = screen.getByRole('link');
+
+    userEvent.click(anchor, { ctrlKey: true });
+    userEvent.click(anchor, { metaKey: true });
+
+    expect(onClick).not.toHaveBeenCalled();
+
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
   });
@@ -104,21 +107,22 @@ describe('RoutedAnchor', () => {
   test('calls router context push', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const preventDefault = jest.fn();
-    const component = renderer.create(
+    render(
       <Grommet>
         <FakeRouter push={push} replace={replace}>
           <RoutedAnchor label="Test" path="/" />
         </FakeRouter>
       </Grommet>,
     );
-    const tree = component.toJSON();
 
-    const anchor = findAllByType(tree, 'a');
-    anchor[0].props.onClick({
-      preventDefault,
-    });
-    expect(preventDefault).toBeCalled();
-    expect(push).toBeCalledWith('/');
+    const anchor = screen.getByRole('link');
+
+    const clickEvent = createEvent.click(anchor);
+    clickEvent.preventDefault = preventDefault;
+    fireEvent(anchor, clickEvent);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(push).toHaveBeenCalledWith('/');
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
   });
@@ -126,21 +130,22 @@ describe('RoutedAnchor', () => {
   test('calls router context replace', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const preventDefault = jest.fn();
-    const component = renderer.create(
+    render(
       <Grommet>
         <FakeRouter replace={replace} push={push}>
           <RoutedAnchor label="Test" path="/" method="replace" />
         </FakeRouter>
       </Grommet>,
     );
-    const tree = component.toJSON();
 
-    const anchor = findAllByType(tree, 'a');
-    anchor[0].props.onClick({
-      preventDefault,
-    });
-    expect(preventDefault).toBeCalled();
-    expect(replace).toBeCalledWith('/');
+    const anchor = screen.getByRole('link');
+
+    const clickEvent = createEvent.click(anchor);
+    clickEvent.preventDefault = preventDefault;
+    fireEvent(anchor, clickEvent);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(replace).toHaveBeenCalledWith('/');
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
   });

--- a/src/js/components/RoutedAnchor/__tests__/RoutedAnchor-test.js
+++ b/src/js/components/RoutedAnchor/__tests__/RoutedAnchor-test.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, screen, fireEvent, createEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-
 import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
@@ -40,8 +39,17 @@ class FakeRouter extends Component {
 describe('RoutedAnchor', () => {
   const replace = jest.fn();
   const push = jest.fn();
+  let warnSpy;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
   test('renders', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const { container } = render(
       <Grommet>
         <FakeRouter push={push} replace={replace}>
@@ -51,13 +59,10 @@ describe('RoutedAnchor', () => {
     );
 
     expect(warnSpy).toHaveBeenCalled();
-    warnSpy.mockRestore();
-
     expect(container.firstChild).toMatchSnapshot();
   });
 
   test('is clickable', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const preventDefault = jest.fn();
     const onClick = jest.fn();
     render(
@@ -77,13 +82,10 @@ describe('RoutedAnchor', () => {
     expect(onClick).toBeCalledTimes(1);
     expect(push).toBeCalledTimes(1);
     expect(preventDefault).toBeCalledTimes(1);
-
     expect(warnSpy).toHaveBeenCalled();
-    warnSpy.mockRestore();
   });
 
   test('skips onClick if right clicked', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const onClick = jest.fn();
     render(
       <Grommet>
@@ -99,13 +101,10 @@ describe('RoutedAnchor', () => {
     userEvent.click(anchor, { metaKey: true });
 
     expect(onClick).not.toHaveBeenCalled();
-
     expect(warnSpy).toHaveBeenCalled();
-    warnSpy.mockRestore();
   });
 
   test('calls router context push', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const preventDefault = jest.fn();
     render(
       <Grommet>
@@ -124,11 +123,9 @@ describe('RoutedAnchor', () => {
     expect(preventDefault).toHaveBeenCalled();
     expect(push).toHaveBeenCalledWith('/');
     expect(warnSpy).toHaveBeenCalled();
-    warnSpy.mockRestore();
   });
 
   test('calls router context replace', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const preventDefault = jest.fn();
     render(
       <Grommet>
@@ -147,6 +144,5 @@ describe('RoutedAnchor', () => {
     expect(preventDefault).toHaveBeenCalled();
     expect(replace).toHaveBeenCalledWith('/');
     expect(warnSpy).toHaveBeenCalled();
-    warnSpy.mockRestore();
   });
 });

--- a/src/js/components/RoutedAnchor/__tests__/__snapshots__/RoutedAnchor-test.js.snap
+++ b/src/js/components/RoutedAnchor/__tests__/__snapshots__/RoutedAnchor-test.js.snap
@@ -28,15 +28,12 @@ exports[`RoutedAnchor renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div>
     <a
-      className="c1"
+      class="c1"
       href="/"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
     >
       Test
     </a>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/RoutedAnchor/__tests__/RoutedAnchor-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.