### PR TITLE
Enhance storybook theming for Clock

### DIFF
--- a/src/js/components/Clock/stories/Analog.js
+++ b/src/js/components/Clock/stories/Analog.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Box, Grommet, Clock, Text } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, Clock, Text } from 'grommet';
 
 const sizes = [
   'xsmall',
@@ -14,9 +13,11 @@ const sizes = [
 ];
 
 export const Analog = () => (
-  <Grommet theme={grommet}>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={...}>
+  <>
     <Box direction="row" gap="small" pad="large">
-      {sizes.map(size => (
+      {sizes.map((size) => (
         <Box key={size} align="center">
           <Text>{size}</Text>
           <Clock type="analog" size={size} />
@@ -29,7 +30,8 @@ export const Analog = () => (
         compatibility.
       </Text>
     </Box>
-  </Grommet>
+  </>
+  // </Grommet>
 );
 
 Analog.parameters = {

--- a/src/js/components/Clock/stories/Countdown.js
+++ b/src/js/components/Clock/stories/Countdown.js
@@ -1,14 +1,14 @@
 import React from 'react';
 
-import { Box, Grommet, Clock } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, Clock } from 'grommet';
 
 export const Countdown = () => (
-  <Grommet theme={grommet}>
-    <Box align="center" justify="start" pad="large">
-      <Clock type="digital" time="PT0H0M20S" run="backward" />
-    </Box>
-  </Grommet>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={grommet}>
+  <Box align="center" justify="start" pad="large">
+    <Clock type="digital" time="PT0H0M20S" run="backward" />
+  </Box>
+  // </Grommet>
 );
 
 Countdown.parameters = {

--- a/src/js/components/Clock/stories/CustomThemed/CustomAnalog.tsx
+++ b/src/js/components/Clock/stories/CustomThemed/CustomAnalog.tsx
@@ -42,5 +42,5 @@ CustomAnalog.parameters = {
 };
 
 export default {
-  title: 'Visualizations/Clock/Custom analog',
+  title: 'Visualizations/Clock/Custom Themed/Custom analog',
 };

--- a/src/js/components/Clock/stories/CustomThemed/Digital.js
+++ b/src/js/components/Clock/stories/CustomThemed/Digital.js
@@ -24,7 +24,7 @@ const clockSizes = ['xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge'];
 export const Digital = () => (
   <Grommet theme={theme}>
     <Box direction="row" gap="medium" pad="medium">
-      {clockSizes.map(size => (
+      {clockSizes.map((size) => (
         <Box key={size} align="center">
           <Text>{size}</Text>
           <Clock type="digital" size={size} />
@@ -50,5 +50,5 @@ Digital.parameters = {
 };
 
 export default {
-  title: 'Visualizations/Clock/Digital',
+  title: 'Visualizations/Clock/Custom Themed/Digital',
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Following #5735 , enhances support to storybook theming for `Clock` component.

#### Where should the reviewer start?

`src/js/components/Clock/stories`

#### What testing has been done on this PR?

`yarn storybook`

#### How should this be manually tested?

`yarn storybook`

#### Any background context you want to provide?

#### What are the relevant issues?

#5735 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
