### PR TITLE
Fix console errors in FileInput stories

### DIFF
--- a/src/js/components/FileInput/stories/Custom.js
+++ b/src/js/components/FileInput/stories/Custom.js
@@ -49,8 +49,8 @@ export const Custom = () => (
               <Text color="text-weak">{file.size} bytes</Text>
             </Box>
           )}
-          onChange={(event) => {
-            const fileList = event.target.files;
+          onChange={(event, { files }) => {
+            const fileList = files;
             for (let i = 0; i < fileList.length; i += 1) {
               const file = fileList[i];
               console.log(file.name);

--- a/src/js/components/FileInput/stories/Simple.js
+++ b/src/js/components/FileInput/stories/Simple.js
@@ -8,8 +8,8 @@ export const Simple = () => (
     <Box fill align="center" justify="start" pad="large">
       <Box width="medium">
         <FileInput
-          onChange={event => {
-            const fileList = event.target.files;
+          onChange={(event, { files }) => {
+            const fileList = files;
             for (let i = 0; i < fileList.length; i += 1) {
               const file = fileList[i];
               console.log(file.name);


### PR DESCRIPTION
#### What does this PR do?
Fixes console errors that were showing up in FileInput Custom and Simple stories when a file is removed.
Related to #5028 and #5143

#### Where should the reviewer start?

#### What testing has been done on this PR?
Storybook

#### How should this be manually tested?
Storybook, add a file and then remove it and check console

#### Any background context you want to provide?

#### What are the relevant issues?
#5143

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible