### PR TITLE
fix(Header): aligns ref support with Box

### DIFF
--- a/src/js/components/Header/Header.js
+++ b/src/js/components/Header/Header.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Box } from '../Box';
 
-const Header = ({ ...rest }) => (
+const Header = React.forwardRef(({ ...rest }, ref) => (
   <Box
     align="center"
     as="header"
@@ -11,8 +11,10 @@ const Header = ({ ...rest }) => (
     justify="between"
     gap="medium"
     {...rest}
+    ref={ref}
   />
-);
+));
+Header.displayName = 'Header';
 
 let HeaderDoc;
 if (process.env.NODE_ENV !== 'production') {

--- a/src/js/components/Header/stories/typescript/Ref.tsx
+++ b/src/js/components/Header/stories/typescript/Ref.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { Avatar, Anchor, Nav, Grommet, Header, Button } from 'grommet';
+import { grommet } from 'grommet/themes';
+
+const gravatarLink =
+  '//s.gravatar.com/avatar/b7fb138d53ba0f573212ccce38a7c43b?s=80';
+
+export const Ref = () => {
+  const ref = React.createRef<HTMLDivElement>();
+  const [color, setColor] = React.useState('');
+
+  const setRandomColor = () => {
+    const red = Math.floor(Math.random() * 255).toString(16);
+    const green = Math.floor(Math.random() * 255).toString(16);
+    const blue = Math.floor(Math.random() * 255).toString(16);
+    setColor(`#${red}${green}${blue}`);
+  };
+
+  React.useEffect(() => {
+    if (ref.current) ref.current.style.backgroundColor = color;
+  });
+
+  return (
+    <Grommet theme={grommet}>
+      <Header background="light-4" pad="small" ref={ref}>
+        <Avatar src={gravatarLink} />
+        <Nav direction="row">
+          <Button primary label="Change Color" onClick={setRandomColor} />
+        </Nav>
+      </Header>
+    </Grommet>
+  );
+};
+
+export default {
+  title: 'Layout/Header/Ref',
+};

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -5307,7 +5307,24 @@ for any grommet children components.",
     "usage": "import { Grommet } from 'grommet';
 <Grommet>...</Grommet>",
   },
-  "Header": [Function],
+  "Header": Object {
+    "availableAt": Array [
+      Object {
+        "badge": "https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png",
+        "label": "Storybook",
+        "url": "https://storybook.grommet.io/?selectedKind=Layout-Header&full=0&stories=1&panelRight=0",
+      },
+      Object {
+        "badge": "https://codesandbox.io/static/img/play-codesandbox.svg",
+        "label": "CodeSandbox",
+        "url": "https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=/header&module=%2Fsrc%2FHeader.js",
+      },
+    ],
+    "description": "Is a Box container for introductory content",
+    "name": "Header",
+    "usage": "import { Header } from 'grommet';
+<Header />",
+  },
   "Heading": Object {
     "availableAt": Array [
       Object {


### PR DESCRIPTION
#### What does this PR do?

This PR adds support for forwarding refs to the Box component (which forwards refs itself)

#### Where should the reviewer start?

`/components/Header/Header.js`

#### What testing has been done on this PR?

I can add tests if necessary

#### How should this be manually tested?

Run `yarn storybook` and then expand the `Header` section.  Click on `Ref` and click the `Change Color` button.

#### Any background context you want to provide?

In our codebase, we have primary, secondary, and tertiary headers.  Each wraps this header, but under certain circumstances, we need to be able to perform various updates to them (e.g. - when another header is present the primary disappears on scroll to free up screen real estate, etc)

#### What are the relevant issues?

N/A

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.  This makes the statement of "a Box with the following properties" more accurate

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible
