### PR TITLE
Change FileInput maxSize factor to 1024

### DIFF
--- a/src/js/components/FileInput/FileInput.js
+++ b/src/js/components/FileInput/FileInput.js
@@ -19,7 +19,7 @@ import { FileInputPropTypes } from './propTypes';
 
 const formatBytes = (size) => {
   const units = ['B', 'KB', 'MB', 'GB', 'TB'];
-  const factor = 1000;
+  const factor = 1024;
   let index = 0;
   let num = size;
   while (num >= factor && index < units.length - 1) {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changes the factor that determines the conversion for fileinput max size message to use 1024 as opposed to 1000.

#### Where should the reviewer start?
src/js/components/FileInput/FileInput.js

#### What testing has been done on this PR?
Tested locally by adjusting the `maxSize` story locally and setting MAX_SIZE to just under a known file size I was going to upload. Then, I uploaded the file and saw the error message.

#### How should this be manually tested?
Same as above.

#### Any background context you want to provide?
1024 is the factor for file size conversions (bytes --> KB ...etc): http://myrepono.com/faq/4

#### What are the relevant issues?
Closes #5756 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes. Fixed FileInput `maxSize` conversion.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.