### PR TITLE
move theme option out of back ticks

### DIFF
--- a/src/js/components/DataTable/StyledDataTable.js
+++ b/src/js/components/DataTable/StyledDataTable.js
@@ -155,8 +155,7 @@ const StyledDataTableCell = styled(TableCell)`
   ${(props) =>
     props.pin &&
     props.pin.length > 0 &&
-    `
-    position: sticky;
+    `position: sticky;
     ${props.pin
       .map(
         (p) =>
@@ -169,15 +168,15 @@ const StyledDataTableCell = styled(TableCell)`
       )
       .join(' ')}
     z-index: ${Object.keys(props.pin).length};
-    ${
-      props.theme.dataTable &&
-      props.theme.dataTable.pinned &&
-      props.theme.dataTable.pinned[props.context] &&
-      props.theme.dataTable.pinned[props.context].extend
-        ? props.theme.dataTable.pinned[props.context].extend
-        : ''
-    }
   `}
+  ${(props) =>
+    props.pin &&
+    props.pin.length > 0 &&
+    props.theme.dataTable.pinned &&
+    props.theme.dataTable.pinned[props.context] &&
+    props.theme.dataTable.pinned[props.context].extend
+      ? props.theme.dataTable.pinned[props.context].extend
+      : ''}
 `;
 
 StyledDataTableCell.defaultProps = {};

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2687,7 +2687,7 @@ exports[`DataTable click 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -2710,7 +2710,7 @@ exports[`DataTable click 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 ceAlRl"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -2728,7 +2728,7 @@ exports[`DataTable click 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 ceAlRl"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -3438,11 +3438,11 @@ exports[`DataTable custom theme 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cdtfii StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cdtfii StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         />
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ejcTAx StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ejcTAx StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -3546,7 +3546,7 @@ exports[`DataTable custom theme 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -3593,7 +3593,7 @@ exports[`DataTable custom theme 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -4993,7 +4993,7 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -5007,7 +5007,7 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -5060,7 +5060,7 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -5074,7 +5074,7 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -5116,7 +5116,7 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -5130,7 +5130,7 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -6287,7 +6287,7 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -6301,7 +6301,7 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -6354,7 +6354,7 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -6368,7 +6368,7 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -6410,7 +6410,7 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -6424,7 +6424,7 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -6946,7 +6946,7 @@ exports[`DataTable groupBy toggle 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -6960,7 +6960,7 @@ exports[`DataTable groupBy toggle 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -7328,7 +7328,7 @@ exports[`DataTable groupBy toggle 3`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -7342,7 +7342,7 @@ exports[`DataTable groupBy toggle 3`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -10664,7 +10664,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hrsVnu StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hrsVnu StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -10729,7 +10729,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -10743,7 +10743,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -10860,7 +10860,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -10874,7 +10874,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -10980,7 +10980,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -10994,7 +10994,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -11051,7 +11051,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hrsVnu StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hrsVnu StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -11077,7 +11077,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -11091,7 +11091,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -11169,7 +11169,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -11183,7 +11183,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -11250,7 +11250,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -11264,7 +11264,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -11634,7 +11634,7 @@ exports[`DataTable onSort 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bYitXi StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bYitXi StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -11734,7 +11734,7 @@ exports[`DataTable onSort 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bYitXi StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bYitXi StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -11765,7 +11765,7 @@ exports[`DataTable onSort 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -11779,7 +11779,7 @@ exports[`DataTable onSort 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -11796,7 +11796,7 @@ exports[`DataTable onSort 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -11810,7 +11810,7 @@ exports[`DataTable onSort 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -11827,7 +11827,7 @@ exports[`DataTable onSort 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -11841,7 +11841,7 @@ exports[`DataTable onSort 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -12282,7 +12282,7 @@ exports[`DataTable onSort external 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bYitXi StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bYitXi StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -12362,7 +12362,7 @@ exports[`DataTable onSort external 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bYitXi StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bYitXi StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -12393,7 +12393,7 @@ exports[`DataTable onSort external 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -12407,7 +12407,7 @@ exports[`DataTable onSort external 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -12424,7 +12424,7 @@ exports[`DataTable onSort external 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -12438,7 +12438,7 @@ exports[`DataTable onSort external 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -12455,7 +12455,7 @@ exports[`DataTable onSort external 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -12469,7 +12469,7 @@ exports[`DataTable onSort external 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -18517,7 +18517,7 @@ exports[`DataTable search 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -18663,7 +18663,7 @@ exports[`DataTable search 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -19156,7 +19156,7 @@ exports[`DataTable select 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hrsVnu StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hrsVnu StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -19213,7 +19213,7 @@ exports[`DataTable select 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -19272,7 +19272,7 @@ exports[`DataTable select 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -19346,7 +19346,7 @@ exports[`DataTable select 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -27931,7 +27931,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="col"
             >
               <div
@@ -27945,7 +27945,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 HHgLC StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="col"
             >
               <div
@@ -27967,7 +27967,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -27981,7 +27981,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -27998,7 +27998,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28012,7 +28012,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28029,7 +28029,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28043,7 +28043,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28060,7 +28060,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28074,7 +28074,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28091,7 +28091,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28105,7 +28105,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28122,7 +28122,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28136,7 +28136,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28153,7 +28153,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28167,7 +28167,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28184,7 +28184,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28198,7 +28198,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28215,7 +28215,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28229,7 +28229,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28246,7 +28246,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28260,7 +28260,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28277,7 +28277,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28291,7 +28291,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28308,7 +28308,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28322,7 +28322,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28339,7 +28339,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28353,7 +28353,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28370,7 +28370,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28384,7 +28384,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28401,7 +28401,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28415,7 +28415,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28432,7 +28432,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28446,7 +28446,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28463,7 +28463,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28477,7 +28477,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28494,7 +28494,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28508,7 +28508,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28525,7 +28525,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28539,7 +28539,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28556,7 +28556,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28570,7 +28570,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28587,7 +28587,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28601,7 +28601,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28618,7 +28618,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28632,7 +28632,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28649,7 +28649,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28663,7 +28663,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28680,7 +28680,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28694,7 +28694,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28711,7 +28711,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28725,7 +28725,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28742,7 +28742,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28756,7 +28756,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28773,7 +28773,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28787,7 +28787,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28804,7 +28804,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28818,7 +28818,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28835,7 +28835,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28849,7 +28849,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28866,7 +28866,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28880,7 +28880,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28897,7 +28897,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28911,7 +28911,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28928,7 +28928,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28942,7 +28942,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28959,7 +28959,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -28973,7 +28973,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -28990,7 +28990,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -29004,7 +29004,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -29021,7 +29021,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -29035,7 +29035,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -29052,7 +29052,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -29066,7 +29066,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -29083,7 +29083,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -29097,7 +29097,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -29114,7 +29114,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -29128,7 +29128,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -29145,7 +29145,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -29159,7 +29159,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -29176,7 +29176,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -29190,7 +29190,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -29207,7 +29207,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -29221,7 +29221,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -29238,7 +29238,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -29252,7 +29252,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -29269,7 +29269,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -29283,7 +29283,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -29300,7 +29300,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -29314,7 +29314,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -29331,7 +29331,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
               scope="row"
             >
               <div
@@ -29345,7 +29345,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
             >
               <div
                 class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -35843,7 +35843,7 @@ exports[`DataTable sortable 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bYitXi StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bYitXi StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -35943,7 +35943,7 @@ exports[`DataTable sortable 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bYitXi StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bYitXi StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="col"
         >
           <div
@@ -35974,7 +35974,7 @@ exports[`DataTable sortable 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -35988,7 +35988,7 @@ exports[`DataTable sortable 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -36005,7 +36005,7 @@ exports[`DataTable sortable 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -36019,7 +36019,7 @@ exports[`DataTable sortable 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"
@@ -36036,7 +36036,7 @@ exports[`DataTable sortable 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-xrlyjm-2 hZNAex"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
           scope="row"
         >
           <div
@@ -36050,7 +36050,7 @@ exports[`DataTable sortable 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 dKSGhN"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hkXmPk StyledDataTable__StyledDataTableCell-xrlyjm-6 hEfZjq"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kUTqHn"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR moved a block of  code outside of backticks 
#### Where should the reviewer start?
styledDataTable.js
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
add an option in the extend to pass theme this was not working before
#### Any background context you want to provide?
https://github.com/grommet/grommet-theme-hpe/pull/202
When trying to add an option for the `background` to look for `theme.dark ?` this was not  working correctly
#### What are the relevant issues?
Need this to work to fix an issue in Hpe theme
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible