### PR TITLE
Text input suggestion update.

### DIFF
--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -481,6 +481,11 @@ const TextInput = forwardRef(
                     if (onChange) onChange(event);
                   }
             }
+            onClick={() => {
+              if (suggestions && !showDrop) {
+                openDrop();
+              }
+            }}
           />
         </Keyboard>
 

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -145,11 +145,21 @@ const TextInput = forwardRef(
       if (onSuggestionsOpen) onSuggestionsOpen();
     }, [announce, messages, format, onSuggestionsOpen, suggestions]);
 
-    const closeDrop = useCallback(() => {
-      setSuggestionsAtClose(suggestions); // must be before closing drop
-      setShowDrop(false);
-      if (onSuggestionsClose) onSuggestionsClose();
-    }, [onSuggestionsClose, suggestions]);
+    const closeDrop = useCallback(
+      (event) => {
+        if (
+          event &&
+          event.type === 'mousedown' &&
+          event.target === inputRef.current
+        ) {
+          return;
+        }
+        setSuggestionsAtClose(suggestions); // must be before closing drop
+        setShowDrop(false);
+        if (onSuggestionsClose) onSuggestionsClose();
+      },
+      [onSuggestionsClose, suggestions, inputRef],
+    );
 
     // Handle scenarios where we have focus, the drop isn't showing,
     // and the suggestions change. We don't want to open the drop if
@@ -478,14 +488,10 @@ const TextInput = forwardRef(
                     // placeholder only appears when there is no value
                     setValue(event.target.value);
                     setActiveSuggestionIndex(resetSuggestionIndex);
+                    setSuggestionsAtClose();
                     if (onChange) onChange(event);
                   }
             }
-            onClick={() => {
-              if (suggestions && !showDrop) {
-                openDrop();
-              }
-            }}
           />
         </Keyboard>
 

--- a/src/js/components/TextInput/__tests__/TextInput-test.tsx
+++ b/src/js/components/TextInput/__tests__/TextInput-test.tsx
@@ -95,7 +95,7 @@ describe('TextInput', () => {
     }, 50);
   });
 
-  test('opens drop on focus after selection of suggestion', (done) => {
+  test('opens drop on typing again after selection of suggestion', (done) => {
     const onChange = jest.fn();
     const onFocus = jest.fn();
     const { getByTestId } = render(

--- a/src/js/components/TextInput/__tests__/TextInput-test.tsx
+++ b/src/js/components/TextInput/__tests__/TextInput-test.tsx
@@ -95,6 +95,49 @@ describe('TextInput', () => {
     }, 50);
   });
 
+  test('opens drop on focus after selection of suggestion', (done) => {
+    const onChange = jest.fn();
+    const onFocus = jest.fn();
+    const { getByTestId } = render(
+      <TextInput
+        data-testid="test-input"
+        id="item"
+        name="item"
+        suggestions={['test']}
+        onChange={onChange}
+        onFocus={onFocus}
+      />,
+    );
+
+    fireEvent.focus(getByTestId('test-input'));
+    fireEvent.change(getByTestId('test-input'), { target: { value: 'test' } });
+
+    setTimeout(() => {
+      expectPortal('text-input-drop__item').toMatchSnapshot();
+      expect(onChange).toBeCalled();
+      expect(onFocus).toBeCalled();
+      expect(
+        document
+          .getElementById('text-input-drop__item')!
+          .querySelectorAll('button'),
+      ).toHaveLength(1);
+      fireEvent.click(getByText(document as unknown as HTMLElement, 'test'));
+      expect(document.getElementById('text-input-drop__item')).toBeNull();
+
+      fireEvent.change(getByTestId('test-input'), { target: { value: 'tes' } });
+
+      setTimeout(() => {
+        expect(document.getElementById('text-input-drop__item')).not.toBeNull();
+        expect(
+          document
+            .getElementById('text-input-drop__item')!
+            .querySelectorAll('button'),
+        ).toHaveLength(1);
+        done();
+      }, 50);
+    }, 50);
+  });
+
   test('complex suggestions', (done) => {
     const { getByTestId, container } = render(
       <Grommet>
@@ -154,7 +197,7 @@ describe('TextInput', () => {
     }, 50);
   });
 
-  test('let escape events propagage if there are no suggestions', (done) => {
+  test('let escape events propagate if there are no suggestions', (done) => {
     const callback = jest.fn();
     const { getByTestId } = render(
       <Grommet>

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -2421,7 +2421,7 @@ exports[`TextInput medium drop height 1`] = `
 
 exports[`TextInput medium drop height 2`] = `""`;
 
-exports[`TextInput opens drop on focus after selection of suggestion 1`] = `
+exports[`TextInput opens drop on typing again after selection of suggestion 1`] = `
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2627,7 +2627,7 @@ exports[`TextInput opens drop on focus after selection of suggestion 1`] = `
 </div>
 `;
 
-exports[`TextInput opens drop on focus after selection of suggestion 2`] = `""`;
+exports[`TextInput opens drop on typing again after selection of suggestion 2`] = `""`;
 
 exports[`TextInput renders size 1`] = `
 HTMLCollection [

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -2421,6 +2421,214 @@ exports[`TextInput medium drop height 1`] = `
 
 exports[`TextInput medium drop height 2`] = `""`;
 
+exports[`TextInput opens drop on focus after selection of suggestion 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: auto;
+  box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: auto;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 12px;
+}
+
+.c1 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  border-radius: 0px;
+  position: fixed;
+  z-index: 20;
+  outline: none;
+  background-color: #FFFFFF;
+  color: #444444;
+  opacity: 0;
+  -webkit-transform-origin: top left;
+  -ms-transform-origin: top left;
+  transform-origin: top left;
+  -webkit-animation: kPQHBD 0.1s forwards;
+  animation: kPQHBD 0.1s forwards;
+  -webkit-animation-delay: 0.01s;
+  animation-delay: 0.01s;
+}
+
+.c5 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c5:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c5:focus > circle,
+.c5:focus > ellipse,
+.c5:focus > line,
+.c5:focus > path,
+.c5:focus > polygon,
+.c5:focus > polyline,
+.c5:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c5:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c5:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c5:focus:not(:focus-visible) > circle,
+.c5:focus:not(:focus-visible) > ellipse,
+.c5:focus:not(:focus-visible) > line,
+.c5:focus:not(:focus-visible) > path,
+.c5:focus:not(:focus-visible) > polygon,
+.c5:focus:not(:focus-visible) > polyline,
+.c5:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c5:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c4 {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.c3 {
+  max-height: inherit;
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    padding: 6px;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c3 {
+    width: 100%;
+  }
+}
+
+<div
+  class="c0 c1"
+  data-g-portal-id="0"
+  id="text-input-drop__item"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
+  tabindex="-1"
+>
+  <div
+    class="c2 c3"
+  >
+    <ol
+      class="c4"
+    >
+      <li>
+        <button
+          class="c5"
+          type="button"
+        >
+          <div
+            class="c6"
+          >
+            test
+          </div>
+        </button>
+      </li>
+    </ol>
+  </div>
+</div>
+`;
+
+exports[`TextInput opens drop on focus after selection of suggestion 2`] = `""`;
+
 exports[`TextInput renders size 1`] = `
 HTMLCollection [
   .c0 {


### PR DESCRIPTION
#### What does this PR do?
Fix suggestions drop handling

#### Where should the reviewer start?
The main issue (for https://github.com/grommet/grommet/issues/5426) here is the simplified solution that checks the `suggestionsAtClose.length` in order to show or not the drop - which especially on dynamic suggestions prop causes issues, since although there might be the same length of suggestions, the suggestions are different and should be shown.
The fix lies on reseting the `suggestionsAtClose` on select and on input value change.

Also, (for https://github.com/grommet/grommet/issues/5440) we should check if the reason that the drop closes is clicking on the input itself.

#### What testing has been done on this PR?
Added a failing test on selecting a suggestion closes the drop. Changing the value of the input, should bring up the suggestions even when the length is the same as before.

#### How should this be manually tested?
https://github.com/grommet/grommet/issues/5440 Clicking on the input again should not close the drop.
https://github.com/grommet/grommet/issues/5426 On the [story](https://storybook.grommet.io/?path=/story/input-textinput-suggestions--suggestions) write "1 suggestion", select the suggestion, remove some chars - suggestions don't come back up.

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/5440
https://github.com/grommet/grommet/issues/5426

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Maybe?

#### Is this change backwards compatible or is it a breaking change?
Yes it is
