### PR TITLE
Fix ref warning on custom search story

### DIFF
--- a/src/js/components/Select/stories/components/SearchInput.js
+++ b/src/js/components/Select/stories/components/SearchInput.js
@@ -1,25 +1,25 @@
-import React, { useEffect, useRef } from 'react';
+import React, { forwardRef, useEffect } from 'react';
 
 import { TextInput } from '../../..';
 
 import { SearchBorderBox } from './SearchBorderBox';
 
-export const SearchInput = ({ searching, ...props }) => {
-  const textInputRef = useRef();
+export const SearchInput = forwardRef(
+  ({ searching, ...props }, textInputRef) => {
+    useEffect(() => {
+      const focusTimeout = setTimeout(() => {
+        textInputRef.current.focus();
+      }, 300);
 
-  useEffect(() => {
-    const focusTimeout = setTimeout(() => {
-      textInputRef.current.focus();
-    }, 300);
+      return () => {
+        clearTimeout(focusTimeout);
+      };
+    }, [textInputRef]);
 
-    return () => {
-      clearTimeout(focusTimeout);
-    };
-  }, []);
-
-  return (
-    <SearchBorderBox searching={searching}>
-      <TextInput {...props} plain ref={textInputRef} />
-    </SearchBorderBox>
-  );
-};
+    return (
+      <SearchBorderBox searching={searching}>
+        <TextInput {...props} plain ref={textInputRef} />
+      </SearchBorderBox>
+    );
+  },
+);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes ref warning for Select --> Custom Search story
![Screen Shot 2021-08-24 at 12 32 54 PM](https://user-images.githubusercontent.com/1756948/130678805-408831a5-8934-49e6-b576-146bc23588c8.png)

#### Where should the reviewer start?

CustomSearch.js relies on a custom theme, which provides a React.FC to `theme.select.searchInput`.

Select/stories/CustomSearch.js --> Select/stories/theme.js --> Select/stories//components/SearchInput.js

#### What testing has been done on this PR?

Storybook

#### How should this be manually tested?

Storybook

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/5543

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
