### PR TITLE
Update default gap NameValueList

### DIFF
--- a/src/js/components/NameValueList/__tests__/__snapshots__/NameValueList-test.tsx.snap
+++ b/src/js/components/NameValueList/__tests__/__snapshots__/NameValueList-test.tsx.snap
@@ -16,7 +16,7 @@ exports[`NameValueList should render 1`] = `
   box-sizing: border-box;
   margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
-  grid-gap: 24px 48px;
+  grid-gap: 12px 48px;
 }
 
 .c2 {
@@ -125,7 +125,7 @@ exports[`NameValueList should render correct alignment of name 1`] = `
   box-sizing: border-box;
   margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
-  grid-gap: 24px 48px;
+  grid-gap: 12px 48px;
 }
 
 .c2 {
@@ -234,7 +234,7 @@ exports[`NameValueList should render correct alignment of value 1`] = `
   box-sizing: border-box;
   margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
-  grid-gap: 24px 48px;
+  grid-gap: 12px 48px;
 }
 
 .c2 {
@@ -452,7 +452,7 @@ exports[`NameValueList should render correct width of name 1`] = `
   box-sizing: border-box;
   margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
-  grid-gap: 24px 48px;
+  grid-gap: 12px 48px;
 }
 
 .c2 {
@@ -561,7 +561,7 @@ exports[`NameValueList should render correct width of value 1`] = `
   box-sizing: border-box;
   margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,96px) );
-  grid-gap: 24px 48px;
+  grid-gap: 12px 48px;
 }
 
 .c2 {
@@ -672,7 +672,7 @@ exports[`NameValueList should render name/value as a column when pairProps = { d
   box-sizing: border-box;
   margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
-  grid-gap: 24px 48px;
+  grid-gap: 12px 48px;
 }
 
 .c2 {
@@ -783,7 +783,7 @@ exports[`NameValueList should render pairs in a grid when layout="grid" 1`] = `
   width: 100%;
   height: 100%;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
-  grid-gap: 24px 48px;
+  grid-gap: 12px 48px;
 }
 
 .c2 {
@@ -889,7 +889,7 @@ exports[`NameValueList should render value above name when pairProps = { directi
   box-sizing: border-box;
   margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
-  grid-gap: 24px 48px;
+  grid-gap: 12px 48px;
 }
 
 .c2 {

--- a/src/js/components/NameValuePair/__tests__/__snapshots__/NameValuePair-test.tsx.snap
+++ b/src/js/components/NameValuePair/__tests__/__snapshots__/NameValuePair-test.tsx.snap
@@ -47,7 +47,7 @@ exports[`NameValuePair should render name when name is JSX Element 1`] = `
   box-sizing: border-box;
   margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
-  grid-gap: 24px 48px;
+  grid-gap: 12px 48px;
 }
 
 .c4 {
@@ -167,7 +167,7 @@ exports[`NameValuePair should render name when name is typeof string 1`] = `
   box-sizing: border-box;
   margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
-  grid-gap: 24px 48px;
+  grid-gap: 12px 48px;
 }
 
 .c3 {
@@ -278,7 +278,7 @@ exports[`NameValuePair should render value when provided as child of type
   box-sizing: border-box;
   margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,96px) );
-  grid-gap: 24px 48px;
+  grid-gap: 12px 48px;
 }
 
 .c3 {
@@ -412,7 +412,7 @@ exports[`NameValuePair should render value when provided as child of type JSX El
   box-sizing: border-box;
   margin: 0px;
   grid-template-columns: repeat( auto-fit,minmax(auto,384px) );
-  grid-gap: 24px 48px;
+  grid-gap: 12px 48px;
 }
 
 .c4 {

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1672,7 +1672,7 @@ Object {
         "nameValueList": Object {
           "gap": Object {
             "column": "large",
-            "row": "medium",
+            "row": "small",
           },
           "name": Object {
             "width": "small",

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1047,7 +1047,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // extend: undefined,
     },
     nameValueList: {
-      gap: { column: 'large', row: 'medium' },
+      gap: { column: 'large', row: 'small' },
       name: {
         width: 'small',
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Sets default `row` gap on NameValueList to small to align with designs.

#### Where should the reviewer start?
src/js/themes/base.js

#### What testing has been done on this PR?

Storybook and snapshots.

#### How should this be manually tested?

Inspect stories.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

Yes.

#### Should this PR be mentioned in the release notes?

No. Not released yet.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.