### PR TITLE
Updated Contributing.md to reflect documentation contributing changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,15 +13,14 @@ Grommet is divided into several projects, the following are notable:
 
 - [grommet] – the primary Grommet 2.X project is actively developed and
   contributions are more than welcome! Be sure to check the [good first issues].
+- [grommet-site] - the Grommet website. Any documentation changes should be made here.
 - [grommet-icons] – iconography for Grommet and React.js.
-- [react-desc] – add a schema to your React components based on React
-  [`PropTypes`][prop-types].
 - [design-kit] – the Grommet Design Kit provides a set of sticker sheets and
   templates to help bootstrap your design process.
 
 ## You can Become a Contributor
 
-Afterall, that’s why you’re here, right?
+After all, that’s why you’re here, right?
 Quick steps and ideas of how you can contribute to Grommet:
 
 1. Code, code, code… (and make a Pull Request).
@@ -148,14 +147,11 @@ started you should:
 1. clone it `git clone https://github.com/<your-username>/grommet.git`
 1. install dependencies using: `yarn install`
 
-The components code lives in `src/js/components`. The structure of the
-project is a bit particular since it is using lots of internal tooling to try to
-produce up-to-date documentation and minimise bugs. A few gotchas you may run
+The components code lives in `src/js/components`. A few gotchas you may run
 into while contributing could include:
 
-- The read-me files in the components are auto-generated. You won’t need to
-  update them. A big chunk of the documentation and prop-type validation is
-  happening via the `doc.js` files.
+- Documentation updates need to be filled with a separate pull request on
+  [grommet-site].
 - Code coverage and unit-testing is an important process of development.
   A pre-commit hook exists which runs the test suite and aborts the commit if
   any fail. To manually run tests, you should run `yarn test`. If you need to
@@ -178,14 +174,14 @@ frequently). If you feel we missed yours don’t hesitate to ping us on
 
 ## Contributing to the Documentation
 
-Grommet uses an internal tool for most of its documentation. If you are looking
-to modify component documentation then you only need to have a look at the
-`doc.js` files.
+The documentation is stored in the [grommet-site] repository. Each component
+has a documentation file under `src/screens`.
 
-These files are used to generate the documentation on the Grommet website. That
-code lives in the [grommet-site] repository.
+If a documentation change is related to a pull request on grommet, mention the
+grommet pull request in the pull request description so that the two are
+associated with each other.
 
-Found an error in the documentation? [File an issue][grommet issues].
+Found an error in the documentation? [File an issue][grommet-site issues].
 
 ## Need More Help?
 
@@ -213,11 +209,11 @@ This contribution guide was inspired by the contribution guides for [Grunt],
 [grommet-design pulls]: https://github.com/grommet/grommet-design/pulls
 [grommet-icons]: https://github.com/grommet/grommet-icons
 [grommet-site]: https://github.com/grommet/grommet-site
+[grommet-site issues]: https://github.com/grommet/grommet-site/issues
 [grunt]: http://gruntjs.com/contributing
 [prettier]: https://prettier.io/docs/en/editors.html
 [prop-types]: https://www.npmjs.com/package/prop-types
 [pull requests]: https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
-[react-desc]: https://github.com/grommet/react-desc
 [slack community]: https://slack-invite.grommet.io/
 [stack overflow]: https://stackoverflow.com/questions/tagged/grommet
 [video]: https://vimeo.com/129681048


### PR DESCRIPTION
#### What does this PR do?
Updates the information in the contributing guide to reflect the recent removal of react-desc and move of the docs to grommet-site.

#### Where should the reviewer start?
Contributing.md

#### What testing has been done on this PR?

#### How should this be manually tested?
Read through information

#### Any background context you want to provide?

#### What are the relevant issues?
#5540 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible