### PR TITLE
Fix: Background not applied to pinned header

### DIFF
--- a/src/js/components/DataTable/buildState.js
+++ b/src/js/components/DataTable/buildState.js
@@ -248,10 +248,12 @@ export const normalizeCellProps = (props, theme) => {
         props?.[propName]?.[context] ||
         // if the propName is used without context, it applies to all contexts
         (tableContextNames.every((n) => !props?.[propName]?.[n]) &&
-          props?.[propName]) ||
+          props?.[propName]);
+      if (value !== undefined) result[context][propName] = value;
+
+      let themeValue =
         theme?.dataTable?.[context]?.[propName] ||
         theme?.table?.[context]?.[propName];
-      if (value !== undefined) result[context][propName] = value;
 
       // pinned case
       value =
@@ -259,27 +261,30 @@ export const normalizeCellProps = (props, theme) => {
         (context === 'body' &&
           tableContextNames.every((n) => !props?.[propName]?.pinned?.[n]) &&
           props?.[propName]?.pinned) ||
-        theme?.dataTable?.pinned?.[context]?.[propName];
-      if (value !== undefined) {
-        if (
-          propName === 'background' &&
-          theme.background &&
-          value.opacity &&
-          !value.color
-        )
-          // theme context has an active background color but the
-          // theme doesn't set an explicit color, repeat the context
-          // background explicitly
-          value.color = normalizeBackgroundColor(theme);
+        value;
 
-        if (context === 'body')
-          // in case we have pinned columns, store the pinned stuff in
-          // cellProps.body.pinned
-          result[context].pinned[propName] = value;
-        else if (props.pin === true || props.pin === context)
-          // this context is pinned, use the pinned value directly
-          result[context][propName] = value;
-      }
+      themeValue =
+        theme?.dataTable?.pinned?.[context]?.[propName] || themeValue;
+
+      if (
+        value !== undefined &&
+        propName === 'background' &&
+        theme.background &&
+        value.opacity &&
+        !value.color
+      )
+        // theme context has an active background color but the
+        // theme doesn't set an explicit color, repeat the context
+        // background explicitly
+        value.color = normalizeBackgroundColor(theme);
+
+      if (context === 'body')
+        // in case we have pinned columns, store the pinned stuff in
+        // cellProps.body.pinned
+        result[context].pinned[propName] = value;
+      else if (props.pin === true || props.pin === context)
+        // this context is pinned, use the pinned value directly
+        result[context][propName] = value || themeValue;
     });
   });
   return result;

--- a/src/js/components/DataTable/buildState.js
+++ b/src/js/components/DataTable/buildState.js
@@ -244,16 +244,16 @@ export const normalizeCellProps = (props, theme) => {
   tableContextNames.forEach((context) => {
     result[context] = { pinned: {} };
     cellPropertyNames.forEach((propName) => {
+      let themeValue =
+        theme?.dataTable?.[context]?.[propName] ||
+        theme?.table?.[context]?.[propName];
+
       let value =
         props?.[propName]?.[context] ||
         // if the propName is used without context, it applies to all contexts
         (tableContextNames.every((n) => !props?.[propName]?.[n]) &&
           props?.[propName]);
-      if (value !== undefined) result[context][propName] = value;
-
-      let themeValue =
-        theme?.dataTable?.[context]?.[propName] ||
-        theme?.table?.[context]?.[propName];
+      result[context][propName] = value || themeValue;
 
       // pinned case
       value =
@@ -261,10 +261,9 @@ export const normalizeCellProps = (props, theme) => {
         (context === 'body' &&
           tableContextNames.every((n) => !props?.[propName]?.pinned?.[n]) &&
           props?.[propName]?.pinned) ||
-        value;
-
-      themeValue =
-        theme?.dataTable?.pinned?.[context]?.[propName] || themeValue;
+        value ||
+        theme?.dataTable?.pinned?.[context]?.[propName] ||
+        themeValue;
 
       if (
         value !== undefined &&
@@ -278,13 +277,15 @@ export const normalizeCellProps = (props, theme) => {
         // background explicitly
         value.color = normalizeBackgroundColor(theme);
 
-      if (context === 'body')
+      if (context === 'body') {
         // in case we have pinned columns, store the pinned stuff in
         // cellProps.body.pinned
         result[context].pinned[propName] = value;
-      else if (props.pin === true || props.pin === context)
+      } else if (props.pin === true || props.pin === context) {
         // this context is pinned, use the pinned value directly
-        result[context][propName] = value || themeValue;
+        console.log(value, themeValue);
+        result[context][propName] = value;
+      }
     });
   });
   return result;

--- a/src/js/components/DataTable/stories/Fill.js
+++ b/src/js/components/DataTable/stories/Fill.js
@@ -7,7 +7,7 @@ import { deepMerge } from 'grommet/utils';
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
 import { columns, data } from './data';
 
-const pinnedColumns = columns.map(c => ({ ...c }));
+const pinnedColumns = columns.map((c) => ({ ...c }));
 pinnedColumns[0].pin = true;
 
 const myTheme = deepMerge(grommet, {
@@ -23,6 +23,7 @@ const myTheme = deepMerge(grommet, {
       header: {
         background: {
           opacity: 'medium',
+          color: 'light-1',
         },
         extend: `backdrop-filter: blur(8px);`,
       },
@@ -42,9 +43,7 @@ export const Fill = () => (
         step={10}
         fill
         pin
-        background={{
-          pinned: { color: 'background-contrast' },
-        }}
+        background={{ body: 'light-1' }}
       />
     </Box>
   </Grommet>

--- a/src/js/components/DataTable/stories/Fill.js
+++ b/src/js/components/DataTable/stories/Fill.js
@@ -43,7 +43,9 @@ export const Fill = () => (
         step={10}
         fill
         pin
-        background={{ body: 'light-1' }}
+        background={{
+          pinned: { color: 'background-contrast' },
+        }}
       />
     </Box>
   </Grommet>

--- a/src/js/components/DataTable/stories/Test.js
+++ b/src/js/components/DataTable/stories/Test.js
@@ -1,0 +1,45 @@
+import { Grommet, Box, DataTable } from 'grommet';
+import React from 'react';
+
+const theme = {
+  dataTable: {
+    pinned: {
+      header: {
+        background: {
+          color: 'blue',
+        },
+      },
+      footer: {
+        background: {
+          color: 'green',
+        },
+      },
+    },
+  },
+};
+
+export const Test = () => (
+  <Grommet theme={theme}>
+    {[true, 'header', 'footer'].map((pin) => (
+      <DataTable
+        // background={{ pinned: 'red' }}
+        key={JSON.stringify(pin)}
+        columns={[
+          { property: 'a', header: 'A', footer: 'Total', pin: true },
+          { property: 'b', header: 'B' },
+        ]}
+        data={[
+          { a: 'one', b: 1 },
+          { a: 'two', b: 2 },
+        ]}
+        pin={pin}
+      />
+    ))}
+  </Grommet>
+);
+
+Test.storyName = 'Test and pin';
+
+export default {
+  title: 'Visualizations/DataTable/Test and pin',
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
This PR aims to fix the issue where the `background` prop when `pin` is enabled does not work as intended (not correctly changing the background color as expected).

#### What does this PR do?
This PR:
- Allows background color when `pin` is active to actually change the background color accordingly
- Introduces hierarchy rules under the hood for picking the correct background value from prop or theme

Hierarchy rules:
- `background="onlyString"` overrides every background styling
- `background={{ header: "someColor", footer: "someColor" }}` overrides what's in theme
- `theme.dataTable.pinned.[header | footer].background` overrules `theme.dataTable.[header | footer].background`
- `theme.dataTable.[header | footer].background` has least priority / last one in the list  

#### Where should the reviewer start?
- `normalizeCellProps()` in `DataTable/buildState.js`

#### What testing has been done on this PR?
- Manual testing going through the combinations listed in the hierarchy rules above

#### How should this be manually tested?
- Make sure `pin` prop is enabled (used the `DataTable/Fill and Pin story`)
- Try any of the combinations in the hierarchy list and view what the code chooses

#### Any background context you want to provide?

#### What are the relevant issues?
Solves #5672 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Yes, involves how background color is determined in terms of prop values vs. theme values

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible