### PR TITLE
Added available type in typescript Interface

### DIFF
--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -67,6 +67,6 @@ type divProps = JSX.IntrinsicElements['div'];
 
 export interface GridExtendedProps extends GridProps, divProps {}
 
-declare const Grid: React.FC<GridExtendedProps>;
+declare const Grid: React.FC<GridExtendedProps> & { available: boolean };
 
 export { Grid };


### PR DESCRIPTION
Signed-off-by: GurkiranSingh <gurkiransinghk@gmail.com>

#### What does this PR do?
Added `available` type definition in Grid/index.d.ts

#### Where should the reviewer start?
components => Grid/index.d.ts

#### What testing has been done on this PR?
N/A

#### How should this be manually tested?
In ts file, access`Grid.available`.

#### Any background context you want to provide?

#### What are the relevant issues?
#5496 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
