### PR TITLE
Refactor TextArea tests to remove react-test-renderer

### DIFF
--- a/src/js/components/TextArea/__tests__/TextArea-test.js
+++ b/src/js/components/TextArea/__tests__/TextArea-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
@@ -9,8 +9,6 @@ import { Grommet } from '../../Grommet';
 import { TextArea } from '..';
 
 describe('TextArea', () => {
-  afterEach(cleanup);
-
   test('should not have accessibility violations', async () => {
     const { container } = render(
       <Grommet>
@@ -106,7 +104,6 @@ describe('TextArea', () => {
   });
 
   describe('Event tests', () => {
-    afterEach(cleanup);
     const keyEvent = {
       key: 'Backspace',
       keyCode: 8,

--- a/src/js/components/TextArea/__tests__/TextArea-test.js
+++ b/src/js/components/TextArea/__tests__/TextArea-test.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 import { cleanup, fireEvent, render } from '@testing-library/react';
-import 'jest-styled-components';
 import { axe } from 'jest-axe';
+import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
@@ -23,86 +22,86 @@ describe('TextArea', () => {
   });
 
   test('basic', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <TextArea id="item" name="item" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('placeholder', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <TextArea id="item" name="item" placeholder="placeholder" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('plain', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <TextArea id="item" name="item" plain />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('disabled', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <TextArea disabled id="item" name="item" plain />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('focusIndicator', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <TextArea id="item" name="item" focusIndicator />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('fill', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <TextArea id="item" name="item" fill />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   [true, false, 'horizontal', 'vertical'].forEach(resize => {
     test(`resize ${resize}`, () => {
-      const component = renderer.create(
+      const { container } = render(
         <Grommet>
           <TextArea id="item" name="item" resize={resize} />
         </Grommet>,
       );
-      const tree = component.toJSON();
-      expect(tree).toMatchSnapshot();
+
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   ['small', 'medium', 'large'].forEach(size => {
     test(`size ${size}`, () => {
-      const component = renderer.create(
+      const { container } = render(
         <Grommet>
           <TextArea id="item" name="item" size={size} />
         </Grommet>,
       );
-      const tree = component.toJSON();
-      expect(tree).toMatchSnapshot();
+
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 

--- a/src/js/components/TextArea/__tests__/__snapshots__/TextArea-test.js.snap
+++ b/src/js/components/TextArea/__tests__/__snapshots__/TextArea-test.js.snap
@@ -158,16 +158,12 @@ exports[`TextArea basic 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <textarea
-    className="c1"
+    class="c1"
     id="item"
     name="item"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
   />
 </div>
 `;
@@ -252,17 +248,13 @@ exports[`TextArea disabled 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <textarea
-    className="c1"
-    disabled={true}
+    class="c1"
+    disabled=""
     id="item"
     name="item"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
   />
 </div>
 `;
@@ -342,16 +334,12 @@ exports[`TextArea fill 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <textarea
-    className="c1"
+    class="c1"
     id="item"
     name="item"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
   />
 </div>
 `;
@@ -430,16 +418,12 @@ exports[`TextArea focusIndicator 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <textarea
-    className="c1"
+    class="c1"
     id="item"
     name="item"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
   />
 </div>
 `;
@@ -518,16 +502,12 @@ exports[`TextArea placeholder 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <textarea
-    className="c1"
+    class="c1"
     id="item"
     name="item"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
     placeholder="placeholder"
   />
 </div>
@@ -611,16 +591,12 @@ exports[`TextArea plain 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <textarea
-    className="c1"
+    class="c1"
     id="item"
     name="item"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
   />
 </div>
 `;
@@ -700,16 +676,12 @@ exports[`TextArea resize false 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <textarea
-    className="c1"
+    class="c1"
     id="item"
     name="item"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
   />
 </div>
 `;
@@ -789,16 +761,12 @@ exports[`TextArea resize horizontal 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <textarea
-    className="c1"
+    class="c1"
     id="item"
     name="item"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
   />
 </div>
 `;
@@ -878,16 +846,12 @@ exports[`TextArea resize true 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <textarea
-    className="c1"
+    class="c1"
     id="item"
     name="item"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
   />
 </div>
 `;
@@ -967,16 +931,12 @@ exports[`TextArea resize vertical 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <textarea
-    className="c1"
+    class="c1"
     id="item"
     name="item"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
   />
 </div>
 `;
@@ -1057,17 +1017,12 @@ exports[`TextArea size large 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <textarea
-    className="c1"
+    class="c1"
     id="item"
     name="item"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    size="large"
   />
 </div>
 `;
@@ -1148,17 +1103,12 @@ exports[`TextArea size medium 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <textarea
-    className="c1"
+    class="c1"
     id="item"
     name="item"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    size="medium"
   />
 </div>
 `;
@@ -1239,17 +1189,12 @@ exports[`TextArea size small 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <textarea
-    className="c1"
+    class="c1"
     id="item"
     name="item"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    size="small"
   />
 </div>
 `;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/TextArea/__tests__/TextArea-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.