### PR TITLE
Refactor Stack tests to remove react-test-renderer

### DIFF
--- a/src/js/components/Stack/__tests__/Stack-test.js
+++ b/src/js/components/Stack/__tests__/Stack-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
@@ -9,29 +9,29 @@ const CONTENTS = [<div key={1}>first</div>, <div key={2}>second</div>];
 
 describe('Stack', () => {
   test('default', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Stack>{CONTENTS}</Stack>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('guidingChild', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Stack guidingChild="first">{CONTENTS}</Stack>
         <Stack guidingChild="last">{CONTENTS}</Stack>
         <Stack guidingChild={0}>{CONTENTS}</Stack>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('anchor', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Stack anchor="center">{CONTENTS}</Stack>
         <Stack anchor="top">{CONTENTS}</Stack>
@@ -44,12 +44,12 @@ describe('Stack', () => {
         <Stack anchor="bottom-right">{CONTENTS}</Stack>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('fill', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Stack fill>{CONTENTS}</Stack>
         <Stack fill={false}>{CONTENTS}</Stack>
@@ -57,19 +57,19 @@ describe('Stack', () => {
         <Stack fill="vertical">{CONTENTS}</Stack>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('interactiveChild', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <Stack interactiveChild="first">{CONTENTS}</Stack>
         <Stack interactiveChild="last">{CONTENTS}</Stack>
         <Stack interactiveChild={0}>{CONTENTS}</Stack>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/components/Stack/__tests__/__snapshots__/Stack-test.js.snap
+++ b/src/js/components/Stack/__tests__/__snapshots__/Stack-test.js.snap
@@ -90,20 +90,20 @@ exports[`Stack anchor 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c3"
+      class="c3"
     >
       <div>
         second
@@ -111,17 +111,17 @@ exports[`Stack anchor 1`] = `
     </div>
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c4"
+      class="c4"
     >
       <div>
         second
@@ -129,17 +129,17 @@ exports[`Stack anchor 1`] = `
     </div>
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c5"
+      class="c5"
     >
       <div>
         second
@@ -147,17 +147,17 @@ exports[`Stack anchor 1`] = `
     </div>
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c6"
+      class="c6"
     >
       <div>
         second
@@ -165,17 +165,17 @@ exports[`Stack anchor 1`] = `
     </div>
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c7"
+      class="c7"
     >
       <div>
         second
@@ -183,17 +183,17 @@ exports[`Stack anchor 1`] = `
     </div>
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c8"
+      class="c8"
     >
       <div>
         second
@@ -201,17 +201,17 @@ exports[`Stack anchor 1`] = `
     </div>
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c9"
+      class="c9"
     >
       <div>
         second
@@ -219,17 +219,17 @@ exports[`Stack anchor 1`] = `
     </div>
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c10"
+      class="c10"
     >
       <div>
         second
@@ -237,17 +237,17 @@ exports[`Stack anchor 1`] = `
     </div>
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c11"
+      class="c11"
     >
       <div>
         second
@@ -286,20 +286,20 @@ exports[`Stack default 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c3"
+      class="c3"
     >
       <div>
         second
@@ -387,20 +387,20 @@ exports[`Stack fill 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c3"
+      class="c3"
     >
       <div>
         second
@@ -408,17 +408,17 @@ exports[`Stack fill 1`] = `
     </div>
   </div>
   <div
-    className="c4"
+    class="c4"
   >
     <div
-      className="c5"
+      class="c5"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c3"
+      class="c3"
     >
       <div>
         second
@@ -426,17 +426,17 @@ exports[`Stack fill 1`] = `
     </div>
   </div>
   <div
-    className="c6"
+    class="c6"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c3"
+      class="c3"
     >
       <div>
         second
@@ -444,17 +444,17 @@ exports[`Stack fill 1`] = `
     </div>
   </div>
   <div
-    className="c7"
+    class="c7"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c3"
+      class="c3"
     >
       <div>
         second
@@ -493,20 +493,20 @@ exports[`Stack guidingChild 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c3"
+      class="c3"
     >
       <div>
         second
@@ -514,17 +514,17 @@ exports[`Stack guidingChild 1`] = `
     </div>
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c3"
+      class="c3"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         second
@@ -532,17 +532,17 @@ exports[`Stack guidingChild 1`] = `
     </div>
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c3"
+      class="c3"
     >
       <div>
         second
@@ -596,20 +596,20 @@ exports[`Stack interactiveChild 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c3"
+      class="c3"
     >
       <div>
         second
@@ -617,17 +617,17 @@ exports[`Stack interactiveChild 1`] = `
     </div>
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c4"
+      class="c4"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c5"
+      class="c5"
     >
       <div>
         second
@@ -635,17 +635,17 @@ exports[`Stack interactiveChild 1`] = `
     </div>
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c2"
+      class="c2"
     >
       <div>
         first
       </div>
     </div>
     <div
-      className="c3"
+      class="c3"
     >
       <div>
         second


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Stack/__tests__/Stack-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.