### PR TITLE
fix paragraph so it accepts a custom string

### DIFF
--- a/src/js/components/Paragraph/StyledParagraph.js
+++ b/src/js/components/Paragraph/StyledParagraph.js
@@ -4,34 +4,34 @@ import { genericStyles, normalizeColor, textAlignStyle } from '../../utils';
 import { defaultProps } from '../../default-props';
 
 const colorStyle = css`
-  color: ${props => normalizeColor(props.colorProp, props.theme)};
+  color: ${(props) => normalizeColor(props.colorProp, props.theme)};
 `;
 
-const sizeStyle = props => {
+const sizeStyle = (props) => {
   const size = props.size || 'medium';
   const data = props.theme.paragraph[size];
   return css`
-    font-size: ${data.size};
-    line-height: ${data.height};
-    max-width: ${props.fillProp ? 'none' : data.maxWidth};
+    font-size: ${data ? data.size : size};
+    line-height: ${data ? data.height : 'normal'};
+    max-width: ${props.fillProp ? 'none' : data && data.maxWidth};
   `;
 };
 
 const fontFamily = css`
-  font-family: ${props => props.theme.paragraph.font.family};
+  font-family: ${(props) => props.theme.paragraph.font.family};
 `;
 
 const StyledParagraph = styled.p`
   ${genericStyles}
-  ${props => sizeStyle(props)}
-  ${props => props.textAlign && textAlignStyle}
-  ${props => props.colorProp && colorStyle}
-  ${props =>
+  ${(props) => sizeStyle(props)}
+  ${(props) => props.textAlign && textAlignStyle}
+  ${(props) => props.colorProp && colorStyle}
+  ${(props) =>
     props.theme.paragraph.font &&
     props.theme.paragraph.font.family &&
     fontFamily}
 
-  ${props => props.theme.paragraph && props.theme.paragraph.extend}
+  ${(props) => props.theme.paragraph && props.theme.paragraph.extend}
 `;
 
 StyledParagraph.defaultProps = {};

--- a/src/js/components/Paragraph/__tests__/Paragraph-test.js
+++ b/src/js/components/Paragraph/__tests__/Paragraph-test.js
@@ -25,6 +25,7 @@ test('Paragraph size renders', () => {
       <Paragraph size="xxlarge" />
       <Paragraph fill />
       <Paragraph fill={false} />
+      <Paragraph size="10px" />
     </Grommet>,
   );
 

--- a/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.js.snap
+++ b/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.js.snap
@@ -150,6 +150,11 @@ exports[`Paragraph size renders 1`] = `
   max-width: none;
 }
 
+.c7 {
+  font-size: 10px;
+  line-height: normal;
+}
+
 <div
   class="c0"
 >
@@ -173,6 +178,9 @@ exports[`Paragraph size renders 1`] = `
   />
   <p
     class="c2"
+  />
+  <p
+    class="c7"
   />
 </div>
 `;

--- a/src/js/components/Paragraph/stories/All.js
+++ b/src/js/components/Paragraph/stories/All.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { Grommet, Paragraph } from 'grommet';
 import { grommet } from 'grommet/themes';
 
-const sizes = ['xxlarge', 'xlarge', 'large', 'medium', 'small'];
+const sizes = ['xxlarge', 'xlarge', 'large', 'medium', 'small', '10px'];
 
 const paragraphFiller = `
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
@@ -12,7 +12,7 @@ tempor incididunt ut labore et dolore magna aliqua.
 
 export const All = () => (
   <Grommet theme={grommet}>
-    {sizes.map(size => (
+    {sizes.map((size) => (
       <Paragraph key={size} size={size}>
         {`Paragraph ${size}`}
         {paragraphFiller}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR allows for a custom string to be passed to `paragraph` size
#### Where should the reviewer start?
styledparagraph.js
#### What testing has been done on this PR?
added a custom string to the test size
#### How should this be manually tested?
storybook
#### Any background context you want to provide?

#### What are the relevant issues?
closes #5464 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible