### PR TITLE
Don't apply role="gridcell" to blank days or role="row" to blank week

### DIFF
--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -640,6 +640,8 @@ const Calendar = forwardRef(
     let day = new Date(displayBounds[0]);
     let days;
     let firstDayInMonth;
+    // if a week is filled with all blank days, we don't want to set role="row"
+    let blankWeek = false;
 
     while (day.getTime() < displayBounds[1].getTime()) {
       if (day.getDay() === firstDayOfWeek) {
@@ -657,7 +659,6 @@ const Calendar = forwardRef(
       if (!showAdjacentDays && otherMonth) {
         days.push(
           <StyledDayContainer
-            role="gridcell"
             key={day.getTime()}
             sizeProp={size}
             fillContainer={fill}
@@ -665,6 +666,15 @@ const Calendar = forwardRef(
             <StyledDay sizeProp={size} fillContainer={fill} />
           </StyledDayContainer>,
         );
+
+        if (
+          weeks.length === 5 &&
+          /* If the length days array is less than the current getDate()
+          we know that all days in the array are from the next month. */
+          days.length < day.getDate()
+        ) {
+          blankWeek = true;
+        }
       } else if (
         /* Do not show adjacent days in 6th row if all days
         fall in the next month */
@@ -675,9 +685,9 @@ const Calendar = forwardRef(
         we know that all days in the array are from the next month. */
         days.length < day.getDate()
       ) {
+        blankWeek = true;
         days.push(
           <StyledDayContainer
-            role="gridcell"
             key={day.getTime()}
             sizeProp={size}
             fillContainer={fill}
@@ -776,11 +786,14 @@ const Calendar = forwardRef(
           );
         }
       }
-
       day = addDays(day, 1);
     }
     weeks.push(
-      <StyledWeek role="row" key={day.getTime()} fillContainer={fill}>
+      <StyledWeek
+        role={!blankWeek ? 'row' : undefined}
+        key={day.getTime()}
+        fillContainer={fill}
+      >
         {days}
       </StyledWeek>,
     );

--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -655,7 +655,6 @@ const Calendar = forwardRef(
     let day = new Date(displayBounds[0]);
     let days;
     let firstDayInMonth;
-    // if a week is filled with all blank days, we don't want to set role="row"
     let blankWeek = false;
 
     while (day.getTime() < displayBounds[1].getTime()) {
@@ -805,6 +804,8 @@ const Calendar = forwardRef(
     }
     weeks.push(
       <StyledWeek
+        // if a week contains only blank days, for screen reader accessibility
+        // we don't want to set role="row"
         role={!blankWeek ? 'row' : undefined}
         key={day.getTime()}
         fillContainer={fill}

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -20060,7 +20060,6 @@ exports[`Calendar showAdjacentDays 1`] = `
           >
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -20068,7 +20067,6 @@ exports[`Calendar showAdjacentDays 1`] = `
             </div>
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -20076,7 +20074,6 @@ exports[`Calendar showAdjacentDays 1`] = `
             </div>
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -20631,7 +20628,6 @@ exports[`Calendar showAdjacentDays 1`] = `
             </div>
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -20640,11 +20636,9 @@ exports[`Calendar showAdjacentDays 1`] = `
           </div>
           <div
             class="c11"
-            role="row"
           >
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -20652,7 +20646,6 @@ exports[`Calendar showAdjacentDays 1`] = `
             </div>
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -20660,7 +20653,6 @@ exports[`Calendar showAdjacentDays 1`] = `
             </div>
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -20668,7 +20660,6 @@ exports[`Calendar showAdjacentDays 1`] = `
             </div>
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -20676,7 +20667,6 @@ exports[`Calendar showAdjacentDays 1`] = `
             </div>
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -20684,7 +20674,6 @@ exports[`Calendar showAdjacentDays 1`] = `
             </div>
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -20692,7 +20681,6 @@ exports[`Calendar showAdjacentDays 1`] = `
             </div>
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -21393,11 +21381,9 @@ exports[`Calendar showAdjacentDays 1`] = `
           </div>
           <div
             class="c11"
-            role="row"
           >
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -21405,7 +21391,6 @@ exports[`Calendar showAdjacentDays 1`] = `
             </div>
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -21413,7 +21398,6 @@ exports[`Calendar showAdjacentDays 1`] = `
             </div>
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -21421,7 +21405,6 @@ exports[`Calendar showAdjacentDays 1`] = `
             </div>
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -21429,7 +21412,6 @@ exports[`Calendar showAdjacentDays 1`] = `
             </div>
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -21437,7 +21419,6 @@ exports[`Calendar showAdjacentDays 1`] = `
             </div>
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"
@@ -21445,7 +21426,6 @@ exports[`Calendar showAdjacentDays 1`] = `
             </div>
             <div
               class="c12"
-              role="gridcell"
             >
               <div
                 class="c15"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Removes use of role="gridcell" on blank Calendar days and role="row" from weeks that are completely blank to improve experience of screen readers.

Removing "gridcell" on blank days ensures a screen reader user doesn't need to navigate over these days.

The removal of role="row" on blank weeks is needed for screen reader to properly calculate number of rows in a table. If not, a completely blank week will still be included in the row count but not accessible by screen reader which is confusing. For example "Row 1 of 6" where only 5 rows are able to be accessed because on week is empty.

#### Where should the reviewer start?
src/js/components/Calendar/Calendar.js

#### What testing has been done on this PR?
Tested with VoiceOver locally.

#### How should this be manually tested?
Test on showAdjacentDays story with VoiceOver and arrow keys. Should not be able to access blank days.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #5436 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes. Improved behavior for screen reader users by removing blank days from navigable Calendar days.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.