### PR TITLE
Refactor Text tests to remove react-test-renderer

### DIFF
--- a/src/js/components/Text/__tests__/Text-test.js
+++ b/src/js/components/Text/__tests__/Text-test.js
@@ -1,9 +1,7 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 import { fireEvent, render } from '@testing-library/react';
-import 'jest-styled-components';
-
 import { axe } from 'jest-axe';
+import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
@@ -16,36 +14,37 @@ test('should have no accessibility violations', async () => {
       <Text a11yTitle="test"> Example</Text>
     </Grommet>,
   );
+
   const results = await axe(container);
   expect(results).toHaveNoViolations();
   expect(container.firstChild).toMatchSnapshot();
 });
 
 test('renders', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Text>text</Text>
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('accepts ref', () => {
   const ref = React.createRef();
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Text ref={ref}>text</Text>
     </Grommet>,
     { createNodeMock: el => el },
   );
+
   expect(ref.current).not.toBeNull();
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('renders size', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Text size="xsmall" />
       <Text size="small" />
@@ -60,12 +59,12 @@ test('renders size', () => {
       <Text size="6xl" />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('renders textAlign', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Text textAlign="start" />
       <Text textAlign="center" />
@@ -73,12 +72,12 @@ test('renders textAlign', () => {
       <Text textAlign="justify" />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('renders margin', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Text margin="small" />
       <Text margin="medium" />
@@ -92,66 +91,67 @@ test('renders margin', () => {
       <Text margin={{ right: 'small' }} />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 const LONG = 'a b c d e f g h i j k l m n o p q r s t u v w x y z';
 
 test('renders truncate', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Text truncate={false}>{LONG}</Text>
       <Text truncate>{LONG}</Text>
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('renders color', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Text color="status-critical" />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('renders tag', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Text as="div" />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('proxies tag', () => {
-  const tagComponent = renderer.create(
+  const { container: tagComponent } = render(
     <Grommet>
       <Text tag="div" />
     </Grommet>,
   );
-  const asComponent = renderer.create(
+  const { container: asComponent } = render(
     <Grommet>
       <Text as="div" />
     </Grommet>,
   );
-  expect(tagComponent.toJSON()).toEqual(asComponent.toJSON());
+
+  expect(tagComponent).toEqual(asComponent);
 });
 
 test('renders weight', () => {
-  const component = renderer.create(
+  const { container } = render(
     <Grommet>
       <Text weight="normal" />
       <Text weight="bold" />
     </Grommet>,
   );
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+
+  expect(container.firstChild).toMatchSnapshot();
 });
 
 test('renders tip', () => {

--- a/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
+++ b/src/js/components/Text/__tests__/__snapshots__/Text-test.js.snap
@@ -17,10 +17,10 @@ exports[`accepts ref 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <span
-    className="c1"
+    class="c1"
   >
     text
   </span>
@@ -44,10 +44,10 @@ exports[`renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <span
-    className="c1"
+    class="c1"
   >
     text
   </span>
@@ -72,10 +72,10 @@ exports[`renders color 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <span
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -154,37 +154,37 @@ exports[`renders margin 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <span
-    className="c1"
+    class="c1"
   />
   <span
-    className="c2"
+    class="c2"
   />
   <span
-    className="c3"
+    class="c3"
   />
   <span
-    className="c4"
+    class="c4"
   />
   <span
-    className="c5"
+    class="c5"
   />
   <span
-    className="c6"
+    class="c6"
   />
   <span
-    className="c7"
+    class="c7"
   />
   <span
-    className="c8"
+    class="c8"
   />
   <span
-    className="c9"
+    class="c9"
   />
   <span
-    className="c10"
+    class="c10"
   />
 </div>
 `;
@@ -251,40 +251,40 @@ exports[`renders size 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <span
-    className="c1"
+    class="c1"
   />
   <span
-    className="c2"
+    class="c2"
   />
   <span
-    className="c3"
+    class="c3"
   />
   <span
-    className="c4"
+    class="c4"
   />
   <span
-    className="c5"
+    class="c5"
   />
   <span
-    className="c6"
+    class="c6"
   />
   <span
-    className="c6"
+    class="c6"
   />
   <span
-    className="c7"
+    class="c7"
   />
   <span
-    className="c8"
+    class="c8"
   />
   <span
-    className="c9"
+    class="c9"
   />
   <span
-    className="c10"
+    class="c10"
   />
 </div>
 `;
@@ -306,10 +306,10 @@ exports[`renders tag 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   />
 </div>
 `;
@@ -350,19 +350,19 @@ exports[`renders textAlign 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <span
-    className="c1"
+    class="c1"
   />
   <span
-    className="c2"
+    class="c2"
   />
   <span
-    className="c3"
+    class="c3"
   />
   <span
-    className="c4"
+    class="c4"
   />
 </div>
 `;
@@ -445,15 +445,15 @@ exports[`renders truncate 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <span
-    className="c1"
+    class="c1"
   >
     a b c d e f g h i j k l m n o p q r s t u v w x y z
   </span>
   <span
-    className="c2"
+    class="c2"
   >
     a b c d e f g h i j k l m n o p q r s t u v w x y z
   </span>
@@ -484,13 +484,13 @@ exports[`renders weight 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <span
-    className="c1"
+    class="c1"
   />
   <span
-    className="c2"
+    class="c2"
   />
 </div>
 `;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Text/__tests__/Text-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.