### PR TITLE
Change radiobutton theme background color to accept symbolic colors

### DIFF
--- a/src/js/components/RadioButton/StyledRadioButton.js
+++ b/src/js/components/RadioButton/StyledRadioButton.js
@@ -102,8 +102,10 @@ Object.setPrototypeOf(StyledRadioButtonIcon.defaultProps, defaultProps);
 
 const StyledRadioButtonBox = styled.div`
   background-color: ${(props) =>
-    props.theme.radioButton.check.background &&
-    props.theme.radioButton.check.background.color};
+    normalizeColor(
+      props.theme.radioButton.check.background?.color,
+      props.theme,
+    )};
   ${(props) => props.focus && focusStyle()};
   ${(props) => props.theme.radioButton.check.extend};
 `;

--- a/src/js/components/RadioButton/stories/Theme.js
+++ b/src/js/components/RadioButton/stories/Theme.js
@@ -18,7 +18,7 @@ const theme = deepMerge(grommet, {
         light: 'neutral-1',
       },
       background: {
-        color: 'red',
+        color: 'brand',
       },
     },
     icon: {


### PR DESCRIPTION
#### What does this PR do?

Change RadioButton to recognize symbolic colors in
theme.radioButton.check.background.color.

#### Where should the reviewer start?
StyledRadioButton.js

#### What testing has been done on this PR?
Storybook with a modified RadioButton/Theme example. The previous version of that theme used the color 'red' which is a valid CSS color so it didn't expose the issue.

#### How should this be manually tested?
Storybook RadioButton/Theme

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #5618 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Sure

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
