### PR TITLE
Fixes Select dropdown rendering issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "grommet-icons": "^4.6.2",
     "hoist-non-react-statics": "^3.2.0",
     "markdown-to-jsx": "^7.1.3",
-    "prop-types": "^15.7.2"
+    "prop-types": "^15.7.2",
+    "use-isomorphic-layout-effect": "^1.1.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.8",

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -5,6 +5,8 @@ import React, {
   useMemo,
   useRef,
 } from 'react';
+import useLayoutEffect from 'use-isomorphic-layout-effect';
+
 import { ThemeContext } from 'styled-components';
 
 import { FocusedContainer } from '../FocusedContainer';
@@ -63,7 +65,7 @@ const DropContainer = forwardRef(
       [portalContext, portalId],
     );
     const dropRef = useRef();
-    useEffect(() => {
+    useLayoutEffect(() => {
       const notifyAlign = () => {
         const styleCurrent = (ref || dropRef).current.style;
         const alignControl = styleCurrent.top !== '' ? 'top' : 'bottom';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12778,7 +12778,7 @@ use-composed-ref@^1.0.0:
   dependencies:
     ts-essentials "^2.0.3"
 
-use-isomorphic-layout-effect@^1.0.0:
+use-isomorphic-layout-effect@^1.0.0, use-isomorphic-layout-effect@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz#7bb6589170cd2987a152042f9084f9effb75c225"
   integrity sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

It fixes a very subtle bug on the Select component dropdown. Sometimes, the Select dropdown content was rendered on the top left corner of the screen during a fraction of a second (it was basically a blink) before it be rendered in the correct place.

#### Where should the reviewer start?

Drop > DropContainer.js

#### What testing has been done on this PR?

The tests where done mainly in a local storybook. I've created a custom storybook page with some basic code just to make debugging easier. 

#### How should this be manually tested?

Run a local storybook, or a custom React project, and run the code specified in #5586. 

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #5586.

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
