### PR TITLE
remove box container from Markdown table cells

### DIFF
--- a/src/js/components/Markdown/Markdown.js
+++ b/src/js/components/Markdown/Markdown.js
@@ -31,7 +31,7 @@ const GrommetMarkdown = ({ components, options, theme, ...rest }) => {
       img: { component: Image },
       p: { component: Paragraph },
       table: { component: Table },
-      td: { component: TableCell },
+      td: { component: TableCell, props: { plain: true } },
       tbody: { component: TableBody },
       tfoot: { component: TableFooter },
       th: { component: TableCell },

--- a/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
+++ b/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
@@ -251,35 +251,23 @@ exports[`Markdown renders 1`] = `
           <td
             class="c10"
           >
-            <div
-              class="c9"
-            >
-              <em>
-                Still
-              </em>
-            </div>
+            <em>
+              Still
+            </em>
           </td>
           <td
             class="c10"
           >
-            <div
-              class="c9"
-            >
-              <code>
-                renders
-              </code>
-            </div>
+            <code>
+              renders
+            </code>
           </td>
           <td
             class="c10"
           >
-            <div
-              class="c9"
-            >
-              <strong>
-                nicely
-              </strong>
-            </div>
+            <strong>
+              nicely
+            </strong>
           </td>
         </tr>
         <tr
@@ -288,29 +276,17 @@ exports[`Markdown renders 1`] = `
           <td
             class="c10"
           >
-            <div
-              class="c9"
-            >
-              1
-            </div>
+            1
           </td>
           <td
             class="c10"
           >
-            <div
-              class="c9"
-            >
-              2
-            </div>
+            2
           </td>
           <td
             class="c10"
           >
-            <div
-              class="c9"
-            >
-              3
-            </div>
+            3
           </td>
         </tr>
       </tbody>

--- a/src/js/components/Markdown/stories/Simple.js
+++ b/src/js/components/Markdown/stories/Simple.js
@@ -22,7 +22,7 @@ import { Grommet } from 'grommet';
 
   Markdown | Less | Pretty
   --- | --- | ---
-  *Still* | \`renders\` | **nicely**
+  Content *still* | \`renders\` | **nicely** in a table
   1 | 2 | 3
 `;
 


### PR DESCRIPTION
Currently Markdown uses `TableCell` for any `<td>` elements generated from the markdown content.
`TableCell` wraps the cell content in a `Box`. However, since `Box` is `display:flex` and `direction=column` so
causes any inline content like `<em>`, `<a>`, `<b>`, etc, to end up `display:block` rather than being inline.

#### What does this PR do?
This PR removes the `Box` wrapper for `<td>` cells in markdown content so that any other interesting inline
elements in the cells continue to be inline.

From what we can tell, we don't need the `Box` wrapper here.

#### Where should the reviewer start?
Markdown.js

#### What testing has been done on this PR?
Storybook, Jest and some handcrafted examples.

#### How should this be manually tested?
Go to the Markdown Simple example in the Storybook and verify the table cells with other markup
continue to be inline as desired.

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #5486 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Should be backwards compatible although it may be hard to predict what interesting markdown people create.
