### PR TITLE
Drop: 'container' prop for portal render

### DIFF
--- a/src/js/components/Drop/Drop.js
+++ b/src/js/components/Drop/Drop.js
@@ -14,6 +14,7 @@ const Drop = forwardRef(
       restrictFocus,
       target: dropTarget, // avoid DOM leakage
       trapFocus = true,
+      container,
       ...rest
     },
     ref,
@@ -21,11 +22,11 @@ const Drop = forwardRef(
     const theme = useContext(ThemeContext) || defaultProps.theme;
     const [originalFocusedElement, setOriginalFocusedElement] = useState();
     useEffect(() => setOriginalFocusedElement(document.activeElement), []);
-    const [dropContainer, setDropContainer] = useState();
+    const [dropContainer, setDropContainer] = useState(container);
     const containerTarget = useContext(ContainerTargetContext);
     useEffect(
-      () => setDropContainer(getNewContainer(containerTarget)),
-      [containerTarget],
+      () => !container || setDropContainer(getNewContainer(containerTarget)),
+      [container, containerTarget],
     );
 
     // just a few things to clean up when the Drop is unmounted
@@ -43,10 +44,16 @@ const Drop = forwardRef(
           }
         }
         if (dropContainer) {
-          containerTarget.removeChild(dropContainer);
+          (container || containerTarget).removeChild(dropContainer);
         }
       },
-      [containerTarget, dropContainer, originalFocusedElement, restrictFocus],
+      [
+        container,
+        containerTarget,
+        dropContainer,
+        originalFocusedElement,
+        restrictFocus,
+      ],
     );
 
     return dropContainer

--- a/src/js/components/Drop/index.d.ts
+++ b/src/js/components/Drop/index.d.ts
@@ -36,6 +36,7 @@ export interface DropProps {
   plain?: boolean;
   margin?: MarginType;
   round?: RoundType;
+  container?: object;
 }
 
 type divProps = JSX.IntrinsicElements['div'];

--- a/src/js/components/Drop/propTypes.js
+++ b/src/js/components/Drop/propTypes.js
@@ -41,6 +41,7 @@ if (process.env.NODE_ENV !== 'production') {
     stretch: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['align'])]),
     target: PropTypes.object.isRequired,
     trapFocus: PropTypes.bool,
+    container: PropTypes.object,
   };
 }
 export const DropPropTypes = PropType;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Add a optional `container` prop to `Drop`. Use this prop to custom portal rendering. Currently `Drop` always render to a fixed div under body. In my case, I need the `Drop` layer inside some place inside my component tree.
#### Where should the reviewer start?
`src/js/components/Drop/Drop.js`
#### What testing has been done on this PR?
Pass all exist test.
#### How should this be manually tested?
Set the prop, see what the dom rendered.
#### Any background context you want to provide?
Currently `Drop` always render to a fixed div under body. In my case, I need the `Drop` layer inside some place inside my component tree.

#### Do the grommet docs need to be updated?
`Drop` coponent's doc. I willing to update that if gromment team think this PR is a good idea.
#### Should this PR be mentioned in the release notes?
New optional `container` prop to customize `Drop` render to.
#### Is this change backwards compatible or is it a breaking change?
Yes.