### PR TITLE
Fix/anchor gap

### DIFF
--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.js.snap
@@ -1663,7 +1663,7 @@ exports[`Accordion change active index 2`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path
@@ -1707,7 +1707,7 @@ exports[`Accordion change active index 2`] = `
           >
             <svg
               aria-label="FormUp"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path
@@ -2122,7 +2122,7 @@ exports[`Accordion change to second Panel 2`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path
@@ -2626,7 +2626,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path
@@ -4243,7 +4243,7 @@ exports[`Accordion multiple panels 2`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path
@@ -4491,7 +4491,7 @@ exports[`Accordion multiple panels 3`] = `
           >
             <svg
               aria-label="FormUp"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path
@@ -4549,7 +4549,7 @@ exports[`Accordion multiple panels 4`] = `
           >
             <svg
               aria-label="FormUp"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path
@@ -4795,7 +4795,7 @@ exports[`Accordion multiple panels 5`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path
@@ -5245,7 +5245,7 @@ exports[`Accordion set on hover 2`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path
@@ -5294,7 +5294,7 @@ exports[`Accordion set on hover 2`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path
@@ -5355,7 +5355,7 @@ exports[`Accordion set on hover 3`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path
@@ -5404,7 +5404,7 @@ exports[`Accordion set on hover 3`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path
@@ -5465,7 +5465,7 @@ exports[`Accordion set on hover 4`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path
@@ -5514,7 +5514,7 @@ exports[`Accordion set on hover 4`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path
@@ -5575,7 +5575,7 @@ exports[`Accordion set on hover 5`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path
@@ -5624,7 +5624,7 @@ exports[`Accordion set on hover 5`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path
@@ -6699,7 +6699,7 @@ exports[`Accordion wrapped panel 2`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+              class="StyledIcon-ofa7kd-0 jLSzwp"
               viewBox="0 0 24 24"
             >
               <path

--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -24,6 +24,7 @@ const Anchor = forwardRef(
       children,
       color,
       disabled,
+      gap = 'small',
       href,
       icon,
       label,
@@ -83,7 +84,7 @@ const Anchor = forwardRef(
             as="span"
             direction="row"
             align="center"
-            gap="small"
+            gap={gap}
             responsive={false}
             style={{ display: 'inline-flex' }}
           >

--- a/src/js/components/Anchor/__tests__/Anchor-test.js
+++ b/src/js/components/Anchor/__tests__/Anchor-test.js
@@ -190,6 +190,18 @@ describe('Anchor', () => {
     expect(container).toMatchSnapshot();
   });
 
+  test('gap renders', () => {
+    const { container } = render(
+      <Grommet>
+        <Anchor icon={<svg />} label="Small Gap" href="#" gap="small" />
+        <Anchor icon={<svg />} label="Medium Gap" href="#" gap="medium" />
+        <Anchor icon={<svg />} label="Large Gap" href="#" gap="large" />
+        <Anchor icon={<svg />} label="5px Gap" href="#" gap="5px" />
+      </Grommet>,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
   test('renders a11yTitle and aria-label', () => {
     const { container, getByLabelText } = render(
       <Grommet>

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.js.snap
@@ -133,6 +133,167 @@ exports[`Anchor focus renders 1`] = `
 </div>
 `;
 
+exports[`Anchor gap renders 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c3 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 12px;
+}
+
+.c4 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 24px;
+}
+
+.c5 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 48px;
+}
+
+.c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 5px;
+}
+
+.c1 {
+  box-sizing: border-box;
+  font-size: inherit;
+  line-height: inherit;
+  color: #7D4CDB;
+  font-weight: 600;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.c1:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+<div>
+  <div
+    class="c0"
+  >
+    <a
+      class="c1"
+      href="#"
+    >
+      <span
+        class="c2"
+        style="display: inline-flex;"
+      >
+        <svg
+          color="#7D4CDB"
+        />
+        <span
+          class="c3"
+        />
+        Small Gap
+      </span>
+    </a>
+    <a
+      class="c1"
+      href="#"
+    >
+      <span
+        class="c2"
+        style="display: inline-flex;"
+      >
+        <svg
+          color="#7D4CDB"
+        />
+        <span
+          class="c4"
+        />
+        Medium Gap
+      </span>
+    </a>
+    <a
+      class="c1"
+      href="#"
+    >
+      <span
+        class="c2"
+        style="display: inline-flex;"
+      >
+        <svg
+          color="#7D4CDB"
+        />
+        <span
+          class="c5"
+        />
+        Large Gap
+      </span>
+    </a>
+    <a
+      class="c1"
+      href="#"
+    >
+      <span
+        class="c2"
+        style="display: inline-flex;"
+      >
+        <svg
+          color="#7D4CDB"
+        />
+        <span
+          class="c6"
+        />
+        5px Gap
+      </span>
+    </a>
+  </div>
+</div>
+`;
+
 exports[`Anchor icon label renders 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -3,6 +3,7 @@ import {
   A11yTitleType,
   AlignSelfType,
   ColorType,
+  GapType,
   GridAreaType,
   MarginType,
   Omit,
@@ -15,6 +16,7 @@ export interface AnchorProps {
   as?: PolymorphicType;
   color?: ColorType;
   disabled?: boolean;
+  gap?: GapType;
   gridArea?: GridAreaType;
   href?: string;
   icon?: JSX.Element;

--- a/src/js/components/Anchor/propTypes.js
+++ b/src/js/components/Anchor/propTypes.js
@@ -9,6 +9,18 @@ if (process.env.NODE_ENV !== 'production') {
     as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     color: colorPropType,
     disabled: PropTypes.bool,
+    gap: PropTypes.oneOfType([
+      PropTypes.oneOf([
+        'none',
+        'xxsmall',
+        'xsmall',
+        'small',
+        'medium',
+        'large',
+        'xlarge',
+      ]),
+      PropTypes.string,
+    ]),
     href: PropTypes.string,
     icon: PropTypes.element,
     label: PropTypes.node,

--- a/src/js/components/Anchor/stories/Gap.js
+++ b/src/js/components/Anchor/stories/Gap.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { Upload } from 'grommet-icons';
+
+import { Anchor, Box, Grommet } from 'grommet';
+import { grommet } from 'grommet/themes';
+
+const GapAnchor = () => (
+  <Grommet theme={grommet}>
+    <Box pad="medium" gap="medium">
+      <Anchor icon={<Upload />} label="Small Gap" href="#" gap="small" />
+      <Anchor icon={<Upload />} label="Medium Gap" href="#" gap="medium" />
+      <Anchor icon={<Upload />} label="Large Gap" href="#" gap="large" />
+      <Anchor icon={<Upload />} label="5px Gap" href="#" gap="5px" />
+    </Box>
+  </Grommet>
+);
+
+export const Gap = () => <GapAnchor />;
+
+export default {
+  title: 'Controls/Anchor/Gap',
+};

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -2702,7 +2702,7 @@ exports[`Button kind mouseOver and mouseOut events 2`] = `
     >
       <svg
         aria-label="Add"
-        class="StyledIcon-sc-ofa7kd-0 fTLzXM"
+        class="StyledIcon-ofa7kd-0 htxtFB"
         viewBox="0 0 24 24"
       >
         <path

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.js.snap
@@ -1189,7 +1189,7 @@ exports[`Calendar change months 2`] = `
           >
             <svg
               aria-label="Previous"
-              class="StyledIcon-sc-ofa7kd-0 tiAWk"
+              class="StyledIcon-ofa7kd-0 hVBrNB"
               viewBox="0 0 24 24"
             >
               <path
@@ -1207,7 +1207,7 @@ exports[`Calendar change months 2`] = `
           >
             <svg
               aria-label="Next"
-              class="StyledIcon-sc-ofa7kd-0 tiAWk"
+              class="StyledIcon-ofa7kd-0 hVBrNB"
               viewBox="0 0 24 24"
             >
               <path
@@ -16003,7 +16003,7 @@ exports[`Calendar select date 2`] = `
           >
             <svg
               aria-label="Previous"
-              class="StyledIcon-sc-ofa7kd-0 tiAWk"
+              class="StyledIcon-ofa7kd-0 hVBrNB"
               viewBox="0 0 24 24"
             >
               <path
@@ -16021,7 +16021,7 @@ exports[`Calendar select date 2`] = `
           >
             <svg
               aria-label="Next"
-              class="StyledIcon-sc-ofa7kd-0 tiAWk"
+              class="StyledIcon-ofa7kd-0 hVBrNB"
               viewBox="0 0 24 24"
             >
               <path
@@ -18021,7 +18021,7 @@ exports[`Calendar select dates 2`] = `
           >
             <svg
               aria-label="Previous"
-              class="StyledIcon-sc-ofa7kd-0 tiAWk"
+              class="StyledIcon-ofa7kd-0 hVBrNB"
               viewBox="0 0 24 24"
             >
               <path
@@ -18039,7 +18039,7 @@ exports[`Calendar select dates 2`] = `
           >
             <svg
               aria-label="Next"
-              class="StyledIcon-sc-ofa7kd-0 tiAWk"
+              class="StyledIcon-ofa7kd-0 hVBrNB"
               viewBox="0 0 24 24"
             >
               <path

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -1607,7 +1607,7 @@ exports[`Carousel navigate 2`] = `
         >
           <svg
             aria-label="Previous"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -1631,7 +1631,7 @@ exports[`Carousel navigate 2`] = `
             >
               <svg
                 aria-label="Subtract"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -1649,7 +1649,7 @@ exports[`Carousel navigate 2`] = `
             >
               <svg
                 aria-label="Subtract"
-                class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+                class="StyledIcon-ofa7kd-0 jLSzwp"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -1669,7 +1669,7 @@ exports[`Carousel navigate 2`] = `
         >
           <svg
             aria-label="Next"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -1742,7 +1742,7 @@ exports[`Carousel navigate 3`] = `
         >
           <svg
             aria-label="Previous"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -1766,7 +1766,7 @@ exports[`Carousel navigate 3`] = `
             >
               <svg
                 aria-label="Subtract"
-                class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+                class="StyledIcon-ofa7kd-0 jLSzwp"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -1784,7 +1784,7 @@ exports[`Carousel navigate 3`] = `
             >
               <svg
                 aria-label="Subtract"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -1803,7 +1803,7 @@ exports[`Carousel navigate 3`] = `
         >
           <svg
             aria-label="Next"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -2391,7 +2391,7 @@ exports[`Carousel play 2`] = `
         >
           <svg
             aria-label="Previous"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -2415,7 +2415,7 @@ exports[`Carousel play 2`] = `
             >
               <svg
                 aria-label="Subtract"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -2433,7 +2433,7 @@ exports[`Carousel play 2`] = `
             >
               <svg
                 aria-label="Subtract"
-                class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+                class="StyledIcon-ofa7kd-0 jLSzwp"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -2453,7 +2453,7 @@ exports[`Carousel play 2`] = `
         >
           <svg
             aria-label="Next"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -4978,7 +4978,7 @@ exports[`DataTable groupBy 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
+                  class="StyledIcon-ofa7kd-0 duBpAF"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -5045,7 +5045,7 @@ exports[`DataTable groupBy 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
+                  class="StyledIcon-ofa7kd-0 duBpAF"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -5101,7 +5101,7 @@ exports[`DataTable groupBy 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
+                  class="StyledIcon-ofa7kd-0 duBpAF"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -6272,7 +6272,7 @@ exports[`DataTable groupBy property 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
+                  class="StyledIcon-ofa7kd-0 duBpAF"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -6339,7 +6339,7 @@ exports[`DataTable groupBy property 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
+                  class="StyledIcon-ofa7kd-0 duBpAF"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -6395,7 +6395,7 @@ exports[`DataTable groupBy property 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
+                  class="StyledIcon-ofa7kd-0 duBpAF"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -10649,7 +10649,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
+                  class="StyledIcon-ofa7kd-0 duBpAF"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -10781,7 +10781,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
+                  class="StyledIcon-ofa7kd-0 duBpAF"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -10901,7 +10901,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
+                  class="StyledIcon-ofa7kd-0 duBpAF"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -11036,7 +11036,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
+                  class="StyledIcon-ofa7kd-0 duBpAF"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -11129,7 +11129,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
+                  class="StyledIcon-ofa7kd-0 duBpAF"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -11210,7 +11210,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 jgaqVE"
+                  class="StyledIcon-ofa7kd-0 duBpAF"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -29384,7 +29384,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 iZdQSA"
+                class="StyledIcon-ofa7kd-0 jehgOx"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -29440,7 +29440,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.js.snap
@@ -1664,7 +1664,7 @@ exports[`DateInput controlled format inline 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-sc-ofa7kd-0 tiAWk"
+          class="StyledIcon-ofa7kd-0 hVBrNB"
           viewBox="0 0 24 24"
         >
           <path
@@ -1712,7 +1712,7 @@ exports[`DateInput controlled format inline 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -1730,7 +1730,7 @@ exports[`DateInput controlled format inline 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -10381,7 +10381,7 @@ exports[`DateInput select format 2`] = `
     >
       <svg
         aria-label="Calendar"
-        class="StyledIcon-sc-ofa7kd-0 tiAWk"
+        class="StyledIcon-ofa7kd-0 hVBrNB"
         viewBox="0 0 24 24"
       >
         <path
@@ -12959,7 +12959,7 @@ exports[`DateInput select format inline 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-sc-ofa7kd-0 tiAWk"
+          class="StyledIcon-ofa7kd-0 hVBrNB"
           viewBox="0 0 24 24"
         >
           <path
@@ -13007,7 +13007,7 @@ exports[`DateInput select format inline 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -13025,7 +13025,7 @@ exports[`DateInput select format inline 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -15127,7 +15127,7 @@ exports[`DateInput select format inline range 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-sc-ofa7kd-0 tiAWk"
+          class="StyledIcon-ofa7kd-0 hVBrNB"
           viewBox="0 0 24 24"
         >
           <path
@@ -15175,7 +15175,7 @@ exports[`DateInput select format inline range 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -15193,7 +15193,7 @@ exports[`DateInput select format inline range 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -18455,7 +18455,7 @@ exports[`DateInput type format inline 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-sc-ofa7kd-0 tiAWk"
+          class="StyledIcon-ofa7kd-0 hVBrNB"
           viewBox="0 0 24 24"
         >
           <path
@@ -18503,7 +18503,7 @@ exports[`DateInput type format inline 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -18521,7 +18521,7 @@ exports[`DateInput type format inline 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -21918,7 +21918,7 @@ exports[`DateInput type format inline range 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-sc-ofa7kd-0 tiAWk"
+          class="StyledIcon-ofa7kd-0 hVBrNB"
           viewBox="0 0 24 24"
         >
           <path
@@ -21966,7 +21966,7 @@ exports[`DateInput type format inline range 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -21984,7 +21984,7 @@ exports[`DateInput type format inline range 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -24086,7 +24086,7 @@ exports[`DateInput type format inline range partial 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-sc-ofa7kd-0 tiAWk"
+          class="StyledIcon-ofa7kd-0 hVBrNB"
           viewBox="0 0 24 24"
         >
           <path
@@ -24134,7 +24134,7 @@ exports[`DateInput type format inline range partial 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -24152,7 +24152,7 @@ exports[`DateInput type format inline range partial 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -24941,7 +24941,7 @@ exports[`DateInput type format inline range partial 3`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-sc-ofa7kd-0 tiAWk"
+          class="StyledIcon-ofa7kd-0 hVBrNB"
           viewBox="0 0 24 24"
         >
           <path
@@ -24989,7 +24989,7 @@ exports[`DateInput type format inline range partial 3`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -25007,7 +25007,7 @@ exports[`DateInput type format inline range partial 3`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -27091,7 +27091,7 @@ exports[`DateInput type format inline short 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-sc-ofa7kd-0 tiAWk"
+          class="StyledIcon-ofa7kd-0 hVBrNB"
           viewBox="0 0 24 24"
         >
           <path
@@ -27139,7 +27139,7 @@ exports[`DateInput type format inline short 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -27157,7 +27157,7 @@ exports[`DateInput type format inline short 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -3385,7 +3385,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
             >
               <svg
                 aria-label="FormDown"
-                class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+                class="StyledIcon-ofa7kd-0 jLSzwp"
                 viewBox="0 0 24 24"
               >
                 <path

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -9522,7 +9522,7 @@ exports[`List events should render new data when page changes 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 iZdQSA"
+                class="StyledIcon-ofa7kd-0 jehgOx"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -9578,7 +9578,7 @@ exports[`List events should render new data when page changes 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 tiAWk"
+                class="StyledIcon-ofa7kd-0 hVBrNB"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -12480,7 +12480,7 @@ exports[`List onOrder Keyboard move down 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -12500,7 +12500,7 @@ exports[`List onOrder Keyboard move down 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -12549,7 +12549,7 @@ exports[`List onOrder Keyboard move down 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -12570,7 +12570,7 @@ exports[`List onOrder Keyboard move down 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -12634,7 +12634,7 @@ exports[`List onOrder Keyboard move down 3`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -12654,7 +12654,7 @@ exports[`List onOrder Keyboard move down 3`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -12703,7 +12703,7 @@ exports[`List onOrder Keyboard move down 3`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -12724,7 +12724,7 @@ exports[`List onOrder Keyboard move down 3`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -13250,7 +13250,7 @@ exports[`List onOrder Keyboard move up 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -13270,7 +13270,7 @@ exports[`List onOrder Keyboard move up 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -13319,7 +13319,7 @@ exports[`List onOrder Keyboard move up 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -13340,7 +13340,7 @@ exports[`List onOrder Keyboard move up 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -13404,7 +13404,7 @@ exports[`List onOrder Keyboard move up 3`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -13424,7 +13424,7 @@ exports[`List onOrder Keyboard move up 3`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -13473,7 +13473,7 @@ exports[`List onOrder Keyboard move up 3`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -13494,7 +13494,7 @@ exports[`List onOrder Keyboard move up 3`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -14019,7 +14019,7 @@ exports[`List onOrder Mouse move down 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -14039,7 +14039,7 @@ exports[`List onOrder Mouse move down 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -14088,7 +14088,7 @@ exports[`List onOrder Mouse move down 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path
@@ -14109,7 +14109,7 @@ exports[`List onOrder Mouse move down 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 tiAWk"
+            class="StyledIcon-ofa7kd-0 hVBrNB"
             viewBox="0 0 24 24"
           >
             <path

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -3033,7 +3033,7 @@ exports[`Menu open and close on click 2`] = `
       />
       <svg
         aria-label="FormDown"
-        class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+        class="StyledIcon-ofa7kd-0 jLSzwp"
         viewBox="0 0 24 24"
       >
         <path

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
@@ -7194,7 +7194,7 @@ exports[`Pagination should display next page of results when "next" is
           >
             <svg
               aria-label="Previous"
-              class="StyledIcon-sc-ofa7kd-0 iZdQSA"
+              class="StyledIcon-ofa7kd-0 jehgOx"
               viewBox="0 0 24 24"
             >
               <path
@@ -7316,7 +7316,7 @@ exports[`Pagination should display next page of results when "next" is
           >
             <svg
               aria-label="Next"
-              class="StyledIcon-sc-ofa7kd-0 iZdQSA"
+              class="StyledIcon-ofa7kd-0 jehgOx"
               viewBox="0 0 24 24"
             >
               <path
@@ -8337,7 +8337,7 @@ exports[`Pagination should display previous page of results when "previous" is
           >
             <svg
               aria-label="Previous"
-              class="StyledIcon-sc-ofa7kd-0 iZdQSA"
+              class="StyledIcon-ofa7kd-0 jehgOx"
               viewBox="0 0 24 24"
             >
               <path
@@ -8459,7 +8459,7 @@ exports[`Pagination should display previous page of results when "previous" is
           >
             <svg
               aria-label="Next"
-              class="StyledIcon-sc-ofa7kd-0 iZdQSA"
+              class="StyledIcon-ofa7kd-0 jehgOx"
               viewBox="0 0 24 24"
             >
               <path

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -2746,7 +2746,7 @@ exports[`Select complex options and children 2`] = `
     >
       <svg
         aria-label="FormDown"
-        class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+        class="StyledIcon-ofa7kd-0 jLSzwp"
         viewBox="0 0 24 24"
       >
         <path
@@ -4607,7 +4607,7 @@ exports[`Select disabled 2`] = `
     >
       <svg
         aria-label="FormDown"
-        class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+        class="StyledIcon-ofa7kd-0 jLSzwp"
         viewBox="0 0 24 24"
       >
         <path
@@ -9243,7 +9243,7 @@ exports[`Select prop: onOpen 2`] = `
     >
       <svg
         aria-label="FormDown"
-        class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+        class="StyledIcon-ofa7kd-0 jLSzwp"
         viewBox="0 0 24 24"
       >
         <path
@@ -14769,7 +14769,7 @@ exports[`Select select option by typing should not break if caller passes JSX 2`
       >
         <svg
           aria-label="FormDown"
-          class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+          class="StyledIcon-ofa7kd-0 jLSzwp"
           viewBox="0 0 24 24"
         >
           <path

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -3178,7 +3178,7 @@ exports[`Select Controlled multiple values 2`] = `
     >
       <svg
         aria-label="FormDown"
-        class="StyledIcon-sc-ofa7kd-0 bsCHQs"
+        class="StyledIcon-ofa7kd-0 jLSzwp"
         viewBox="0 0 24 24"
       >
         <path

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -1612,7 +1612,7 @@ exports[`Video Play and Pause event handlers 2`] = `
             />
             <svg
               aria-label="Actions"
-              class="StyledIcon-sc-ofa7kd-0 fTLzXM"
+              class="StyledIcon-ofa7kd-0 htxtFB"
               viewBox="0 0 24 24"
             >
               <path
@@ -5544,7 +5544,7 @@ exports[`Video mouse events handlers of controls 2`] = `
         >
           <svg
             aria-label="play"
-            class="StyledIcon-sc-ofa7kd-0 fTLzXM"
+            class="StyledIcon-ofa7kd-0 htxtFB"
             viewBox="0 0 24 24"
           >
             <path
@@ -5619,7 +5619,7 @@ exports[`Video mouse events handlers of controls 2`] = `
             />
             <svg
               aria-label="Actions"
-              class="StyledIcon-sc-ofa7kd-0 fTLzXM"
+              class="StyledIcon-ofa7kd-0 htxtFB"
               viewBox="0 0 24 24"
             >
               <path
@@ -5665,7 +5665,7 @@ exports[`Video mouse events handlers of controls 3`] = `
         >
           <svg
             aria-label="play"
-            class="StyledIcon-sc-ofa7kd-0 fTLzXM"
+            class="StyledIcon-ofa7kd-0 htxtFB"
             viewBox="0 0 24 24"
           >
             <path
@@ -5740,7 +5740,7 @@ exports[`Video mouse events handlers of controls 3`] = `
             />
             <svg
               aria-label="Actions"
-              class="StyledIcon-sc-ofa7kd-0 fTLzXM"
+              class="StyledIcon-ofa7kd-0 htxtFB"
               viewBox="0 0 24 24"
             >
               <path
@@ -7726,7 +7726,7 @@ exports[`Video scrubber 2`] = `
         >
           <svg
             aria-label="play"
-            class="StyledIcon-sc-ofa7kd-0 fTLzXM"
+            class="StyledIcon-ofa7kd-0 htxtFB"
             viewBox="0 0 24 24"
           >
             <path
@@ -7801,7 +7801,7 @@ exports[`Video scrubber 2`] = `
             />
             <svg
               aria-label="Actions"
-              class="StyledIcon-sc-ofa7kd-0 fTLzXM"
+              class="StyledIcon-ofa7kd-0 htxtFB"
               viewBox="0 0 24 24"
             >
               <path

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -34,6 +34,7 @@ Object {
       "as": [Function],
       "color": [Function],
       "disabled": [Function],
+      "gap": [Function],
       "gridArea": [Function],
       "href": [Function],
       "icon": [Function],
@@ -715,14 +716,8 @@ Object {
             },
           },
           "icons": Object {
-            "collapse": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
-            "expand": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
+            "collapse": [Function],
+            "expand": [Function],
           },
           "panel": Object {},
         },
@@ -840,23 +835,11 @@ Object {
             "level": "4",
           },
           "icons": Object {
-            "next": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
-            "previous": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
+            "next": [Function],
+            "previous": [Function],
             "small": Object {
-              "next": Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "render": [Function],
-              },
-              "previous": Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "render": [Function],
-              },
+              "next": [Function],
+              "previous": [Function],
             },
           },
           "large": Object {
@@ -895,18 +878,9 @@ Object {
             "icons": Object {},
           },
           "icons": Object {
-            "current": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
-            "next": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
-            "previous": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
+            "current": [Function],
+            "next": [Function],
+            "previous": [Function],
           },
         },
         "chart": Object {
@@ -1055,22 +1029,10 @@ Object {
             },
           },
           "icons": Object {
-            "ascending": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
-            "contract": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
-            "descending": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
-            "expand": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
+            "ascending": [Function],
+            "contract": [Function],
+            "descending": [Function],
+            "expand": [Function],
           },
           "pinned": Object {
             "footer": Object {
@@ -1117,10 +1079,7 @@ Object {
             },
           },
           "icons": Object {
-            "remove": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
+            "remove": [Function],
           },
           "label": Object {
             "margin": "small",
@@ -1616,14 +1575,8 @@ Object {
             "gap": "xsmall",
           },
           "icons": Object {
-            "down": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
-            "up": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
+            "down": [Function],
+            "up": [Function],
           },
           "item": Object {
             "border": "horizontal",
@@ -1642,10 +1595,7 @@ Object {
             },
           },
           "icons": Object {
-            "down": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
+            "down": [Function],
           },
         },
         "meter": Object {
@@ -1727,14 +1677,8 @@ Object {
             "pad": "none",
           },
           "icons": Object {
-            "next": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
-            "previous": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
+            "next": [Function],
+            "previous": [Function],
           },
         },
         "paragraph": Object {
@@ -1819,10 +1763,7 @@ Object {
           "container": Object {},
           "control": Object {},
           "icons": Object {
-            "down": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
+            "down": [Function],
             "margin": Object {
               "horizontal": "small",
             },
@@ -2022,34 +1963,13 @@ Object {
             "background": "rgba(0, 0, 0, 0.7)",
           },
           "icons": Object {
-            "closedCaption": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
-            "configure": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
-            "fullScreen": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
-            "pause": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
-            "play": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
-            "reduceVolume": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
-            "volume": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "render": [Function],
-            },
+            "closedCaption": [Function],
+            "configure": [Function],
+            "fullScreen": [Function],
+            "pause": [Function],
+            "play": [Function],
+            "reduceVolume": [Function],
+            "volume": [Function],
           },
           "scrubber": Object {
             "color": "light-4",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
Added the possibility to the user to set the `gap` between icon and label in `Anchor`.
#### What does this PR do?

- Adds a new optional prop in the Anchor component.
- Adds a new storybook as **Anchor/Gap**
- Adds a new test function inside `anchor-test.js`

#### Where should the reviewer start?
Inside the `src/components/Anchor`

#### What testing has been done on this PR?
Only manual inspection is needed.

#### How should this be manually tested?
By navigating to storybook->Anchor->Gap Page.

#### Any background context you want to provide?

#### What are the relevant issues?
#5528 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, need to update props.

#### Should this PR be mentioned in the release notes?
As you like.

#### Is this change backwards compatible or is it a breaking change?
Backward compatible 
