### PR TITLE
Fix: Adding className to Select component

### DIFF
--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -57,8 +57,12 @@ export interface SelectProps {
   emptySearchMessage?: string | React.ReactNode;
 }
 
-declare const Select: React.FC<
-  SelectProps & React.RefAttributes<HTMLButtonElement>
->;
+// Try without Omit<> to see where we define our own attributes for overrides
+// value, name, id, onChange, placeholder
+export interface SelectExtendedProps
+  extends SelectProps,
+    Omit<JSX.IntrinsicElements['input'], keyof SelectProps> {}
+
+declare const Select: React.FC<SelectExtendedProps>;
 
 export { Select };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR aims to:
- Add `className` as a valid attribute to the `Select` component

#### Where should the reviewer start?
- View `src/js/components/Select/index.d.ts` file to see changes that were made
- Inside `src/js/components/Select/stories/typescript/CreateOption.tsx` try to add a `className` to `<Select>` and note how TypeScript doesn't complain about the attribute

#### What testing has been done on this PR?
Manual testing inside code editor (VSCode)

#### How should this be manually tested?
After adding a `className` to the story mentioned above, hover over the className and see how TypeScript will not mark the attribute as an error

#### Any background context you want to provide?

#### What are the relevant issues?
#5249

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible