### PR TITLE
Fix options layer bug

### DIFF
--- a/src/js/components/FocusedContainer.js
+++ b/src/js/components/FocusedContainer.js
@@ -45,15 +45,14 @@ export const FocusedContainer = ({
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      if (!hidden && trapFocus && roots && roots[0] !== null) {
+      if (!hidden && trapFocus && roots && roots[0]) {
         roots.forEach(makeNodeUnfocusable);
       }
     }, 0);
 
     return () => {
       // remove trap and restore ability to focus on the last root only
-      if (roots && roots[0] !== null)
-        makeNodeFocusable(roots[roots.length - 1]);
+      if (roots && roots[0]) makeNodeFocusable(roots[roots.length - 1]);
       clearTimeout(timer);
     };
   }, [hidden, roots, trapFocus]);

--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -52,7 +52,7 @@ const LayerContainer = forwardRef(
     const size = useContext(ResponsiveContext);
     // layerOptions was created to preserve backwards compatibility but
     // should not be supported in v3
-    const { layer: layerOptions } = useContext(OptionsContext) || {};
+    const { layer: layerOptions } = useContext(OptionsContext);
     const anchorRef = useRef();
     const containerRef = useRef();
     const layerRef = useRef();

--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -52,7 +52,7 @@ const LayerContainer = forwardRef(
     const size = useContext(ResponsiveContext);
     // layerOptions was created to preserve backwards compatibility but
     // should not be supported in v3
-    const { layer: layerOptions } = useContext(OptionsContext);
+    const { layer: layerOptions } = useContext(OptionsContext) || {};
     const anchorRef = useRef();
     const containerRef = useRef();
     const layerRef = useRef();

--- a/src/js/components/Layer/stories/MarginTop.js
+++ b/src/js/components/Layer/stories/MarginTop.js
@@ -4,8 +4,16 @@ import { Box, Grommet, Layer } from 'grommet';
 import { grommet } from 'grommet/themes';
 
 const MarginLayer = ({ margin, ...rest }) => (
-  <Grommet theme={grommet}>
+  <Grommet
+    options={{
+      layer: {
+        singleId: true,
+      },
+    }}
+    theme={grommet}
+  >
     <Layer
+      id="Margin top center"
       margin={
         margin || { left: '40px', top: '50px', right: '30px', bottom: '10px' }
       }

--- a/src/js/contexts/OptionsContext.js
+++ b/src/js/contexts/OptionsContext.js
@@ -1,3 +1,3 @@
 import React from 'react';
 
-export const OptionsContext = React.createContext(undefined);
+export const OptionsContext = React.createContext({});

--- a/src/js/contexts/RootsContext.js
+++ b/src/js/contexts/RootsContext.js
@@ -3,4 +3,4 @@ import React from 'react';
 // When toggling aria-hidden values, we only want to affect elements
 // in the DOM that come from Grommet, so we track those elements in this
 // context value. See FocusedContainer.js
-export const RootsContext = React.createContext(undefined);
+export const RootsContext = React.createContext([]);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds default values for both `OptionsContext` and `RootsContext` 
#### Where should the reviewer start?
RootsContext.js
OptionsContext.js

#### What testing has been done on this PR?
Storybook
#### How should this be manually tested?
Take out `<Grommet/>` wrapper to ensure that `Layer`  is still being rendered correctly
#### Any background context you want to provide?
There was no default value there was only `undefined` being passed through.
__This default value can be helpful for testing components in isolation without wrapping them.__
The default value needs to match what is being passed to the  `useContext` for instance `OptionsContext` would expect an object so the default value needs to be an object
#### What are the relevant issues?
closes #5516 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible