### PR TITLE
Edge case fix for paginated DataTable

### DIFF
--- a/src/js/utils/pagination.js
+++ b/src/js/utils/pagination.js
@@ -16,7 +16,10 @@ export const usePagination = ({ data, page, step, ...rest }) => {
   const totalPages = data ? Math.ceil(data.length / step) : 0;
   const [activePage, setActivePage] = useState(Math.min(page, totalPages) || 1);
 
-  if (activePage > totalPages) setActivePage(totalPages);
+  // ensure activePage is never lower than 1 to ensure that itemsBeginIndex
+  // and itemsEndIndex aren't negative
+  if (activePage > totalPages && data?.length > 0)
+    setActivePage(Math.max(totalPages, 1));
 
   const itemsBeginIndex = step * (activePage - 1);
   const itemsEndIndex = itemsBeginIndex + step;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes an edge case when totalPages = 0, but when don't want to set activePage to 0 ever because this will lead to negative indices when data arrives. This can occur during the initial render.

#### Where should the reviewer start?
src/js/utils/pagination.js

#### What testing has been done on this PR?
Testing was done in collaboration with @thomas-friedrich who confirmed this fixed the issue.

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Small fix for https://github.com/grommet/grommet/pull/5683

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.