### PR TITLE
Changed WorldMap to add content and dropProps to places

### DIFF
--- a/src/js/components/WorldMap/__tests__/WorldMap-test.tsx
+++ b/src/js/components/WorldMap/__tests__/WorldMap-test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
+import { Text } from '../../Text';
 import { WorldMap } from '..';
 
 describe('WorldMap', () => {
@@ -214,5 +215,28 @@ describe('WorldMap', () => {
     fireEvent.mouseLeave(getByLabelText('Africa'));
     expect(onContinentHover).toHaveBeenCalledTimes(2);
     expect(onContinentHover).toHaveBeenCalledWith(false);
+  });
+
+  test('places content', () => {
+    const { container } = render(
+      <Grommet>
+        <WorldMap
+          places={[
+            {
+              name: 'Sydney',
+              location: [-33.8830555556, 151.216666667],
+              color: 'accent-1',
+              content: <Text>Sydney</Text>,
+              dropProps: {
+                align: { left: 'right' },
+                elevation: 'medium',
+                margin: { left: 'small' },
+              },
+            },
+          ]}
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/components/WorldMap/__tests__/__snapshots__/WorldMap-test.tsx.snap
+++ b/src/js/components/WorldMap/__tests__/__snapshots__/WorldMap-test.tsx.snap
@@ -1613,3 +1613,136 @@ exports[`WorldMap places 1`] = `
   </svg>
 </div>
 `;
+
+exports[`WorldMap places content 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  width: 100%;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
+<div
+  class="c0"
+>
+  <svg
+    class="c1"
+    height="460"
+    preserveAspectRatio="xMinYMin meet"
+    viewBox="0 0 940 460"
+    width="940"
+  >
+    <g
+      fill="none"
+      fill-rule="evenodd"
+      stroke="none"
+    >
+      <g>
+        <path
+          d="M790,330 L820,340 L900,400 L880,420 L830,410 L750,390 L750,350 Z"
+          fill="#fff"
+          fill-opacity="0.01"
+          stroke="none"
+        />
+        <path
+          d="M790,330 h0 M770,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,370 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M750,380 h0 m10,0 h0 m10,0 h0 M800,380 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M800,390 h0 m10,0 h0 m10,0 h0 m10,0 h0 M830,410 h0 M900,400 h0 M890,410 h0 M880,420 h0"
+          stroke="#EDEDED"
+          stroke-linecap="round"
+          stroke-width="6"
+        />
+      </g>
+      <g>
+        <path
+          d="M690,20 L910,70 L930,90 L810,190 L770,270 L820,310 L720,310 L640,260 L560,250 L530,220 L530,210 L590,150 L600,80 Z"
+          fill="#fff"
+          fill-opacity="0.01"
+          stroke="none"
+        />
+        <path
+          d="M690,20 h0 M700,30 h0 m10,0 h0 M710,40 h0 m10,0 h0 M680,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M810,50 h0 M830,50 h0 M630,60 h0 m10,0 h0 M660,60 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M770,60 h0 M620,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,70 h0 M910,70 h0 M600,80 h0 m10,0 h0 M630,80 h0 M650,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M600,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M870,110 h0 m10,0 h0 m10,0 h0 M600,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M840,120 h0 M860,120 h0 M600,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,130 h0 m10,0 h0 M600,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,140 h0 M590,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M850,150 h0 M590,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M580,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,180 h0 m10,0 h0 M590,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,190 h0 m10,0 h0 m10,0 h0 M590,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M770,190 h0 M810,190 h0 M540,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M790,200 h0 m10,0 h0 M530,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M530,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M590,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M630,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M640,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 M690,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,250 h0 m10,0 h0 m10,0 h0 M640,250 h0 m10,0 h0 M700,250 h0 m10,0 h0 m10,0 h0 M760,250 h0 M640,260 h0 m10,0 h0 M710,260 h0 m10,0 h0 M760,260 h0 M770,270 h0 M710,280 h0 M750,280 h0 M710,290 h0 M730,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 M710,300 h0 M740,300 h0 M760,300 h0 M790,300 h0 m10,0 h0 m10,0 h0 M720,310 h0 M810,310 h0 m10,0 h0"
+          stroke="#EDEDED"
+          stroke-linecap="round"
+          stroke-width="6"
+        />
+      </g>
+      <g>
+        <path
+          d="M440,200 L470,200 L520,220 L570,270 L570,350 L520,380 L500,380 L410,260 L410,230 Z"
+          fill="#fff"
+          fill-opacity="0.01"
+          stroke="none"
+        />
+        <path
+          d="M440,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M500,210 h0 m10,0 h0 M420,220 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,230 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,240 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,250 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M410,260 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M420,270 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,280 h0 m10,0 h0 M470,280 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,300 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,310 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M490,320 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,330 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M480,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M570,340 h0 M490,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M560,350 h0 m10,0 h0 M490,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M500,370 h0 m10,0 h0 m10,0 h0 M500,380 h0 m10,0 h0 m10,0 h0"
+          stroke="#EDEDED"
+          stroke-linecap="round"
+          stroke-width="6"
+        />
+      </g>
+      <g>
+        <path
+          d="M480,30 L500,30 L600,50 L590,140 L580,160 L540,190 L430,190 L400,100 Z"
+          fill="#fff"
+          fill-opacity="0.01"
+          stroke="none"
+        />
+        <path
+          d="M480,30 h0 m10,0 h0 m10,0 h0 M490,40 h0 M600,50 h0 M590,60 h0 M520,70 h0 M590,70 h0 M490,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M490,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M570,90 h0 m10,0 h0 m10,0 h0 M400,100 h0 M480,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M470,110 h0 m10,0 h0 m10,0 h0 M510,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M470,120 h0 m10,0 h0 m10,0 h0 M510,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,130 h0 M470,130 h0 M490,130 h0 M510,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M430,140 h0 m10,0 h0 M470,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,150 h0 M460,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M440,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M450,170 h0 m10,0 h0 m10,0 h0 M490,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 M550,170 h0 m10,0 h0 M430,180 h0 m10,0 h0 m10,0 h0 M480,180 h0 M500,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M460,180 h0 m10,0 h0 M430,190 h0 m10,0 h0 M500,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0"
+          stroke="#EDEDED"
+          stroke-linecap="round"
+          stroke-width="6"
+        />
+      </g>
+      <g>
+        <path
+          d="M250,270 L280,270 L340,310 L340,350 L260,450 L250,440 L230,310 L230,300 Z"
+          fill="#fff"
+          fill-opacity="0.01"
+          stroke="none"
+        />
+        <path
+          d="M250,270 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,280 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,290 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M230,300 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M230,310 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,320 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,330 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,340 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,350 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,360 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,370 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,380 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M260,390 h0 m10,0 h0 m10,0 h0 M250,400 h0 m10,0 h0 m10,0 h0 M250,410 h0 m10,0 h0 m10,0 h0 M250,420 h0 m10,0 h0 M250,430 h0 m10,0 h0 M250,440 h0 m10,0 h0 M260,450 h0"
+          stroke="#EDEDED"
+          stroke-linecap="round"
+          stroke-width="6"
+        />
+      </g>
+      <g>
+        <path
+          d="M220,10 L400,10 L400,70 L230,270 L170,240 L30,130 L10,80 Z"
+          fill="#fff"
+          fill-opacity="0.01"
+          stroke="none"
+        />
+        <path
+          d="M230,10 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M300,10 h0 M320,10 h0 M340,10 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M210,20 h0 M230,20 h0 M250,20 h0 m10,0 h0 M280,20 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M180,30 h0 M210,30 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M270,30 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M140,40 h0 M200,40 h0 M220,40 h0 m10,0 h0 m10,0 h0 M270,40 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M150,50 h0 M170,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 M220,50 h0 m10,0 h0 m10,0 h0 M300,50 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,60 h0 m10,0 h0 m10,0 h0 M170,60 h0 M190,60 h0 M210,60 h0 m10,0 h0 m10,0 h0 M250,60 h0 M310,60 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M150,70 h0 m10,0 h0 m10,0 h0 M200,70 h0 M230,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 M320,70 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M10,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M170,80 h0 M190,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,80 h0 m10,0 h0 M310,80 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M30,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,90 h0 m10,0 h0 m10,0 h0 M300,90 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M30,100 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,100 h0 m10,0 h0 M310,100 h0 m10,0 h0 m10,0 h0 M20,110 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,110 h0 m10,0 h0 M320,110 h0 M30,120 h0 m10,0 h0 M90,120 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,120 h0 m10,0 h0 M270,120 h0 M30,130 h0 M90,130 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M250,130 h0 m10,0 h0 m10,0 h0 M110,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,140 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,150 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M220,160 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M290,160 h0 m10,0 h0 M120,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M240,170 h0 m10,0 h0 m10,0 h0 m10,0 h0 M120,180 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,190 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M130,200 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M140,210 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 m10,0 h0 M160,220 h0 m10,0 h0 m10,0 h0 M230,220 h0 M170,230 h0 m10,0 h0 M170,240 h0 m10,0 h0 M210,240 h0 M240,240 h0 M190,250 h0 m10,0 h0 m10,0 h0 M220,260 h0 M230,270 h0"
+          stroke="#EDEDED"
+          stroke-linecap="round"
+          stroke-width="6"
+        />
+      </g>
+    </g>
+    <path
+      d="M840, 380 h0"
+      stroke="#6FFFB0"
+      stroke-linecap="round"
+      stroke-width="8"
+    />
+  </svg>
+</div>
+`;

--- a/src/js/components/WorldMap/index.d.ts
+++ b/src/js/components/WorldMap/index.d.ts
@@ -7,6 +7,7 @@ import {
   GridAreaType,
   MarginType,
 } from '../../utils';
+import { DropProps } from '../Drop';
 
 export interface WorldMapProps {
   a11yTitle?: A11yTitleType;
@@ -31,6 +32,8 @@ export interface WorldMapProps {
   onSelectPlace?: (place: [number, number]) => void;
   places?: {
     color?: string | { dark?: string; light?: string };
+    content?: React.ReactNode;
+    dropProps?: DropProps;
     name?: string;
     location: number[];
     onClick?: (name: string) => void;

--- a/src/js/components/WorldMap/propTypes.js
+++ b/src/js/components/WorldMap/propTypes.js
@@ -29,6 +29,8 @@ if (process.env.NODE_ENV !== 'production') {
     places: PropTypes.arrayOf(
       PropTypes.shape({
         color: colorPropType,
+        content: PropTypes.node,
+        dropProps: PropTypes.shape({}),
         name: PropTypes.string, // for a11y aria-label
         location: PropTypes.arrayOf(PropTypes.number).isRequired,
         onClick: PropTypes.func,

--- a/src/js/components/WorldMap/stories/Places.js
+++ b/src/js/components/WorldMap/stories/Places.js
@@ -1,24 +1,51 @@
 import React from 'react';
 
-import { Box, Grommet, WorldMap } from 'grommet';
+import { Box, CheckBox, Grommet, Text, WorldMap } from 'grommet';
 import { grommet } from 'grommet/themes';
 
+const placeProps = (name, color, showDrop) => ({
+  name,
+  color,
+  ...(showDrop
+    ? {
+        content: (
+          <Box pad={{ horizontal: 'small', vertical: 'xsmall' }}>
+            <Text>{name}</Text>
+          </Box>
+        ),
+        dropProps: {
+          align: { left: 'right' },
+          background: { color, opacity: 'strong' },
+          elevation: 'medium',
+          margin: { left: 'small' },
+          round: 'xsmall',
+        },
+      }
+    : {}),
+});
+
 export const Places = () => {
-  const [active, setActive] = React.useState();
+  const [showDrops, setShowDrops] = React.useState(true);
   return (
     <Grommet theme={grommet}>
       <Box align="center" pad="large">
+        <CheckBox
+          label="show"
+          checked={showDrops}
+          onChange={() => setShowDrops(!showDrops)}
+        />
         <WorldMap
           places={[
             {
-              name: 'Sydney',
               location: [-33.8830555556, 151.216666667],
-              color: 'graph-1',
-              onClick: () => setActive(!active),
+              ...placeProps('Sydney', 'graph-1', showDrops),
+            },
+            {
+              location: [9.933333, -84.083333],
+              ...placeProps('San José', 'graph-2', showDrops),
             },
           ]}
         />
-        {active && <Box margin="large">Sydney</Box>}
       </Box>
     </Grommet>
   );


### PR DESCRIPTION
#### What does this PR do?

Changed WorldMap to add content and dropProps to places.
This allows callers to place Drop content around places.

<img width="665" alt="Screen Shot 2021-10-08 at 7 33 43 AM" src="https://user-images.githubusercontent.com/11637956/136575396-1729a78a-3fcf-4e90-b5db-4fa2d72e4c37.png">

#### Where should the reviewer start?

Take a look at index.d.ts to see the API surface and then WorldMap.js for the implementation.

#### What testing has been done on this PR?

Enriched the Places story and added a unit test.

#### How should this be manually tested?

Places story.

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
