### PR TITLE
Fixes Truncate prop of Text component as a child of div tag didn't works

### DIFF
--- a/src/js/components/Text/Text.js
+++ b/src/js/components/Text/Text.js
@@ -4,6 +4,7 @@ import { StyledText } from './StyledText';
 import { Tip } from '../Tip';
 import { useForwardedRef } from '../../utils';
 import { TextPropTypes } from './propTypes';
+import { Box } from '../Box';
 
 const Text = forwardRef(
   (
@@ -37,16 +38,19 @@ const Text = forwardRef(
     }, [children, textRef, truncate]);
 
     const styledTextResult = (
-      <StyledText
-        as={!as && tag ? tag : as}
-        colorProp={color}
-        aria-label={a11yTitle}
-        truncate={truncate}
-        {...rest}
-        ref={textRef}
-      >
-        {children}
-      </StyledText>
+      <Box>
+        <StyledText
+          as={!as && tag ? tag : as}
+          colorProp={color}
+          aria-label={a11yTitle}
+          truncate={truncate}
+          {...rest}
+          ref={textRef}
+        >
+          {children}
+        </StyledText>
+      </Box>
+
     );
 
     if (tip) {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

Fixes #5469 issue

`truncate` prop of `Text` component isn't working in the following case 
```
  <div style={{width: "10%"}}>
        <Text truncate>
          This is the truncated longggggggggggggggggggggggggggggggggg texxttttttttttttttttttttttttttttttttttttttttttttttt.
        </Text>
      </div>
```
so wrapped the `StyledText` component inside a `Box` component and its working now

#### What does this PR do?
Fixes #5469 issue

#### Where should the reviewer start?
By creating a `Text` component and passing truncate prop

#### What testing has been done on this PR?
Tested locally

#### How should this be manually tested?
Manual testing can be done by creating a `Text` component with `truncate` prop as in example above

#### Any background context you want to provide?
None
#### What are the relevant issues?
#5469
#### Screenshots (if appropriate)
None
#### Do the grommet docs need to be updated?
not sure
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
yes