### PR TITLE
Update DateInput to avoid timezone conflicts

### DIFF
--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -212,6 +212,7 @@ const Calendar = forwardRef(
       reference: referenceProp,
       showAdjacentDays = true,
       size = 'medium',
+      timestamp,
       ...rest
     },
     ref,
@@ -455,24 +456,25 @@ const Calendar = forwardRef(
         // output date with no timestamp if that's how user provided it
         let adjustedDate;
         if (!range) {
-          nextDate = selectedDate;
+          nextDate = `${formatToLocalYYYYMMDD(selectedDate)}T${
+            selectedDate.split('T')[1]
+          }`;
           if (datesProp) {
             datesProp.forEach((d) => {
               if (!timeStamp.test(d)) {
                 adjustedDate = formatToLocalYYYYMMDD(nextDate);
                 if (d === adjustedDate) {
                   nextDate = undefined;
-                } else {
                   adjustedDate = undefined;
                 }
               }
             });
           } else if (typeof dateProp === 'string') {
+            // console.log('iam here', nextDate, formatToLocalYYYYMMDD(nextDate));
             if (!timeStamp.test(dateProp)) {
               adjustedDate = formatToLocalYYYYMMDD(selectedDate);
               if (dateProp === adjustedDate) {
                 nextDate = undefined;
-              } else {
                 adjustedDate = undefined;
               }
             }
@@ -482,7 +484,6 @@ const Calendar = forwardRef(
                 adjustedDate = formatToLocalYYYYMMDD(nextDate);
                 if (d === adjustedDate) {
                   nextDate = undefined;
-                } else {
                   adjustedDate = undefined;
                 }
               }
@@ -579,6 +580,16 @@ const Calendar = forwardRef(
           ) {
             // return string for backwards compatibility
             [adjustedDates] = nextDates[0].filter((d) => d);
+            // timestamp is false when original date doesn't have timestamp
+            if (timestamp === false)
+              adjustedDates = formatToLocalYYYYMMDD(adjustedDates);
+          } else if (nextDates && timestamp === false) {
+            adjustedDates = [
+              [
+                formatToLocalYYYYMMDD(nextDates[0][0]),
+                formatToLocalYYYYMMDD(nextDates[0][1]),
+              ],
+            ];
           } else {
             adjustedDates = nextDates;
           }
@@ -594,6 +605,7 @@ const Calendar = forwardRef(
         datesProp,
         onSelect,
         range,
+        timestamp,
       ],
     );
 
@@ -760,11 +772,13 @@ const Calendar = forwardRef(
           </StyledDayContainer>,
         );
       } else {
+        // date string takes local into UTC
         const dateString = day.toISOString();
         // this.dayRefs[dateString] = React.createRef();
         let selected = false;
         let inRange = false;
 
+        console.log(day, date || dates);
         const selectedState = withinDates(day, date || dates);
         if (selectedState === 2) {
           selected = true;

--- a/src/js/components/DateInput/__tests__/DateInput-test.tsx
+++ b/src/js/components/DateInput/__tests__/DateInput-test.tsx
@@ -197,46 +197,12 @@ describe('DateInput', () => {
           defaultValue={[]}
           inline
           onChange={onChange}
-          calendarProps={{ animate: false }}
+          calendarProps={{ reference: '2021-11-20' }}
         />
       </Grommet>,
     );
 
-    const monthNames = [
-      'January',
-      'February',
-      'March',
-      'April',
-      'May',
-      'June',
-      'July',
-      'August',
-      'September',
-      'October',
-      'November',
-      'December',
-    ];
-    const d = new Date();
-
-    let previousMonth = d.getMonth() - 1;
-    // if current month is january, then the previous month should be december at index 11
-    if (previousMonth < 0) previousMonth = 11;
-
-    // get month and year to build aria-label for previous button
-    const month = monthNames[previousMonth];
-    const year = d.getFullYear();
-
-    const previousButton = screen.getByRole('button', {
-      name: `${month} ${year}`,
-    });
-    const desiredMonth = 'October 2021';
-
-    // ensure that this test always runs on the same month
-    while (!screen.queryByRole('heading', { name: desiredMonth })) {
-      userEvent.click(previousButton);
-    }
-
-    userEvent.click(screen.getByRole('button', { name: 'Wed Oct 20 2021' }));
+    userEvent.click(screen.getByRole('button', { name: 'Sat Nov 20 2021' }));
     expect(onChange).toHaveBeenCalled();
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -2951,14 +2951,14 @@ exports[`DateInput dates initialized with empty array 1`] = `
           <h3
             class="c5"
           >
-            October 2021
+            November 2021
           </h3>
         </div>
         <div
           class="c6"
         >
           <button
-            aria-label="September 2021"
+            aria-label="October 2021"
             class="c7"
             type="button"
           >
@@ -2976,7 +2976,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
             </svg>
           </button>
           <button
-            aria-label="November 2021"
+            aria-label="December 2021"
             class="c7"
             type="button"
           >
@@ -2997,9 +2997,9 @@ exports[`DateInput dates initialized with empty array 1`] = `
       </div>
       <div
         aria-label="
-                October 2021;
+                November 2021;
                 Currently selected 
-  2021-10-20 through 2021-10-20
+  2021-11-20 through 2021-11-20
               "
         class="c9"
         role="grid"
@@ -3017,633 +3017,13 @@ exports[`DateInput dates initialized with empty array 1`] = `
               role="gridcell"
             >
               <button
-                aria-label="Sun Sep 26 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c14"
-                >
-                  26
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Mon Sep 27 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c14"
-                >
-                  27
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Tue Sep 28 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c14"
-                >
-                  28
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Wed Sep 29 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c14"
-                >
-                  29
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Thu Sep 30 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c14"
-                >
-                  30
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Fri Oct 01 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  1
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Sat Oct 02 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  2
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="c11"
-            role="row"
-          >
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Sun Oct 03 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  3
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Mon Oct 04 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  4
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Tue Oct 05 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  5
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Wed Oct 06 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  6
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Thu Oct 07 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  7
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Fri Oct 08 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  8
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Sat Oct 09 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  9
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="c11"
-            role="row"
-          >
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Sun Oct 10 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  10
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Mon Oct 11 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  11
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Tue Oct 12 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  12
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Wed Oct 13 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  13
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Thu Oct 14 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  14
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Fri Oct 15 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  15
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Sat Oct 16 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  16
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="c11"
-            role="row"
-          >
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Sun Oct 17 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  17
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Mon Oct 18 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  18
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Tue Oct 19 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  19
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Wed Oct 20 2021"
-                class="c16"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c17"
-                >
-                  20
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Thu Oct 21 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  21
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Fri Oct 22 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  22
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Sat Oct 23 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  23
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="c11"
-            role="row"
-          >
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Sun Oct 24 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  24
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Mon Oct 25 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  25
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Tue Oct 26 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  26
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Wed Oct 27 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  27
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Thu Oct 28 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  28
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Fri Oct 29 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  29
-                </div>
-              </button>
-            </div>
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
-                aria-label="Sat Oct 30 2021"
-                class="c13"
-                tabindex="-1"
-                type="button"
-              >
-                <div
-                  class="c15"
-                >
-                  30
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="c11"
-            role="row"
-          >
-            <div
-              class="c12"
-              role="gridcell"
-            >
-              <button
                 aria-label="Sun Oct 31 2021"
                 class="c13"
                 tabindex="-1"
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c14"
                 >
                   31
                 </div>
@@ -3660,7 +3040,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   1
                 </div>
@@ -3677,7 +3057,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   2
                 </div>
@@ -3694,7 +3074,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   3
                 </div>
@@ -3711,7 +3091,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   4
                 </div>
@@ -3728,7 +3108,7 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
-                  class="c14"
+                  class="c15"
                 >
                   5
                 </div>
@@ -3745,9 +3125,629 @@ exports[`DateInput dates initialized with empty array 1`] = `
                 type="button"
               >
                 <div
+                  class="c15"
+                >
+                  6
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+            role="row"
+          >
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sun Nov 07 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  7
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Mon Nov 08 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  8
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Tue Nov 09 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  9
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Wed Nov 10 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  10
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Thu Nov 11 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  11
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Fri Nov 12 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  12
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sat Nov 13 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  13
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+            role="row"
+          >
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sun Nov 14 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  14
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Mon Nov 15 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  15
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Tue Nov 16 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  16
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Wed Nov 17 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  17
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Thu Nov 18 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  18
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Fri Nov 19 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  19
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sat Nov 20 2021"
+                class="c16"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c17"
+                >
+                  20
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+            role="row"
+          >
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sun Nov 21 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  21
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Mon Nov 22 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  22
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Tue Nov 23 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  23
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Wed Nov 24 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  24
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Thu Nov 25 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  25
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Fri Nov 26 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  26
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sat Nov 27 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  27
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+            role="row"
+          >
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sun Nov 28 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  28
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Mon Nov 29 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  29
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Tue Nov 30 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  30
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Wed Dec 01 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  1
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Thu Dec 02 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  2
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Fri Dec 03 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  3
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sat Dec 04 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  4
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+            role="row"
+          >
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sun Dec 05 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  5
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Mon Dec 06 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
                   class="c14"
                 >
                   6
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Tue Dec 07 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  7
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Wed Dec 08 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  8
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Thu Dec 09 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  9
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Fri Dec 10 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  10
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sat Dec 11 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  11
                 </div>
               </button>
             </div>

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -2500,6 +2500,1265 @@ exports[`DateInput controlled format inline 2`] = `
 </div>
 `;
 
+exports[`DateInput dates initialized with empty array 1`] = `
+.c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) > circle,
+.c7:focus:not(:focus-visible) > ellipse,
+.c7:focus:not(:focus-visible) > line,
+.c7:focus:not(:focus-visible) > path,
+.c7:focus:not(:focus-visible) > polygon,
+.c7:focus:not(:focus-visible) > polyline,
+.c7:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c13 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c13:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus > circle,
+.c13:focus > ellipse,
+.c13:focus > line,
+.c13:focus > path,
+.c13:focus > polygon,
+.c13:focus > polyline,
+.c13:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c13:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) > circle,
+.c13:focus:not(:focus-visible) > ellipse,
+.c13:focus:not(:focus-visible) > line,
+.c13:focus:not(:focus-visible) > path,
+.c13:focus:not(:focus-visible) > polygon,
+.c13:focus:not(:focus-visible) > polyline,
+.c13:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c16 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
+.c16:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c16:focus > circle,
+.c16:focus > ellipse,
+.c16:focus > line,
+.c16:focus > path,
+.c16:focus > polygon,
+.c16:focus > polyline,
+.c16:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c16:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c16:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c16:focus:not(:focus-visible) > circle,
+.c16:focus:not(:focus-visible) > ellipse,
+.c16:focus:not(:focus-visible) > line,
+.c16:focus:not(:focus-visible) > path,
+.c16:focus:not(:focus-visible) > polygon,
+.c16:focus:not(:focus-visible) > polyline,
+.c16:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c16:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  margin: 0px;
+  font-size: 26px;
+  line-height: 32px;
+  max-width: 624px;
+  font-weight: 600;
+}
+
+.c1 {
+  font-size: 18px;
+  line-height: 1.45;
+  width: 384px;
+}
+
+.c9 {
+  overflow: hidden;
+  height: 329.1428571428571px;
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9 > circle,
+.c9 > ellipse,
+.c9 > line,
+.c9 > path,
+.c9 > polygon,
+.c9 > polyline,
+.c9 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  position: relative;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c12 {
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
+  opacity: 0.5;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  font-weight: bold;
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+    id="item"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        <div
+          class="c4"
+        >
+          <h3
+            class="c5"
+          >
+            October 2021
+          </h3>
+        </div>
+        <div
+          class="c6"
+        >
+          <button
+            aria-label="September 2021"
+            class="c7"
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c8"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="November 2021"
+            class="c7"
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c8"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div
+        aria-label="
+                October 2021;
+                Currently selected 
+  2021-10-20 through 2021-10-20
+              "
+        class="c9"
+        role="grid"
+        tabindex="0"
+      >
+        <div
+          class="c10"
+        >
+          <div
+            class="c11"
+            role="row"
+          >
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sun Sep 26 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  26
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Mon Sep 27 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  27
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Tue Sep 28 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  28
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Wed Sep 29 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  29
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Thu Sep 30 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  30
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Fri Oct 01 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  1
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sat Oct 02 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  2
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+            role="row"
+          >
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sun Oct 03 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  3
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Mon Oct 04 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  4
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Tue Oct 05 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  5
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Wed Oct 06 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  6
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Thu Oct 07 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  7
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Fri Oct 08 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  8
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sat Oct 09 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  9
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+            role="row"
+          >
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sun Oct 10 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  10
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Mon Oct 11 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  11
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Tue Oct 12 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  12
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Wed Oct 13 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  13
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Thu Oct 14 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  14
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Fri Oct 15 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  15
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sat Oct 16 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  16
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+            role="row"
+          >
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sun Oct 17 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  17
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Mon Oct 18 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  18
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Tue Oct 19 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  19
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Wed Oct 20 2021"
+                class="c16"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c17"
+                >
+                  20
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Thu Oct 21 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  21
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Fri Oct 22 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  22
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sat Oct 23 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  23
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+            role="row"
+          >
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sun Oct 24 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  24
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Mon Oct 25 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  25
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Tue Oct 26 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  26
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Wed Oct 27 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  27
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Thu Oct 28 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  28
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Fri Oct 29 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  29
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sat Oct 30 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  30
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="c11"
+            role="row"
+          >
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sun Oct 31 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c15"
+                >
+                  31
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Mon Nov 01 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  1
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Tue Nov 02 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  2
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Wed Nov 03 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  3
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Thu Nov 04 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  4
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Fri Nov 05 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  5
+                </div>
+              </button>
+            </div>
+            <div
+              class="c12"
+              role="gridcell"
+            >
+              <button
+                aria-label="Sat Nov 06 2021"
+                class="c13"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c14"
+                >
+                  6
+                </div>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DateInput disabled 1`] = `
 .c2 {
   display: inline-block;

--- a/src/js/components/DateInput/stories/FormatInline.js
+++ b/src/js/components/DateInput/stories/FormatInline.js
@@ -1,21 +1,202 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-import { Box, Button, DateInput } from 'grommet';
+import { Box, Button, DateInput, Text } from 'grommet';
+
+const DATE = '2020-07-02';
+const DATETZ = '2020-07-02T00:00:00-08:00';
+const DATE_RANGE = ['2020-07-02', '2020-07-05'];
+const DATE_RANGETZ = ['2020-07-02T00:00:00-08:00', '2020-07-05T00:00:00-08:00'];
 
 export const FormatInline = () => {
-  const [value, setValue] = React.useState('');
-  const onChange = (event) => {
+  const [date, setDate] = useState();
+  const [emptyDate, setEmptyDate] = useState();
+  const [dateRange, setDateRange] = useState();
+  const [dateNoTZ, setDateNoTZ] = useState();
+  const [dateRangeNoTZ, setDateRangeNoTZ] = useState();
+  const [dateNoDefault, setDateNoDefault] = useState();
+  const [dateStateDefault, setDateStateDefault] = useState(DATETZ);
+  const [dateStateDefaultNoTZ, setDateStateDefaultNoTZ] = useState(DATE);
+
+  const onChangeEmpty = (event) => {
     const nextValue = event.value;
     console.log('onChange', nextValue);
-    setValue(nextValue);
+    setEmptyDate(nextValue);
   };
+
+  const onChangeTZ = (event) => {
+    const nextValue = event.value;
+    console.log('onChange', nextValue);
+    setDate(nextValue);
+  };
+
+  const onChangeNoTZ = (event) => {
+    const nextValue = event.value;
+    console.log('onChange', nextValue);
+    setDateNoTZ(nextValue);
+  };
+
+  const onChangeRange = (event) => {
+    const nextValue = event.value;
+    console.log('onChange', nextValue);
+    setDateRange(nextValue);
+  };
+
+  const onChangeRangeNoTZ = (event) => {
+    const nextValue = event.value;
+    console.log('onChange', nextValue);
+    setDateRangeNoTZ(nextValue);
+  };
+
+  const onChangeNoDefault = (event) => {
+    const nextValue = event.value;
+    console.log('onChange', nextValue);
+    setDateNoDefault(nextValue);
+  };
+
+  const onChangeStateDefault = (event) => {
+    const nextValue = event.value;
+    console.log('onChange', nextValue);
+    setDateStateDefault(nextValue);
+  };
+
+  const onChangeStateDefaultNoTZ = (event) => {
+    const nextValue = event.value;
+    console.log('onChange', nextValue);
+    setDateStateDefaultNoTZ(nextValue);
+  };
+
   return (
-    <Box align="center" pad="large" gap="medium">
-      <DateInput format="mm/dd/yyyy" inline value={value} onChange={onChange} />
-      <Button
+    <Box pad="large" gap="medium">
+      <Box gap="small" align="start">
+        <Text weight="bold">
+          1) When defaultValue is [], everything should be UTC (IN PROGRESS)
+        </Text>
+        <Text>defaultValue: []</Text>
+        <Text>
+          Current value:{' '}
+          {emptyDate ? `${emptyDate[0]} — ${emptyDate[1]}` : '--'}
+        </Text>
+        <DateInput
+          id="item"
+          name="item"
+          defaultValue={[]}
+          format="mm/dd/yyyy-mm/dd/yyyy"
+          inline
+          value={emptyDate}
+          onChange={onChangeEmpty}
+        />
+      </Box>
+      <Box gap="small" align="start">
+        <Text weight="bold">
+          2) When defaultValue has a timezone, everything stays in that timezone
+          (IN PROGRESS FOR TIMEZONES BEFORE PT)
+        </Text>
+        <Text>defaultValue: {DATETZ}</Text>
+        <Text>Current value: {date || '--'}</Text>
+        <DateInput
+          format="mm/dd/yyyy"
+          inline
+          value={date}
+          onChange={onChangeTZ}
+          defaultValue={DATETZ}
+        />
+      </Box>
+      <Box gap="small" align="start">
+        <Text weight="bold">
+          3) When defaultValue has no timezone, everything is returned without a
+          timezone and is assumed to be local time
+        </Text>
+        <Text>defaultValue: {DATE}</Text>
+        <Text>Current value: {dateNoTZ || '--'}</Text>
+        <DateInput
+          format="mm/dd/yyyy"
+          inline
+          value={dateNoTZ}
+          onChange={onChangeNoTZ}
+          defaultValue={DATE}
+        />
+      </Box>
+      <Box gap="small" align="start">
+        <Text weight="bold">
+          4) When defaultValue is a range and has a timezone, everything stays
+          in that timezone (IN PROGRESS FOR TIMEZONES BEFORE PT)
+        </Text>
+        <Text>defaultValue: {`${DATE_RANGETZ[0]} — ${DATE_RANGETZ[1]}`}</Text>
+        <Text>
+          Current value:{' '}
+          {dateRange ? `${dateRange[0]} — ${dateRange[1]}` : '--'}
+        </Text>
+        <DateInput
+          format="mm/dd/yyyy-mm/dd/yyyy"
+          inline
+          value={dateRange}
+          onChange={onChangeRange}
+          defaultValue={DATE_RANGETZ}
+        />
+      </Box>
+      <Box gap="small" align="start">
+        <Text weight="bold">
+          5) When defaultValue is a range and has no timezone, everything is
+          returned without a timezone and is assumed to be local time
+        </Text>
+        <Text>defaultValue: {`${DATE_RANGE[0]} — ${DATE_RANGE[1]}`}</Text>
+        <Text>
+          Current value:{' '}
+          {dateRangeNoTZ ? `${dateRangeNoTZ[0]} — ${dateRangeNoTZ[1]}` : '--'}
+        </Text>
+        <DateInput
+          format="mm/dd/yyyy-mm/dd/yyyy"
+          inline
+          value={dateRangeNoTZ}
+          onChange={onChangeRangeNoTZ}
+          defaultValue={DATE_RANGE}
+        />
+      </Box>
+      <Box gap="small" align="start">
+        <Text weight="bold">
+          6) When no defaultValue, everything is in UTC relative to local
+        </Text>
+        <Text>defaultValue: undefined</Text>
+        <Text>Current value: {dateNoDefault || '--'}</Text>
+        <DateInput
+          format="mm/dd/yyyy"
+          inline
+          value={dateNoDefault}
+          onChange={onChangeNoDefault}
+        />
+      </Box>
+      <Box gap="small" align="start">
+        <Text weight="bold">
+          7) When state has default value with TZ, everything everything stays
+          in that timezone
+        </Text>
+        <Text>defaultValue: {DATETZ}</Text>
+        <Text>Current value: {dateStateDefault || '--'}</Text>
+        <DateInput
+          format="mm/dd/yyyy"
+          inline
+          value={dateStateDefault}
+          onChange={onChangeStateDefault}
+        />
+      </Box>
+      <Box gap="small" align="start">
+        <Text weight="bold">
+          8) When state has default value w/o TZ, everything is returned without
+          a timezone and is assumed to be local time
+        </Text>
+        <Text>defaultValue: {DATE}</Text>
+        <Text>Current value: {dateStateDefaultNoTZ || '--'}</Text>
+        <DateInput
+          format="mm/dd/yyyy"
+          inline
+          value={dateStateDefaultNoTZ}
+          onChange={onChangeStateDefaultNoTZ}
+        />
+      </Box>
+      {/* <Button
         label="today"
-        onClick={() => setValue(new Date().toISOString())}
-      />
+        // onClick={() => setValue(new Date().toISOString())}
+      /> */}
     </Box>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

[Preview behavior](https://deploy-preview-5805--sad-tereshkova-173d07.netlify.app/?path=/story/input-dateinput-format-inline--format-inline)

#### What does this PR do?

This PR updates DateInput / Calendar to support all timezones. The intended behavior is:
1. If defaultValue or value is provided with a timezone, all returned values will maintain that timezone and the calendar selected styling with correspond to that timezone.
2. If defaultValue or value is provided _without_ a timezone, all returned values will just be YYYY-MM-DD.
3. If defaultValue or value is provided as undefined / [], all returned values will be in UTC relative to local timezone.
 
TO-DO:
- [ ] Selected date is off when in a timezone pre-PT

#### Where should the reviewer start?
src/js/components/DateInput/__tests__/DateInput-test.tsx

#### What testing has been done on this PR?
Testing behavior using this modified story: https://deploy-preview-5805--sad-tereshkova-173d07.netlify.app/?path=/story/input-dateinput-format-inline--format-inline

#### How should this be manually tested?
Use the story above and interact with each one via clicking, typing values, pasting full date value (as it happens in the jest test)

try changing your computer timezone to something before and after PT.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #5539 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
backwards compatible.