### PR TITLE
Remove default margin of `dl` from NameValueList

### DIFF
--- a/src/js/components/NameValueList/NameValueList.js
+++ b/src/js/components/NameValueList/NameValueList.js
@@ -41,6 +41,7 @@ const NameValueList = forwardRef(
           columns={columns}
           gap={theme.nameValueList.gap}
           fill={layout === 'grid'}
+          margin="none" // override browser default margin for dl
           {...rest}
         />
       </NameValueListContext.Provider>

--- a/src/js/components/NameValueList/__tests__/__snapshots__/NameValueList-test.tsx.snap
+++ b/src/js/components/NameValueList/__tests__/__snapshots__/NameValueList-test.tsx.snap
@@ -14,6 +14,7 @@ exports[`NameValueList should render 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
+  margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
   grid-gap: 24px 48px;
 }
@@ -44,6 +45,16 @@ exports[`NameValueList should render 1`] = `
   font-size: 18px;
   line-height: 24px;
   color: #444444;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
 }
 
 <div
@@ -112,6 +123,7 @@ exports[`NameValueList should render correct alignment of name 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
+  margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
   grid-gap: 24px 48px;
 }
@@ -142,6 +154,16 @@ exports[`NameValueList should render correct alignment of name 1`] = `
   line-height: 24px;
   color: #444444;
   font-weight: bold;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
 }
 
 <div
@@ -210,6 +232,7 @@ exports[`NameValueList should render correct alignment of value 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
+  margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
   grid-gap: 24px 48px;
 }
@@ -240,6 +263,16 @@ exports[`NameValueList should render correct alignment of value 1`] = `
   font-size: 18px;
   line-height: 24px;
   color: #444444;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
 }
 
 <div
@@ -308,6 +341,7 @@ exports[`NameValueList should render correct gap between rows and columns 1`] = 
 .c1 {
   display: grid;
   box-sizing: border-box;
+  margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
   grid-gap: 48px 12px;
 }
@@ -338,6 +372,16 @@ exports[`NameValueList should render correct gap between rows and columns 1`] = 
   font-size: 18px;
   line-height: 24px;
   color: #444444;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
 }
 
 <div
@@ -406,6 +450,7 @@ exports[`NameValueList should render correct width of name 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
+  margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
   grid-gap: 24px 48px;
 }
@@ -436,6 +481,16 @@ exports[`NameValueList should render correct width of name 1`] = `
   font-size: 18px;
   line-height: 24px;
   color: #444444;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
 }
 
 <div
@@ -504,6 +559,7 @@ exports[`NameValueList should render correct width of value 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
+  margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,96px) );
   grid-gap: 24px 48px;
 }
@@ -535,6 +591,16 @@ exports[`NameValueList should render correct width of value 1`] = `
   font-size: 18px;
   line-height: 24px;
   color: #444444;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
 }
 
 <div
@@ -604,6 +670,7 @@ exports[`NameValueList should render name/value as a column when pairProps = { d
 .c1 {
   display: grid;
   box-sizing: border-box;
+  margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
   grid-gap: 24px 48px;
 }
@@ -634,6 +701,16 @@ exports[`NameValueList should render name/value as a column when pairProps = { d
   font-size: 18px;
   line-height: 24px;
   color: #444444;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
 }
 
 <div
@@ -702,6 +779,7 @@ exports[`NameValueList should render pairs in a grid when layout="grid" 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
+  margin: 0px;
   width: 100%;
   height: 100%;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
@@ -734,6 +812,12 @@ exports[`NameValueList should render pairs in a grid when layout="grid" 1`] = `
   font-size: 18px;
   line-height: 24px;
   color: #444444;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
 }
 
 <div
@@ -803,6 +887,7 @@ exports[`NameValueList should render value above name when pairProps = { directi
 .c1 {
   display: grid;
   box-sizing: border-box;
+  margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
   grid-gap: 24px 48px;
 }
@@ -833,6 +918,16 @@ exports[`NameValueList should render value above name when pairProps = { directi
   line-height: 24px;
   color: #444444;
   font-weight: bold;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
 }
 
 <div
@@ -901,6 +996,7 @@ exports[`NameValueList should support custom theme 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
+  margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,192px) );
   grid-gap: 48px 12px;
 }
@@ -932,6 +1028,16 @@ exports[`NameValueList should support custom theme 1`] = `
   line-height: 24px;
   color: #444444;
   font-weight: lighter;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
 }
 
 <div

--- a/src/js/components/NameValuePair/__tests__/__snapshots__/NameValuePair-test.tsx.snap
+++ b/src/js/components/NameValuePair/__tests__/__snapshots__/NameValuePair-test.tsx.snap
@@ -45,6 +45,7 @@ exports[`NameValuePair should render name when name is JSX Element 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
+  margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
   grid-gap: 24px 48px;
 }
@@ -59,6 +60,16 @@ exports[`NameValuePair should render name when name is JSX Element 1`] = `
 @media only screen and (max-width:768px) {
   .c3 {
     padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
   }
 }
 
@@ -154,6 +165,7 @@ exports[`NameValuePair should render name when name is typeof string 1`] = `
 .c1 {
   display: grid;
   box-sizing: border-box;
+  margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
   grid-gap: 24px 48px;
 }
@@ -170,6 +182,16 @@ exports[`NameValuePair should render name when name is typeof string 1`] = `
   font-size: 18px;
   line-height: 24px;
   color: #444444;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
 }
 
 <div
@@ -254,6 +276,7 @@ exports[`NameValuePair should render value when provided as child of type
 .c1 {
   display: grid;
   box-sizing: border-box;
+  margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,96px) );
   grid-gap: 24px 48px;
 }
@@ -270,6 +293,16 @@ exports[`NameValuePair should render value when provided as child of type
   font-size: 18px;
   line-height: 24px;
   color: #444444;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
 }
 
 <div
@@ -377,6 +410,7 @@ exports[`NameValuePair should render value when provided as child of type JSX El
 .c1 {
   display: grid;
   box-sizing: border-box;
+  margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
   grid-gap: 24px 48px;
 }
@@ -397,6 +431,16 @@ exports[`NameValuePair should render value when provided as child of type JSX El
 
 @media only screen and (max-width:768px) {
   .c5 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
     margin: 0px;
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Removes the browser default margin of `dl` from NameValueList ,similar to what is done in NameValuePair.

#### Where should the reviewer start?
src/js/components/NameValueList/NameValueList.js

#### What testing has been done on this PR?
Inspected browser on NameValueList stories and confirmed there was no margin.

#### How should this be manually tested?
Same as above.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No (component has not been released).

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.