### PR TITLE
Add options prop to Markdown index.d.ts

### DIFF
--- a/src/js/components/Markdown/index.d.ts
+++ b/src/js/components/Markdown/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 export interface MarkdownProps {
   components?: {};
+  options?: {};
 }
 
 type divProps = JSX.IntrinsicElements['div'];


### PR DESCRIPTION
#### What does this PR do?
Added options prop to index.d.ts in the Markdown component

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #5470 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no

#### Should this PR be mentioned in the release notes?
maybe (fixed Typescript compatibility for Markdown component)

#### Is this change backwards compatible or is it a breaking change?
backwards compatible