### PR TITLE
Upgraded grommet-icons to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "styled-components": ">= 5.1"
   },
   "dependencies": {
-    "grommet-icons": "^4.6.0",
+    "grommet-icons": "^4.6.1",
     "hoist-non-react-statics": "^3.2.0",
     "markdown-to-jsx": "^7.1.3",
     "prop-types": "^15.7.2"

--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -1663,7 +1663,7 @@ exports[`Accordion change active index 2`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path
@@ -1707,7 +1707,7 @@ exports[`Accordion change active index 2`] = `
           >
             <svg
               aria-label="FormUp"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path
@@ -2122,7 +2122,7 @@ exports[`Accordion change to second Panel 2`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path
@@ -2626,7 +2626,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path
@@ -4243,7 +4243,7 @@ exports[`Accordion multiple panels 2`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path
@@ -4491,7 +4491,7 @@ exports[`Accordion multiple panels 3`] = `
           >
             <svg
               aria-label="FormUp"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path
@@ -4549,7 +4549,7 @@ exports[`Accordion multiple panels 4`] = `
           >
             <svg
               aria-label="FormUp"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path
@@ -4795,7 +4795,7 @@ exports[`Accordion multiple panels 5`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path
@@ -5245,7 +5245,7 @@ exports[`Accordion set on hover 2`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path
@@ -5294,7 +5294,7 @@ exports[`Accordion set on hover 2`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path
@@ -5355,7 +5355,7 @@ exports[`Accordion set on hover 3`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path
@@ -5404,7 +5404,7 @@ exports[`Accordion set on hover 3`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path
@@ -5465,7 +5465,7 @@ exports[`Accordion set on hover 4`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path
@@ -5514,7 +5514,7 @@ exports[`Accordion set on hover 4`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path
@@ -5575,7 +5575,7 @@ exports[`Accordion set on hover 5`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path
@@ -5624,7 +5624,7 @@ exports[`Accordion set on hover 5`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path
@@ -6699,7 +6699,7 @@ exports[`Accordion wrapped panel 2`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-ofa7kd-0 jLSzwp"
+              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
               viewBox="0 0 24 24"
             >
               <path

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -2702,7 +2702,7 @@ exports[`Button kind mouseOver and mouseOut events 2`] = `
     >
       <svg
         aria-label="Add"
-        class="StyledIcon-ofa7kd-0 htxtFB"
+        class="StyledIcon-sc-ofa7kd-0 fTLzXM"
         viewBox="0 0 24 24"
       >
         <path

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -1189,7 +1189,7 @@ exports[`Calendar change months 2`] = `
           >
             <svg
               aria-label="Previous"
-              class="StyledIcon-ofa7kd-0 hVBrNB"
+              class="StyledIcon-sc-ofa7kd-0 tiAWk"
               viewBox="0 0 24 24"
             >
               <path
@@ -1207,7 +1207,7 @@ exports[`Calendar change months 2`] = `
           >
             <svg
               aria-label="Next"
-              class="StyledIcon-ofa7kd-0 hVBrNB"
+              class="StyledIcon-sc-ofa7kd-0 tiAWk"
               viewBox="0 0 24 24"
             >
               <path
@@ -16003,7 +16003,7 @@ exports[`Calendar select date 2`] = `
           >
             <svg
               aria-label="Previous"
-              class="StyledIcon-ofa7kd-0 hVBrNB"
+              class="StyledIcon-sc-ofa7kd-0 tiAWk"
               viewBox="0 0 24 24"
             >
               <path
@@ -16021,7 +16021,7 @@ exports[`Calendar select date 2`] = `
           >
             <svg
               aria-label="Next"
-              class="StyledIcon-ofa7kd-0 hVBrNB"
+              class="StyledIcon-sc-ofa7kd-0 tiAWk"
               viewBox="0 0 24 24"
             >
               <path
@@ -18021,7 +18021,7 @@ exports[`Calendar select dates 2`] = `
           >
             <svg
               aria-label="Previous"
-              class="StyledIcon-ofa7kd-0 hVBrNB"
+              class="StyledIcon-sc-ofa7kd-0 tiAWk"
               viewBox="0 0 24 24"
             >
               <path
@@ -18039,7 +18039,7 @@ exports[`Calendar select dates 2`] = `
           >
             <svg
               aria-label="Next"
-              class="StyledIcon-ofa7kd-0 hVBrNB"
+              class="StyledIcon-sc-ofa7kd-0 tiAWk"
               viewBox="0 0 24 24"
             >
               <path

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -1607,7 +1607,7 @@ exports[`Carousel navigate 2`] = `
         >
           <svg
             aria-label="Previous"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -1631,7 +1631,7 @@ exports[`Carousel navigate 2`] = `
             >
               <svg
                 aria-label="Subtract"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -1649,7 +1649,7 @@ exports[`Carousel navigate 2`] = `
             >
               <svg
                 aria-label="Subtract"
-                class="StyledIcon-ofa7kd-0 jLSzwp"
+                class="StyledIcon-sc-ofa7kd-0 bsCHQs"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -1669,7 +1669,7 @@ exports[`Carousel navigate 2`] = `
         >
           <svg
             aria-label="Next"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -1742,7 +1742,7 @@ exports[`Carousel navigate 3`] = `
         >
           <svg
             aria-label="Previous"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -1766,7 +1766,7 @@ exports[`Carousel navigate 3`] = `
             >
               <svg
                 aria-label="Subtract"
-                class="StyledIcon-ofa7kd-0 jLSzwp"
+                class="StyledIcon-sc-ofa7kd-0 bsCHQs"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -1784,7 +1784,7 @@ exports[`Carousel navigate 3`] = `
             >
               <svg
                 aria-label="Subtract"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -1803,7 +1803,7 @@ exports[`Carousel navigate 3`] = `
         >
           <svg
             aria-label="Next"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -2391,7 +2391,7 @@ exports[`Carousel play 2`] = `
         >
           <svg
             aria-label="Previous"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -2415,7 +2415,7 @@ exports[`Carousel play 2`] = `
             >
               <svg
                 aria-label="Subtract"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -2433,7 +2433,7 @@ exports[`Carousel play 2`] = `
             >
               <svg
                 aria-label="Subtract"
-                class="StyledIcon-ofa7kd-0 jLSzwp"
+                class="StyledIcon-sc-ofa7kd-0 bsCHQs"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -2453,7 +2453,7 @@ exports[`Carousel play 2`] = `
         >
           <svg
             aria-label="Next"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -4978,7 +4978,7 @@ exports[`DataTable groupBy 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-ofa7kd-0 duBpAF"
+                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -5045,7 +5045,7 @@ exports[`DataTable groupBy 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-ofa7kd-0 duBpAF"
+                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -5101,7 +5101,7 @@ exports[`DataTable groupBy 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-ofa7kd-0 duBpAF"
+                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -6272,7 +6272,7 @@ exports[`DataTable groupBy property 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-ofa7kd-0 duBpAF"
+                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -6339,7 +6339,7 @@ exports[`DataTable groupBy property 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-ofa7kd-0 duBpAF"
+                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -6395,7 +6395,7 @@ exports[`DataTable groupBy property 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-ofa7kd-0 duBpAF"
+                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -10649,7 +10649,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-ofa7kd-0 duBpAF"
+                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -10781,7 +10781,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-ofa7kd-0 duBpAF"
+                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -10901,7 +10901,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-ofa7kd-0 duBpAF"
+                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -11036,7 +11036,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-ofa7kd-0 duBpAF"
+                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -11129,7 +11129,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-ofa7kd-0 duBpAF"
+                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -11210,7 +11210,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-ofa7kd-0 duBpAF"
+                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -29384,7 +29384,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-ofa7kd-0 jehgOx"
+                class="StyledIcon-sc-ofa7kd-0 iZdQSA"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -29440,7 +29440,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
@@ -1664,7 +1664,7 @@ exports[`DateInput controlled format inline 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-ofa7kd-0 hVBrNB"
+          class="StyledIcon-sc-ofa7kd-0 tiAWk"
           viewBox="0 0 24 24"
         >
           <path
@@ -1712,7 +1712,7 @@ exports[`DateInput controlled format inline 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -1730,7 +1730,7 @@ exports[`DateInput controlled format inline 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -10381,7 +10381,7 @@ exports[`DateInput select format 2`] = `
     >
       <svg
         aria-label="Calendar"
-        class="StyledIcon-ofa7kd-0 hVBrNB"
+        class="StyledIcon-sc-ofa7kd-0 tiAWk"
         viewBox="0 0 24 24"
       >
         <path
@@ -12959,7 +12959,7 @@ exports[`DateInput select format inline 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-ofa7kd-0 hVBrNB"
+          class="StyledIcon-sc-ofa7kd-0 tiAWk"
           viewBox="0 0 24 24"
         >
           <path
@@ -13007,7 +13007,7 @@ exports[`DateInput select format inline 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -13025,7 +13025,7 @@ exports[`DateInput select format inline 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -15127,7 +15127,7 @@ exports[`DateInput select format inline range 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-ofa7kd-0 hVBrNB"
+          class="StyledIcon-sc-ofa7kd-0 tiAWk"
           viewBox="0 0 24 24"
         >
           <path
@@ -15175,7 +15175,7 @@ exports[`DateInput select format inline range 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -15193,7 +15193,7 @@ exports[`DateInput select format inline range 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -18455,7 +18455,7 @@ exports[`DateInput type format inline 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-ofa7kd-0 hVBrNB"
+          class="StyledIcon-sc-ofa7kd-0 tiAWk"
           viewBox="0 0 24 24"
         >
           <path
@@ -18503,7 +18503,7 @@ exports[`DateInput type format inline 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -18521,7 +18521,7 @@ exports[`DateInput type format inline 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -21918,7 +21918,7 @@ exports[`DateInput type format inline range 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-ofa7kd-0 hVBrNB"
+          class="StyledIcon-sc-ofa7kd-0 tiAWk"
           viewBox="0 0 24 24"
         >
           <path
@@ -21966,7 +21966,7 @@ exports[`DateInput type format inline range 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -21984,7 +21984,7 @@ exports[`DateInput type format inline range 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -24086,7 +24086,7 @@ exports[`DateInput type format inline range partial 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-ofa7kd-0 hVBrNB"
+          class="StyledIcon-sc-ofa7kd-0 tiAWk"
           viewBox="0 0 24 24"
         >
           <path
@@ -24134,7 +24134,7 @@ exports[`DateInput type format inline range partial 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -24152,7 +24152,7 @@ exports[`DateInput type format inline range partial 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -24941,7 +24941,7 @@ exports[`DateInput type format inline range partial 3`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-ofa7kd-0 hVBrNB"
+          class="StyledIcon-sc-ofa7kd-0 tiAWk"
           viewBox="0 0 24 24"
         >
           <path
@@ -24989,7 +24989,7 @@ exports[`DateInput type format inline range partial 3`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -25007,7 +25007,7 @@ exports[`DateInput type format inline range partial 3`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -27091,7 +27091,7 @@ exports[`DateInput type format inline short 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-ofa7kd-0 hVBrNB"
+          class="StyledIcon-sc-ofa7kd-0 tiAWk"
           viewBox="0 0 24 24"
         >
           <path
@@ -27139,7 +27139,7 @@ exports[`DateInput type format inline short 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -27157,7 +27157,7 @@ exports[`DateInput type format inline short 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -3385,7 +3385,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
             >
               <svg
                 aria-label="FormDown"
-                class="StyledIcon-ofa7kd-0 jLSzwp"
+                class="StyledIcon-sc-ofa7kd-0 bsCHQs"
                 viewBox="0 0 24 24"
               >
                 <path

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -9522,7 +9522,7 @@ exports[`List events should render new data when page changes 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-ofa7kd-0 jehgOx"
+                class="StyledIcon-sc-ofa7kd-0 iZdQSA"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -9578,7 +9578,7 @@ exports[`List events should render new data when page changes 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-ofa7kd-0 hVBrNB"
+                class="StyledIcon-sc-ofa7kd-0 tiAWk"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -12480,7 +12480,7 @@ exports[`List onOrder Keyboard move down 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -12500,7 +12500,7 @@ exports[`List onOrder Keyboard move down 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -12549,7 +12549,7 @@ exports[`List onOrder Keyboard move down 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -12570,7 +12570,7 @@ exports[`List onOrder Keyboard move down 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -12634,7 +12634,7 @@ exports[`List onOrder Keyboard move down 3`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -12654,7 +12654,7 @@ exports[`List onOrder Keyboard move down 3`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -12703,7 +12703,7 @@ exports[`List onOrder Keyboard move down 3`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -12724,7 +12724,7 @@ exports[`List onOrder Keyboard move down 3`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -13250,7 +13250,7 @@ exports[`List onOrder Keyboard move up 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -13270,7 +13270,7 @@ exports[`List onOrder Keyboard move up 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -13319,7 +13319,7 @@ exports[`List onOrder Keyboard move up 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -13340,7 +13340,7 @@ exports[`List onOrder Keyboard move up 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -13404,7 +13404,7 @@ exports[`List onOrder Keyboard move up 3`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -13424,7 +13424,7 @@ exports[`List onOrder Keyboard move up 3`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -13473,7 +13473,7 @@ exports[`List onOrder Keyboard move up 3`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -13494,7 +13494,7 @@ exports[`List onOrder Keyboard move up 3`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -14019,7 +14019,7 @@ exports[`List onOrder Mouse move down 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -14039,7 +14039,7 @@ exports[`List onOrder Mouse move down 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -14088,7 +14088,7 @@ exports[`List onOrder Mouse move down 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path
@@ -14109,7 +14109,7 @@ exports[`List onOrder Mouse move down 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-ofa7kd-0 hVBrNB"
+            class="StyledIcon-sc-ofa7kd-0 tiAWk"
             viewBox="0 0 24 24"
           >
             <path

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -3033,7 +3033,7 @@ exports[`Menu open and close on click 2`] = `
       />
       <svg
         aria-label="FormDown"
-        class="StyledIcon-ofa7kd-0 jLSzwp"
+        class="StyledIcon-sc-ofa7kd-0 bsCHQs"
         viewBox="0 0 24 24"
       >
         <path

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
@@ -7194,7 +7194,7 @@ exports[`Pagination should display next page of results when "next" is
           >
             <svg
               aria-label="Previous"
-              class="StyledIcon-ofa7kd-0 jehgOx"
+              class="StyledIcon-sc-ofa7kd-0 iZdQSA"
               viewBox="0 0 24 24"
             >
               <path
@@ -7316,7 +7316,7 @@ exports[`Pagination should display next page of results when "next" is
           >
             <svg
               aria-label="Next"
-              class="StyledIcon-ofa7kd-0 jehgOx"
+              class="StyledIcon-sc-ofa7kd-0 iZdQSA"
               viewBox="0 0 24 24"
             >
               <path
@@ -8337,7 +8337,7 @@ exports[`Pagination should display previous page of results when "previous" is
           >
             <svg
               aria-label="Previous"
-              class="StyledIcon-ofa7kd-0 jehgOx"
+              class="StyledIcon-sc-ofa7kd-0 iZdQSA"
               viewBox="0 0 24 24"
             >
               <path
@@ -8459,7 +8459,7 @@ exports[`Pagination should display previous page of results when "previous" is
           >
             <svg
               aria-label="Next"
-              class="StyledIcon-ofa7kd-0 jehgOx"
+              class="StyledIcon-sc-ofa7kd-0 iZdQSA"
               viewBox="0 0 24 24"
             >
               <path

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -2746,7 +2746,7 @@ exports[`Select complex options and children 2`] = `
     >
       <svg
         aria-label="FormDown"
-        class="StyledIcon-ofa7kd-0 jLSzwp"
+        class="StyledIcon-sc-ofa7kd-0 bsCHQs"
         viewBox="0 0 24 24"
       >
         <path
@@ -4607,7 +4607,7 @@ exports[`Select disabled 2`] = `
     >
       <svg
         aria-label="FormDown"
-        class="StyledIcon-ofa7kd-0 jLSzwp"
+        class="StyledIcon-sc-ofa7kd-0 bsCHQs"
         viewBox="0 0 24 24"
       >
         <path
@@ -9243,7 +9243,7 @@ exports[`Select prop: onOpen 2`] = `
     >
       <svg
         aria-label="FormDown"
-        class="StyledIcon-ofa7kd-0 jLSzwp"
+        class="StyledIcon-sc-ofa7kd-0 bsCHQs"
         viewBox="0 0 24 24"
       >
         <path
@@ -14769,7 +14769,7 @@ exports[`Select select option by typing should not break if caller passes JSX 2`
       >
         <svg
           aria-label="FormDown"
-          class="StyledIcon-ofa7kd-0 jLSzwp"
+          class="StyledIcon-sc-ofa7kd-0 bsCHQs"
           viewBox="0 0 24 24"
         >
           <path

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -3178,7 +3178,7 @@ exports[`Select Controlled multiple values 2`] = `
     >
       <svg
         aria-label="FormDown"
-        class="StyledIcon-ofa7kd-0 jLSzwp"
+        class="StyledIcon-sc-ofa7kd-0 bsCHQs"
         viewBox="0 0 24 24"
       >
         <path

--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -28,7 +28,7 @@ export interface SelectProps {
   dropTarget?: object;
   dropProps?: DropProps;
   focusIndicator?: boolean;
-  icon?: boolean | ((...args: any[]) => any) | React.ReactNode;
+  icon?: boolean | ((...args: any[]) => any) | React.ReactNode | React.FC;
   id?: string;
   labelKey?: string | ((...args: any[]) => any);
   margin?: MarginType;

--- a/src/js/components/Select/propTypes.js
+++ b/src/js/components/Select/propTypes.js
@@ -50,7 +50,12 @@ if (process.env.NODE_ENV !== 'production') {
     dropTarget: PropTypes.object,
     dropProps: PropTypes.object,
     focusIndicator: PropTypes.bool,
-    icon: PropTypes.oneOfType([PropTypes.bool, PropTypes.func, PropTypes.node]),
+    icon: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.func,
+      PropTypes.node,
+      PropTypes.elementType,
+    ]),
     labelKey: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     messages: PropTypes.shape({
       multiple: PropTypes.string,

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -1612,7 +1612,7 @@ exports[`Video Play and Pause event handlers 2`] = `
             />
             <svg
               aria-label="Actions"
-              class="StyledIcon-ofa7kd-0 htxtFB"
+              class="StyledIcon-sc-ofa7kd-0 fTLzXM"
               viewBox="0 0 24 24"
             >
               <path
@@ -5544,7 +5544,7 @@ exports[`Video mouse events handlers of controls 2`] = `
         >
           <svg
             aria-label="play"
-            class="StyledIcon-ofa7kd-0 htxtFB"
+            class="StyledIcon-sc-ofa7kd-0 fTLzXM"
             viewBox="0 0 24 24"
           >
             <path
@@ -5619,7 +5619,7 @@ exports[`Video mouse events handlers of controls 2`] = `
             />
             <svg
               aria-label="Actions"
-              class="StyledIcon-ofa7kd-0 htxtFB"
+              class="StyledIcon-sc-ofa7kd-0 fTLzXM"
               viewBox="0 0 24 24"
             >
               <path
@@ -5665,7 +5665,7 @@ exports[`Video mouse events handlers of controls 3`] = `
         >
           <svg
             aria-label="play"
-            class="StyledIcon-ofa7kd-0 htxtFB"
+            class="StyledIcon-sc-ofa7kd-0 fTLzXM"
             viewBox="0 0 24 24"
           >
             <path
@@ -5740,7 +5740,7 @@ exports[`Video mouse events handlers of controls 3`] = `
             />
             <svg
               aria-label="Actions"
-              class="StyledIcon-ofa7kd-0 htxtFB"
+              class="StyledIcon-sc-ofa7kd-0 fTLzXM"
               viewBox="0 0 24 24"
             >
               <path
@@ -7726,7 +7726,7 @@ exports[`Video scrubber 2`] = `
         >
           <svg
             aria-label="play"
-            class="StyledIcon-ofa7kd-0 htxtFB"
+            class="StyledIcon-sc-ofa7kd-0 fTLzXM"
             viewBox="0 0 24 24"
           >
             <path
@@ -7801,7 +7801,7 @@ exports[`Video scrubber 2`] = `
             />
             <svg
               aria-label="Actions"
-              class="StyledIcon-ofa7kd-0 htxtFB"
+              class="StyledIcon-sc-ofa7kd-0 fTLzXM"
               viewBox="0 0 24 24"
             >
               <path

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -715,8 +715,14 @@ Object {
             },
           },
           "icons": Object {
-            "collapse": [Function],
-            "expand": [Function],
+            "collapse": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
+            "expand": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
           },
           "panel": Object {},
         },
@@ -834,11 +840,23 @@ Object {
             "level": "4",
           },
           "icons": Object {
-            "next": [Function],
-            "previous": [Function],
+            "next": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
+            "previous": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
             "small": Object {
-              "next": [Function],
-              "previous": [Function],
+              "next": Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "render": [Function],
+              },
+              "previous": Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "render": [Function],
+              },
             },
           },
           "large": Object {
@@ -877,9 +895,18 @@ Object {
             "icons": Object {},
           },
           "icons": Object {
-            "current": [Function],
-            "next": [Function],
-            "previous": [Function],
+            "current": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
+            "next": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
+            "previous": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
           },
         },
         "chart": Object {
@@ -1028,10 +1055,22 @@ Object {
             },
           },
           "icons": Object {
-            "ascending": [Function],
-            "contract": [Function],
-            "descending": [Function],
-            "expand": [Function],
+            "ascending": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
+            "contract": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
+            "descending": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
+            "expand": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
           },
           "pinned": Object {
             "footer": Object {
@@ -1078,7 +1117,10 @@ Object {
             },
           },
           "icons": Object {
-            "remove": [Function],
+            "remove": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
           },
           "label": Object {
             "margin": "small",
@@ -1574,8 +1616,14 @@ Object {
             "gap": "xsmall",
           },
           "icons": Object {
-            "down": [Function],
-            "up": [Function],
+            "down": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
+            "up": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
           },
           "item": Object {
             "border": "horizontal",
@@ -1594,7 +1642,10 @@ Object {
             },
           },
           "icons": Object {
-            "down": [Function],
+            "down": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
           },
         },
         "meter": Object {
@@ -1676,8 +1727,14 @@ Object {
             "pad": "none",
           },
           "icons": Object {
-            "next": [Function],
-            "previous": [Function],
+            "next": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
+            "previous": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
           },
         },
         "paragraph": Object {
@@ -1762,7 +1819,10 @@ Object {
           "container": Object {},
           "control": Object {},
           "icons": Object {
-            "down": [Function],
+            "down": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
             "margin": Object {
               "horizontal": "small",
             },
@@ -1962,13 +2022,34 @@ Object {
             "background": "rgba(0, 0, 0, 0.7)",
           },
           "icons": Object {
-            "closedCaption": [Function],
-            "configure": [Function],
-            "fullScreen": [Function],
-            "pause": [Function],
-            "play": [Function],
-            "reduceVolume": [Function],
-            "volume": [Function],
+            "closedCaption": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
+            "configure": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
+            "fullScreen": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
+            "pause": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
+            "play": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
+            "reduceVolume": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
+            "volume": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "render": [Function],
+            },
           },
           "scrubber": Object {
             "color": "light-4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6947,10 +6947,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
-grommet-icons@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.6.0.tgz#f5933a4cc23a4c70d2378f12391643e49a542e5b"
-  integrity sha512-ytnFHPvCEDv7dUZddXUDxG/r/2Mbiq1MDy+kbmCelLXZ09B2zyC2N9KQPKHsm/XbJV6LnOnwchz2pobdz0OITQ==
+grommet-icons@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.6.1.tgz#5fc8116160c8626f0ff93d8339acf632be26ddf5"
+  integrity sha512-DimRmfF5mJHkWjBcx7mkJ9zbdmWKvMpDQR0oVZ4HCcGmyEPndonlnypjXAlec8awTwjaXKdiZfgUiWyMtdViIg==
   dependencies:
     grommet-styles "^0.2.0"
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Upgrades `grommet-icons` to `4.6.1` which includes a fix to forward refs to `<StyledIcon />`.

#### Where should the reviewer start?

- `package.json`

#### What testing has been done on this PR?

- Commit test suite
- Manual review of snapshot changes

#### How should this be manually tested?

#### Any background context you want to provide?

- Using grommet-icon v4.6.1 will close https://github.com/grommet/grommet/issues/5256.
- Snapshot changes result from SVGs using updated `<StyledIcon />` resulting in new classNames.
- Valid Select `icon` PropTypes needed to be extended to accept React elementType.

#### What are the relevant issues?

Closes https://github.com/grommet/grommet/issues/5256

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

Yes. "Fixed bug when using a Grommet icon as a direct child of Tip."

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.