### PR TITLE
fix: Update onOrder parameters' type definition

### DIFF
--- a/src/js/components/List/index.d.ts
+++ b/src/js/components/List/index.d.ts
@@ -52,7 +52,7 @@ export interface ListProps<ListItemType> {
   onClickItem?:
     | ((event: React.MouseEvent) => void)
     | ((event: { item?: ListItemType; index?: number }) => void);
-  onOrder?: () => void;
+  onOrder?: (orderedData: ListItemType[]) => void;
   pad?: PadType;
   paginate?: boolean | PaginationType;
   primaryKey?: string | ((item: ListItemType) => React.ReactElement);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Updates the List component's onOrder function prop to receive the reordered data.

#### Where should the reviewer start?
At the single line change
#### What testing has been done on this PR?
Only manual testing. The tests for the onOnder fuctions were already created with the reordered data.
#### How should this be manually tested?
Creating the List component, at some typescript project, with the updated onOrder prop

#### What are the relevant issues?
Closes #5441

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
It's possible to break List components, at some typescript project, thats uses the onOrder without arguments