### PR TITLE
Fixes Checkbox focus state is stuck if the checkbox is disabled

### DIFF
--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -66,6 +66,11 @@ const CheckBox = forwardRef(
       initialValue: defaultChecked,
     });
 
+    if (disabled) {
+      /* eslint-disable no-param-reassign */
+      focusProp = false; 
+    }
+
     const [focus, setFocus] = useState(focusProp);
     useEffect(() => setFocus(focusProp), [focusProp]);
 


### PR DESCRIPTION
Updated CheckBox component to turn off the focus when checkbox is disabled
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes [Checkbox focus state is stuck if the checkbox is disabled](https://github.com/grommet/grommet/issues/5403) issue

#### Where should the reviewer start?
Can start by creating a checkbox and then disable it and watching on focus

#### What testing has been done on this PR?
Tested locally and also on the sample code provided on the issue page

#### Any background context you want to provide?
None
#### What are the relevant issues?
#5403 
#### Screenshots (if appropriate)
none
#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
yes, backwards compatible