### PR TITLE
Add tip as value for truncate on Text

### DIFF
--- a/src/js/components/Text/README.md
+++ b/src/js/components/Text/README.md
@@ -213,10 +213,13 @@ string
 
 Restrict the text to a single line and truncate with ellipsis if it
 is too long to all fit. For truncate to be applied, Text needs to be 
-contained within a layout component (such as Box or a generic div).
+contained within a layout component (such as Box or a generic div). If 
+truncate = tip, the full text content will be placed in a Tip that will appear 
+on hover.
 
 ```
 boolean
+tip
 ```
 
 **weight**

--- a/src/js/components/Text/Text.js
+++ b/src/js/components/Text/Text.js
@@ -1,29 +1,51 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
 
 import { StyledText } from './StyledText';
 import { Tip } from '../Tip';
+import { useForwardedRef } from '../../utils';
 
 const Text = forwardRef(
   (
     {
+      children,
       color,
       tag,
       as,
-      tip,
+      tip: tipProp,
       // can't alphabetize a11yTitle before tip is defined
-      a11yTitle = typeof tip === 'string' ? tip : undefined,
+      a11yTitle = typeof tipProp === 'string' ? tipProp : undefined,
+      truncate,
       ...rest
     },
     ref,
   ) => {
+    const textRef = useForwardedRef(ref);
+    const [tip, setTip] = useState(tipProp);
+
+    // place the text content in a tip if truncate === 'tip'
+    // and the text has been truncated
+    useEffect(() => {
+      if (truncate === 'tip') {
+        if (
+          textRef.current &&
+          textRef.current.scrollWidth > textRef.current.offsetWidth
+        ) {
+          setTip(children);
+        } else setTip(undefined);
+      }
+    }, [children, textRef, truncate]);
+
     const styledTextResult = (
       <StyledText
         as={!as && tag ? tag : as}
         colorProp={color}
         aria-label={a11yTitle}
+        truncate={truncate}
         {...rest}
-        ref={ref}
-      />
+        ref={textRef}
+      >
+        {children}
+      </StyledText>
     );
 
     if (tip) {

--- a/src/js/components/Text/doc.js
+++ b/src/js/components/Text/doc.js
@@ -108,11 +108,13 @@ export const doc = (Text) => {
     ]).description(`tooltip or a hint when hovering over the text. If the
         value is a string and no a11yTitle value is provided, tip value will be
         used for the a11yTitle default value.`),
-    truncate: PropTypes.bool
+    truncate: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['tip'])])
       .description(
         `Restrict the text to a single line and truncate with ellipsis if it
 is too long to all fit. For truncate to be applied, Text needs to be 
-contained within a layout component (such as Box or a generic div).`,
+contained within a layout component (such as Box or a generic div). If 
+truncate = tip, the full text content will be placed in a Tip that will appear 
+on hover.`,
       )
       .defaultValue(false),
     weight: PropTypes.oneOfType([

--- a/src/js/components/Text/index.d.ts
+++ b/src/js/components/Text/index.d.ts
@@ -34,7 +34,7 @@ export interface TextProps {
     | string;
   tag?: PolymorphicType;
   textAlign?: TextAlignType;
-  truncate?: boolean;
+  truncate?: boolean | 'tip';
   weight?: 'normal' | 'bold' | number;
   wordBreak?: 'normal' | 'break-all' | 'keep-all' | 'break-word';
   tip?: TipProps;

--- a/src/js/components/Text/stories/Tip.js
+++ b/src/js/components/Text/stories/Tip.js
@@ -8,9 +8,7 @@ export const Tip = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="medium" gap="xlarge">
       <Box width="small">
-        <Text tip={alphabet} truncate>
-          {alphabet}
-        </Text>
+        <Text truncate="tip">{alphabet}</Text>
       </Box>
       <Text
         tip={{ dropProps: { align: { left: 'right' } }, content: 'tooltip' }}

--- a/src/js/components/__tests__/__snapshots__/README-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/README-test.js.snap
@@ -17750,10 +17750,13 @@ string
 
 Restrict the text to a single line and truncate with ellipsis if it
 is too long to all fit. For truncate to be applied, Text needs to be 
-contained within a layout component (such as Box or a generic div).
+contained within a layout component (such as Box or a generic div). If 
+truncate = tip, the full text content will be placed in a Tip that will appear 
+on hover.
 
 \`\`\`
 boolean
+tip
 \`\`\`
 
 **weight**

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -8516,8 +8516,11 @@ string",
         "defaultValue": false,
         "description": "Restrict the text to a single line and truncate with ellipsis if it
 is too long to all fit. For truncate to be applied, Text needs to be 
-contained within a layout component (such as Box or a generic div).",
-        "format": "boolean",
+contained within a layout component (such as Box or a generic div). If 
+truncate = tip, the full text content will be placed in a Tip that will appear 
+on hover.",
+        "format": "boolean
+tip",
         "name": "truncate",
       },
       Object {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

When truncate="tip", if the text has been truncated, the entirety of the text will be placed in a Tip.

#### Where should the reviewer start?
src/js/components/Text/Text.js

#### What testing has been done on this PR?
Adjusted Tip.js story to demo `truncate="tip"`.

#### How should this be manually tested?
Checkout deploy Tip.js under Text stories.

#### Any background context you want to provide?
Minimize implementation effort to be able to place truncated content into a tip.

#### What are the relevant issues?
Related to: https://github.com/grommet/hpe-design-system/issues/1503
Related to: https://github.com/grommet/hpe-design-system/pull/1734

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Updated here.

#### Should this PR be mentioned in the release notes?
Yes. Added `truncate="tip"` to Text.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.