### PR TITLE
NEW NameValueList - Grid Approach

### DIFF
--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -34,6 +34,13 @@ export type GridSizeType =
   | string
   | string[];
 
+export type GridColumnsType =
+  | GridSizeType
+  | GridSizeType[]
+  | {
+      count?: 'fit' | 'fill' | number;
+      size?: GridSizeType;
+    };
 export interface GridProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
@@ -42,13 +49,7 @@ export interface GridProps {
   areas?: { name?: string; start?: number[]; end?: number[] }[] | string[][];
   as?: PolymorphicType;
   border?: BorderType;
-  columns?:
-    | GridSizeType
-    | GridSizeType[]
-    | {
-        count?: 'fit' | 'fill' | number;
-        size?: GridSizeType;
-      };
+  columns?: GridColumnsType;
   fill?: FillType;
   gap?: GapType | { row?: GapType; column?: GapType };
   gridArea?: GridAreaType;

--- a/src/js/components/NameValueList/NameValueList.js
+++ b/src/js/components/NameValueList/NameValueList.js
@@ -28,6 +28,7 @@ const NameValueList = forwardRef(
 
     return (
       <Grid
+        as="dl"
         ref={ref}
         columns={columnsProp || columns}
         gap={gap || theme.nameValueList.gap}

--- a/src/js/components/NameValueList/NameValueList.js
+++ b/src/js/components/NameValueList/NameValueList.js
@@ -1,0 +1,54 @@
+import React, { forwardRef, useContext } from 'react';
+import { ThemeContext } from 'styled-components';
+import { Grid } from '../Grid';
+import { ResponsiveContext } from '../../contexts/ResponsiveContext';
+import { NameValuePair } from './NameValuePair';
+
+const NameValueList = forwardRef(
+  (
+    {
+      a11yTitle,
+      align,
+      columns: columnsProp,
+      data,
+      direction = { list: 'column', pair: 'row' },
+      gap,
+      nameProps,
+      valueProps,
+      ...rest
+    },
+    ref,
+  ) => {
+    const size = useContext(ResponsiveContext);
+    const theme = useContext(ThemeContext);
+
+    let columns;
+    if (size === 'small' || direction.list === 'row') columns = 'medium';
+    else if (direction.list === 'column') columns = ['small', 'medium'];
+
+    return (
+      <Grid
+        ref={ref}
+        columns={columnsProp || columns}
+        gap={gap || theme.nameValueList.gap}
+        fill={direction.list === 'row'}
+        {...rest}
+      >
+        {data.map((datum) => (
+          <NameValuePair
+            key={datum?.name}
+            align={align}
+            data={datum}
+            direction={direction.pair}
+            nameProps={nameProps}
+            valueProps={valueProps}
+          />
+        ))}
+      </Grid>
+    );
+  },
+);
+
+NameValueList.displayName = 'NameValueList';
+
+export { NameValueList };

--- a/src/js/components/NameValueList/NameValuePair.js
+++ b/src/js/components/NameValueList/NameValuePair.js
@@ -1,0 +1,73 @@
+import React, { Fragment, useContext } from 'react';
+import { ThemeContext } from 'styled-components';
+import { Box } from '../Box';
+import { Text } from '../Text';
+import { ResponsiveContext } from '../../contexts/ResponsiveContext';
+
+export const NameValuePair = ({
+  align,
+  data,
+  direction,
+  nameProps,
+  valueProps,
+}) => {
+  const size = useContext(ResponsiveContext);
+  const theme = useContext(ThemeContext);
+  const columnPair = direction === 'column' || size === 'small';
+
+  const Container = columnPair ? Box : Fragment;
+  const containerProps = columnPair ? { width: 'medium' } : undefined;
+
+  let name = (
+    <Text
+      textAlign={size !== 'small' ? align?.name : undefined}
+      {...theme.nameValueList.name.text}
+      {...nameProps?.text}
+    >
+      {data?.name}
+    </Text>
+  );
+  if (data?.nameIcon || nameProps?.container) {
+    name = (
+      <Box
+        align={size !== 'small' ? align?.name : undefined}
+        {...theme.nameValueList.name.container}
+        {...nameProps?.container}
+      >
+        {data?.nameIcon ? <Box flex={false}>{data?.nameIcon}</Box> : undefined}
+        {name}
+      </Box>
+    );
+  }
+
+  let value = (
+    <Text
+      textAlign={size !== 'small' ? align?.value : undefined}
+      {...theme.nameValueList.value.text}
+      {...valueProps?.text}
+    >
+      {data?.value}
+    </Text>
+  );
+  if (data?.valueIcon || valueProps?.container) {
+    value = (
+      <Box
+        align={align?.value}
+        {...theme.nameValueList.value.container}
+        {...valueProps?.container}
+      >
+        {data?.valueIcon ? (
+          <Box flex={false}>{data?.valueIcon}</Box>
+        ) : undefined}
+        {value}
+      </Box>
+    );
+  }
+
+  return (
+    <Container {...containerProps}>
+      {name}
+      {value}
+    </Container>
+  );
+};

--- a/src/js/components/NameValueList/NameValuePair.js
+++ b/src/js/components/NameValueList/NameValuePair.js
@@ -20,6 +20,7 @@ export const NameValuePair = ({
 
   let name = (
     <Text
+      as="dt"
       textAlign={size !== 'small' ? align?.name : undefined}
       {...theme.nameValueList.name.text}
       {...nameProps?.text}
@@ -42,6 +43,7 @@ export const NameValuePair = ({
 
   let value = (
     <Text
+      as="dd"
       textAlign={size !== 'small' ? align?.value : undefined}
       {...theme.nameValueList.value.text}
       {...valueProps?.text}

--- a/src/js/components/NameValueList/index.d.ts
+++ b/src/js/components/NameValueList/index.d.ts
@@ -1,0 +1,38 @@
+import { BoxTypes } from 'grommet';
+import * as React from 'react';
+import {
+  A11yTitleType,
+  AlignSelfType,
+  AlignType,
+  GapType,
+  GridAreaType,
+  MarginType,
+} from '../../utils';
+import { GridColumnsType } from '../Grid/index';
+
+export interface NameValueListProps {
+  a11yTitle?: A11yTitleType;
+  alignSelf?: AlignSelfType;
+  gridArea?: GridAreaType;
+  margin?: MarginType;
+  align?: {
+    name?: AlignType;
+    value?: AlignType;
+  };
+  columns?: GridColumnsType;
+  data?: {
+    name?: string;
+    nameIcon?: React.ReactElement;
+    value?: string;
+    valueIcon?: React.ReactElement;
+  }[];
+  direction?: { list?: 'column' | 'row'; pair?: 'column' | 'row' };
+  gap?: GapType | { row?: GapType; column?: GapType };
+  nameProps?: BoxTypes;
+  valueProps?: BoxTypes;
+}
+
+declare const NameValueList: React.FC<NameValueListProps>;
+export type NameValueListType = NameValueListProps;
+
+export { NameValueList };

--- a/src/js/components/NameValueList/index.js
+++ b/src/js/components/NameValueList/index.js
@@ -1,0 +1,1 @@
+export { NameValueList } from './NameValueList';

--- a/src/js/components/NameValueList/stories/Simple.js
+++ b/src/js/components/NameValueList/stories/Simple.js
@@ -1,0 +1,120 @@
+import React from 'react';
+import {
+  Box,
+  Grommet,
+  Heading,
+  NameValueList,
+  ResponsiveContext,
+} from 'grommet';
+import { grommet } from 'grommet/themes';
+import { StatusGoodSmall, StatusCriticalSmall } from 'grommet-icons';
+
+const data = [
+  { name: 'Model type', value: 'MXQ83700F3' },
+  { name: 'Last synced on some date', value: '34343738-3036-584DFD3422SA' },
+  { name: 'Created on', value: '172.16.255.321.8' },
+  {
+    name: 'Policies',
+    value: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget 
+    est at turpis imperdiet blandit porttitor eu enim. Phasellus faucibus 
+    pharetra risus nec bibendum.`,
+  },
+];
+
+const numericData = [
+  { name: 'Model type', value: 'MXQ83700F3' },
+  { name: 'Last synced on', value: '34343738-3036-584DFD3422SA' },
+  { name: 'Created on', value: '172.16.255.321.8' },
+  {
+    name: 'Policies',
+    value: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget 
+    est at turpis imperdiet blandit porttitor eu enim. Phasellus faucibus 
+    pharetra risus nec bibendum.`,
+  },
+];
+
+const dataVisual = [
+  {
+    name: 'Model type',
+    value: 'MXQ83700F3',
+    valueIcon: (
+      <Box margin={{ top: 'xsmall' }}>
+        <StatusGoodSmall size="small" color="status-ok" />
+      </Box>
+    ),
+  },
+  {
+    name: 'Last synced on some date',
+    value: '34343738-3036-584DFD3422SA',
+    valueIcon: (
+      <Box margin={{ top: 'xsmall' }}>
+        <StatusCriticalSmall size="small" color="status-critical" />
+      </Box>
+    ),
+  },
+  {
+    name: 'Created on',
+    value: '172.16.255.321.8',
+  },
+  {
+    name: 'Policies',
+    value: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget 
+    est at turpis imperdiet blandit porttitor eu enim. Phasellus faucibus 
+    pharetra risus nec bibendum.`,
+    valueIcon: (
+      <Box margin={{ top: 'xsmall' }}>
+        <StatusGoodSmall size="small" color="status-ok" />
+      </Box>
+    ),
+  },
+];
+
+export const Simple = () => (
+  <Grommet theme={grommet}>
+    <ResponsiveContext.Consumer>
+      {(size) => (
+        <Box align="start" pad="small" gap="medium">
+          <Heading>Default</Heading>
+          <NameValueList data={data} />
+          <Heading>Value Icon</Heading>
+          <NameValueList data={dataVisual} />
+          <Heading>Align Value: end</Heading>
+          <NameValueList data={numericData} align={{ value: 'end' }} />
+          <Heading>Align Name: end </Heading>
+          <NameValueList data={numericData} align={{ name: 'end' }} />
+          <Heading>Pair Direction: column</Heading>
+          <NameValueList data={data} direction={{ pair: 'column' }} />
+          <Heading>List Direction: row</Heading>
+          <NameValueList
+            data={data}
+            direction={{ pair: 'column', list: 'row' }}
+          />
+          <Heading>nameProps</Heading>
+          <NameValueList
+            data={data}
+            direction={{ pair: 'column' }}
+            nameProps={{ text: { size: 'xsmall', weight: 500 } }}
+          />
+          <Heading>Custom Columns</Heading>
+          <NameValueList
+            columns={
+              size !== 'small'
+                ? [
+                    ['small', 'medium'],
+                    ['auto', 'large'],
+                  ]
+                : undefined
+            }
+            data={data}
+            nameProps={{ text: { size: 'xlarge' } }}
+            valueProps={{ text: { size: 'xlarge' } }}
+          />
+        </Box>
+      )}
+    </ResponsiveContext.Consumer>
+  </Grommet>
+);
+
+export default {
+  title: 'Visualizations/NameValueList/Simple',
+};

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -607,6 +607,10 @@ Object {
     },
     "render": [Function],
   },
+  "NameValueList": Object {
+    "$$typeof": Symbol(react.forward_ref),
+    "render": [Function],
+  },
   "Nav": [Function],
   "Notification": [Function],
   "Pagination": Object {
@@ -1661,6 +1665,31 @@ Object {
         },
         "meter": Object {
           "color": "graph-0",
+        },
+        "nameValueList": Object {
+          "gap": Object {
+            "column": "large",
+            "row": "medium",
+          },
+          "name": Object {
+            "container": Object {
+              "direction": "row",
+              "gap": "small",
+            },
+            "text": Object {
+              "color": "text-strong",
+              "weight": "bold",
+            },
+          },
+          "value": Object {
+            "container": Object {
+              "direction": "row",
+              "gap": "small",
+            },
+            "text": Object {
+              "color": "text-strong",
+            },
+          },
         },
         "notification": Object {
           "close": Object {

--- a/src/js/components/index.js
+++ b/src/js/components/index.js
@@ -40,6 +40,7 @@ export * from './Markdown';
 export * from './MaskedInput';
 export * from './Menu';
 export * from './Meter';
+export * from './NameValueList';
 export * from './Pagination';
 export * from './Paragraph';
 export * from './Nav';

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1040,6 +1040,24 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // colors: [] || colors: ['graph-0', 'graph-1', 'graph-2', 'graph-3'],
       // extend: undefined,
     },
+    nameValueList: {
+      gap: { column: 'large', row: 'medium' },
+      name: {
+        // any box props
+        container: { direction: 'row', gap: 'small' },
+        text: {
+          color: 'text-strong',
+          weight: 'bold',
+        },
+      },
+      value: {
+        // any box props
+        container: { direction: 'row', gap: 'small' },
+        text: {
+          color: 'text-strong',
+        },
+      },
+    },
     notification: {
       time: 8000,
       container: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This is a first pass to explore the API structure for a NameValueList component. This is an "Approach 2" to the other NameValueList approach started in https://github.com/grommet/grommet/pull/5623.

The layout of this approach relies on Grid component. Where the Grid becomes single column once size of `small` is reached.

Proposed API is as follows:
```
align?: {
    name?: AlignType;
    value?: AlignType;
  };
  columns?: GridColumnsType;
  data?: {
    name?: string;
    nameIcon?: React.ReactElement;
    value?: string;
    valueIcon?: React.ReactElement;
  }[];
  direction?: { list?: 'column' | 'row'; pair?: 'column' | 'row' };
  gap?: GapType | { row?: GapType; column?: GapType };
  nameProps?: BoxTypes;
  valueProps?: BoxTypes;
```

Things to consider:
- [ ] Expected data structure (not sure about `nameIcon` / `valueIcon`)

To-do:
- [ ] Add in any additional accessibility attributes
- [ ] Add / Split up stories
- [ ] Add tests
- [ ] Add propTypes, etc. files

#### Where should the reviewer start?
src/js/components/NameValueList/NameValueList.js

#### What testing has been done on this PR?

#### How should this be manually tested?
View the storybook deploy: 

#### Any background context you want to provide?
https://www.figma.com/file/Ny7rYK5gI5VO4PtZsq6vGC/HPE-Name-Value-Pair?node-id=148%3A1936

#### What are the relevant issues?
Related to https://github.com/grommet/grommet/issues/5604

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
