### PR TITLE
Remove Developer's Certificate of Origin from Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,52 +74,6 @@ passes testing and the pull request can merge cleanly.
 
 At least one review from a maintainer is required for all patches.
 
-### Developer’s Certificate of Origin
-
-All contributions must include acceptance of the DCO:
-
-> Developer Certificate of Origin Version 1.1
->
-> Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 660
-> York Street, Suite 102, San Francisco, CA 94110 USA
->
-> Everyone is permitted to copy and distribute verbatim copies of this
-> license document, but changing it is not allowed.
->
-> Developer's Certificate of Origin 1.1
->
-> By making a contribution to this project, I certify that:
->
-> \(a) The contribution was created in whole or in part by me and I have
-> the right to submit it under the open source license indicated in the
-> file; or
->
-> \(b) The contribution is based upon previous work that, to the best of my
-> knowledge, is covered under an appropriate open source license and I
-> have the right under that license to submit that work with
-> modifications, whether created in whole or in part by me, under the same
-> open source license (unless I am permitted to submit under a different
-> license), as indicated in the file; or
->
-> \(c) The contribution was provided directly to me by some other person
-> who certified (a), (b) or (c) and I have not modified it.
->
-> \(d) I understand and agree that this project and the contribution are
-> public and that a record of the contribution (including all personal
-> information I submit with it, including my sign-off) is maintained
-> indefinitely and may be redistributed consistent with this project or
-> the open source license(s) involved.
-
-### Sign Your Work
-
-To accept the DCO, simply add this line to each commit message with your
-name and email address (`git commit -s` will do this for you):
-
-    Signed-off-by: Jane Example <jane@example.com>
-
-For legal reasons, no anonymous or pseudonymous contributions are
-accepted.
-
 ## Design Contributions
 
 The Grommet community values contributions on the design side of the


### PR DESCRIPTION
#### What does this PR do?
Removes the Developer's Certificate of Origin from the contributing guide. This wasn't something we were enforcing and it is covered by the Apache 2.0 license.

#### Where should the reviewer start?
Contributing.md

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?
Grommet is licensed under Apache 2.0
Section 5 of Apache 2.0 states:

> Submission of Contributions. Unless You explicitly state otherwise,
> any Contribution intentionally submitted for inclusion in the Work
> by You to the Licensor shall be under the terms and conditions of
> this License, without any additional terms or conditions.
> Notwithstanding the above, nothing herein shall supersede or modify
> the terms of any separate license agreement you may have executed
> with Licensor regarding such Contributions.
> This serves the same purpose as the Developer's Certificate of Origin.

More info:
https://opensource.guide/legal/#does-my-project-need-an-additional-contributor-agreement
https://opensource.stackexchange.com/questions/5585/benefits-of-a-cla-when-using-apache-2-0-license

#### What are the relevant issues?
Closes #5578 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible