### PR TITLE
Available boolean: now accessible from extended props

### DIFF
--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -67,6 +67,6 @@ type divProps = JSX.IntrinsicElements['div'];
 
 export interface GridExtendedProps extends GridProps, divProps {}
 
-declare const Grid: React.FC<GridExtendedProps>;
+declare const Grid: React.FC<GridExtendedProps> & { available?: boolean };
 
 export { Grid };

--- a/src/js/components/Grid/stories/typescript/App.tsx
+++ b/src/js/components/Grid/stories/typescript/App.tsx
@@ -8,52 +8,56 @@ export const AppGrid = () => {
 
   return (
     <Grommet full theme={grommet}>
-      <Grid
-        fill
-        rows={['auto', 'flex']}
-        columns={['auto', 'flex']}
-        areas={[
-          { name: 'header', start: [0, 0], end: [1, 0] },
-          { name: 'sidebar', start: [0, 1], end: [0, 1] },
-          { name: 'main', start: [1, 1], end: [1, 1] },
-        ]}
-      >
-        <Box
-          gridArea="header"
-          direction="row"
-          align="center"
-          justify="between"
-          pad={{ horizontal: 'medium', vertical: 'small' }}
-          background="dark-2"
+      {Grid.available ? (
+        <Grid
+          fill
+          rows={['auto', 'flex']}
+          columns={['auto', 'flex']}
+          areas={[
+            { name: 'header', start: [0, 0], end: [1, 0] },
+            { name: 'sidebar', start: [0, 1], end: [0, 1] },
+            { name: 'main', start: [1, 1], end: [1, 1] },
+          ]}
         >
-          <Button onClick={() => setSidebar(!sidebar)}>
-            <Text size="large">Title</Text>
-          </Button>
-          <Text>my@email</Text>
-        </Box>
-        {sidebar && (
           <Box
-            gridArea="sidebar"
-            background="dark-3"
-            width="small"
-            animation={[
-              { type: 'fadeIn', duration: 300 },
-              { type: 'slideRight', size: 'xlarge', duration: 150 },
-            ]}
+            gridArea="header"
+            direction="row"
+            align="center"
+            justify="between"
+            pad={{ horizontal: 'medium', vertical: 'small' }}
+            background="dark-2"
           >
-            {['First', 'Second', 'Third'].map(name => (
-              <Button key={name} href="#" hoverIndicator>
-                <Box pad={{ horizontal: 'medium', vertical: 'small' }}>
-                  <Text>{name}</Text>
-                </Box>
-              </Button>
-            ))}
+            <Button onClick={() => setSidebar(!sidebar)}>
+              <Text size="large">Title</Text>
+            </Button>
+            <Text>my@email</Text>
           </Box>
-        )}
-        <Box gridArea="main" justify="center" align="center">
-          <Text>main</Text>
-        </Box>
-      </Grid>
+          {sidebar && (
+            <Box
+              gridArea="sidebar"
+              background="dark-3"
+              width="small"
+              animation={[
+                { type: 'fadeIn', duration: 300 },
+                { type: 'slideRight', size: 'xlarge', duration: 150 },
+              ]}
+            >
+              {['First', 'Second', 'Third'].map((name) => (
+                <Button key={name} href="#" hoverIndicator>
+                  <Box pad={{ horizontal: 'medium', vertical: 'small' }}>
+                    <Text>{name}</Text>
+                  </Box>
+                </Button>
+              ))}
+            </Box>
+          )}
+          <Box gridArea="main" justify="center" align="center">
+            <Text>main</Text>
+          </Box>
+        </Grid>
+      ) : (
+        <Text>Grid is not supported by your browser</Text>
+      )}
     </Grommet>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Aims to resolve #5496. Introduces `Grid.available` as a part of the `GridExtendedProps` to stop TypeScript from marking it as an issue when trying to access `Grid.available` in your own code.

#### Where should the reviewer start?
`Grid/index.d.ts`: to view the addition of the boolean to GridExtendedProps
`Grid/Grid.js`: to see where it is given a value

#### What testing has been done on this PR?
Manual testing in Grid's TypeScript story (`Grid/stories/typescript/App.tsx`) by trying to console log `Grid.available`.

#### How should this be manually tested?
1. Open Grid's TypeScript story (`Grid/stories/typescript/App.tsx`)
2. Try to log/access `Grid.available` and notice how TypeScript does not complain about the `available` property

#### Any background context you want to provide?

#### What are the relevant issues?
Issue #5496 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible