### PR TITLE
Text to accept dropProps when truncate='tip'

### DIFF
--- a/src/js/components/Text/Text.js
+++ b/src/js/components/Text/Text.js
@@ -51,7 +51,11 @@ const Text = forwardRef(
 
     if (tip) {
       if (typeof tip === 'string') {
-        return <Tip content={tip}>{styledTextResult}</Tip>;
+        return (
+          <Tip content={tip} dropProps={rest?.dropProps}>
+            {styledTextResult}
+          </Tip>
+        );
       }
       return <Tip {...tip}>{styledTextResult}</Tip>;
     }

--- a/src/js/components/Text/stories/Tip.js
+++ b/src/js/components/Text/stories/Tip.js
@@ -8,7 +8,12 @@ export const Tip = () => (
   <Grommet theme={grommet}>
     <Box align="center" pad="medium" gap="xlarge">
       <Box width="small">
-        <Text truncate="tip">{alphabet}</Text>
+        <Text
+          truncate="tip"
+          dropProps={{ align: { left: 'right', top: 'bottom' } }}
+        >
+          {alphabet}
+        </Text>
       </Box>
       <Text
         tip={{ dropProps: { align: { left: 'right' } }, content: 'tooltip' }}


### PR DESCRIPTION
Signed-off-by: GurkiranSingh <gurkiransinghk@gmail.com>

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Text Component to accept dropProps when truncate='tip'

#### Where should the reviewer start?
components => Text

#### What testing has been done on this PR?
None

#### How should this be manually tested?
Check the storybook changes

#### Any background context you want to provide?
N/A

#### What are the relevant issues?
#5605

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Not sure

#### Should this PR be mentioned in the release notes?
Not sure

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
