### PR TITLE
Refactor Sidebar tests to remove react-test-renderer

### DIFF
--- a/src/js/components/Sidebar/__tests__/Sidebar-test.js
+++ b/src/js/components/Sidebar/__tests__/Sidebar-test.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { cleanup } from '@testing-library/react';
-import renderer from 'react-test-renderer';
+import { cleanup, render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Avatar } from '../../Avatar';
@@ -13,37 +12,37 @@ describe('Sidebar', () => {
   afterEach(cleanup);
 
   test('renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Sidebar id="test id" name="test name" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('header', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Sidebar header={<Avatar src={src} />} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('footer', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Sidebar footer={<Avatar src={src} />} />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('children', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Sidebar>
           <Avatar src={src} />
@@ -51,12 +50,12 @@ describe('Sidebar', () => {
         </Sidebar>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('all', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Sidebar
           footer={<Avatar>SY</Avatar>}
@@ -67,7 +66,7 @@ describe('Sidebar', () => {
         </Sidebar>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/components/Sidebar/__tests__/Sidebar-test.js
+++ b/src/js/components/Sidebar/__tests__/Sidebar-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Avatar } from '../../Avatar';
@@ -9,8 +9,6 @@ import { Sidebar } from '..';
 const src = '';
 
 describe('Sidebar', () => {
-  afterEach(cleanup);
-
   test('renders', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Sidebar/__tests__/__snapshots__/Sidebar-test.js.snap
+++ b/src/js/components/Sidebar/__tests__/__snapshots__/Sidebar-test.js.snap
@@ -131,30 +131,30 @@ exports[`Sidebar all 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2 StyledAvatar-sc-1suyamb-1"
+      class="c2 StyledAvatar-sc-1suyamb-1"
     />
     <div
-      className="c3"
+      class="c3"
     />
     <div
-      className="c4"
+      class="c4"
     >
       test all props and children
     </div>
     <div
-      className="c3"
+      class="c3"
     />
     <div
-      className="c5 StyledAvatar-sc-1suyamb-1"
+      class="c5 StyledAvatar-sc-1suyamb-1"
     >
       <span
-        className="c6 "
+        class="c6 "
       >
         SY
       </span>
@@ -242,16 +242,16 @@ exports[`Sidebar children 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div
-        className="c3 StyledAvatar-sc-1suyamb-1"
+        class="c3 StyledAvatar-sc-1suyamb-1"
       />
       children test
     </div>
@@ -354,19 +354,19 @@ exports[`Sidebar footer 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     />
     <div
-      className="c3"
+      class="c3"
     />
     <div
-      className="c4 StyledAvatar-sc-1suyamb-1"
+      class="c4 StyledAvatar-sc-1suyamb-1"
     />
   </div>
 </div>
@@ -467,19 +467,19 @@ exports[`Sidebar header 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2 StyledAvatar-sc-1suyamb-1"
+      class="c2 StyledAvatar-sc-1suyamb-1"
     />
     <div
-      className="c3"
+      class="c3"
     />
     <div
-      className="c4"
+      class="c4"
     />
   </div>
 </div>
@@ -536,15 +536,15 @@ exports[`Sidebar renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
     id="test id"
     name="test name"
   >
     <div
-      className="c2"
+      class="c2"
     />
   </div>
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Sidebar/__tests__/Sidebar-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.