### PR TITLE
Expand accepted value types for anchor weight.

### DIFF
--- a/src/js/components/Anchor/__tests__/Anchor-test.js
+++ b/src/js/components/Anchor/__tests__/Anchor-test.js
@@ -185,6 +185,12 @@ describe('Anchor', () => {
         <Anchor href="#" label="Normal" weight="normal" />
         <Anchor href="#" label="Bold" weight="bold" />
         <Anchor href="#" label="Bold" weight={500} />
+        <Anchor href="#" label="Lighter" weight="lighter" />
+        <Anchor href="#" label="Bolder" weight="bolder" />
+        <Anchor href="#" label="Inherit" weight="inherit" />
+        <Anchor href="#" label="Initial" weight="initial" />
+        <Anchor href="#" label="Revert" weight="revert" />
+        <Anchor href="#" label="Unset" weight="unset" />
       </Grommet>,
     );
     expect(container).toMatchSnapshot();

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -29,7 +29,16 @@ export interface AnchorProps {
     | 'xlarge'
     | 'xxlarge'
     | string;
-  weight?: 'normal' | 'bold' | number;
+  weight?:
+    | 'normal'
+    | 'bold'
+    | 'lighter'
+    | 'bolder'
+    | 'inherit'
+    | 'initial'
+    | 'revert'
+    | 'unset'
+    | number;
 }
 
 type aProps = Omit<JSX.IntrinsicElements['a'], 'color'>;

--- a/src/js/components/Anchor/propTypes.js
+++ b/src/js/components/Anchor/propTypes.js
@@ -24,7 +24,16 @@ export const AnchorType = {
     PropTypes.string,
   ]),
   weight: PropTypes.oneOfType([
-    PropTypes.oneOf(['normal', 'bold']),
+    PropTypes.oneOf([
+      'normal',
+      'bold',
+      'lighter',
+      'bolder',
+      'inherit',
+      'initial',
+      'revert',
+      'unset',
+    ]),
     PropTypes.number,
   ]),
 };

--- a/src/js/components/Anchor/stories/Weight.js
+++ b/src/js/components/Anchor/stories/Weight.js
@@ -12,6 +12,12 @@ const WeightAnchor = () => (
       <Anchor href="#" label="Anchor weight 200" weight={200} />
       <Anchor href="#" label="Anchor weight 400" weight={400} />
       <Anchor href="#" label="Anchor weight 600" weight={600} />
+      <Anchor href="#" label="Anchor weight Lighter" weight="lighter" />
+      <Anchor href="#" label="Anchor weight Bolder" weight="bolder" />
+      <Anchor href="#" label="Anchor weight Inherit" weight="inherit" />
+      <Anchor href="#" label="Anchor weight Initial" weight="initial" />
+      <Anchor href="#" label="Anchor weight Revert" weight="revert" />
+      <Anchor href="#" label="Anchor weight Unset" weight="unset" />
     </Box>
   </Grommet>
 );


### PR DESCRIPTION
#### What does this PR do?

Resolve https://github.com/grommet/grommet/issues/5483 by adding all acceptable values for font-weight to anchor weight.

See https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight.

#### Where should the reviewer start?

There are only three files among which one is the test file. 

#### What testing has been done on this PR?

I've followed the current test cases for font weight and added more to cover the new acceptable values.

#### How should this be manually tested?

Make sure all acceptable values in https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight do not throw type errors or prop-type check errors.

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/5483

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

The docs promised "any browser font-weight definition" so it's already generous enough.

#### Should this PR be mentioned in the release notes?

Sure.

#### Is this change backwards compatible or is it a breaking change?

I don't think this breaks anything.
However I do think the `'inherit' | 'initial' | 'revert' | 'unset'` part is universal to all override-able styles and should be a defined constant if there isn't already one somewhere.