### PR TITLE
Adding a prop to the InputFile to pass a function to the remove button in onClick

### DIFF
--- a/src/js/components/FileInput/FileInput.js
+++ b/src/js/components/FileInput/FileInput.js
@@ -67,6 +67,7 @@ const FileInput = forwardRef(
       multiple,
       name,
       onChange,
+      onClickRemove,
       pad,
       value: valueProp,
       ...rest
@@ -247,6 +248,7 @@ const FileInput = forwardRef(
                 icon={<RemoveIcon />}
                 hoverIndicator
                 onClick={(event) => {
+                  if (onClickRemove) onClickRemove();
                   event.stopPropagation();
                   if (onChange) onChange(event, { files: [] });
                   setFiles([]);
@@ -328,6 +330,7 @@ const FileInput = forwardRef(
                   icon={<RemoveIcon />}
                   hoverIndicator
                   onClick={(event) => {
+                    if (onClickRemove) if (!onClickRemove()) return;
                     event.stopPropagation();
                     const nextFiles = [...files];
                     nextFiles.splice(index, 1);

--- a/src/js/components/FileInput/stories/Simple.js
+++ b/src/js/components/FileInput/stories/Simple.js
@@ -3,11 +3,16 @@ import React from 'react';
 import { Box, Grommet, FileInput } from 'grommet';
 import { grommet } from 'grommet/themes';
 
+function confirmationDialog() {
+  return window.confirm('Do you really want to delete this file');
+}
+
 export const Simple = () => (
   <Grommet full theme={grommet}>
     <Box fill align="center" justify="start" pad="large">
       <Box width="medium">
         <FileInput
+          onClickRemove={confirmationDialog}
           onChange={(event, { files }) => {
             const fileList = files;
             for (let i = 0; i < fileList.length; i += 1) {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
The new prop in FileInput receives a function and passes it to be executed in onClick in the remove button.

#### Where should the reviewer start?
FileInput.js

#### What testing has been done on this PR?

#### How should this be manually tested?
Passing a function to onClickRemove, and see that be executed when clicking on the remove button

#### Any background context you want to provide?
Some doubts. The function passed to the remove button need to override the onClick that removes the file? Or be executed inside the onClick with the other commands?

#### What are the relevant issues?
#5321 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Is compatible
