### PR TITLE
Include extend type in ThemeType.layer.container

### DIFF
--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -969,6 +969,7 @@ export interface ThemeType {
     };
     container?: {
       elevation?: ElevationType;
+      extend?: ExtendType;
       zIndex?: string;
     };
     extend?: ExtendType;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds the missing `extend` to `ThemeType.layer.container`

#### Where should the reviewer start?

Confirm creating a typed theme allows `theme.layer.container.extend: () => {}`

#### What testing has been done on this PR?

Linked my local fork to an existing project with a typed theme to confirm `theme.layer.container.extend: () => {}`

#### How should this be manually tested?

Confirm the types. This doesn't change any functionality.

#### What are the relevant issues?

#5515

#### Do the grommet docs need to be updated?

No, this is already in the docs https://v2.grommet.io/layer#layer.container.extend

#### Should this PR be mentioned in the release notes?

Probably not!

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible