### PR TITLE
add prop orderAlign for list order

### DIFF
--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -132,6 +132,7 @@ const List = React.forwardRef(
       step = paginate ? 50 : undefined,
       onClickItem,
       onMore,
+      orderAlign,
       ...rest
     },
     ref,
@@ -488,7 +489,7 @@ const List = React.forwardRef(
                   boxProps = { ...boxProps, ...itemProps[index] };
                 }
 
-                return (
+                return !orderAlign ? (
                   <StyledItem
                     key={key}
                     tag="li"
@@ -502,6 +503,24 @@ const List = React.forwardRef(
                   >
                     {onOrder && <Text>{index + 1}</Text>}
                     {content}
+                    {orderControls}
+                  </StyledItem>
+                ) : (
+                  <StyledItem
+                    key={key}
+                    tag="li"
+                    flex={false}
+                    pad={pad || theme.list.item.pad}
+                    background={adjustedBackground}
+                    border={adjustedBorder}
+                    {...boxProps}
+                    {...clickProps}
+                    {...orderProps}
+                  >
+                    <Box direction="row" align={orderAlign} flex {...boxProps}>
+                      {onOrder && <Text>{index + 1}</Text>}
+                      {content}
+                    </Box>
                     {orderControls}
                   </StyledItem>
                 );

--- a/src/js/components/List/index.d.ts
+++ b/src/js/components/List/index.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   A11yTitleType,
   AlignSelfType,
+  AlignType,
   GridAreaType,
   MarginType,
   PadType,
@@ -53,6 +54,7 @@ export interface ListProps<ListItemType> {
     | ((event: React.MouseEvent) => void)
     | ((event: { item?: ListItemType; index?: number }) => void);
   onOrder?: (orderedData: ListItemType[]) => void;
+  orderAlign?: AlignType;
   pad?: PadType;
   paginate?: boolean | PaginationType;
   primaryKey?: string | ((item: ListItemType) => React.ReactElement);

--- a/src/js/components/List/propTypes.js
+++ b/src/js/components/List/propTypes.js
@@ -61,6 +61,7 @@ if (process.env.NODE_ENV !== 'production') {
     onMore: PropTypes.func,
     onClickItem: PropTypes.func,
     onOrder: PropTypes.func,
+    orderAlign: PropTypes.string,
     pad: PropTypes.oneOfType([padPropType]),
     paginate: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
     primaryKey: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),

--- a/src/js/components/List/stories/Order.js
+++ b/src/js/components/List/stories/Order.js
@@ -4,9 +4,14 @@ import { Grommet, Box, List } from 'grommet';
 import { grommet } from 'grommet/themes';
 
 const locations = [
-  'Boise',
-  'Fort Collins',
-  'Los Gatos',
+  `Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+   sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
+  `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+   eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
+  `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+   eiusmod tempor incididunt ut labore et dolore magna aliqua.
+   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+  eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
   'Palo Alto',
   'San Francisco',
 ];

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -519,6 +519,7 @@ Object {
       "onClickItem": [Function],
       "onMore": [Function],
       "onOrder": [Function],
+      "orderAlign": [Function],
       "pad": [Function],
       "paginate": [Function],
       "primaryKey": [Function],


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds a `orderAlign` prop 
#### Where should the reviewer start?
list.js
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
Changed the one-story  `order` to use this prop 
THIS STORY SHOULD NOT BE MERGED JUST CHAGED IT FOR TESTING PURPOSES
#### Any background context you want to provide?
When there was longer content  within the list it was being `aligned in the center` this makes to hard to follow horizontally 

**I added the one prop to only adjust the alignment of the index and the content. If we want to also add something for the user to control the `controls` alignment then maybe we can discuss and expand on the prop or leave it how it is.**
#### What are the relevant issues?
closes #5567 
#### Screenshots (if appropriate)
none
#### Do the grommet docs need to be updated?
yes I will update docs in grommet site
#### Should this PR be mentioned in the release notes?
yes a new prop
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible