### PR TITLE
Refactor Theme tests to remove react-test-renderer

### DIFF
--- a/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
+++ b/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
@@ -31,12 +31,10 @@ exports[`Grommet ThemeContext theme 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <a
-    className="c1"
-    onBlur={[Function]}
-    onFocus={[Function]}
+    class="c1"
   >
     Hello
   </a>
@@ -343,153 +341,125 @@ exports[`Grommet custom theme 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <a
-      className="c2"
-      onBlur={[Function]}
-      onFocus={[Function]}
+      class="c2"
     >
       <span
-        className="c3"
-        style={
-          Object {
-            "display": "inline-flex",
-          }
-        }
+        class="c3"
+        style="display: inline-flex;"
       >
         <svg
           aria-label="Add"
-          className="c4"
+          class="c4"
           viewBox="0 0 24 24"
         >
           <path
             d="M12 22V2M2 12h20"
             fill="none"
             stroke="#000"
-            strokeWidth="2"
+            stroke-width="2"
           />
         </svg>
         <span
-          className="c5"
+          class="c5"
         />
         Add
       </span>
     </a>
     <a
-      className="c6"
-      onBlur={[Function]}
-      onFocus={[Function]}
+      class="c6"
     >
       <span
-        className="c3"
-        style={
-          Object {
-            "display": "inline-flex",
-          }
-        }
+        class="c3"
+        style="display: inline-flex;"
       >
         <svg
           aria-label="Add"
-          className="c7"
+          class="c7"
           viewBox="0 0 24 24"
         >
           <path
             d="M12 22V2M2 12h20"
             fill="none"
             stroke="#000"
-            strokeWidth="2"
+            stroke-width="2"
           />
         </svg>
         <span
-          className="c5"
+          class="c5"
         />
         Add
       </span>
     </a>
   </div>
   <div
-    className="c8"
+    class="c8"
   >
     <a
-      className="c9"
-      onBlur={[Function]}
-      onFocus={[Function]}
+      class="c9"
     >
       <span
-        className="c3"
-        style={
-          Object {
-            "display": "inline-flex",
-          }
-        }
+        class="c3"
+        style="display: inline-flex;"
       >
         <svg
           aria-label="Add"
-          className="c10"
+          class="c10"
           viewBox="0 0 24 24"
         >
           <path
             d="M12 22V2M2 12h20"
             fill="none"
             stroke="#000"
-            strokeWidth="2"
+            stroke-width="2"
           />
         </svg>
         <span
-          className="c5"
+          class="c5"
         />
         Add
       </span>
     </a>
     <a
-      className="c6"
-      onBlur={[Function]}
-      onFocus={[Function]}
+      class="c6"
     >
       <span
-        className="c3"
-        style={
-          Object {
-            "display": "inline-flex",
-          }
-        }
+        class="c3"
+        style="display: inline-flex;"
       >
         <svg
           aria-label="Add"
-          className="c7"
+          class="c7"
           viewBox="0 0 24 24"
         >
           <path
             d="M12 22V2M2 12h20"
             fill="none"
             stroke="#000"
-            strokeWidth="2"
+            stroke-width="2"
           />
         </svg>
         <span
-          className="c5"
+          class="c5"
         />
         Add
       </span>
     </a>
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <div
-      className="c11"
+      class="c11"
     >
       <input
-        autoComplete="off"
-        className="c12"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
+        autocomplete="off"
+        class="c12"
         placeholder="Placeholder"
         value="Value"
       />
@@ -822,229 +792,229 @@ exports[`Grommet dark theme 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <span
-      className="c2"
+      class="c2"
     >
       accent-1
     </span>
   </div>
   <div
-    className="c3"
+    class="c3"
   >
     <span
-      className="c2"
+      class="c2"
     >
       accent-2
     </span>
   </div>
   <div
-    className="c4"
+    class="c4"
   >
     <span
-      className="c2"
+      class="c2"
     >
       accent-3
     </span>
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <span
-      className="c2"
+      class="c2"
     >
       brand
     </span>
   </div>
   <div
-    className="c5"
+    class="c5"
   >
     <span
-      className="c2"
+      class="c2"
     >
       dark-1
     </span>
   </div>
   <div
-    className="c6"
+    class="c6"
   >
     <span
-      className="c2"
+      class="c2"
     >
       dark-2
     </span>
   </div>
   <div
-    className="c7"
+    class="c7"
   >
     <span
-      className="c2"
+      class="c2"
     >
       dark-3
     </span>
   </div>
   <div
-    className="c8"
+    class="c8"
   >
     <span
-      className="c2"
+      class="c2"
     >
       dark-4
     </span>
   </div>
   <div
-    className="c8"
+    class="c8"
   >
     <span
-      className="c2"
+      class="c2"
     >
       dark-5
     </span>
   </div>
   <div
-    className="c8"
+    class="c8"
   >
     <span
-      className="c2"
+      class="c2"
     >
       dark-6
     </span>
   </div>
   <div
-    className="c9"
+    class="c9"
   >
     <span
-      className="c2"
+      class="c2"
     >
       focus
     </span>
   </div>
   <div
-    className="c10"
+    class="c10"
   >
     <span
-      className="c2"
+      class="c2"
     >
       light-1
     </span>
   </div>
   <div
-    className="c11"
+    class="c11"
   >
     <span
-      className="c2"
+      class="c2"
     >
       light-2
     </span>
   </div>
   <div
-    className="c12"
+    class="c12"
   >
     <span
-      className="c2"
+      class="c2"
     >
       light-3
     </span>
   </div>
   <div
-    className="c13"
+    class="c13"
   >
     <span
-      className="c2"
+      class="c2"
     >
       light-4
     </span>
   </div>
   <div
-    className="c13"
+    class="c13"
   >
     <span
-      className="c2"
+      class="c2"
     >
       light-5
     </span>
   </div>
   <div
-    className="c13"
+    class="c13"
   >
     <span
-      className="c2"
+      class="c2"
     >
       light-6
     </span>
   </div>
   <div
-    className="c14"
+    class="c14"
   >
     <span
-      className="c2"
+      class="c2"
     >
       neutral-1
     </span>
   </div>
   <div
-    className="c15"
+    class="c15"
   >
     <span
-      className="c2"
+      class="c2"
     >
       neutral-2
     </span>
   </div>
   <div
-    className="c16"
+    class="c16"
   >
     <span
-      className="c2"
+      class="c2"
     >
       neutral-3
     </span>
   </div>
   <div
-    className="c17"
+    class="c17"
   >
     <span
-      className="c2"
+      class="c2"
     >
       status-critical
     </span>
   </div>
   <div
-    className="c18"
+    class="c18"
   >
     <span
-      className="c2"
+      class="c2"
     >
       status-disabled
     </span>
   </div>
   <div
-    className="c19"
+    class="c19"
   >
     <span
-      className="c2"
+      class="c2"
     >
       status-ok
     </span>
   </div>
   <div
-    className="c18"
+    class="c18"
   >
     <span
-      className="c2"
+      class="c2"
     >
       status-unknown
     </span>
   </div>
   <div
-    className="c20"
+    class="c20"
   >
     <span
-      className="c2"
+      class="c2"
     >
       status-warning
     </span>
@@ -1373,229 +1343,229 @@ exports[`Grommet default theme 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <span
-      className="c2"
+      class="c2"
     >
       accent-1
     </span>
   </div>
   <div
-    className="c3"
+    class="c3"
   >
     <span
-      className="c2"
+      class="c2"
     >
       accent-2
     </span>
   </div>
   <div
-    className="c4"
+    class="c4"
   >
     <span
-      className="c2"
+      class="c2"
     >
       accent-3
     </span>
   </div>
   <div
-    className="c5"
+    class="c5"
   >
     <span
-      className="c2"
+      class="c2"
     >
       brand
     </span>
   </div>
   <div
-    className="c6"
+    class="c6"
   >
     <span
-      className="c2"
+      class="c2"
     >
       dark-1
     </span>
   </div>
   <div
-    className="c7"
+    class="c7"
   >
     <span
-      className="c2"
+      class="c2"
     >
       dark-2
     </span>
   </div>
   <div
-    className="c8"
+    class="c8"
   >
     <span
-      className="c2"
+      class="c2"
     >
       dark-3
     </span>
   </div>
   <div
-    className="c9"
+    class="c9"
   >
     <span
-      className="c2"
+      class="c2"
     >
       dark-4
     </span>
   </div>
   <div
-    className="c9"
+    class="c9"
   >
     <span
-      className="c2"
+      class="c2"
     >
       dark-5
     </span>
   </div>
   <div
-    className="c9"
+    class="c9"
   >
     <span
-      className="c2"
+      class="c2"
     >
       dark-6
     </span>
   </div>
   <div
-    className="c1"
+    class="c1"
   >
     <span
-      className="c2"
+      class="c2"
     >
       focus
     </span>
   </div>
   <div
-    className="c10"
+    class="c10"
   >
     <span
-      className="c2"
+      class="c2"
     >
       light-1
     </span>
   </div>
   <div
-    className="c11"
+    class="c11"
   >
     <span
-      className="c2"
+      class="c2"
     >
       light-2
     </span>
   </div>
   <div
-    className="c12"
+    class="c12"
   >
     <span
-      className="c2"
+      class="c2"
     >
       light-3
     </span>
   </div>
   <div
-    className="c13"
+    class="c13"
   >
     <span
-      className="c2"
+      class="c2"
     >
       light-4
     </span>
   </div>
   <div
-    className="c13"
+    class="c13"
   >
     <span
-      className="c2"
+      class="c2"
     >
       light-5
     </span>
   </div>
   <div
-    className="c13"
+    class="c13"
   >
     <span
-      className="c2"
+      class="c2"
     >
       light-6
     </span>
   </div>
   <div
-    className="c14"
+    class="c14"
   >
     <span
-      className="c2"
+      class="c2"
     >
       neutral-1
     </span>
   </div>
   <div
-    className="c15"
+    class="c15"
   >
     <span
-      className="c2"
+      class="c2"
     >
       neutral-2
     </span>
   </div>
   <div
-    className="c16"
+    class="c16"
   >
     <span
-      className="c2"
+      class="c2"
     >
       neutral-3
     </span>
   </div>
   <div
-    className="c17"
+    class="c17"
   >
     <span
-      className="c2"
+      class="c2"
     >
       status-critical
     </span>
   </div>
   <div
-    className="c18"
+    class="c18"
   >
     <span
-      className="c2"
+      class="c2"
     >
       status-disabled
     </span>
   </div>
   <div
-    className="c19"
+    class="c19"
   >
     <span
-      className="c2"
+      class="c2"
     >
       status-ok
     </span>
   </div>
   <div
-    className="c18"
+    class="c18"
   >
     <span
-      className="c2"
+      class="c2"
     >
       status-unknown
     </span>
   </div>
   <div
-    className="c20"
+    class="c20"
   >
     <span
-      className="c2"
+      class="c2"
     >
       status-warning
     </span>
@@ -1746,24 +1716,16 @@ exports[`Grommet grommet theme 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <button
-    className="c1"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c1"
     type="button"
   >
     test
   </button>
   <button
-    className="c2"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    class="c2"
     type="button"
   >
     test
@@ -1998,148 +1960,148 @@ exports[`Grommet hpe theme 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div
-    className="c1"
+    class="c1"
   >
     <span
-      className="c2"
+      class="c2"
     >
       brand
     </span>
   </div>
   <div
-    className="c3"
+    class="c3"
   >
     <span
-      className="c2"
+      class="c2"
     >
       background-contrast
     </span>
   </div>
   <div
-    className="c4"
+    class="c4"
   >
     <span
-      className="c2"
+      class="c2"
     >
       background-front
     </span>
   </div>
   <div
-    className="c5"
+    class="c5"
   >
     <span
-      className="c2"
+      class="c2"
     >
       control
     </span>
   </div>
   <div
-    className="c6"
+    class="c6"
   >
     <span
-      className="c2"
+      class="c2"
     >
       graph-0
     </span>
   </div>
   <div
-    className="c7"
+    class="c7"
   >
     <span
-      className="c2"
+      class="c2"
     >
       graph-1
     </span>
   </div>
   <div
-    className="c8"
+    class="c8"
   >
     <span
-      className="c2"
+      class="c2"
     >
       graph-2
     </span>
   </div>
   <div
-    className="c9"
+    class="c9"
   >
     <span
-      className="c2"
+      class="c2"
     >
       graph-3
     </span>
   </div>
   <div
-    className="c10"
+    class="c10"
   >
     <span
-      className="c2"
+      class="c2"
     >
       graph-4
     </span>
   </div>
   <div
-    className="c10"
+    class="c10"
   >
     <span
-      className="c2"
+      class="c2"
     >
       focus
     </span>
   </div>
   <div
-    className="c11"
+    class="c11"
   >
     <span
-      className="c2"
+      class="c2"
     >
       status-critical
     </span>
   </div>
   <div
-    className="c12"
+    class="c12"
   >
     <span
-      className="c2"
+      class="c2"
     >
       status-disabled
     </span>
   </div>
   <div
-    className="c5"
+    class="c5"
   >
     <span
-      className="c2"
+      class="c2"
     >
       status-ok
     </span>
   </div>
   <div
-    className="c12"
+    class="c12"
   >
     <span
-      className="c2"
+      class="c2"
     >
       status-unknown
     </span>
   </div>
   <div
-    className="c13"
+    class="c13"
   >
     <span
-      className="c2"
+      class="c2"
     >
       status-warning
     </span>
   </div>
   <div
-    className="c14"
+    class="c14"
   >
     <span
-      className="c2"
+      class="c2"
     >
       text
     </span>

--- a/src/js/themes/__tests__/theme-test.js
+++ b/src/js/themes/__tests__/theme-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { hpe } from 'grommet-theme-hpe';
@@ -97,7 +97,7 @@ const customTheme = {
 
 describe('Grommet', () => {
   test('default theme', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         {colors.map(color => (
           <Box key={color} background={color}>
@@ -106,23 +106,23 @@ describe('Grommet', () => {
         ))}
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('grommet theme', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet theme={grommet}>
         <Button label="test" />
         <Button plain label="test" />
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('ThemeContext theme', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet theme={grommet}>
         <ThemeContext.Extend
           value={{
@@ -137,12 +137,12 @@ describe('Grommet', () => {
         </ThemeContext.Extend>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('dark theme', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet theme={dark}>
         {colors.map(color => (
           <Box key={color} background={color}>
@@ -151,12 +151,12 @@ describe('Grommet', () => {
         ))}
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('hpe theme', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet theme={hpe}>
         {hpeColors.map(color => (
           <Box key={color} background={color}>
@@ -165,12 +165,12 @@ describe('Grommet', () => {
         ))}
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('custom theme', () => {
-    const component = renderer.create(
+    const { container } = render(
       <Grommet theme={customTheme}>
         <Box>
           <Anchor icon={<Add />} label="Add" />
@@ -185,7 +185,7 @@ describe('Grommet', () => {
         </Box>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/themes/__tests__/theme-test.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.