### PR TITLE
borders: Support passing arrays to allow per side border config.

### DIFF
--- a/src/js/components/Table/stories/CustomBorders.js
+++ b/src/js/components/Table/stories/CustomBorders.js
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import {
+  Box,
+  Grommet,
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHeader,
+  TableRow,
+  Text,
+} from 'grommet';
+import { grommet } from 'grommet/themes';
+import { data, columns } from './data';
+
+export const Default = () => (
+  <Grommet theme={grommet}>
+    <Box align="center" pad="large">
+      <Table caption="Default Table">
+        <TableHeader>
+          <TableRow>
+            {columns.map((c) => (
+              <TableCell
+                key={c.property}
+                scope="col"
+                border={[
+                  { size: 'medium', side: 'left' },
+                  {
+                    size: 'small',
+                    side: 'top',
+                  },
+                ]}
+                align={c.align}
+              >
+                <Text>{c.label}</Text>
+              </TableCell>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data.map((datum) => (
+            <TableRow key={datum.id}>
+              {columns.map((c) => (
+                <TableCell key={c.property} scope={c.dataScope} align={c.align}>
+                  <Text>{c.format ? c.format(datum) : datum[c.property]}</Text>
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            {columns.map((c) => (
+              <TableCell key={c.property} align={c.align}>
+                <Text>{c.footer}</Text>
+              </TableCell>
+            ))}
+          </TableRow>
+        </TableFooter>
+      </Table>
+    </Box>
+  </Grommet>
+);
+
+export default {
+  title: 'Visualizations/Table/CustomBorders',
+};

--- a/src/js/utils/border.js
+++ b/src/js/utils/border.js
@@ -41,12 +41,21 @@ export const responsiveBorderStyle = (data, theme) => {
 
 export const borderStyle = (data, responsive, theme) => {
   const styles = [];
+  if (Array.isArray(data)) {
+    data.forEach((d) => {
+      if (d) {
+        styles.push(borderStyle(d, responsive, theme));
+      }
+    });
+    return styles;
+  }
   const color = normalizeColor(data.color || 'border', theme);
   const borderSize = data.size || 'xsmall';
   const style = data.style || 'solid';
   const side = typeof data === 'string' ? data : data.side || 'all';
-  const value = `${style} ${theme.global.borderSize[borderSize] ||
-    borderSize} ${color}`;
+  const value = `${style} ${
+    theme.global.borderSize[borderSize] || borderSize
+  } ${color}`;
   const responsiveStyle = responsive && responsiveBorderStyle(data, theme);
   const breakpoint =
     responsiveStyle &&


### PR DESCRIPTION
BorderType suggests that it supports arrays to allow configuring each
side of the border independently of the other sides, however, when
actually trying to use an array of border objects, we find that they are
not respected. This commit adds support for arrays by recursively
merging each border entry and returns that. Added a storybook entry to
demonstrate this.

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

#### Where should the reviewer start?

Check the storybook for "CustomBorders"

#### What testing has been done on this PR?

Storybook + my site.

#### How should this be manually tested?

Storybook

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

With this change, the grommet docs should now be more correct :)

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
It is not breaking as grommet suggests that this functionality is already supported.
