### PR TITLE
Refactor Select tests to remove react-test-renderer

### DIFF
--- a/src/js/components/Select/__tests__/Select-test.js
+++ b/src/js/components/Select/__tests__/Select-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, render, fireEvent, act } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import 'jest-axe/extend-expect';
 import 'jest-styled-components';
@@ -14,7 +14,6 @@ import { Select } from '..';
 describe('Select', () => {
   window.scrollTo = jest.fn();
   beforeEach(createPortal);
-  afterEach(cleanup);
 
   test('should not have accessibility violations', async () => {
     const { container } = render(

--- a/src/js/components/Select/__tests__/Select-test.js
+++ b/src/js/components/Select/__tests__/Select-test.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import 'jest-styled-components';
-import renderer from 'react-test-renderer';
 import { cleanup, render, fireEvent, act } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import 'jest-axe/extend-expect';
+import 'jest-styled-components';
 import 'regenerator-runtime/runtime';
 
 import { CaretDown, CaretUp, FormDown } from 'grommet-icons';
@@ -23,27 +22,31 @@ describe('Select', () => {
         <Select options={['one', 'two', 'three']} a11yTitle="test" />
       </Grommet>,
     );
+
     const results = await axe(container);
-    expect(container.firstChild).toMatchSnapshot();
     expect(results).toHaveNoViolations();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('basic', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Select id="test-select" options={['one', 'two']} a11yTitle="Select" />,
     );
-    expect(component.toJSON()).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('dark', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Box fill background="dark-1" align="center" justify="center">
           <Select placeholder="Select" options={['one', 'two']} />
         </Box>
       </Grommet>,
     );
-    expect(component.toJSON()).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('prop: onOpen', () => {
@@ -96,7 +99,7 @@ describe('Select', () => {
   });
 
   test('0 value', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Select
         id="test-select"
         placeholder="test select"
@@ -104,7 +107,8 @@ describe('Select', () => {
         value={0}
       />,
     );
-    expect(component.toJSON()).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('search', () => {
@@ -202,7 +206,7 @@ describe('Select', () => {
   });
 
   test('size', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Select
         id="test-select"
         size="large"
@@ -212,7 +216,8 @@ describe('Select', () => {
         onChange={() => {}}
       />,
     );
-    expect(component.toJSON()).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   ['small', 'medium', 'large'].forEach(dropHeight => {
@@ -599,24 +604,27 @@ describe('Select', () => {
   });
 
   test('renders without icon', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Select id="test-select" options={['one', 'two']} icon={false} />,
     );
-    expect(component.toJSON()).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders custom icon', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Select id="test-select" options={['one', 'two']} icon={CaretDown} />,
     );
-    expect(component.toJSON()).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders default icon', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Select id="test-select" options={['one', 'two']} icon />,
     );
-    expect(component.toJSON()).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('modifies select control style on open', () => {

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -220,58 +220,45 @@ exports[`Select 0 value 1`] = `
 
 <button
   aria-label="Open Drop"
-  className="c0 c1"
+  class="c0 c1"
   id="test-select"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  onMouseOut={[Function]}
-  onMouseOver={[Function]}
   type="button"
 >
   <div
-    className="c2"
+    class="c2"
   >
     <div
-      className="c3"
+      class="c3"
     >
       <div
-        className="c4"
+        class="c4"
       >
         <input
-          autoComplete="off"
-          className="c5 c6"
+          autocomplete="off"
+          class="c5 c6"
           id="test-select__input"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
           placeholder="test select"
-          readOnly={true}
-          tabIndex="-1"
+          readonly=""
+          tabindex="-1"
           type="text"
-          value={0}
+          value="0"
         />
       </div>
     </div>
     <div
-      className="c7"
-      style={
-        Object {
-          "minWidth": "auto",
-        }
-      }
+      class="c7"
+      style="min-width: auto;"
     >
       <svg
         aria-label="FormDown"
-        className="c8"
+        class="c8"
         viewBox="0 0 24 24"
       >
         <path
           d="m18 9-6 6-6-6"
           fill="none"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>
@@ -2413,58 +2400,45 @@ exports[`Select basic 1`] = `
 
 <button
   aria-label="Select"
-  className="c0 c1"
+  class="c0 c1"
   id="test-select"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  onMouseOut={[Function]}
-  onMouseOver={[Function]}
   type="button"
 >
   <div
-    className="c2"
+    class="c2"
   >
     <div
-      className="c3"
+      class="c3"
     >
       <div
-        className="c4"
+        class="c4"
       >
         <input
           aria-label="Select"
-          autoComplete="off"
-          className="c5 c6"
+          autocomplete="off"
+          class="c5 c6"
           id="test-select__input"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          readOnly={true}
-          tabIndex="-1"
+          readonly=""
+          tabindex="-1"
           type="text"
           value=""
         />
       </div>
     </div>
     <div
-      className="c7"
-      style={
-        Object {
-          "minWidth": "auto",
-        }
-      }
+      class="c7"
+      style="min-width: auto;"
     >
       <svg
         aria-label="FormDown"
-        className="c8"
+        class="c8"
         viewBox="0 0 24 24"
       >
         <path
           d="m18 9-6 6-6-6"
           fill="none"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>
@@ -3273,63 +3247,50 @@ exports[`Select dark 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <button
       aria-label="Open Drop"
-      className="c2 c3"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+      class="c2 c3"
       type="button"
     >
       <div
-        className="c4"
+        class="c4"
       >
         <div
-          className="c5"
+          class="c5"
         >
           <div
-            className="c6"
+            class="c6"
           >
             <input
-              autoComplete="off"
-              className="c7 c8"
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
+              autocomplete="off"
+              class="c7 c8"
               placeholder="Select"
-              readOnly={true}
-              tabIndex="-1"
+              readonly=""
+              tabindex="-1"
               type="text"
               value=""
             />
           </div>
         </div>
         <div
-          className="c9"
-          style={
-            Object {
-              "minWidth": "auto",
-            }
-          }
+          class="c9"
+          style="min-width: auto;"
         >
           <svg
             aria-label="FormDown"
-            className="c10"
+            class="c10"
             viewBox="0 0 24 24"
           >
             <path
               d="m18 9-6 6-6-6"
               fill="none"
               stroke="#000"
-              strokeWidth="2"
+              stroke-width="2"
             />
           </svg>
         </div>
@@ -9835,57 +9796,44 @@ exports[`Select renders custom icon 1`] = `
 
 <button
   aria-label="Open Drop"
-  className="c0 c1"
+  class="c0 c1"
   id="test-select"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  onMouseOut={[Function]}
-  onMouseOver={[Function]}
   type="button"
 >
   <div
-    className="c2"
+    class="c2"
   >
     <div
-      className="c3"
+      class="c3"
     >
       <div
-        className="c4"
+        class="c4"
       >
         <input
-          autoComplete="off"
-          className="c5 c6"
+          autocomplete="off"
+          class="c5 c6"
           id="test-select__input"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          readOnly={true}
-          tabIndex="-1"
+          readonly=""
+          tabindex="-1"
           type="text"
           value=""
         />
       </div>
     </div>
     <div
-      className="c7"
-      style={
-        Object {
-          "minWidth": "auto",
-        }
-      }
+      class="c7"
+      style="min-width: auto;"
     >
       <svg
         aria-label="CaretDown"
-        className="c8"
+        class="c8"
         viewBox="0 0 24 24"
       >
         <path
           d="M22 8 12 20 2 8z"
           fill="none"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>
@@ -10492,57 +10440,44 @@ exports[`Select renders default icon 1`] = `
 
 <button
   aria-label="Open Drop"
-  className="c0 c1"
+  class="c0 c1"
   id="test-select"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  onMouseOut={[Function]}
-  onMouseOver={[Function]}
   type="button"
 >
   <div
-    className="c2"
+    class="c2"
   >
     <div
-      className="c3"
+      class="c3"
     >
       <div
-        className="c4"
+        class="c4"
       >
         <input
-          autoComplete="off"
-          className="c5 c6"
+          autocomplete="off"
+          class="c5 c6"
           id="test-select__input"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          readOnly={true}
-          tabIndex="-1"
+          readonly=""
+          tabindex="-1"
           type="text"
           value=""
         />
       </div>
     </div>
     <div
-      className="c7"
-      style={
-        Object {
-          "minWidth": "auto",
-        }
-      }
+      class="c7"
+      style="min-width: auto;"
     >
       <svg
         aria-label="FormDown"
-        className="c8"
+        class="c8"
         viewBox="0 0 24 24"
       >
         <path
           d="m18 9-6 6-6-6"
           fill="none"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>
@@ -11556,34 +11491,25 @@ exports[`Select renders without icon 1`] = `
 
 <button
   aria-label="Open Drop"
-  className="c0 c1"
+  class="c0 c1"
   id="test-select"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  onMouseOut={[Function]}
-  onMouseOver={[Function]}
   type="button"
 >
   <div
-    className="c2"
+    class="c2"
   >
     <div
-      className="c3"
+      class="c3"
     >
       <div
-        className="c4"
+        class="c4"
       >
         <input
-          autoComplete="off"
-          className="c5 c6"
+          autocomplete="off"
+          class="c5 c6"
           id="test-select__input"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          readOnly={true}
-          tabIndex="-1"
+          readonly=""
+          tabindex="-1"
           type="text"
           value=""
         />
@@ -15639,58 +15565,44 @@ exports[`Select size 1`] = `
 
 <button
   aria-label="Open Drop"
-  className="c0 c1"
+  class="c0 c1"
   id="test-select"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  onMouseOut={[Function]}
-  onMouseOver={[Function]}
   type="button"
 >
   <div
-    className="c2"
+    class="c2"
   >
     <div
-      className="c3"
+      class="c3"
     >
       <div
-        className="c4"
+        class="c4"
       >
         <input
-          autoComplete="off"
-          className="c5 c6"
+          autocomplete="off"
+          class="c5 c6"
           id="test-select__input"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          readOnly={true}
-          size="large"
-          tabIndex="-1"
+          readonly=""
+          tabindex="-1"
           type="text"
           value=""
         />
       </div>
     </div>
     <div
-      className="c7"
-      style={
-        Object {
-          "minWidth": "auto",
-        }
-      }
+      class="c7"
+      style="min-width: auto;"
     >
       <svg
         aria-label="FormDown"
-        className="c8"
+        class="c8"
         viewBox="0 0 24 24"
       >
         <path
           d="m18 9-6 6-6-6"
           fill="none"
           stroke="#000"
-          strokeWidth="2"
+          stroke-width="2"
         />
       </svg>
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Select/__tests__/Select-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.