### PR TITLE
Upgraded markdown-to-jsx latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "grommet-icons": "^4.6.0",
     "hoist-non-react-statics": "^3.2.0",
-    "markdown-to-jsx": "^6.11.4",
+    "markdown-to-jsx": "^7.1.3",
     "prop-types": "^15.7.2",
     "react-desc": "^4.1.3"
   },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

- Upgrades `markdown-to-jsx` from 6.11.4 to 7.1.4

#### Where should the reviewer start?

package.json

#### What testing has been done on this PR?

- Commit test suite
- Storybook markdown stories

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/5373

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

backwards compatible