### PR TITLE
Fix Tip behavior after getting focus back from another element

### DIFF
--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -4,6 +4,7 @@ import React, {
   forwardRef,
   useContext,
   useState,
+  useEffect,
 } from 'react';
 import { ThemeContext } from 'styled-components';
 
@@ -15,6 +16,16 @@ import { TipPropTypes } from './propTypes';
 const Tip = forwardRef(({ children, content, dropProps, plain }, tipRef) => {
   const theme = useContext(ThemeContext);
   const [over, setOver] = useState(false);
+  const [usingKeyboard, setUsingKeyboard] = useState();
+
+  useEffect(() => {
+    document.addEventListener('mousedown', () => setUsingKeyboard(false));
+    document.addEventListener('keydown', () => setUsingKeyboard(true));
+    return () => {
+      document.removeEventListener('mousedown', () => setUsingKeyboard(false));
+      document.removeEventListener('keydown', () => setUsingKeyboard(true));
+    };
+  }, []);
 
   const componentRef = useForwardedRef(tipRef);
 
@@ -36,8 +47,12 @@ const Tip = forwardRef(({ children, content, dropProps, plain }, tipRef) => {
   const clonedChild = cloneElement(child, {
     onMouseEnter: () => setOver(true),
     onMouseLeave: () => setOver(false),
-    onFocus: () => setOver(true),
-    onBlur: () => setOver(false),
+    onFocus: () => {
+      if (usingKeyboard) setOver(true);
+    },
+    onBlur: () => {
+      if (usingKeyboard) setOver(false);
+    },
     key: 'tip-child',
     ref: (node) => {
       // https://github.com/facebook/react/issues/8873#issuecomment-287873307

--- a/src/js/components/Tip/__tests__/__snapshots__/Tip-test.js.snap
+++ b/src/js/components/Tip/__tests__/__snapshots__/Tip-test.js.snap
@@ -204,30 +204,6 @@ exports[`Tip focus and blur events on the Tip's child 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-
-}
-
 <div
   class="c0"
 >


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where the Tip would display after getting focus back (ex. when Tip is on a Button and the Button opens a Layer the Tip would display when the Layer closes).

Now the Tip only displays after getting focus back from another element when navigating with the keyboard. This maintains accessibility while removing the behavior for mouse users.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with the following story:
```javascript
import React from 'react';
import { Add } from 'grommet-icons';
import { Box, Button, Grommet, Layer, Text, Tip } from 'grommet';
import { grommet } from 'grommet/themes';

export const Test = () => {
  const [open, setOpen] = React.useState();
  const onOpen = () => setOpen(true);
  const onClose = () => setOpen(undefined);

  return (
    <Grommet theme={grommet} full>
      <Box fill align="center" justify="center" gap="medium">
        <Tip
          plain
          dropProps={{ align: { left: 'right' } }}
          content={
            <Box
              align="center"
              background="accent-1"
              margin="xsmall"
              pad="xsmall"
              round="medium"
              flex={false}
            >
              <Text color="brand">Tooltip</Text>
            </Box>
          }
        >
          <Button
            icon={<Add color="brand" />}
            label={
              <Text>
                <strong>Add Corner Layer</strong>
              </Text>
            }
            onClick={onOpen}
            plain
            focusIndicator
          />
        </Tip>
        <Tip
          plain
          dropProps={{ align: { left: 'right' } }}
          content="tip"
        >
          <Button
            icon={<Add color="brand" />}
            label={
              <Text>
                <strong>Add Corner Layer</strong>
              </Text>
            }
            onClick={onOpen}
            plain
            focusIndicator
          />
        </Tip>
      </Box>
      {open && (
        <Layer position="top-right" onClickOutside={onClose}>
            <Box pad="large" margin="small">This is a Layer</Box>
            <Button label="Close" onClick={onClose} />
        </Layer>
      )}
    </Grommet>
  );
};

export default {
  title: 'Layout/Layer/Test',
};
```

#### How should this be manually tested?
With storybook stories using Tip and Layer

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #5569 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Maybe

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible