### PR TITLE
Add alwaysShowMask to MaskedInput

### DIFF
--- a/src/js/components/MaskedInput/stories/URL.js
+++ b/src/js/components/MaskedInput/stories/URL.js
@@ -4,15 +4,33 @@ import { grommet } from 'grommet/themes';
 
 export const UrlMaskedInput = () => {
   const [value, setValue] = React.useState('');
+  const [value2, setValue2] = React.useState('');
 
   return (
     <Grommet full theme={grommet}>
       <Box fill align="center" justify="start" pad="large">
         <Box width="medium" gap="medium">
           <MaskedInput
-            mask={[{ fixed: 'https://' }, { regexp: /^.*$/ }]}
+            mask={[
+              { fixed: 'https://' },
+              { regexp: /^[A-Za-z0-9_]*$/, placeholder: 'mysubdomain' },
+              { fixed: '.foobar.'},
+              { regexp: /^[A-Za-z0-9_]*$/, placeholder: 'com'},
+            ]}
             value={value}
             onChange={event => setValue(event.target.value)}
+          />
+          <MaskedInput
+            alwaysShowMask
+            mask={[
+              { fixed: 'https://' },
+              { regexp: /^[^./:]*$/, placeholder: 'mysubdomain' },
+              { fixed: '.foobar.' },
+              { regexp: /^[A-Za-z0-9_]*$/, placeholder: 'com'},
+
+            ]}
+            value={value2}
+            onChange={event => setValue2(event.target.value)}
           />
         </Box>
       </Box>


### PR DESCRIPTION
#### What does this PR do?
This is an early experiment to add `alwaysShowMask` to MaskedInput.
The goal is to give people a chance to look at the behavior in the Storybook/MaskedInput/URL example. The second example there is based on the original request #5480 to have a permanent style of fixed sections.

Please ignore the details in the code at the moment, including `console.log`s :) and any test failures.

With this property set, the value of the input will always try to show all parts of the mask. Fixed sections will always be their fixed value and non-fixed parts will be their inputted values or the placeholder for that chunk if possible.

When you focus the input it tries to select the first part this is just a placeholder.
When you move the caret left or right it tries to only allow that caret in the non-fixed sections.

It still has some edge case issues, especially on last non-fixed sections on regarding backspace/delete. This is partially given to how it maps existing text to the mask.
One improvement idea is to select a placeholder section if the caret is moved to the start of the placeholder chunk.

Any feedback welcome on whether this seems useful.

#### Where should the reviewer start?
Storybook/MaskedInput/URL

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #5480 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible