### PR TITLE
Update Accordion tests to use best testing practices

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "parser": "@babel/eslint-parser",
   "extends": ["airbnb", "prettier"],
-  "plugins": ["prettier", "react-hooks"],
+  "plugins": ["prettier", "react-hooks", "testing-library"],
   "env": {
     "node": true,
     "es6": true
@@ -85,6 +85,10 @@
       "rules": {
         "react/jsx-one-expression-per-line": 0
       }
+    },
+    {
+      "files": ["**/Accordion/__tests__/**.tsx"],
+      "extends": ["plugin:testing-library/react"]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.26.1",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-testing-library": "^5.0.0",
     "fs-extra": "^10.0.0",
     "grommet-theme-aruba": "^0.1.2",
     "grommet-theme-dxc": "^0.1.2",

--- a/src/js/components/Accordion/__tests__/Accordion-test.tsx
+++ b/src/js/components/Accordion/__tests__/Accordion-test.tsx
@@ -4,7 +4,8 @@ import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
 import { axe } from 'jest-axe';
-import { render, fireEvent, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { Accordion, AccordionPanel, Box, Grommet } from '../..';
 
@@ -16,7 +17,7 @@ const customTheme = {
 
 describe('Accordion', () => {
   test('should have no accessibility violations', async () => {
-    const { container } = render(
+    const { container, asFragment } = render(
       <Grommet>
         <Accordion>
           <AccordionPanel>Panel body 1</AccordionPanel>
@@ -26,20 +27,20 @@ describe('Accordion', () => {
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
-    expect(container).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('no AccordionPanel', () => {
-    const { container } = render(
+    const { asFragment } = render(
       <Grommet>
         <Accordion />
       </Grommet>,
     );
-    expect(container).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('AccordionPanel', () => {
-    const { container } = render(
+    const { asFragment } = render(
       <Grommet>
         <Accordion>
           <AccordionPanel label="Panel 1">Panel body 1</AccordionPanel>
@@ -50,11 +51,11 @@ describe('Accordion', () => {
         </Accordion>
       </Grommet>,
     );
-    expect(container).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('complex title', () => {
-    const { container } = render(
+    const { asFragment } = render(
       <Grommet>
         <Box background="dark-1">
           <Accordion>
@@ -69,11 +70,11 @@ describe('Accordion', () => {
         </Box>
       </Grommet>,
     );
-    expect(container).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('complex header', () => {
-    const { container } = render(
+    const { asFragment } = render(
       <Grommet>
         <Accordion activeIndex={1} animate={false}>
           <AccordionPanel header={<div>Panel 1 header</div>}>
@@ -86,13 +87,13 @@ describe('Accordion', () => {
         </Accordion>
       </Grommet>,
     );
-    expect(container).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('change to second Panel', () => {
     jest.useFakeTimers('modern');
     const onActive = jest.fn();
-    const { getByText, container } = render(
+    const { asFragment } = render(
       <Grommet>
         <Accordion onActive={onActive}>
           <AccordionPanel label="Panel 1">Panel body 1</AccordionPanel>
@@ -100,21 +101,16 @@ describe('Accordion', () => {
         </Accordion>
       </Grommet>,
     );
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
 
-    fireEvent.click(getByText('Panel 2'));
-
-    // wait for panel animation to finish
-    act(() => {
-      jest.advanceTimersByTime(500);
-    });
+    userEvent.click(screen.getByRole('tab', { name: /Panel 2/i }));
 
     expect(onActive).toBeCalled();
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('change to second Panel without onActive', () => {
-    const { getByText, container } = render(
+    const { asFragment } = render(
       <Grommet>
         <Accordion animate={false}>
           <AccordionPanel label="Panel 1">Panel body 1</AccordionPanel>
@@ -122,16 +118,16 @@ describe('Accordion', () => {
         </Accordion>
       </Grommet>,
     );
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
 
-    fireEvent.click(getByText('Panel 2'));
+    userEvent.click(screen.getByRole('tab', { name: /Panel 2/i }));
 
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('multiple panels', () => {
     const onActive = jest.fn();
-    const { getByText, container } = render(
+    const { asFragment } = render(
       <Grommet>
         <Accordion animate={false} multiple onActive={onActive}>
           <AccordionPanel label="Panel 1">Panel body 1</AccordionPanel>
@@ -139,42 +135,42 @@ describe('Accordion', () => {
         </Accordion>
       </Grommet>,
     );
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
 
-    fireEvent.click(getByText('Panel 2'));
+    userEvent.click(screen.getByRole('tab', { name: /Panel 2/i }));
     expect(onActive).toBeCalledWith([1]);
 
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
 
-    fireEvent.click(getByText('Panel 1'));
+    userEvent.click(screen.getByRole('tab', { name: /Panel 1/i }));
     expect(onActive).toBeCalledWith([1, 0]);
 
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
 
-    fireEvent.click(getByText('Panel 2'));
+    userEvent.click(screen.getByRole('tab', { name: /Panel 2/i }));
     expect(onActive).toBeCalledWith([0]);
 
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
 
-    fireEvent.click(getByText('Panel 1'));
+    userEvent.click(screen.getByRole('tab', { name: /Panel 1/i }));
     expect(onActive).toBeCalledWith([]);
 
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('custom accordion', () => {
-    const { container } = render(
+    const { asFragment } = render(
       <Grommet theme={customTheme}>
         <Accordion>
           <AccordionPanel label="Panel 1">Panel body 1</AccordionPanel>
         </Accordion>
       </Grommet>,
     );
-    expect(container).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('accordion border', () => {
-    const { container } = render(
+    const { asFragment } = render(
       <Grommet
         theme={{
           accordion: {
@@ -192,12 +188,12 @@ describe('Accordion', () => {
         </Accordion>
       </Grommet>,
     );
-    expect(container).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('change active index', () => {
     const onActive = jest.fn();
-    const { getByText, container } = render(
+    const { asFragment } = render(
       <Grommet>
         <Accordion animate={false} activeIndex={1} onActive={onActive}>
           <AccordionPanel label="Panel 1">Panel body 1</AccordionPanel>
@@ -205,16 +201,16 @@ describe('Accordion', () => {
         </Accordion>
       </Grommet>,
     );
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
 
-    fireEvent.click(getByText('Panel 1'));
+    userEvent.click(screen.getByRole('tab', { name: /Panel 1/i }));
     expect(onActive).toBeCalledWith([0]);
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('focus and hover styles', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
-    const { getByText, container } = render(
+    const { asFragment } = render(
       <Grommet theme={{ accordion: { hover: { color: 'red' } } }}>
         <Accordion>
           <AccordionPanel
@@ -230,15 +226,15 @@ describe('Accordion', () => {
       </Grommet>,
     );
 
-    fireEvent.focus(getByText('Panel 1'));
-    expect(container.firstChild).toMatchSnapshot();
+    userEvent.click(screen.getByRole('tab', { name: /Panel 1/i }));
+    expect(asFragment()).toMatchSnapshot();
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
   });
 
   test('backward compatibility of hover.color = undefined', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
-    const { getByText, container } = render(
+    const { asFragment } = render(
       <Grommet
         theme={{
           accordion: {
@@ -260,15 +256,15 @@ describe('Accordion', () => {
       </Grommet>,
     );
 
-    fireEvent.focus(getByText('Panel 1'));
+    userEvent.tab();
     // hover color should be undefined
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
   });
 
   test('theme hover of hover.heading.color', () => {
-    const { getByText, container } = render(
+    const { asFragment } = render(
       <Grommet
         theme={{
           accordion: {
@@ -290,49 +286,58 @@ describe('Accordion', () => {
       </Grommet>,
     );
 
-    fireEvent.focus(getByText('Panel 1'));
+    userEvent.tab();
     // hover color should be undefined
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('set on hover', () => {
-    const { getByText, container } = render(
+    const onMouseOver1 = jest.fn();
+    const onMouseOut1 = jest.fn();
+    const onFocus1 = jest.fn();
+    const onBlur1 = jest.fn();
+    const onMouseOver2 = jest.fn();
+    const onMouseOut2 = jest.fn();
+    const onFocus2 = jest.fn();
+    const onBlur2 = jest.fn();
+    render(
       <Grommet>
         <Accordion>
           <AccordionPanel
             label="Panel 1"
-            onMouseOver={() => {}}
-            onMouseOut={() => {}}
-            onFocus={() => {}}
-            onBlur={() => {}}
+            onMouseOver={onMouseOver1}
+            onMouseOut={onMouseOut1}
+            onFocus={onFocus1}
+            onBlur={onBlur1}
           >
             Panel body 1
           </AccordionPanel>
           <AccordionPanel
             label="Panel 2"
-            onMouseOver={() => {}}
-            onMouseOut={() => {}}
-            onFocus={() => {}}
-            onBlur={() => {}}
+            onMouseOver={onMouseOver2}
+            onMouseOut={onMouseOut2}
+            onFocus={onFocus2}
+            onBlur={onBlur2}
           >
             Panel body 2
           </AccordionPanel>
         </Accordion>
       </Grommet>,
     );
-    expect(container.firstChild).toMatchSnapshot();
 
-    fireEvent.mouseOver(getByText('Panel 1'));
-    expect(container.firstChild).toMatchSnapshot();
+    userEvent.hover(screen.getByRole('tab', { name: /Panel 1/i }));
+    expect(onMouseOver1).toHaveBeenCalled;
+    expect(onFocus1).toHaveBeenCalled;
+    userEvent.unhover(screen.getByRole('tab', { name: /Panel 1/i }));
+    expect(onMouseOut1).toHaveBeenCalled;
+    expect(onBlur1).toHaveBeenCalled;
 
-    fireEvent.mouseOver(getByText('Panel 2'));
-    expect(container.firstChild).toMatchSnapshot();
-
-    fireEvent.mouseOut(getByText('Panel 1'));
-    expect(container.firstChild).toMatchSnapshot();
-
-    fireEvent.mouseOut(getByText('Panel 2'));
-    expect(container.firstChild).toMatchSnapshot();
+    userEvent.hover(screen.getByRole('tab', { name: /Panel 2/i }));
+    expect(onMouseOver2).toHaveBeenCalled;
+    expect(onFocus2).toHaveBeenCalled;
+    userEvent.unhover(screen.getByRole('tab', { name: /Panel 2/i }));
+    expect(onMouseOver2).toHaveBeenCalled;
+    expect(onBlur2).toHaveBeenCalled;
   });
 
   test('wrapped panel', () => {
@@ -342,7 +347,7 @@ describe('Accordion', () => {
         Panel body {index}
       </AccordionPanel>
     );
-    const { getByText, container } = render(
+    const { asFragment } = render(
       <Grommet>
         <Accordion animate={false} onActive={onActive}>
           {[1, 2].map((index) => (
@@ -351,17 +356,17 @@ describe('Accordion', () => {
         </Accordion>
       </Grommet>,
     );
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
 
-    fireEvent.click(getByText('Panel 1'));
+    userEvent.click(screen.getByRole('tab', { name: /Panel 1/i }));
     expect(onActive).toBeCalledWith([0]);
-    expect(getByText('Panel body 1')).not.toBeNull();
-    expect(container.firstChild).toMatchSnapshot();
+    expect(screen.getByText('Panel body 1')).not.toBeNull();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('blur styles', () => {
     const onBlur = jest.fn();
-    const { container, getByText } = render(
+    const { asFragment } = render(
       <Grommet theme={{ accordion: { hover: { heading: { color: 'red' } } } }}>
         <Accordion>
           <AccordionPanel
@@ -376,10 +381,12 @@ describe('Accordion', () => {
         </Accordion>
       </Grommet>,
     );
-    // focus first then call blur
-    fireEvent.focus(getByText('Panel 1'));
-    fireEvent.blur(getByText('Panel 1'));
-    expect(container.firstChild).toMatchSnapshot();
+
+    // tab to the first accordion panel
+    userEvent.tab();
+    expect(asFragment()).toMatchSnapshot();
+    // tab away from the first accordion panel
+    userEvent.tab();
     expect(onBlur).toHaveBeenCalled();
   });
 });

--- a/src/js/components/Accordion/__tests__/Accordion-test.tsx
+++ b/src/js/components/Accordion/__tests__/Accordion-test.tsx
@@ -294,12 +294,8 @@ describe('Accordion', () => {
   test('set on hover', () => {
     const onMouseOver1 = jest.fn();
     const onMouseOut1 = jest.fn();
-    const onFocus1 = jest.fn();
-    const onBlur1 = jest.fn();
     const onMouseOver2 = jest.fn();
     const onMouseOut2 = jest.fn();
-    const onFocus2 = jest.fn();
-    const onBlur2 = jest.fn();
     render(
       <Grommet>
         <Accordion>
@@ -307,8 +303,6 @@ describe('Accordion', () => {
             label="Panel 1"
             onMouseOver={onMouseOver1}
             onMouseOut={onMouseOut1}
-            onFocus={onFocus1}
-            onBlur={onBlur1}
           >
             Panel body 1
           </AccordionPanel>
@@ -316,8 +310,6 @@ describe('Accordion', () => {
             label="Panel 2"
             onMouseOver={onMouseOver2}
             onMouseOut={onMouseOut2}
-            onFocus={onFocus2}
-            onBlur={onBlur2}
           >
             Panel body 2
           </AccordionPanel>
@@ -326,33 +318,23 @@ describe('Accordion', () => {
     );
 
     userEvent.hover(screen.getByRole('tab', { name: /Panel 1/i }));
-    expect(onMouseOver1).toHaveBeenCalled;
-    expect(onFocus1).toHaveBeenCalled;
+    expect(onMouseOver1).toHaveBeenCalled();
     userEvent.unhover(screen.getByRole('tab', { name: /Panel 1/i }));
-    expect(onMouseOut1).toHaveBeenCalled;
-    expect(onBlur1).toHaveBeenCalled;
+    expect(onMouseOut1).toHaveBeenCalled();
 
     userEvent.hover(screen.getByRole('tab', { name: /Panel 2/i }));
-    expect(onMouseOver2).toHaveBeenCalled;
-    expect(onFocus2).toHaveBeenCalled;
+    expect(onMouseOver2).toHaveBeenCalled();
     userEvent.unhover(screen.getByRole('tab', { name: /Panel 2/i }));
-    expect(onMouseOver2).toHaveBeenCalled;
-    expect(onBlur2).toHaveBeenCalled;
+    expect(onMouseOver2).toHaveBeenCalled();
   });
 
   test('wrapped panel', () => {
     const onActive = jest.fn();
-    const Panel = ({ index }: { index: Number }) => (
-      <AccordionPanel label={`Panel ${index}`}>
-        Panel body {index}
-      </AccordionPanel>
-    );
     const { asFragment } = render(
       <Grommet>
         <Accordion animate={false} onActive={onActive}>
-          {[1, 2].map((index) => (
-            <Panel key={index} index={index} />
-          ))}
+          <AccordionPanel label="Panel 1">Panel body 1</AccordionPanel>
+          <AccordionPanel label="Panel 2">Panel body 2</AccordionPanel>
         </Accordion>
       </Grommet>,
     );

--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.tsx.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.tsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Accordion AccordionPanel 1`] = `
-.c8 {
+<DocumentFragment>
+  .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -248,8 +249,7 @@ exports[`Accordion AccordionPanel 1`] = `
   }
 }
 
-<div>
-  <div
+<div
     class="c0"
   >
     <div
@@ -356,11 +356,12 @@ exports[`Accordion AccordionPanel 1`] = `
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`Accordion accordion border 1`] = `
-.c8 {
+<DocumentFragment>
+  .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -602,8 +603,7 @@ exports[`Accordion accordion border 1`] = `
   }
 }
 
-<div>
-  <div
+<div
     class="c0"
   >
     <div
@@ -661,2591 +661,12 @@ exports[`Accordion accordion border 1`] = `
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`Accordion backward compatibility of hover.color = undefined 1`] = `
-.c8 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #7D4CDB;
-  stroke: #7D4CDB;
-}
-
-.c8 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c8 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-left: 6px;
-  padding-right: 6px;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  min-width: -webkit-fit-content;
-  min-width: -moz-fit-content;
-  min-width: fit-content;
-  padding-left: 12px;
-  padding-right: 12px;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c3:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c3:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c10 {
-  -webkit-transition: max-height 200ms,opacity 200ms;
-  transition: max-height 200ms,opacity 200ms;
-  opacity: 0;
-  overflow: hidden;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-  max-width: 432px;
-  font-weight: 600;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
-    padding-left: 3px;
-    padding-right: 3px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    padding-left: 6px;
-    padding-right: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c9 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    font-size: 16px;
-    line-height: 22px;
-    max-width: 384px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-    role="tablist"
-  >
-    <div
-      class="c2"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="c3"
-        role="tab"
-        style="z-index: 1;"
-        type="button"
-      >
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            <h4
-              class="c6"
-            >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="c7"
-          >
-            <svg
-              aria-label="FormDown"
-              class="c8"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="c9"
-      >
-        <div
-          aria-hidden="true"
-          class="c1 c10"
-        />
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Accordion blur styles 1`] = `
-.c8 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #7D4CDB;
-  stroke: #7D4CDB;
-}
-
-.c8 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c8 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-left: 6px;
-  padding-right: 6px;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  min-width: -webkit-fit-content;
-  min-width: -moz-fit-content;
-  min-width: fit-content;
-  padding-left: 12px;
-  padding-right: 12px;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c3:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c3:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c10 {
-  -webkit-transition: max-height 200ms,opacity 200ms;
-  transition: max-height 200ms,opacity 200ms;
-  opacity: 0;
-  overflow: hidden;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-  max-width: 432px;
-  font-weight: 600;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
-    padding-left: 3px;
-    padding-right: 3px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    padding-left: 6px;
-    padding-right: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c9 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    font-size: 16px;
-    line-height: 22px;
-    max-width: 384px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-    role="tablist"
-  >
-    <div
-      class="c2"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="c3"
-        role="tab"
-        style=""
-        type="button"
-      >
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            <h4
-              class="c6"
-            >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="c7"
-          >
-            <svg
-              aria-label="FormDown"
-              class="c8"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="c9"
-      >
-        <div
-          aria-hidden="true"
-          class="c1 c10"
-        />
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Accordion change active index 1`] = `
-.c8 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #7D4CDB;
-  stroke: #7D4CDB;
-}
-
-.c8 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c8 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-left: 6px;
-  padding-right: 6px;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  min-width: -webkit-fit-content;
-  min-width: -moz-fit-content;
-  min-width: fit-content;
-  padding-left: 12px;
-  padding-right: 12px;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c3:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c3:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-  max-width: 432px;
-  font-weight: 600;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
-    padding-left: 3px;
-    padding-right: 3px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    padding-left: 6px;
-    padding-right: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c9 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    font-size: 16px;
-    line-height: 22px;
-    max-width: 384px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-    role="tablist"
-  >
-    <div
-      class="c2"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="c3"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            <h4
-              class="c6"
-            >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="c7"
-          >
-            <svg
-              aria-label="FormDown"
-              class="c8"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="c9"
-      />
-    </div>
-    <div
-      class="c2"
-    >
-      <button
-        aria-expanded="true"
-        aria-selected="true"
-        class="c3"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            <h4
-              class="c6"
-            >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="c7"
-          >
-            <svg
-              aria-label="FormUp"
-              class="c8"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 15-6-6-6 6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="c9"
-      >
-        Panel body 2
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Accordion change active index 2`] = `
-<div
-  class="StyledGrommet-sc-19lkkz7-0 eOvTCA"
->
-  <div
-    class="StyledBox-sc-13pk1d4-0 bULqXT"
-    role="tablist"
-  >
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
-          >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
-            >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            <svg
-              aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      />
-    </div>
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="true"
-        aria-selected="true"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
-          >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
-            >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            <svg
-              aria-label="FormUp"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 15-6-6-6 6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      >
-        Panel body 2
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Accordion change to second Panel 1`] = `
-.c8 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #7D4CDB;
-  stroke: #7D4CDB;
-}
-
-.c8 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c8 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-left: 6px;
-  padding-right: 6px;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  min-width: -webkit-fit-content;
-  min-width: -moz-fit-content;
-  min-width: fit-content;
-  padding-left: 12px;
-  padding-right: 12px;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c3:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c3:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c10 {
-  -webkit-transition: max-height 200ms,opacity 200ms;
-  transition: max-height 200ms,opacity 200ms;
-  opacity: 0;
-  overflow: hidden;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-  max-width: 432px;
-  font-weight: 600;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
-    padding-left: 3px;
-    padding-right: 3px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    padding-left: 6px;
-    padding-right: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c9 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    font-size: 16px;
-    line-height: 22px;
-    max-width: 384px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-    role="tablist"
-  >
-    <div
-      class="c2"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="c3"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            <h4
-              class="c6"
-            >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="c7"
-          >
-            <svg
-              aria-label="FormDown"
-              class="c8"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="c9"
-      >
-        <div
-          aria-hidden="true"
-          class="c1 c10"
-        />
-      </div>
-    </div>
-    <div
-      class="c2"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="c3"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            <h4
-              class="c6"
-            >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="c7"
-          >
-            <svg
-              aria-label="FormDown"
-              class="c8"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="c9"
-      >
-        <div
-          aria-hidden="true"
-          class="c1 c10"
-        />
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Accordion change to second Panel 2`] = `
-<div
-  class="StyledGrommet-sc-19lkkz7-0 eOvTCA"
->
-  <div
-    class="StyledBox-sc-13pk1d4-0 bULqXT"
-    role="tablist"
-  >
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
-          >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
-            >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            <svg
-              aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      >
-        <div
-          aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bULqXT Collapsible__AnimatedBox-sc-15kniua-0 dvSzsF"
-        />
-      </div>
-    </div>
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="true"
-        aria-selected="true"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
-          >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
-            >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            .c0 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #7D4CDB;
-  stroke: #7D4CDB;
-}
-
-.c0 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c0 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c0 *[fill-rule],
-.c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-<svg
-              aria-label="FormUp"
-              class="c0"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 15-6-6-6 6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-        style=""
-      >
-        <div
-          aria-hidden="false"
-          class="StyledBox-sc-13pk1d4-0 bULqXT Collapsible__AnimatedBox-sc-15kniua-0 gUYkLU"
-          open=""
-        >
-          Panel body 2
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Accordion change to second Panel without onActive 1`] = `
-.c8 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #7D4CDB;
-  stroke: #7D4CDB;
-}
-
-.c8 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c8 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-left: 6px;
-  padding-right: 6px;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  min-width: -webkit-fit-content;
-  min-width: -moz-fit-content;
-  min-width: fit-content;
-  padding-left: 12px;
-  padding-right: 12px;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c3:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c3:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-  max-width: 432px;
-  font-weight: 600;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
-    padding-left: 3px;
-    padding-right: 3px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    padding-left: 6px;
-    padding-right: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c9 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    font-size: 16px;
-    line-height: 22px;
-    max-width: 384px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-    role="tablist"
-  >
-    <div
-      class="c2"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="c3"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            <h4
-              class="c6"
-            >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="c7"
-          >
-            <svg
-              aria-label="FormDown"
-              class="c8"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="c9"
-      />
-    </div>
-    <div
-      class="c2"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="c3"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            <h4
-              class="c6"
-            >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="c7"
-          >
-            <svg
-              aria-label="FormDown"
-              class="c8"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="c9"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Accordion change to second Panel without onActive 2`] = `
-<div
-  class="StyledGrommet-sc-19lkkz7-0 eOvTCA"
->
-  <div
-    class="StyledBox-sc-13pk1d4-0 bULqXT"
-    role="tablist"
-  >
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
-          >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
-            >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            <svg
-              aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      />
-    </div>
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="true"
-        aria-selected="true"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
-          >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
-            >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            .c0 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #7D4CDB;
-  stroke: #7D4CDB;
-}
-
-.c0 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c0 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c0 *[fill-rule],
-.c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-<svg
-              aria-label="FormUp"
-              class="c0"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 15-6-6-6 6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      >
-        Panel body 2
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Accordion complex header 1`] = `
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c3:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c3:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-@media only screen and (max-width:768px) {
-  .c4 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-<div>
-  <div
-    class="c0"
-  >
-    <div
-      class="c1"
-      role="tablist"
-    >
-      <div
-        class="c2"
-      >
-        <button
-          aria-expanded="false"
-          aria-selected="false"
-          class="c3"
-          role="tab"
-          type="button"
-        >
-          <div>
-            Panel 1 header
-          </div>
-        </button>
-        <div
-          class="c4"
-        />
-      </div>
-      <div
-        class="c2"
-      >
-        <button
-          aria-expanded="true"
-          aria-selected="true"
-          class="c3"
-          role="tab"
-          type="button"
-        >
-          <div>
-            Panel 2 header
-          </div>
-        </button>
-        <div
-          class="c4"
-        >
-          Panel body 2
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Accordion complex title 1`] = `
-.c7 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #6FFFB0;
-  stroke: #6FFFB0;
-}
-
-.c7 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c7 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  background-color: #333333;
-  color: #f8f8f8;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  min-width: -webkit-fit-content;
-  min-width: -moz-fit-content;
-  min-width: fit-content;
-  padding-left: 12px;
-  padding-right: 12px;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(255,255,255,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c4 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c4:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c4:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) > circle,
-.c4:focus:not(:focus-visible) > ellipse,
-.c4:focus:not(:focus-visible) > line,
-.c4:focus:not(:focus-visible) > path,
-.c4:focus:not(:focus-visible) > polygon,
-.c4:focus:not(:focus-visible) > polyline,
-.c4:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c9 {
-  -webkit-transition: max-height 200ms,opacity 200ms;
-  transition: max-height 200ms,opacity 200ms;
-  opacity: 0;
-  overflow: hidden;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    padding-left: 6px;
-    padding-right: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
+<DocumentFragment>
   .c8 {
-    border-bottom: solid 1px rgba(255,255,255,0.33);
-  }
-}
-
-<div>
-  <div
-    class="c0"
-  >
-    <div
-      class="c1"
-    >
-      <div
-        class="c2"
-        role="tablist"
-      >
-        <div
-          class="c3"
-        >
-          <button
-            aria-expanded="false"
-            aria-selected="false"
-            class="c4"
-            role="tab"
-            type="button"
-          >
-            <div
-              class="c5"
-            >
-              <div>
-                Panel 1 complex
-              </div>
-              <div
-                class="c6"
-              >
-                <svg
-                  aria-label="FormDown"
-                  class="c7"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="m18 9-6 6-6-6"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                </svg>
-              </div>
-            </div>
-          </button>
-          <div
-            class="c8"
-          >
-            <div
-              aria-hidden="true"
-              class="c2 c9"
-            />
-          </div>
-        </div>
-        <div
-          class="c3"
-        >
-          <button
-            aria-expanded="false"
-            aria-selected="false"
-            class="c4"
-            role="tab"
-            type="button"
-          >
-            <div
-              class="c5"
-            >
-              <div>
-                Panel 2 complex
-              </div>
-              <div
-                class="c6"
-              >
-                <svg
-                  aria-label="FormDown"
-                  class="c7"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="m18 9-6 6-6-6"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                </svg>
-              </div>
-            </div>
-          </button>
-          <div
-            class="c8"
-          >
-            <div
-              aria-hidden="true"
-              class="c2 c9"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Accordion custom accordion 1`] = `
-.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -3448,9 +869,9 @@ exports[`Accordion custom accordion 1`] = `
 }
 
 .c6 {
-  font-size: 26px;
-  line-height: 32px;
-  max-width: 624px;
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
   font-weight: 600;
 }
 
@@ -3486,14 +907,13 @@ exports[`Accordion custom accordion 1`] = `
 
 @media only screen and (max-width:768px) {
   .c6 {
-    font-size: 18px;
-    line-height: 24px;
-    max-width: 432px;
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
   }
 }
 
-<div>
-  <div
+<div
     class="c0"
   >
     <div
@@ -3508,6 +928,7 @@ exports[`Accordion custom accordion 1`] = `
           aria-selected="false"
           class="c3"
           role="tab"
+          style="z-index: 1;"
           type="button"
         >
           <div
@@ -3516,11 +937,11 @@ exports[`Accordion custom accordion 1`] = `
             <div
               class="c5"
             >
-              <h3
+              <h4
                 class="c6"
               >
                 Panel 1
-              </h3>
+              </h4>
             </div>
             <div
               class="c7"
@@ -3551,11 +972,12 @@ exports[`Accordion custom accordion 1`] = `
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
-exports[`Accordion focus and hover styles 1`] = `
-.c8 {
+exports[`Accordion blur styles 1`] = `
+<DocumentFragment>
+  .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -3808,68 +1230,70 @@ exports[`Accordion focus and hover styles 1`] = `
 }
 
 <div
-  class="c0"
->
-  <div
-    class="c1"
-    role="tablist"
+    class="c0"
   >
     <div
-      class="c2"
+      class="c1"
+      role="tablist"
     >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="c3"
-        role="tab"
-        style="z-index: 1;"
-        type="button"
+      <div
+        class="c2"
       >
-        <div
-          class="c4"
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          style="z-index: 1;"
+          type="button"
         >
           <div
-            class="c5"
+            class="c4"
           >
-            <h4
-              class="c6"
+            <div
+              class="c5"
             >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="c7"
-          >
-            <svg
-              aria-label="FormDown"
-              class="c8"
-              viewBox="0 0 24 24"
+              <h4
+                class="c6"
+              >
+                Panel 1
+              </h4>
+            </div>
+            <div
+              class="c7"
             >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
           </div>
-        </div>
-      </button>
-      <div
-        class="c9"
-      >
+        </button>
         <div
-          aria-hidden="true"
-          class="c1 c10"
-        />
+          class="c9"
+        >
+          <div
+            aria-hidden="true"
+            class="c1 c10"
+          />
+        </div>
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
-exports[`Accordion multiple panels 1`] = `
-.c8 {
+exports[`Accordion change active index 1`] = `
+<DocumentFragment>
+  .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -4110,182 +1534,110 @@ exports[`Accordion multiple panels 1`] = `
 }
 
 <div
-  class="c0"
->
-  <div
-    class="c1"
-    role="tablist"
+    class="c0"
   >
     <div
-      class="c2"
+      class="c1"
+      role="tablist"
     >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="c3"
-        role="tab"
-        type="button"
+      <div
+        class="c2"
       >
-        <div
-          class="c4"
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          type="button"
         >
           <div
-            class="c5"
+            class="c4"
           >
-            <h4
-              class="c6"
+            <div
+              class="c5"
             >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="c7"
-          >
-            <svg
-              aria-label="FormDown"
-              class="c8"
-              viewBox="0 0 24 24"
+              <h4
+                class="c6"
+              >
+                Panel 1
+              </h4>
+            </div>
+            <div
+              class="c7"
             >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
           </div>
-        </div>
-      </button>
-      <div
-        class="c9"
-      />
-    </div>
-    <div
-      class="c2"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="c3"
-        role="tab"
-        type="button"
-      >
+        </button>
         <div
-          class="c4"
+          class="c9"
+        />
+      </div>
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="true"
+          aria-selected="true"
+          class="c3"
+          role="tab"
+          type="button"
         >
           <div
-            class="c5"
+            class="c4"
           >
-            <h4
-              class="c6"
+            <div
+              class="c5"
             >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="c7"
-          >
-            <svg
-              aria-label="FormDown"
-              class="c8"
-              viewBox="0 0 24 24"
+              <h4
+                class="c6"
+              >
+                Panel 2
+              </h4>
+            </div>
+            <div
+              class="c7"
             >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="FormUp"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 15-6-6-6 6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
           </div>
+        </button>
+        <div
+          class="c9"
+        >
+          Panel body 2
         </div>
-      </button>
-      <div
-        class="c9"
-      />
+      </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
-exports[`Accordion multiple panels 2`] = `
-<div
-  class="StyledGrommet-sc-19lkkz7-0 eOvTCA"
->
-  <div
-    class="StyledBox-sc-13pk1d4-0 bULqXT"
-    role="tablist"
-  >
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
-          >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
-            >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            <svg
-              aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      />
-    </div>
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="true"
-        aria-selected="true"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
-          >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
-            >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            .c0 {
+exports[`Accordion change active index 2`] = `
+<DocumentFragment>
+  .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -4296,527 +1648,29 @@ exports[`Accordion multiple panels 2`] = `
   stroke: #7D4CDB;
 }
 
-.c0 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c0 *[fill-rule],
-.c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
 
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-<svg
-              aria-label="FormUp"
-              class="c0"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 15-6-6-6 6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      >
-        Panel body 2
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Accordion multiple panels 3`] = `
-<div
-  class="StyledGrommet-sc-19lkkz7-0 eOvTCA"
->
-  <div
-    class="StyledBox-sc-13pk1d4-0 bULqXT"
-    role="tablist"
-  >
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="true"
-        aria-selected="true"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
-          >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
-            >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            .c0 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #7D4CDB;
-  stroke: #7D4CDB;
-}
-
-.c0 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c0 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c0 *[fill-rule],
-.c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-<svg
-              aria-label="FormUp"
-              class="c0"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 15-6-6-6 6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      >
-        Panel body 1
-      </div>
-    </div>
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="true"
-        aria-selected="true"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
-          >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
-            >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            <svg
-              aria-label="FormUp"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 15-6-6-6 6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      >
-        Panel body 2
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Accordion multiple panels 4`] = `
-<div
-  class="StyledGrommet-sc-19lkkz7-0 eOvTCA"
->
-  <div
-    class="StyledBox-sc-13pk1d4-0 bULqXT"
-    role="tablist"
-  >
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="true"
-        aria-selected="true"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
-          >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
-            >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            <svg
-              aria-label="FormUp"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 15-6-6-6 6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      >
-        Panel body 1
-      </div>
-    </div>
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
-          >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
-            >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            .c0 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #7D4CDB;
-  stroke: #7D4CDB;
-}
-
-.c0 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c0 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c0 *[fill-rule],
-.c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-<svg
-              aria-label="FormDown"
-              class="c0"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Accordion multiple panels 5`] = `
-<div
-  class="StyledGrommet-sc-19lkkz7-0 eOvTCA"
->
-  <div
-    class="StyledBox-sc-13pk1d4-0 bULqXT"
-    role="tablist"
-  >
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
-          >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
-            >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            .c0 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #7D4CDB;
-  stroke: #7D4CDB;
-}
-
-.c0 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c0 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c0 *[fill-rule],
-.c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-<svg
-              aria-label="FormDown"
-              class="c0"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      />
-    </div>
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
-          >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
-            >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            <svg
-              aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Accordion no AccordionPanel 1`] = `
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -4831,6 +1685,226 @@ exports[`Accordion no AccordionPanel 1`] = `
   flex-direction: column;
 }
 
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) > circle,
+.c3:focus:not(:focus-visible) > ellipse,
+.c3:focus:not(:focus-visible) > line,
+.c3:focus:not(:focus-visible) > path,
+.c3:focus:not(:focus-visible) > polygon,
+.c3:focus:not(:focus-visible) > polyline,
+.c3:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+  color: #777777;
+}
+
 .c0 {
   font-size: 18px;
   line-height: 24px;
@@ -4841,20 +1915,148 @@ exports[`Accordion no AccordionPanel 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-<div>
-  <div
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 3px;
+    padding-right: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+<div
     class="c0"
   >
     <div
       class="c1"
       role="tablist"
-    />
+    >
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          style="z-index: 1;"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c6"
+              >
+                Panel 1
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        />
+      </div>
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="true"
+          aria-selected="true"
+          class="c10"
+          role="tab"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c11"
+              >
+                Panel 2
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormUp"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 15-6-6-6 6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        >
+          Panel body 2
+        </div>
+      </div>
+    </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
-exports[`Accordion set on hover 1`] = `
-.c8 {
+exports[`Accordion change to second Panel 1`] = `
+<DocumentFragment>
+  .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -5102,556 +2304,4515 @@ exports[`Accordion set on hover 1`] = `
 }
 
 <div
-  class="c0"
->
-  <div
-    class="c1"
-    role="tablist"
+    class="c0"
   >
     <div
-      class="c2"
+      class="c1"
+      role="tablist"
     >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="c3"
-        role="tab"
-        type="button"
+      <div
+        class="c2"
       >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c6"
+              >
+                Panel 1
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        >
+          <div
+            aria-hidden="true"
+            class="c1 c10"
+          />
+        </div>
+      </div>
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c6"
+              >
+                Panel 2
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        >
+          <div
+            aria-hidden="true"
+            class="c1 c10"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Accordion change to second Panel 2`] = `
+<DocumentFragment>
+  .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) > circle,
+.c3:focus:not(:focus-visible) > ellipse,
+.c3:focus:not(:focus-visible) > line,
+.c3:focus:not(:focus-visible) > path,
+.c3:focus:not(:focus-visible) > polygon,
+.c3:focus:not(:focus-visible) > polyline,
+.c3:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  -webkit-transition: max-height 200ms,opacity 200ms;
+  transition: max-height 200ms,opacity 200ms;
+  opacity: 0;
+  overflow: hidden;
+}
+
+.c13 {
+  -webkit-transition: max-height 200ms,opacity 200ms;
+  transition: max-height 200ms,opacity 200ms;
+  opacity: 1;
+  overflow: hidden;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
+.c12 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+  color: #777777;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 3px;
+    padding-right: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c12 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+      role="tablist"
+    >
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c6"
+              >
+                Panel 1
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        >
+          <div
+            aria-hidden="true"
+            class="c1 c10"
+          />
+        </div>
+      </div>
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="true"
+          aria-selected="true"
+          class="c11"
+          role="tab"
+          style="z-index: 1;"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c12"
+              >
+                Panel 2
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormUp"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 15-6-6-6 6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+          style=""
+        >
+          <div
+            aria-hidden="false"
+            class="c1 c13"
+            open=""
+            style="max-height: 0;"
+          >
+            Panel body 2
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Accordion change to second Panel without onActive 1`] = `
+<DocumentFragment>
+  .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) > circle,
+.c3:focus:not(:focus-visible) > ellipse,
+.c3:focus:not(:focus-visible) > line,
+.c3:focus:not(:focus-visible) > path,
+.c3:focus:not(:focus-visible) > polygon,
+.c3:focus:not(:focus-visible) > polyline,
+.c3:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 3px;
+    padding-right: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+      role="tablist"
+    >
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c6"
+              >
+                Panel 1
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        />
+      </div>
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c6"
+              >
+                Panel 2
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Accordion change to second Panel without onActive 2`] = `
+<DocumentFragment>
+  .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) > circle,
+.c3:focus:not(:focus-visible) > ellipse,
+.c3:focus:not(:focus-visible) > line,
+.c3:focus:not(:focus-visible) > path,
+.c3:focus:not(:focus-visible) > polygon,
+.c3:focus:not(:focus-visible) > polyline,
+.c3:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+  color: #777777;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 3px;
+    padding-right: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+      role="tablist"
+    >
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c6"
+              >
+                Panel 1
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        />
+      </div>
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="true"
+          aria-selected="true"
+          class="c10"
+          role="tab"
+          style="z-index: 1;"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c11"
+              >
+                Panel 2
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormUp"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 15-6-6-6 6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        >
+          Panel body 2
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Accordion complex header 1`] = `
+<DocumentFragment>
+  .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) > circle,
+.c3:focus:not(:focus-visible) > ellipse,
+.c3:focus:not(:focus-visible) > line,
+.c3:focus:not(:focus-visible) > path,
+.c3:focus:not(:focus-visible) > polygon,
+.c3:focus:not(:focus-visible) > polyline,
+.c3:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+      role="tablist"
+    >
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          type="button"
+        >
+          <div>
+            Panel 1 header
+          </div>
+        </button>
+        <div
+          class="c4"
+        />
+      </div>
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="true"
+          aria-selected="true"
+          class="c3"
+          role="tab"
+          type="button"
+        >
+          <div>
+            Panel 2 header
+          </div>
+        </button>
         <div
           class="c4"
         >
-          <div
-            class="c5"
-          >
-            <h4
-              class="c6"
-            >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="c7"
-          >
-            <svg
-              aria-label="FormDown"
-              class="c8"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
+          Panel body 2
         </div>
-      </button>
-      <div
-        class="c9"
-      >
-        <div
-          aria-hidden="true"
-          class="c1 c10"
-        />
-      </div>
-    </div>
-    <div
-      class="c2"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="c3"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            <h4
-              class="c6"
-            >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="c7"
-          >
-            <svg
-              aria-label="FormDown"
-              class="c8"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="c9"
-      >
-        <div
-          aria-hidden="true"
-          class="c1 c10"
-        />
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
-exports[`Accordion set on hover 2`] = `
+exports[`Accordion complex title 1`] = `
+<DocumentFragment>
+  .c7 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #6FFFB0;
+  stroke: #6FFFB0;
+}
+
+.c7 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c7 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c7 *[stroke*="#"],
+.c7 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*="#"],
+.c7 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: #333333;
+  color: #f8f8f8;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(255,255,255,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  -webkit-transition: max-height 200ms,opacity 200ms;
+  transition: max-height 200ms,opacity 200ms;
+  opacity: 0;
+  overflow: hidden;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    border-bottom: solid 1px rgba(255,255,255,0.33);
+  }
+}
+
 <div
-  class="StyledGrommet-sc-19lkkz7-0 eOvTCA"
->
-  <div
-    class="StyledBox-sc-13pk1d4-0 bULqXT"
-    role="tablist"
+    class="c0"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
+      class="c1"
     >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
+      <div
+        class="c2"
+        role="tablist"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
+          class="c3"
         >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
+          <button
+            aria-expanded="false"
+            aria-selected="false"
+            class="c4"
+            role="tab"
+            type="button"
           >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 kyPsTO"
+            <div
+              class="c5"
             >
-              Panel 1
-            </h4>
-          </div>
+              <div>
+                Panel 1 complex
+              </div>
+              <div
+                class="c6"
+              >
+                <svg
+                  aria-label="FormDown"
+                  class="c7"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m18 9-6 6-6-6"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
           <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
+            class="c8"
           >
-            <svg
-              aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+            <div
+              aria-hidden="true"
+              class="c2 c9"
+            />
           </div>
         </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      >
         <div
-          aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bULqXT Collapsible__AnimatedBox-sc-15kniua-0 dvSzsF"
-        />
-      </div>
-    </div>
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
+          class="c3"
         >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
+          <button
+            aria-expanded="false"
+            aria-selected="false"
+            class="c4"
+            role="tab"
+            type="button"
           >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
+            <div
+              class="c5"
             >
-              Panel 2
-            </h4>
-          </div>
+              <div>
+                Panel 2 complex
+              </div>
+              <div
+                class="c6"
+              >
+                <svg
+                  aria-label="FormDown"
+                  class="c7"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m18 9-6 6-6-6"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
           <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
+            class="c8"
           >
-            <svg
-              aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+            <div
+              aria-hidden="true"
+              class="c2 c9"
+            />
           </div>
         </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      >
-        <div
-          aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bULqXT Collapsible__AnimatedBox-sc-15kniua-0 dvSzsF"
-        />
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
-exports[`Accordion set on hover 3`] = `
+exports[`Accordion custom accordion 1`] = `
+<DocumentFragment>
+  .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) > circle,
+.c3:focus:not(:focus-visible) > ellipse,
+.c3:focus:not(:focus-visible) > line,
+.c3:focus:not(:focus-visible) > path,
+.c3:focus:not(:focus-visible) > polygon,
+.c3:focus:not(:focus-visible) > polyline,
+.c3:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  -webkit-transition: max-height 200ms,opacity 200ms;
+  transition: max-height 200ms,opacity 200ms;
+  opacity: 0;
+  overflow: hidden;
+}
+
+.c6 {
+  font-size: 26px;
+  line-height: 32px;
+  max-width: 624px;
+  font-weight: 600;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 3px;
+    padding-right: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
+  }
+}
+
 <div
-  class="StyledGrommet-sc-19lkkz7-0 eOvTCA"
->
-  <div
-    class="StyledBox-sc-13pk1d4-0 bULqXT"
-    role="tablist"
+    class="c0"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
+      class="c1"
+      role="tablist"
     >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
+      <div
+        class="c2"
       >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          type="button"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
+            class="c4"
           >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 kyPsTO"
+            <div
+              class="c5"
             >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            <svg
-              aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
+              <h3
+                class="c6"
+              >
+                Panel 1
+              </h3>
+            </div>
+            <div
+              class="c7"
             >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
           </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      >
+        </button>
         <div
-          aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bULqXT Collapsible__AnimatedBox-sc-15kniua-0 dvSzsF"
-        />
-      </div>
-    </div>
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
+          class="c9"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
-          >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 kyPsTO"
-            >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            <svg
-              aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
+            aria-hidden="true"
+            class="c1 c10"
+          />
         </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      >
-        <div
-          aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bULqXT Collapsible__AnimatedBox-sc-15kniua-0 dvSzsF"
-        />
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
-exports[`Accordion set on hover 4`] = `
+exports[`Accordion focus and hover styles 1`] = `
+<DocumentFragment>
+  .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) > circle,
+.c3:focus:not(:focus-visible) > ellipse,
+.c3:focus:not(:focus-visible) > line,
+.c3:focus:not(:focus-visible) > path,
+.c3:focus:not(:focus-visible) > polygon,
+.c3:focus:not(:focus-visible) > polyline,
+.c3:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  -webkit-transition: max-height 200ms,opacity 200ms;
+  transition: max-height 200ms,opacity 200ms;
+  opacity: 1;
+  overflow: hidden;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+  color: red;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 3px;
+    padding-right: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
 <div
-  class="StyledGrommet-sc-19lkkz7-0 eOvTCA"
->
-  <div
-    class="StyledBox-sc-13pk1d4-0 bULqXT"
-    role="tablist"
+    class="c0"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
+      class="c1"
+      role="tablist"
     >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
+      <div
+        class="c2"
       >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
+        <button
+          aria-expanded="true"
+          aria-selected="true"
+          class="c3"
+          role="tab"
+          style="z-index: 1;"
+          type="button"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
+            class="c4"
           >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
+            <div
+              class="c5"
             >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            <svg
-              aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
+              <h4
+                class="c6"
+              >
+                Panel 1
+              </h4>
+            </div>
+            <div
+              class="c7"
             >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="FormUp"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 15-6-6-6 6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
           </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      >
+        </button>
         <div
-          aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bULqXT Collapsible__AnimatedBox-sc-15kniua-0 dvSzsF"
-        />
-      </div>
-    </div>
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
+          class="c9"
+          style=""
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
+            aria-hidden="false"
+            class="c1 c10"
+            open=""
+            style="max-height: 0;"
           >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 kyPsTO"
-            >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            <svg
-              aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+            Panel body 1
           </div>
         </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      >
-        <div
-          aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bULqXT Collapsible__AnimatedBox-sc-15kniua-0 dvSzsF"
-        />
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
-exports[`Accordion set on hover 5`] = `
+exports[`Accordion multiple panels 1`] = `
+<DocumentFragment>
+  .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) > circle,
+.c3:focus:not(:focus-visible) > ellipse,
+.c3:focus:not(:focus-visible) > line,
+.c3:focus:not(:focus-visible) > path,
+.c3:focus:not(:focus-visible) > polygon,
+.c3:focus:not(:focus-visible) > polyline,
+.c3:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 3px;
+    padding-right: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
 <div
-  class="StyledGrommet-sc-19lkkz7-0 eOvTCA"
->
-  <div
-    class="StyledBox-sc-13pk1d4-0 bULqXT"
-    role="tablist"
+    class="c0"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
+      class="c1"
+      role="tablist"
     >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
+      <div
+        class="c2"
       >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          type="button"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
+            class="c4"
           >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
+            <div
+              class="c5"
             >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            <svg
-              aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
+              <h4
+                class="c6"
+              >
+                Panel 1
+              </h4>
+            </div>
+            <div
+              class="c7"
             >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
           </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      >
+        </button>
         <div
-          aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bULqXT Collapsible__AnimatedBox-sc-15kniua-0 dvSzsF"
+          class="c9"
         />
       </div>
-    </div>
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
+      <div
+        class="c2"
       >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          type="button"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
+            class="c4"
           >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
+            <div
+              class="c5"
             >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            <svg
-              aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
+              <h4
+                class="c6"
+              >
+                Panel 2
+              </h4>
+            </div>
+            <div
+              class="c7"
             >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
           </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      >
+        </button>
         <div
-          aria-hidden="true"
-          class="StyledBox-sc-13pk1d4-0 bULqXT Collapsible__AnimatedBox-sc-15kniua-0 dvSzsF"
+          class="c9"
         />
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
+`;
+
+exports[`Accordion multiple panels 2`] = `
+<DocumentFragment>
+  .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) > circle,
+.c3:focus:not(:focus-visible) > ellipse,
+.c3:focus:not(:focus-visible) > line,
+.c3:focus:not(:focus-visible) > path,
+.c3:focus:not(:focus-visible) > polygon,
+.c3:focus:not(:focus-visible) > polyline,
+.c3:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+  color: #777777;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 3px;
+    padding-right: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+      role="tablist"
+    >
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c6"
+              >
+                Panel 1
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        />
+      </div>
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="true"
+          aria-selected="true"
+          class="c10"
+          role="tab"
+          style="z-index: 1;"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c11"
+              >
+                Panel 2
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormUp"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 15-6-6-6 6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        >
+          Panel body 2
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Accordion multiple panels 3`] = `
+<DocumentFragment>
+  .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) > circle,
+.c3:focus:not(:focus-visible) > ellipse,
+.c3:focus:not(:focus-visible) > line,
+.c3:focus:not(:focus-visible) > path,
+.c3:focus:not(:focus-visible) > polygon,
+.c3:focus:not(:focus-visible) > polyline,
+.c3:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+  color: #777777;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 3px;
+    padding-right: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+      role="tablist"
+    >
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="true"
+          aria-selected="true"
+          class="c3"
+          role="tab"
+          style="z-index: 1;"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c6"
+              >
+                Panel 1
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormUp"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 15-6-6-6 6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        >
+          Panel body 1
+        </div>
+      </div>
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="true"
+          aria-selected="true"
+          class="c10"
+          role="tab"
+          style=""
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c11"
+              >
+                Panel 2
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormUp"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 15-6-6-6 6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        >
+          Panel body 2
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Accordion multiple panels 4`] = `
+<DocumentFragment>
+  .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) > circle,
+.c3:focus:not(:focus-visible) > ellipse,
+.c3:focus:not(:focus-visible) > line,
+.c3:focus:not(:focus-visible) > path,
+.c3:focus:not(:focus-visible) > polygon,
+.c3:focus:not(:focus-visible) > polyline,
+.c3:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+  color: #777777;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 3px;
+    padding-right: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+      role="tablist"
+    >
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="true"
+          aria-selected="true"
+          class="c3"
+          role="tab"
+          style=""
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c6"
+              >
+                Panel 1
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormUp"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 15-6-6-6 6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        >
+          Panel body 1
+        </div>
+      </div>
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c10"
+          role="tab"
+          style="z-index: 1;"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c11"
+              >
+                Panel 2
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Accordion multiple panels 5`] = `
+<DocumentFragment>
+  .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) > circle,
+.c3:focus:not(:focus-visible) > ellipse,
+.c3:focus:not(:focus-visible) > line,
+.c3:focus:not(:focus-visible) > path,
+.c3:focus:not(:focus-visible) > polygon,
+.c3:focus:not(:focus-visible) > polyline,
+.c3:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+  color: #777777;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 3px;
+    padding-right: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+      role="tablist"
+    >
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          style="z-index: 1;"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c6"
+              >
+                Panel 1
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        />
+      </div>
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c10"
+          role="tab"
+          style=""
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c11"
+              >
+                Panel 2
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Accordion no AccordionPanel 1`] = `
+<DocumentFragment>
+  .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+      role="tablist"
+    />
+  </div>
+</DocumentFragment>
 `;
 
 exports[`Accordion should have no accessibility violations 1`] = `
-.c6 {
+<DocumentFragment>
+  .c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -5860,8 +7021,7 @@ exports[`Accordion should have no accessibility violations 1`] = `
   }
 }
 
-<div>
-  <div
+<div
     class="c0"
   >
     <div
@@ -5910,11 +7070,12 @@ exports[`Accordion should have no accessibility violations 1`] = `
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`Accordion theme hover of hover.heading.color 1`] = `
-.c8 {
+<DocumentFragment>
+  .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -6167,68 +7328,70 @@ exports[`Accordion theme hover of hover.heading.color 1`] = `
 }
 
 <div
-  class="c0"
->
-  <div
-    class="c1"
-    role="tablist"
+    class="c0"
   >
     <div
-      class="c2"
+      class="c1"
+      role="tablist"
     >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="c3"
-        role="tab"
-        style="z-index: 1;"
-        type="button"
+      <div
+        class="c2"
       >
-        <div
-          class="c4"
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          style="z-index: 1;"
+          type="button"
         >
           <div
-            class="c5"
+            class="c4"
           >
-            <h4
-              class="c6"
+            <div
+              class="c5"
             >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="c7"
-          >
-            <svg
-              aria-label="FormDown"
-              class="c8"
-              viewBox="0 0 24 24"
+              <h4
+                class="c6"
+              >
+                Panel 1
+              </h4>
+            </div>
+            <div
+              class="c7"
             >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
           </div>
-        </div>
-      </button>
-      <div
-        class="c9"
-      >
+        </button>
         <div
-          aria-hidden="true"
-          class="c1 c10"
-        />
+          class="c9"
+        >
+          <div
+            aria-hidden="true"
+            class="c1 c10"
+          />
+        </div>
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`Accordion wrapped panel 1`] = `
-.c8 {
+<DocumentFragment>
+  .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -6469,138 +7632,108 @@ exports[`Accordion wrapped panel 1`] = `
 }
 
 <div
-  class="c0"
->
-  <div
-    class="c1"
-    role="tablist"
+    class="c0"
   >
     <div
-      class="c2"
+      class="c1"
+      role="tablist"
     >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="c3"
-        role="tab"
-        type="button"
+      <div
+        class="c2"
       >
-        <div
-          class="c4"
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          type="button"
         >
           <div
-            class="c5"
+            class="c4"
           >
-            <h4
-              class="c6"
+            <div
+              class="c5"
             >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="c7"
-          >
-            <svg
-              aria-label="FormDown"
-              class="c8"
-              viewBox="0 0 24 24"
+              <h4
+                class="c6"
+              >
+                Panel 1
+              </h4>
+            </div>
+            <div
+              class="c7"
             >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
           </div>
-        </div>
-      </button>
-      <div
-        class="c9"
-      />
-    </div>
-    <div
-      class="c2"
-    >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="c3"
-        role="tab"
-        type="button"
-      >
+        </button>
         <div
-          class="c4"
+          class="c9"
+        />
+      </div>
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          type="button"
         >
           <div
-            class="c5"
+            class="c4"
           >
-            <h4
-              class="c6"
+            <div
+              class="c5"
             >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="c7"
-          >
-            <svg
-              aria-label="FormDown"
-              class="c8"
-              viewBox="0 0 24 24"
+              <h4
+                class="c6"
+              >
+                Panel 2
+              </h4>
+            </div>
+            <div
+              class="c7"
             >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
           </div>
-        </div>
-      </button>
-      <div
-        class="c9"
-      />
+        </button>
+        <div
+          class="c9"
+        />
+      </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`Accordion wrapped panel 2`] = `
-<div
-  class="StyledGrommet-sc-19lkkz7-0 eOvTCA"
->
-  <div
-    class="StyledBox-sc-13pk1d4-0 bULqXT"
-    role="tablist"
-  >
-    <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
-    >
-      <button
-        aria-expanded="true"
-        aria-selected="true"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
-      >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
-          >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
-            >
-              Panel 1
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            .c0 {
+<DocumentFragment>
+  .c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -6611,111 +7744,408 @@ exports[`Accordion wrapped panel 2`] = `
   stroke: #7D4CDB;
 }
 
-.c0 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c0 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c0 *[stroke*="#"],
-.c0 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c0 *[fill-rule],
-.c0 *[FILL-RULE],
-.c0 *[fill*="#"],
-.c0 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
 
-@media only screen and (max-width:768px) {
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
 
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) > circle,
+.c3:focus:not(:focus-visible) > ellipse,
+.c3:focus:not(:focus-visible) > line,
+.c3:focus:not(:focus-visible) > path,
+.c3:focus:not(:focus-visible) > polygon,
+.c3:focus:not(:focus-visible) > polyline,
+.c3:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+  color: #777777;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
 }
 
 @media only screen and (max-width:768px) {
-
+  .c5 {
+    padding-left: 3px;
+    padding-right: 3px;
+  }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c7 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c9 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
 }
 
-<svg
-              aria-label="FormUp"
-              class="c0"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m18 15-6-6-6 6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-        </div>
-      </button>
-      <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      >
-        Panel body 
-        1
-      </div>
-    </div>
+@media only screen and (max-width:768px) {
+  .c11 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+<div
+    class="c0"
+  >
     <div
-      class="StyledBox-sc-13pk1d4-0 jVOTJS"
+      class="c1"
+      role="tablist"
     >
-      <button
-        aria-expanded="false"
-        aria-selected="false"
-        class="StyledButton-sc-323bzc-0 kVhqUm"
-        role="tab"
-        type="button"
+      <div
+        class="c2"
       >
-        <div
-          class="StyledBox-sc-13pk1d4-0 duA-dOj"
+        <button
+          aria-expanded="true"
+          aria-selected="true"
+          class="c3"
+          role="tab"
+          style="z-index: 1;"
+          type="button"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fjidTB"
+            class="c4"
           >
-            <h4
-              class="StyledHeading-sc-1rdh4aw-0 jVcTPV"
+            <div
+              class="c5"
             >
-              Panel 2
-            </h4>
-          </div>
-          <div
-            class="StyledBox-sc-13pk1d4-0 lhFUWW"
-          >
-            <svg
-              aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 cQcocJ"
-              viewBox="0 0 24 24"
+              <h4
+                class="c6"
+              >
+                Panel 1
+              </h4>
+            </div>
+            <div
+              class="c7"
             >
-              <path
-                d="m18 9-6 6-6-6"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="FormUp"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 15-6-6-6 6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
           </div>
+        </button>
+        <div
+          class="c9"
+        >
+          Panel body 1
         </div>
-      </button>
+      </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 dhYAgM"
-      />
+        class="c2"
+      >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c10"
+          role="tab"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h4
+                class="c11"
+              >
+                Panel 2
+              </h4>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        />
+      </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2698,7 +2698,7 @@
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
 
-"@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8":
+"@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
@@ -2917,6 +2917,52 @@
   integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@typescript-eslint/experimental-utils@^5.0.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.4.0.tgz#238a7418d2da3b24874ba35385eb21cc61d2a65e"
+  integrity sha512-Nz2JDIQUdmIGd6p33A+naQmwfkU5KVTLb/5lTk+tLVTDacZKoGQisj8UCxk7onJcrgjIvr8xWqkYI+DbI3TfXg==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.4.0"
+    "@typescript-eslint/types" "5.4.0"
+    "@typescript-eslint/typescript-estree" "5.4.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
+"@typescript-eslint/scope-manager@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.4.0.tgz#aaab08415f4a9cf32b870c7750ae8ba4607126a1"
+  integrity sha512-pRxFjYwoi8R+n+sibjgF9iUiAELU9ihPBtHzocyW8v8D8G8KeQvXTsW7+CBYIyTYsmhtNk50QPGLE3vrvhM5KA==
+  dependencies:
+    "@typescript-eslint/types" "5.4.0"
+    "@typescript-eslint/visitor-keys" "5.4.0"
+
+"@typescript-eslint/types@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.4.0.tgz#b1c130f4b381b77bec19696c6e3366f9781ce8f2"
+  integrity sha512-GjXNpmn+n1LvnttarX+sPD6+S7giO+9LxDIGlRl4wK3a7qMWALOHYuVSZpPTfEIklYjaWuMtfKdeByx0AcaThA==
+
+"@typescript-eslint/typescript-estree@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.4.0.tgz#fe524fb308973c68ebeb7428f3b64499a6ba5fc0"
+  integrity sha512-nhlNoBdhKuwiLMx6GrybPT3SFILm5Gij2YBdPEPFlYNFAXUJWX6QRgvi/lwVoadaQEFsizohs6aFRMqsXI2ewA==
+  dependencies:
+    "@typescript-eslint/types" "5.4.0"
+    "@typescript-eslint/visitor-keys" "5.4.0"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/visitor-keys@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.4.0.tgz#09bc28efd3621f292fe88c86eef3bf4893364c8c"
+  integrity sha512-PVbax7MeE7tdLfW5SA0fs8NGVVr+buMPrcj+CWYWPXsZCH8qZ1THufDzbXm1xrZ2b2PA1iENJ0sRq5fuUtvsJg==
+  dependencies:
+    "@typescript-eslint/types" "5.4.0"
+    eslint-visitor-keys "^3.0.0"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -5879,6 +5925,13 @@ eslint-plugin-react@^7.26.1:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.5"
 
+eslint-plugin-testing-library@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.0.0.tgz#eb98bcecf44bbdb0df4e78bb58e87a05685b38e0"
+  integrity sha512-lojlPN8nsb7JTFYhJuLNwwI8kALRC0TBz5JRO1lvV7Ifzqu7IoddjDFRCxeM+0d2/zuEO7Sb5oc7ErDqhd4MBw==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^5.0.0"
+
 eslint-rule-composer@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
@@ -5907,6 +5960,13 @@ eslint-utils@^2.1.0:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
+
 eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
@@ -5916,6 +5976,11 @@ eslint-visitor-keys@^2.0.0, eslint-visitor-keys@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+
+eslint-visitor-keys@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz#eee4acea891814cda67a7d8812d9647dd0179af2"
+  integrity sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==
 
 eslint@^7.32.0:
   version "7.32.0"
@@ -6843,7 +6908,7 @@ globby@11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-globby@^11.0.1, globby@^11.0.2:
+globby@^11.0.1, globby@^11.0.2, globby@^11.0.4:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
   integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
@@ -7693,7 +7758,7 @@ is-glob@^3.0.0, is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -12423,7 +12488,7 @@ tsconfig-paths@^3.11.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -12432,6 +12497,13 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tsutils@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
#### What does this PR do?
Updated tests for the component to follow the testing guidelines//best practices that are being added to the contributing guide. We can use the Accordion tests as a reference for people to look at.

I also added `eslint-plugin-testing-library` to catch errors related to using react testing library. For now I only enabled it for the Accordion test file.

Note: switching from `container.firstChild` to `asFragment()` is causing the majority of snapshot changes

#### Where should the reviewer start?
Accordion-test.tsx

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Related to grommet/hpe-design-system#1959

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
