### PR TITLE
Refactor Spinner tests to remove react-test-renderer

### DIFF
--- a/src/js/components/Spinner/__tests__/Spinner-test.js
+++ b/src/js/components/Spinner/__tests__/Spinner-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import 'jest-styled-components';
 import 'regenerator-runtime/runtime';
@@ -10,8 +10,6 @@ import { Grommet } from '../../Grommet';
 import { Spinner } from '..';
 
 describe('Spinner', () => {
-  afterEach(cleanup);
-
   test('should have no accessibility violations', async () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Spinner/__tests__/Spinner-test.js
+++ b/src/js/components/Spinner/__tests__/Spinner-test.js
@@ -1,11 +1,9 @@
 import React from 'react';
-
 import { cleanup, render } from '@testing-library/react';
-import renderer from 'react-test-renderer';
+import { axe } from 'jest-axe';
 import 'jest-styled-components';
 import 'regenerator-runtime/runtime';
 import 'jest-axe/extend-expect';
-import { axe } from 'jest-axe';
 
 import { Node } from 'grommet-icons';
 import { Grommet } from '../../Grommet';
@@ -23,22 +21,22 @@ describe('Spinner', () => {
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
-    expect(container).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Spinner />
         <Spinner id="test id" name="test name" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('size renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Spinner size="xsmall" />
         <Spinner size="small" />
@@ -47,12 +45,12 @@ describe('Spinner', () => {
         <Spinner size="xlarge" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('size renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Spinner color="graph-0" />
         <Spinner color="graph-1" />
@@ -61,12 +59,12 @@ describe('Spinner', () => {
         <Spinner color="graph-4" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('round renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Spinner round={false} />
         <Spinner round="small" />
@@ -74,12 +72,12 @@ describe('Spinner', () => {
         <Spinner round="large" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('border renders', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Spinner
           border={[
@@ -120,8 +118,8 @@ describe('Spinner', () => {
         />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('spinner changes according to theme', () => {
@@ -140,13 +138,13 @@ describe('Spinner', () => {
       },
     };
 
-    const component = renderer.create(
+    const { container } = render(
       <Grommet theme={theme}>
         <Spinner />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('spinner icon changes according to theme', () => {
@@ -163,12 +161,12 @@ describe('Spinner', () => {
       },
     };
 
-    const component = renderer.create(
+    const { container } = render(
       <Grommet theme={theme}>
         <Spinner />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/components/Spinner/__tests__/__snapshots__/Spinner-test.js.snap
+++ b/src/js/components/Spinner/__tests__/__snapshots__/Spinner-test.js.snap
@@ -226,22 +226,22 @@ exports[`Spinner border renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
 </div>
 `;
@@ -301,13 +301,13 @@ exports[`Spinner renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c1"
+    class="c1"
     id="test id"
     name="test name"
   />
@@ -515,19 +515,19 @@ exports[`Spinner round renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
 </div>
 `;
@@ -586,14 +586,12 @@ exports[`Spinner should have no accessibility violations 1`] = `
   }
 }
 
-<div>
+<div
+  class="c0"
+>
   <div
-    class="c0"
-  >
-    <div
-      class="c1"
-    />
-  </div>
+    class="c1"
+  />
 </div>
 `;
 
@@ -824,22 +822,22 @@ exports[`Spinner size renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
 </div>
 `;
@@ -1071,22 +1069,22 @@ exports[`Spinner size renders 2`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
   <div
-    className="c2"
+    class="c2"
   />
   <div
-    className="c3"
+    class="c3"
   />
   <div
-    className="c4"
+    class="c4"
   />
   <div
-    className="c5"
+    class="c5"
   />
 </div>
 `;
@@ -1139,10 +1137,10 @@ exports[`Spinner spinner changes according to theme 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -1230,14 +1228,14 @@ exports[`Spinner spinner icon changes according to theme 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <svg
       aria-label="Node"
-      className="c2"
+      class="c2"
       viewBox="0 0 24 24"
     >
       <path


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Spinner/__tests__/Spinner-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.