### PR TITLE
Fix an InfiniteScroll onMore infinite recursion

### DIFF
--- a/src/js/components/InfiniteScroll/InfiniteScroll.js
+++ b/src/js/components/InfiniteScroll/InfiniteScroll.js
@@ -139,7 +139,8 @@ const InfiniteScroll = ({
     if (
       onMore &&
       renderPageBounds[1] === lastPage &&
-      items.length >= pendingLength
+      items.length >= pendingLength &&
+      items.length > 0
     ) {
       // remember we've asked for more, so we don't keep asking if it takes
       // a while


### PR DESCRIPTION
#### What does this PR do?
When an InfiniteScroll is passed an empty items array and it has an onMore callback, onMore was getting called continuously.

#### Where should the reviewer start?
InfiniteScroll.js

#### What testing has been done on this PR?
Storybook example, jest tests

#### How should this be manually tested?
Storybook InfiniteScroll examples

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #5633 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible