### PR TITLE
Fix prop type error in MaskedInput Story

### DIFF
--- a/src/js/components/MaskedInput/stories/CustomBox.js
+++ b/src/js/components/MaskedInput/stories/CustomBox.js
@@ -4,7 +4,15 @@ import { grommet } from 'grommet/themes';
 
 export const CustomBoxMaskedInput = () => {
   const [value, setValue] = React.useState('');
+  const [dropProps, setDropProps] = React.useState({});
   const boxRef = React.useRef();
+
+  // Update the DropProps target once ref exists
+  React.useEffect(() => {
+    const nextDropProps = { ...dropProps };
+    nextDropProps.target = boxRef.current;
+    setDropProps(nextDropProps);
+  }, [boxRef]);
 
   return (
     <Grommet full theme={grommet}>
@@ -22,7 +30,7 @@ export const CustomBoxMaskedInput = () => {
         <Box flex width="medium" gap="medium">
           <MaskedInput
             plain
-            dropProps={{ target: boxRef.current }}
+            dropProps={dropProps}
             mask={[
               {
                 length: [1, 4],


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes a prop type error that was in the MaskedInput story
#### Where should the reviewer start?
MaskedInput/customBox
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
run the story
#### Any background context you want to provide?
```
react.development.js:220 Warning: Failed prop type: The prop `target` is marked as required in `Drop`, but its value is `undefined`.

```

There was an error because the ref was not yet defined so it was trying to pass `undefined` to `target` prop
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible