### PR TITLE
Fix Spinner color being override by theme

### DIFF
--- a/src/js/components/Spinner/Spinner.js
+++ b/src/js/components/Spinner/Spinner.js
@@ -44,6 +44,7 @@ const Spinner = forwardRef(
     const {
       size: sizeThemeProp,
       color: colorThemeProp,
+      border: borderThemeProp,
       ...themeProps
     } = theme.spinner.container;
 
@@ -52,6 +53,21 @@ const Spinner = forwardRef(
 
     const color = colorProp || colorThemeProp;
     const Icon = theme.spinner.icon;
+
+    const defaultBorder = [
+      { side: 'all', color: 'background-contrast', size },
+      { side: 'top', color, size },
+    ];
+    const spinnerBorder = Array.isArray(borderThemeProp)
+      ? borderThemeProp.map((borderSide) => ({
+          ...borderSide,
+          color:
+            borderSide.side === 'all'
+              ? borderSide.color || 'background-contrast'
+              : color,
+          size: normalizedSize,
+        }))
+      : defaultBorder;
 
     // children will take precedence over theme attributes
     if (children) {
@@ -79,10 +95,7 @@ const Spinner = forwardRef(
       <BasicSpinner
         size={spinnerSize}
         ref={ref}
-        border={[
-          { side: 'all', color: 'background-contrast', size },
-          { side: 'top', color, size },
-        ]}
+        border={spinnerBorder}
         {...themeProps}
         {...rest}
       />


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Prevent the Spinner color prop (when set) from being override by theme setting.

#### Where should the reviewer start?
`src/js/components/Spinner/Spinner.js`

#### What testing has been done on this PR?
`yarn test`

#### How should this be manually tested?
`yarn storybook`

#### Any background context you want to provide?

#### What are the relevant issues?
See #5598 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
backwards compatible