### PR TITLE
Refactor Keyboard and RoutedButton tests to remove react-test-renderer

### DIFF
--- a/src/js/components/Keyboard/__tests__/Keyboard-test.js
+++ b/src/js/components/Keyboard/__tests__/Keyboard-test.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import { create } from 'react-test-renderer';
+import { render, fireEvent, screen } from '@testing-library/react';
 import 'jest-styled-components';
-import { render, fireEvent } from '@testing-library/react';
 
 import { Grommet } from '../../Grommet';
 import { Keyboard } from '..';
@@ -9,44 +8,42 @@ import { Keyboard } from '..';
 describe('Keyboard', () => {
   test('onDown', () => {
     const onDown = jest.fn();
-    const component = create(
+    const { container } = render(
       <Grommet>
         <Keyboard onDown={onDown}>
           <span>hi</span>
         </Keyboard>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    tree.children[0].props.onKeyDown({
-      keyCode: 40,
-    });
-    tree.children[0].props.onKeyDown({
-      which: 40,
-    });
-    tree.children[0].props.onKeyDown({
-      which: 0,
-    });
-    expect(onDown).toBeCalled();
+
+    const element = screen.getByText('hi');
+
+    fireEvent.keyDown(element, { keyCode: 40 });
+    fireEvent.keyDown(element, { which: 40 });
+    fireEvent.keyDown(element, { which: 0 });
+
+    expect(onDown).toHaveBeenCalled();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('onKeyDown', () => {
     const onDown = jest.fn();
     const onKeyDown = jest.fn();
-    const component = create(
+    const { container } = render(
       <Grommet>
         <Keyboard onDown={onDown} onKeyDown={onKeyDown}>
           <span>hi</span>
         </Keyboard>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    tree.children[0].props.onKeyDown({
-      keyCode: 40,
-    });
+
+    const element = screen.getByText('hi');
+
+    fireEvent.keyDown(element, { keyCode: 40 });
+
     expect(onDown).toBeCalled();
     expect(onKeyDown).toBeCalled();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('change onKeyDown', () => {

--- a/src/js/components/Keyboard/__tests__/__snapshots__/Keyboard-test.js.snap
+++ b/src/js/components/Keyboard/__tests__/__snapshots__/Keyboard-test.js.snap
@@ -24,11 +24,9 @@ exports[`Keyboard onDown 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
-  <span
-    onKeyDown={[Function]}
-  >
+  <span>
     hi
   </span>
 </div>
@@ -46,11 +44,9 @@ exports[`Keyboard onKeyDown 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
-  <span
-    onKeyDown={[Function]}
-  >
+  <span>
     hi
   </span>
 </div>

--- a/src/js/components/RoutedButton/RoutedButton.js
+++ b/src/js/components/RoutedButton/RoutedButton.js
@@ -37,7 +37,7 @@ class RoutedButton extends Component {
     if (process.env.NODE_ENV !== 'production') {
       console.warn(
         `This component will be deprecated in the upcoming releases.
-         Please refer to https://github.com/grommet/grommet/issues/2855 
+         Please refer to https://github.com/grommet/grommet/issues/2855
          for more information.`,
       );
     }

--- a/src/js/components/RoutedButton/__tests__/RoutedButton-test.js
+++ b/src/js/components/RoutedButton/__tests__/RoutedButton-test.js
@@ -36,15 +36,29 @@ class FakeRouter extends Component {
 }
 
 describe('RoutedButton', () => {
-  const push = jest.fn();
-  const replace = jest.fn();
-  const warning = `This component will be deprecated in the upcoming releases.
+  let push;
+  let replace;
+  let warning;
+  let warnSpy;
+
+  beforeEach(() => {
+    push = jest.fn();
+    replace = jest.fn();
+    warning = `This component will be deprecated in the upcoming releases.
          Please refer to https://github.com/grommet/grommet/issues/2855
          for more information.`;
 
-  test('renders', () => {
     console.warn = jest.fn();
-    const warnSpy = jest.spyOn(console, 'warn');
+    warnSpy = jest.spyOn(console, 'warn');
+  });
+
+  afterEach(() => {
+    warnSpy.mockReset();
+    warnSpy.mockRestore();
+    console.warn.mockReset();
+  });
+
+  test('renders', () => {
     const { container } = render(
       <Grommet>
         <FakeRouter replace={replace} push={push}>
@@ -55,15 +69,9 @@ describe('RoutedButton', () => {
 
     expect(warnSpy).toBeCalledWith(warning);
     expect(container.firstChild).toMatchSnapshot();
-
-    warnSpy.mockReset();
-    warnSpy.mockRestore();
-    console.warn.mockReset();
   });
 
   test('RoutedButton is clickable', () => {
-    console.warn = jest.fn();
-    const warnSpy = jest.spyOn(console, 'warn');
     const preventDefault = jest.fn();
     const onClick = jest.fn();
     render(
@@ -84,15 +92,9 @@ describe('RoutedButton', () => {
     expect(push).toHaveBeenCalled();
     expect(preventDefault).toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith(warning);
-
-    warnSpy.mockReset();
-    warnSpy.mockRestore();
-    console.warn.mockReset();
   });
 
   test('RoutedButton skips onClick if right clicked', () => {
-    console.warn = jest.fn();
-    const warnSpy = jest.spyOn(console, 'warn');
     const onClick = jest.fn();
     render(
       <Grommet>
@@ -109,15 +111,9 @@ describe('RoutedButton', () => {
 
     expect(onClick).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith(warning);
-
-    warnSpy.mockReset();
-    warnSpy.mockRestore();
-    console.warn.mockReset();
   });
 
   test('RoutedButton calls router context push', () => {
-    console.warn = jest.fn();
-    const warnSpy = jest.spyOn(console, 'warn');
     const preventDefault = jest.fn();
     render(
       <Grommet>
@@ -137,15 +133,9 @@ describe('RoutedButton', () => {
     expect(push).toHaveBeenCalledWith('/');
 
     expect(warnSpy).toHaveBeenCalledWith(warning);
-
-    warnSpy.mockReset();
-    warnSpy.mockRestore();
-    console.warn.mockReset();
   });
 
   test('RoutedButton calls router context replace', () => {
-    console.warn = jest.fn();
-    const warnSpy = jest.spyOn(console, 'warn');
     const preventDefault = jest.fn();
     render(
       <Grommet>
@@ -164,9 +154,5 @@ describe('RoutedButton', () => {
     expect(preventDefault).toHaveBeenCalled();
     expect(replace).toHaveBeenCalledWith('/');
     expect(warnSpy).toHaveBeenCalledWith(warning);
-
-    warnSpy.mockReset();
-    warnSpy.mockRestore();
-    console.warn.mockReset();
   });
 });

--- a/src/js/components/RoutedButton/__tests__/RoutedButton-test.js
+++ b/src/js/components/RoutedButton/__tests__/RoutedButton-test.js
@@ -1,9 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import renderer from 'react-test-renderer';
+import { createEvent, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import 'jest-styled-components';
-
-import { findAllByType } from '../../../utils';
 
 import { Grommet, RoutedButton } from '../..';
 
@@ -40,22 +39,22 @@ describe('RoutedButton', () => {
   const push = jest.fn();
   const replace = jest.fn();
   const warning = `This component will be deprecated in the upcoming releases.
-         Please refer to https://github.com/grommet/grommet/issues/2855 
+         Please refer to https://github.com/grommet/grommet/issues/2855
          for more information.`;
+
   test('renders', () => {
     console.warn = jest.fn();
     const warnSpy = jest.spyOn(console, 'warn');
-    const component = renderer.create(
+    const { container } = render(
       <Grommet>
         <FakeRouter replace={replace} push={push}>
           <RoutedButton label="Test" path="/" />
         </FakeRouter>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
 
     expect(warnSpy).toBeCalledWith(warning);
+    expect(container.firstChild).toMatchSnapshot();
 
     warnSpy.mockReset();
     warnSpy.mockRestore();
@@ -67,21 +66,24 @@ describe('RoutedButton', () => {
     const warnSpy = jest.spyOn(console, 'warn');
     const preventDefault = jest.fn();
     const onClick = jest.fn();
-    const component = renderer.create(
+    render(
       <Grommet>
         <FakeRouter replace={replace} push={push}>
           <RoutedButton label="Test" onClick={onClick} path="/" />
         </FakeRouter>
       </Grommet>,
     );
-    const tree = component.toJSON();
-    const anchor = findAllByType(tree, 'a');
-    anchor[0].props.onClick({ preventDefault });
-    expect(onClick).toBeCalled();
-    expect(push).toBeCalled();
-    expect(preventDefault).toBeCalled();
 
-    expect(warnSpy).toBeCalledWith(warning);
+    const anchor = screen.getByRole('link');
+
+    const clickEvent = createEvent.click(anchor);
+    clickEvent.preventDefault = preventDefault;
+    fireEvent(anchor, clickEvent);
+
+    expect(onClick).toBeCalled();
+    expect(push).toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(warning);
 
     warnSpy.mockReset();
     warnSpy.mockRestore();
@@ -92,25 +94,21 @@ describe('RoutedButton', () => {
     console.warn = jest.fn();
     const warnSpy = jest.spyOn(console, 'warn');
     const onClick = jest.fn();
-    const component = renderer.create(
+    render(
       <Grommet>
         <FakeRouter replace={replace} push={push}>
           <RoutedButton label="Test" onClick={onClick} path="/" />
         </FakeRouter>
       </Grommet>,
     );
-    const tree = component.toJSON();
 
-    const anchor = findAllByType(tree, 'a');
-    anchor[0].props.onClick({
-      ctrlKey: true,
-    });
-    anchor[0].props.onClick({
-      metaKey: true,
-    });
-    expect(onClick).not.toBeCalled();
+    const anchor = screen.getByRole('link');
 
-    expect(warnSpy).toBeCalledWith(warning);
+    userEvent.click(anchor, { ctrlKey: true });
+    userEvent.click(anchor, { metaKey: true });
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(warning);
 
     warnSpy.mockReset();
     warnSpy.mockRestore();
@@ -121,23 +119,24 @@ describe('RoutedButton', () => {
     console.warn = jest.fn();
     const warnSpy = jest.spyOn(console, 'warn');
     const preventDefault = jest.fn();
-    const component = renderer.create(
+    render(
       <Grommet>
         <FakeRouter replace={replace} push={push}>
           <RoutedButton label="Test" path="/" />
         </FakeRouter>
       </Grommet>,
     );
-    const tree = component.toJSON();
 
-    const button = findAllByType(tree, 'a');
-    button[0].props.onClick({
-      preventDefault,
-    });
-    expect(preventDefault).toBeCalled();
-    expect(push).toBeCalledWith('/');
+    const anchor = screen.getByRole('link');
 
-    expect(warnSpy).toBeCalledWith(warning);
+    const clickEvent = createEvent.click(anchor);
+    clickEvent.preventDefault = preventDefault;
+    fireEvent(anchor, clickEvent);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(push).toHaveBeenCalledWith('/');
+
+    expect(warnSpy).toHaveBeenCalledWith(warning);
 
     warnSpy.mockReset();
     warnSpy.mockRestore();
@@ -148,23 +147,23 @@ describe('RoutedButton', () => {
     console.warn = jest.fn();
     const warnSpy = jest.spyOn(console, 'warn');
     const preventDefault = jest.fn();
-    const component = renderer.create(
+    render(
       <Grommet>
         <FakeRouter replace={replace} push={push}>
           <RoutedButton label="Test" path="/" method="replace" />
         </FakeRouter>
       </Grommet>,
     );
-    const tree = component.toJSON();
 
-    const button = findAllByType(tree, 'a');
-    button[0].props.onClick({
-      preventDefault,
-    });
-    expect(preventDefault).toBeCalled();
-    expect(replace).toBeCalledWith('/');
+    const anchor = screen.getByRole('link');
 
-    expect(warnSpy).toBeCalledWith(warning);
+    const clickEvent = createEvent.click(anchor);
+    clickEvent.preventDefault = preventDefault;
+    fireEvent(anchor, clickEvent);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(replace).toHaveBeenCalledWith('/');
+    expect(warnSpy).toHaveBeenCalledWith(warning);
 
     warnSpy.mockReset();
     warnSpy.mockRestore();

--- a/src/js/components/RoutedButton/__tests__/__snapshots__/RoutedButton-test.js.snap
+++ b/src/js/components/RoutedButton/__tests__/__snapshots__/RoutedButton-test.js.snap
@@ -81,18 +81,12 @@ exports[`RoutedButton renders 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   <div>
     <a
-      className="c1"
-      disabled={false}
+      class="c1"
       href="/"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
     >
       Test
     </a>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update Button legacy tests to use the standard render method from [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).

#### Where should the reviewer start?

`src/js/components/Keyboard/__tests__/Keyboard-test.js`
`src/js/components/RoutedButton/RoutedButton.js`

#### What testing has been done on this PR?

`yarn test`

#### How should this be manually tested?

Run: `yarn test`

#### Any background context you want to provide?

#### What are the relevant issues?

#5197 - Testing - Refactor the usage of `renderer.create` to `render`

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.