### PR TITLE
fix extra box gap for empty child

### DIFF
--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -5,6 +5,7 @@ import React, {
   useMemo,
   useState,
 } from 'react';
+import ReactDOMServer from "react-dom/server";
 
 import { ThemeContext } from 'styled-components';
 import { defaultProps } from '../../default-props';
@@ -88,7 +89,7 @@ const Box = forwardRef(
       contents = [];
       let firstIndex;
       Children.forEach(children, (child, index) => {
-        if (child) {
+        if (!isChildNull(child)) {
           if (firstIndex === undefined) {
             firstIndex = index;
           } else {
@@ -163,6 +164,10 @@ const Box = forwardRef(
     return content;
   },
 );
+
+const isChildNull = (children) => {
+  return !Boolean(ReactDOMServer.renderToStaticMarkup(children));
+};
 
 Box.displayName = 'Box';
 


### PR DESCRIPTION
Conditional rendering does not play well for Box with the `gap` property, it's applied for empty (null / <></>). This PR resolves this issue.

#### What does this PR do?
Checking if children are null with a helper, instead of relying it being truthy, which will always(?) be true if the result is coming from a render function.

#### Where should the reviewer start?

#### What testing has been done on this PR?
None

#### How should this be manually tested?
The codesandbox example

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #5523
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Not aware of breaking changes