### PR TITLE
clean up imports that were not taken out and remove a11ytitle

### DIFF
--- a/src/js/components/NameValueList/index.d.ts
+++ b/src/js/components/NameValueList/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { A11yTitleType, AlignType, GapType, WidthType } from '../../utils';
+import { AlignType, WidthType } from '../../utils';
 export interface NameValueListProps {
   align?: AlignType;
   layout?: 'column' | 'grid';

--- a/src/js/components/NameValueList/propTypes.js
+++ b/src/js/components/NameValueList/propTypes.js
@@ -1,14 +1,9 @@
 import PropTypes from 'prop-types';
-import {
-  a11yTitlePropType,
-  alignPropType,
-  widthPropType,
-} from '../../utils/general-prop-types';
+import { alignPropType, widthPropType } from '../../utils/general-prop-types';
 
 let PropType = {};
 if (process.env.NODE_ENV !== 'production') {
   PropType = {
-    a11yTitle: a11yTitlePropType,
     align: alignPropType,
     layout: PropTypes.oneOfType(['column', 'grid']),
     nameProps: PropTypes.shape({


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR cleans up some imports that were not removed
take out `a11ytitle` 
#### Where should the reviewer start?
namevaluelist.js
#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
