### PR TITLE
chore - remove unnecessary elements from tests

### DIFF
--- a/src/js/components/Accordion/__tests__/Accordion-test.tsx
+++ b/src/js/components/Accordion/__tests__/Accordion-test.tsx
@@ -4,7 +4,7 @@ import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
 import { axe } from 'jest-axe';
-import { cleanup, render, fireEvent, act } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 
 import { Accordion, AccordionPanel, Box, Grommet } from '../..';
 
@@ -15,8 +15,6 @@ const customTheme = {
 };
 
 describe('Accordion', () => {
-  afterEach(cleanup);
-
   test('should have no accessibility violations', async () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Anchor/__tests__/Anchor-test.tsx
+++ b/src/js/components/Anchor/__tests__/Anchor-test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
@@ -10,8 +10,6 @@ import { Grommet } from '../../Grommet';
 import { Anchor } from '..';
 
 describe('Anchor', () => {
-  afterEach(cleanup);
-
   test('should have no accessibility violations', async () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Button/__tests__/Button-kind-test.js
+++ b/src/js/components/Button/__tests__/Button-kind-test.js
@@ -5,15 +5,13 @@ import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
 import { axe } from 'jest-axe';
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { Add } from 'grommet-icons';
 
 import { Grommet, Button } from '../..';
 import { buttonKindTheme } from './theme/buttonKindTheme';
 
 describe('Button kind', () => {
-  afterEach(cleanup);
-
   test('should have no accessibility violations', async () => {
     const { container, getByText } = render(
       <Grommet

--- a/src/js/components/Carousel/__tests__/Carousel-test.tsx
+++ b/src/js/components/Carousel/__tests__/Carousel-test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, render, fireEvent, act } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
@@ -7,8 +7,6 @@ import { Carousel } from '..';
 import { Image } from '../../Image';
 
 describe('Carousel', () => {
-  afterEach(cleanup);
-
   test('basic', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/CheckBoxGroup/__tests__/CheckBoxGroup-test.tsx
+++ b/src/js/components/CheckBoxGroup/__tests__/CheckBoxGroup-test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, render, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import 'jest-axe/extend-expect';
@@ -9,8 +9,6 @@ import { Grommet } from '../../Grommet';
 import { CheckBoxGroup } from '..';
 
 describe('CheckBoxGroup', () => {
-  afterEach(cleanup);
-
   test('should have no accessibility violations', async () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Collapsible/__tests__/Collapsible-test.tsx
+++ b/src/js/components/Collapsible/__tests__/Collapsible-test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import { cleanup, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
@@ -10,8 +10,6 @@ import { Grommet } from '../../Grommet';
 import { Text } from '../../Text';
 
 describe('Collapsible', () => {
-  afterEach(cleanup);
-
   test('no accessibility violations', async () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import { cleanup, render, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 
 import { Grommet } from '../../Grommet';
 import { Box } from '../../Box';
@@ -13,8 +13,6 @@ for (let i = 0; i < 95; i += 1) {
 }
 
 describe('DataTable', () => {
-  afterEach(cleanup);
-
   test('empty', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/DateInput/__tests__/DateInput-test.tsx
+++ b/src/js/components/DateInput/__tests__/DateInput-test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import 'jest-axe/extend-expect';
@@ -17,8 +17,6 @@ const DATES = ['2020-07-02T00:00:00-08:00', '2020-07-07T00:00:00-08:00'];
 
 describe('DateInput', () => {
   beforeEach(createPortal);
-
-  afterEach(cleanup);
 
   test('should reset date if passed empty string', async () => {
     const Test = () => {

--- a/src/js/components/Diagram/__tests__/Diagram-test.tsx
+++ b/src/js/components/Diagram/__tests__/Diagram-test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import 'jest-styled-components';
-import { cleanup, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import { Grommet, Box, Diagram, Stack } from '../..';
 
@@ -22,8 +22,6 @@ Context.propTypes = {
 };
 
 describe('Diagram', () => {
-  afterEach(cleanup);
-
   test('basic', () => {
     const { container } = render(
       <Context>

--- a/src/js/components/Drop/__tests__/Drop-test.tsx
+++ b/src/js/components/Drop/__tests__/Drop-test.tsx
@@ -61,8 +61,6 @@ const TestInput = ({
 };
 
 describe('Drop', () => {
-  afterEach(cleanup);
-
   test('should have no accessibility violations', async () => {
     window.scrollTo = jest.fn();
     const { container } = render(<TestInput />);

--- a/src/js/components/DropButton/__tests__/DropButton-test.js
+++ b/src/js/components/DropButton/__tests__/DropButton-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
@@ -12,8 +12,6 @@ import { DropButton } from '..';
 
 describe('DropButton', () => {
   beforeEach(createPortal);
-
-  afterEach(cleanup);
 
   test('should have no accessibility violations', async () => {
     const { container } = render(

--- a/src/js/components/Form/__tests__/Form-test-controlled.js
+++ b/src/js/components/Form/__tests__/Form-test-controlled.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import 'jest-styled-components';
 
-import { act, cleanup, render, fireEvent } from '@testing-library/react';
+import { act, render, fireEvent } from '@testing-library/react';
 import { Grommet } from '../../Grommet';
 import { Form } from '..';
 import { FormField } from '../../FormField';
@@ -11,8 +11,6 @@ import { TextInput } from '../../TextInput';
 import { CheckBox } from '../../CheckBox';
 
 describe('Form controlled', () => {
-  afterEach(cleanup);
-
   test('controlled', () => {
     const onSubmit = jest.fn();
     const Test = () => {

--- a/src/js/components/Form/__tests__/Form-test-uncontrolled.js
+++ b/src/js/components/Form/__tests__/Form-test-uncontrolled.js
@@ -5,13 +5,7 @@ import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 import '@testing-library/jest-dom';
 
-import {
-  act,
-  cleanup,
-  render,
-  fireEvent,
-  screen,
-} from '@testing-library/react';
+import { act, render, fireEvent, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 import { Grommet } from '../../Grommet';
@@ -27,8 +21,6 @@ import { Box } from '../../Box';
 import { DateInput } from '../../DateInput';
 
 describe('Form accessibility', () => {
-  afterEach(cleanup);
-
   test(`TextInput in Form should have
   no accessibility violations`, async () => {
     const { container } = render(
@@ -122,8 +114,6 @@ describe('Form accessibility', () => {
 });
 
 describe('Form uncontrolled', () => {
-  afterEach(cleanup);
-
   test('empty', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Image/__tests__/Image-test.tsx
+++ b/src/js/components/Image/__tests__/Image-test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import 'jest-styled-components';
@@ -23,8 +23,6 @@ test('image should have no violations', async () => {
 
   const results = await axe(container);
   expect(results).toHaveNoViolations();
-
-  cleanup();
 });
 
 test('Image renders', () => {

--- a/src/js/components/Layer/__tests__/Layer-test.js
+++ b/src/js/components/Layer/__tests__/Layer-test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import { cleanup, render, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { getByTestId, queryByTestId } from '@testing-library/dom';
 import 'regenerator-runtime/runtime';
 import { createPortal, expectPortal } from '../../../utils/portal';
@@ -64,7 +64,6 @@ const TargetLayer = (props) => {
 
 describe('Layer', () => {
   beforeEach(createPortal);
-  afterEach(cleanup);
   const positions = [
     'top',
     'bottom',

--- a/src/js/components/List/__tests__/List-test.js
+++ b/src/js/components/List/__tests__/List-test.js
@@ -3,7 +3,7 @@ import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
-import { cleanup, render, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 
 import { axe } from 'jest-axe';
 import { Grommet } from '../../Grommet';
@@ -15,8 +15,6 @@ for (let i = 0; i < 95; i += 1) {
 }
 
 describe('List', () => {
-  afterEach(cleanup);
-
   test('should have no accessibility violations', async () => {
     const onClickItem = jest.fn();
     const { container, getByText } = render(
@@ -272,8 +270,6 @@ describe('List events', () => {
     );
   });
 
-  afterEach(cleanup);
-
   test('Enter key', () => {
     const { container, getByText } = render(<App />);
 
@@ -473,8 +469,6 @@ describe('List onOrder', () => {
       );
     };
   });
-
-  afterEach(cleanup);
 
   test('Mouse move down', () => {
     const { container } = render(<App />);

--- a/src/js/components/Main/__tests__/Main-test.tsx
+++ b/src/js/components/Main/__tests__/Main-test.tsx
@@ -4,13 +4,11 @@ import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
 import { axe } from 'jest-axe';
-import { render, cleanup } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import { Grommet, Main } from '../..';
 
 describe('Main', () => {
-  afterEach(cleanup);
-
   test('should have no accessibility violations', async () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
+++ b/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import 'jest-styled-components';
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { getByText, screen } from '@testing-library/dom';
 import { axe } from 'jest-axe';
 import 'jest-axe/extend-expect';
@@ -17,7 +17,6 @@ import { MaskedInput } from '..';
 
 describe('MaskedInput', () => {
   beforeEach(createPortal);
-  afterEach(cleanup);
 
   test('should have no accessibility violations', async () => {
     const { container } = render(

--- a/src/js/components/NameValueList/__tests__/NameValueList-test.tsx
+++ b/src/js/components/NameValueList/__tests__/NameValueList-test.tsx
@@ -4,7 +4,7 @@ import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 import { axe } from 'jest-axe';
 
-import { cleanup, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import { ThemeType } from '../../../themes';
 import { Grommet } from '../../Grommet';
@@ -18,8 +18,6 @@ const data = {
 };
 
 describe('NameValueList', () => {
-  afterEach(cleanup);
-
   test('should have no accessibility violations', async () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/NameValuePair/__tests__/NameValuePair-test.tsx
+++ b/src/js/components/NameValuePair/__tests__/NameValuePair-test.tsx
@@ -3,7 +3,7 @@ import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
-import { cleanup, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import { Box } from '../../Box';
 import { Grommet } from '../../Grommet';
@@ -18,8 +18,6 @@ const data = {
 };
 
 describe('NameValuePair', () => {
-  afterEach(cleanup);
-
   test(`should render name when name is typeof string`, () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Nav/__tests__/Nav-test.tsx
+++ b/src/js/components/Nav/__tests__/Nav-test.tsx
@@ -4,13 +4,11 @@ import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
 import { axe } from 'jest-axe';
-import { render, cleanup } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import { Grommet, Nav } from '../..';
 
 describe('Nav', () => {
-  afterEach(cleanup);
-
   test('should have no accessibility violations', async () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Notification/__tests__/Notification-test.js
+++ b/src/js/components/Notification/__tests__/Notification-test.js
@@ -4,13 +4,11 @@ import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
 import { axe } from 'jest-axe';
-import { render, cleanup, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 import { Grommet, Notification } from '../..';
 
 describe('Notification', () => {
-  afterEach(cleanup);
-
   test('should have no accessibility violations', async () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Pagination/__tests__/Pagination-test.tsx
+++ b/src/js/components/Pagination/__tests__/Pagination-test.tsx
@@ -3,7 +3,7 @@ import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
-import { cleanup, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { fireEvent } from '@testing-library/dom';
 
 import { Grommet } from '../../Grommet';
@@ -17,8 +17,6 @@ for (let i = 0; i < 95; i += 1) {
 }
 
 describe('Pagination', () => {
-  afterEach(cleanup);
-
   test(`should display the correct last page based on items length
   and step`, () => {
     const { container, getByText } = render(

--- a/src/js/components/Select/__tests__/SelectMultiple-test.js
+++ b/src/js/components/Select/__tests__/SelectMultiple-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, cleanup, render, fireEvent } from '@testing-library/react';
+import { act, render, fireEvent } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
@@ -13,7 +13,6 @@ import { Select } from '..';
 describe('Select Controlled', () => {
   window.scrollTo = jest.fn();
   beforeEach(createPortal);
-  afterEach(cleanup);
 
   test('should not have accessibility violations', async () => {
     const { container } = render(

--- a/src/js/components/SkipLinks/__tests__/SkipLink-test.js
+++ b/src/js/components/SkipLinks/__tests__/SkipLink-test.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import 'jest-styled-components';
-import { act, cleanup, render, fireEvent } from '@testing-library/react';
+import { act, render, fireEvent } from '@testing-library/react';
 
 import { Grommet, SkipLinks, SkipLink, SkipLinkTarget } from '../..';
 
 describe('SkipLink', () => {
-  afterEach(cleanup);
-
   test('basic', () => {
     jest.useFakeTimers('modern');
     const { container } = render(

--- a/src/js/components/TextInput/__tests__/TextInput-test.tsx
+++ b/src/js/components/TextInput/__tests__/TextInput-test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import 'jest-styled-components';
 import 'regenerator-runtime/runtime';
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { getByText, screen } from '@testing-library/dom';
 import { axe } from 'jest-axe';
 import 'jest-axe/extend-expect';
@@ -16,7 +16,6 @@ import { Text } from '../../Text';
 
 describe('TextInput', () => {
   beforeEach(createPortal);
-  afterEach(cleanup);
 
   test('should not have accessibility violations', async () => {
     const { container } = render(

--- a/src/js/components/Tip/__tests__/Tip-test.js
+++ b/src/js/components/Tip/__tests__/Tip-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
 import { axe } from 'jest-axe';
 import 'jest-styled-components';
@@ -12,7 +12,6 @@ import { Grommet } from '../../Grommet';
 import { Tip } from '../Tip';
 
 describe('Tip', () => {
-  afterEach(cleanup);
   test('should have no accessibility violations', async () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Video/__tests__/Video-test.js
+++ b/src/js/components/Video/__tests__/Video-test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import { cleanup, render, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
@@ -20,8 +20,6 @@ describe('Video', () => {
       </Grommet>
     );
   });
-
-  afterEach(cleanup);
 
   test('should have no accessibility violations', async () => {
     const { container } = render(<App />);

--- a/src/js/components/__tests__/FocusedContainer-test.js
+++ b/src/js/components/__tests__/FocusedContainer-test.js
@@ -5,8 +5,6 @@ import { cleanup, render, fireEvent } from '@testing-library/react';
 import { FocusedContainer } from '../FocusedContainer';
 
 describe('FocusedContainer', () => {
-  afterEach(cleanup);
-
   test('basic', () => {
     jest.useFakeTimers('modern');
     const { container: trapped } = render(


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Remove unnecessary act() and cleanup() from tests

#### What are the relevant issues?

Closes #5757 and Closes #5758 

#### Do the grommet docs need to be updated?
No
