### PR TITLE
Pass along RadioButton focus state to children.

### DIFF
--- a/src/js/components/RadioButton/RadioButton.js
+++ b/src/js/components/RadioButton/RadioButton.js
@@ -82,7 +82,7 @@ const RadioButton = forwardRef(
             })}
           />
           {children ? (
-            children({ checked, hover })
+            children({ checked, focus: focus && focusIndicator, hover })
           ) : (
             <StyledRadioButtonBox
               focus={focus && focusIndicator}

--- a/src/js/components/RadioButtonGroup/stories/Children.js
+++ b/src/js/components/RadioButtonGroup/stories/Children.js
@@ -16,13 +16,14 @@ export const Children = () => {
           gap="xsmall"
           options={['asc', 'desc']}
           value={value}
-          onChange={event => setValue(event.target.value)}
+          onChange={(event) => setValue(event.target.value)}
         >
-          {(option, { checked, hover }) => {
+          {(option, { checked, focus, hover }) => {
             const Icon = option === 'asc' ? Ascend : Descend;
             let background;
             if (checked) background = 'brand';
             else if (hover) background = 'light-4';
+            else if (focus) background = 'light-4';
             else background = 'light-2';
             return (
               <Box background={background} pad="xsmall">


### PR DESCRIPTION
Signed-off-by: Sarah Allen <sarah@zooniverse.org>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This fixes #5472 by including the `RadioButton` focus state as part of the state object that gets passed to children by the `RadioButtonGroup`.

#### Where should the reviewer start?

The `RadioButtonGroup` children story is now updated to demonstrate that the focus state is now available and the children can now be styled based on that state like it is for hover and checked.

#### What testing has been done on this PR?

Manual testing via storybook. I didn't see an existing unit test for testing hover with children, so I didn't add one for focus. Happy to do so if requested.

#### How should this be manually tested?

As noted above, the story is now updated.

#### Any background context you want to provide?

As of right now, if someone uses `RadioButtonGroup` and defines custom children, then the child components can be inaccessible for keyboard users if there's no focus state styling.

#### What are the relevant issues?
#5472 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.