### PR TITLE
Align DateInput behavior with native HTML date picker

### DIFF
--- a/src/js/components/DateInput/DateInput.js
+++ b/src/js/components/DateInput/DateInput.js
@@ -201,10 +201,11 @@ const DateInput = forwardRef(
               }
             }}
             onFocus={(event) => {
-              openCalendar();
+              announce(
+                formatMessage({ id: 'dateInput.openCalendar', messages }),
+              );
               if (onFocus) onFocus(event);
             }}
-            onClick={openCalendar}
           />
         </Keyboard>
       </FormContext.Provider>

--- a/src/js/components/DateInput/__tests__/DateInput-test.js
+++ b/src/js/components/DateInput/__tests__/DateInput-test.js
@@ -256,7 +256,7 @@ describe('DateInput', () => {
     );
 
     userEvent.click(getByPlaceholderText('mm/dd/yyyy'));
-    expect(document.getElementById('item__drop')).not.toBeNull();
+    expect(document.getElementById('item__drop')).toBeNull();
   });
 
   test('select inline', () => {

--- a/src/js/languages/default.json
+++ b/src/js/languages/default.json
@@ -4,7 +4,8 @@
     "next": "Moved to {date}"
   },
   "dateInput": {
-    "enterCalendar": "Calendar is open, press tab to enter the calendar",
+    "openCalendar": "Press space to open calendar",
+    "enterCalendar": "Calendar is open, use arrow keys and enter to select a date.",
     "exitCalendar": "Exited calendar dialog"
   },
   "fileInput": {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Completes work started by https://github.com/grommet/grommet/pull/5550 to align DateInput with [native HTML date picker behavior](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date). Some of the changes from #5550 were reverted in a later DateInput PR that was open concurrently, so this re-aligns with the desired behavior for keyboard. Additionally, when DateInput is clicked, the calendar should not open right away, instead the user clicks "space" to open the drop. This is consistent with other inputs and native HTML date picker behavior.

I have also updated the accessibility messages to align with the behavior and confirmed they were announced properly with VoiceOver.

#### Where should the reviewer start?
src/js/components/DateInput/DateInput.js

#### What testing has been done on this PR?
Storybook with DateInput

#### How should this be manually tested?
Storybook.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes. Improved DateInput keyboard and mouse behavior.

#### Is this change backwards compatible or is it a breaking change?
Changes when DateInput calendar opens, but aligns it with native HTML as was desired by #5550 