### PR TITLE
Fix DataTable groupBy.onSelect condition

### DIFF
--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -152,10 +152,13 @@ const Header = forwardRef(
       ? [...pin, 'left']
       : pin;
 
-    const totalSelectedGroups = groupBy?.select ?
-      Object.keys(groupBy.select).reduce((total, cur) =>
-        cur && groupBy.select[cur] === 'all' ? total + 1 : total,
-      0) : 0;
+    const totalSelectedGroups = groupBy?.select
+      ? Object.keys(groupBy.select).reduce(
+          (total, cur) =>
+            cur && groupBy.select[cur] === 'all' ? total + 1 : total,
+          0,
+        )
+      : 0;
     const totalSelected = (selected?.length || 0) + totalSelectedGroups;
 
     return (
@@ -194,45 +197,45 @@ const Header = forwardRef(
                       : 'select all'
                   }
                   checked={
-                    groupBy?.select ?
-                      groupBy.select[''] === 'all' :
-                      totalSelected > 0 &&
-                      data.length > 0 &&
-                      totalSelected === data.length
+                    groupBy?.select
+                      ? groupBy.select[''] === 'all'
+                      : totalSelected > 0 &&
+                        data.length > 0 &&
+                        totalSelected === data.length
                   }
                   indeterminate={
-                    groupBy?.select ?
-                      groupBy.select[''] === 'some' :
-                      totalSelected > 0 && totalSelected < data.length
+                    groupBy?.select
+                      ? groupBy.select[''] === 'some'
+                      : totalSelected > 0 && totalSelected < data.length
                   }
                   onChange={() => {
                     let nextSelected;
                     const nextGroupSelected = {};
-                    const allSelected = groupBy?.select ?
-                      groupBy.select[''] === 'all' :
-                      totalSelected === data.length;
-                  
+                    const allSelected = groupBy?.select
+                      ? groupBy.select[''] === 'all'
+                      : totalSelected === data.length;
+
                     // if all are selected, clear selection
                     if (allSelected) {
                       nextSelected = [];
                       nextGroupSelected[''] = 'none';
                     } else {
                       // if some or none are selected, select all data
-                      nextSelected = 
-                        data.map((datum) => datumValue(datum, primaryProperty));
+                      nextSelected = data.map((datum) =>
+                        datumValue(datum, primaryProperty),
+                      );
                       nextGroupSelected[''] = 'all';
-                      groupBy?.expandable?.forEach(key => {
+                      groupBy?.expandable?.forEach((key) => {
                         nextGroupSelected[key] = 'all';
                       });
                     }
-                    if (groupBy.onSelect) {
+                    if (groupBy?.onSelect) {
                       groupBy.onSelect(
                         nextSelected,
                         undefined,
                         nextGroupSelected,
                       );
-                    }
-                    else onSelect(nextSelected);
+                    } else onSelect(nextSelected);
                   }}
                   pad={cellProps.pad}
                 />

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -946,8 +946,10 @@ describe('DataTable', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
     fireEvent.click(getByLabelText('select beta'));
-    expect(onSelect).toBeCalledWith(expect.arrayContaining(['alpha', 'beta']),
-      undefined);
+    expect(onSelect).toBeCalledWith(
+      expect.arrayContaining(['alpha', 'beta']),
+      undefined,
+    );
     expect(container.firstChild).toMatchSnapshot();
   });
 
@@ -1210,6 +1212,41 @@ describe('DataTable', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('onSelect select/unselect all', () => {
+    const onSelect = jest.fn();
+    const { container, getByLabelText } = render(
+      <Grommet>
+        <DataTable
+          columns={[
+            { property: 'a', header: 'A' },
+            { property: 'b', header: 'B', primary: true },
+          ]}
+          data={[
+            { a: 'one', b: 1.1 },
+            { a: 'one', b: 1.2 },
+            { a: 'two', b: 2.1 },
+            { a: 'two', b: 2.2 },
+          ]}
+          onSelect={onSelect}
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+
+    let headerCheckBox;
+    headerCheckBox = getByLabelText('select all');
+    fireEvent.click(headerCheckBox);
+    expect(onSelect).toBeCalledWith([1.1, 1.2, 2.1, 2.2]);
+    expect(container.firstChild).toMatchSnapshot();
+
+    // aria-label should have changed since all entries
+    // are selected
+    headerCheckBox = getByLabelText('unselect all');
+    fireEvent.click(headerCheckBox);
+    expect(onSelect).toBeCalledWith([]);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('onSelect + groupBy should select/deselect all when grouped', () => {
     const onSelect = jest.fn();
     const { container, getByLabelText } = render(
@@ -1267,8 +1304,10 @@ describe('DataTable', () => {
 
     const groupCheckBox = getByLabelText('select one');
     fireEvent.click(groupCheckBox);
-    expect(onSelect).toBeCalledWith(expect.arrayContaining([1.1, 1.2]),
-      expect.objectContaining({"a":"one"}));
+    expect(onSelect).toBeCalledWith(
+      expect.arrayContaining([1.1, 1.2]),
+      expect.objectContaining({ a: 'one' }),
+    );
     expect(container.firstChild).toMatchSnapshot();
   });
 

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -11256,6 +11256,1308 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
 </div>
 `;
 
+exports[`DataTable onSelect select/unselect all 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px rgba(0,0,0,0.15);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c17 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  cursor: pointer;
+}
+
+.c5:hover input:not([disabled]) + div,
+.c5:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c8 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.c8:checked + span > span {
+  left: calc( 48px - 24px );
+  background: #7D4CDB;
+}
+
+.c7 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  width: 1px;
+  overflow: hidden;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+}
+
+.c10 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c14 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  width: 1px;
+  overflow: hidden;
+  text-align: start;
+}
+
+.c15 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c2 {
+  position: relative;
+  border-spacing: 0;
+  border-collapse: separate;
+  height: auto;
+}
+
+.c13:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c13:focus:not(:focus-visible) {
+  outline: none;
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border: solid 2px rgba(0,0,0,0.15);
+  }
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+            style="height: 0px;"
+          >
+            <label
+              aria-label="select all"
+              class="c5"
+            >
+              <div
+                class="c6 c7"
+              >
+                <input
+                  class="c8"
+                  type="checkbox"
+                />
+                <div
+                  class="c9 "
+                />
+              </div>
+            </label>
+          </div>
+        </th>
+        <th
+          class="c10 "
+          scope="col"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c10 "
+          scope="col"
+        >
+          <div
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 c13"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <td
+          class="c14 "
+        >
+          <div
+            class="c4"
+            style="height: 0px;"
+          >
+            <label
+              aria-label="select 1.1"
+              class="c5"
+            >
+              <div
+                class="c6 c7"
+              >
+                <input
+                  class="c8"
+                  type="checkbox"
+                />
+                <div
+                  class="c9 "
+                />
+              </div>
+            </label>
+          </div>
+        </td>
+        <td
+          class="c15 "
+        >
+          <div
+            class="c16"
+          >
+            <span
+              class="c12"
+            >
+              one
+            </span>
+          </div>
+        </td>
+        <th
+          class="c15 "
+          scope="row"
+        >
+          <div
+            class="c16"
+          >
+            <span
+              class="c17"
+            >
+              1.1
+            </span>
+          </div>
+        </th>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <td
+          class="c14 "
+        >
+          <div
+            class="c4"
+            style="height: 0px;"
+          >
+            <label
+              aria-label="select 1.2"
+              class="c5"
+            >
+              <div
+                class="c6 c7"
+              >
+                <input
+                  class="c8"
+                  type="checkbox"
+                />
+                <div
+                  class="c9 "
+                />
+              </div>
+            </label>
+          </div>
+        </td>
+        <td
+          class="c15 "
+        >
+          <div
+            class="c16"
+          >
+            <span
+              class="c12"
+            >
+              one
+            </span>
+          </div>
+        </td>
+        <th
+          class="c15 "
+          scope="row"
+        >
+          <div
+            class="c16"
+          >
+            <span
+              class="c17"
+            >
+              1.2
+            </span>
+          </div>
+        </th>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <td
+          class="c14 "
+        >
+          <div
+            class="c4"
+            style="height: 0px;"
+          >
+            <label
+              aria-label="select 2.1"
+              class="c5"
+            >
+              <div
+                class="c6 c7"
+              >
+                <input
+                  class="c8"
+                  type="checkbox"
+                />
+                <div
+                  class="c9 "
+                />
+              </div>
+            </label>
+          </div>
+        </td>
+        <td
+          class="c15 "
+        >
+          <div
+            class="c16"
+          >
+            <span
+              class="c12"
+            >
+              two
+            </span>
+          </div>
+        </td>
+        <th
+          class="c15 "
+          scope="row"
+        >
+          <div
+            class="c16"
+          >
+            <span
+              class="c17"
+            >
+              2.1
+            </span>
+          </div>
+        </th>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <td
+          class="c14 "
+        >
+          <div
+            class="c4"
+            style="height: 0px;"
+          >
+            <label
+              aria-label="select 2.2"
+              class="c5"
+            >
+              <div
+                class="c6 c7"
+              >
+                <input
+                  class="c8"
+                  type="checkbox"
+                />
+                <div
+                  class="c9 "
+                />
+              </div>
+            </label>
+          </div>
+        </td>
+        <td
+          class="c15 "
+        >
+          <div
+            class="c16"
+          >
+            <span
+              class="c12"
+            >
+              two
+            </span>
+          </div>
+        </td>
+        <th
+          class="c15 "
+          scope="row"
+        >
+          <div
+            class="c16"
+          >
+            <span
+              class="c17"
+            >
+              2.2
+            </span>
+          </div>
+        </th>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable onSelect select/unselect all 2`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 eOvTCA"
+>
+  <table
+    class="StyledTable-sc-1m3u5g-6 lfIBVd StyledDataTable-sc-xrlyjm-0 hsvjLV"
+  >
+    <thead
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 bhjpql"
+      >
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYowDL StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+          scope="col"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 VweX"
+            style="height: 0px;"
+          >
+            <label
+              aria-label="unselect all"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fFmVaU"
+            >
+              <div
+                class="StyledBox-sc-13pk1d4-0 kUMPgf StyledCheckBox-sc-1dbk5ju-6 bXiBYz"
+              >
+                <input
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 iaLOrJ"
+                  type="checkbox"
+                />
+                <div
+                  class="StyledBox-sc-13pk1d4-0 eFkyap StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 WtXtt"
+                >
+                  .c0 {
+  box-sizing: border-box;
+  stroke-width: 4px;
+  stroke: #7D4CDB;
+  width: 24px;
+  height: 24px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+
+}
+
+<svg
+                    class="c0"
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6,11.3 L10.3,16 L18,6.2"
+                      fill="none"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </label>
+          </div>
+        </th>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dcreUj StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+          scope="col"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 hHytfL"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fkNrQP"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dcreUj StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+          scope="col"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 hHytfL"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fkNrQP"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-3 dCDxqt"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 bhjpql"
+      >
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bzvxGh StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 VweX"
+            style="height: 0px;"
+          >
+            <label
+              aria-label="unselect 1.1"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fFmVaU"
+            >
+              <div
+                class="StyledBox-sc-13pk1d4-0 kUMPgf StyledCheckBox-sc-1dbk5ju-6 bXiBYz"
+              >
+                <input
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 iaLOrJ"
+                  type="checkbox"
+                />
+                <div
+                  class="StyledBox-sc-13pk1d4-0 eFkyap StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 WtXtt"
+                >
+                  .c0 {
+  box-sizing: border-box;
+  stroke-width: 4px;
+  stroke: #7D4CDB;
+  width: 24px;
+  height: 24px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+
+}
+
+<svg
+                    class="c0"
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6,11.3 L10.3,16 L18,6.2"
+                      fill="none"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </label>
+          </div>
+        </td>
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dkctaV StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bULqXT"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fkNrQP"
+            >
+              one
+            </span>
+          </div>
+        </td>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dkctaV StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+          scope="row"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bULqXT"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fDswbh"
+            >
+              1.1
+            </span>
+          </div>
+        </th>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 bhjpql"
+      >
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bzvxGh StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 VweX"
+            style="height: 0px;"
+          >
+            <label
+              aria-label="unselect 1.2"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fFmVaU"
+            >
+              <div
+                class="StyledBox-sc-13pk1d4-0 kUMPgf StyledCheckBox-sc-1dbk5ju-6 bXiBYz"
+              >
+                <input
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 iaLOrJ"
+                  type="checkbox"
+                />
+                <div
+                  class="StyledBox-sc-13pk1d4-0 eFkyap StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 WtXtt"
+                >
+                  .c0 {
+  box-sizing: border-box;
+  stroke-width: 4px;
+  stroke: #7D4CDB;
+  width: 24px;
+  height: 24px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+
+}
+
+<svg
+                    class="c0"
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6,11.3 L10.3,16 L18,6.2"
+                      fill="none"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </label>
+          </div>
+        </td>
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dkctaV StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bULqXT"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fkNrQP"
+            >
+              one
+            </span>
+          </div>
+        </td>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dkctaV StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+          scope="row"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bULqXT"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fDswbh"
+            >
+              1.2
+            </span>
+          </div>
+        </th>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 bhjpql"
+      >
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bzvxGh StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 VweX"
+            style="height: 0px;"
+          >
+            <label
+              aria-label="unselect 2.1"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fFmVaU"
+            >
+              <div
+                class="StyledBox-sc-13pk1d4-0 kUMPgf StyledCheckBox-sc-1dbk5ju-6 bXiBYz"
+              >
+                <input
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 iaLOrJ"
+                  type="checkbox"
+                />
+                <div
+                  class="StyledBox-sc-13pk1d4-0 eFkyap StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 WtXtt"
+                >
+                  .c0 {
+  box-sizing: border-box;
+  stroke-width: 4px;
+  stroke: #7D4CDB;
+  width: 24px;
+  height: 24px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+
+}
+
+<svg
+                    class="c0"
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6,11.3 L10.3,16 L18,6.2"
+                      fill="none"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </label>
+          </div>
+        </td>
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dkctaV StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bULqXT"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fkNrQP"
+            >
+              two
+            </span>
+          </div>
+        </td>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dkctaV StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+          scope="row"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bULqXT"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fDswbh"
+            >
+              2.1
+            </span>
+          </div>
+        </th>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 bhjpql"
+      >
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bzvxGh StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 VweX"
+            style="height: 0px;"
+          >
+            <label
+              aria-label="unselect 2.2"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fFmVaU"
+            >
+              <div
+                class="StyledBox-sc-13pk1d4-0 kUMPgf StyledCheckBox-sc-1dbk5ju-6 bXiBYz"
+              >
+                <input
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 iaLOrJ"
+                  type="checkbox"
+                />
+                <div
+                  class="StyledBox-sc-13pk1d4-0 eFkyap StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 WtXtt"
+                >
+                  .c0 {
+  box-sizing: border-box;
+  stroke-width: 4px;
+  stroke: #7D4CDB;
+  width: 24px;
+  height: 24px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+
+}
+
+<svg
+                    class="c0"
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6,11.3 L10.3,16 L18,6.2"
+                      fill="none"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </label>
+          </div>
+        </td>
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dkctaV StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bULqXT"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fkNrQP"
+            >
+              two
+            </span>
+          </div>
+        </td>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dkctaV StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+          scope="row"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bULqXT"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fDswbh"
+            >
+              2.2
+            </span>
+          </div>
+        </th>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable onSelect select/unselect all 3`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 eOvTCA"
+>
+  <table
+    class="StyledTable-sc-1m3u5g-6 lfIBVd StyledDataTable-sc-xrlyjm-0 hsvjLV"
+  >
+    <thead
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 bhjpql"
+      >
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYowDL StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+          scope="col"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 VweX"
+            style="height: 0px;"
+          >
+            <label
+              aria-label="select all"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fFmVaU"
+            >
+              <div
+                class="StyledBox-sc-13pk1d4-0 kUMPgf StyledCheckBox-sc-1dbk5ju-6 bXiBYz"
+              >
+                <input
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 iaLOrJ"
+                  type="checkbox"
+                />
+                <div
+                  class="StyledBox-sc-13pk1d4-0 gDQNNZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 WtXtt"
+                />
+              </div>
+            </label>
+          </div>
+        </th>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dcreUj StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+          scope="col"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 hHytfL"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fkNrQP"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dcreUj StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+          scope="col"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 hHytfL"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fkNrQP"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-3 dCDxqt"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 bhjpql"
+      >
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bzvxGh StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 VweX"
+            style="height: 0px;"
+          >
+            <label
+              aria-label="select 1.1"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fFmVaU"
+            >
+              <div
+                class="StyledBox-sc-13pk1d4-0 kUMPgf StyledCheckBox-sc-1dbk5ju-6 bXiBYz"
+              >
+                <input
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 iaLOrJ"
+                  type="checkbox"
+                />
+                <div
+                  class="StyledBox-sc-13pk1d4-0 gDQNNZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 WtXtt"
+                />
+              </div>
+            </label>
+          </div>
+        </td>
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dkctaV StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bULqXT"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fkNrQP"
+            >
+              one
+            </span>
+          </div>
+        </td>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dkctaV StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+          scope="row"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bULqXT"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fDswbh"
+            >
+              1.1
+            </span>
+          </div>
+        </th>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 bhjpql"
+      >
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bzvxGh StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 VweX"
+            style="height: 0px;"
+          >
+            <label
+              aria-label="select 1.2"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fFmVaU"
+            >
+              <div
+                class="StyledBox-sc-13pk1d4-0 kUMPgf StyledCheckBox-sc-1dbk5ju-6 bXiBYz"
+              >
+                <input
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 iaLOrJ"
+                  type="checkbox"
+                />
+                <div
+                  class="StyledBox-sc-13pk1d4-0 gDQNNZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 WtXtt"
+                />
+              </div>
+            </label>
+          </div>
+        </td>
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dkctaV StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bULqXT"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fkNrQP"
+            >
+              one
+            </span>
+          </div>
+        </td>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dkctaV StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+          scope="row"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bULqXT"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fDswbh"
+            >
+              1.2
+            </span>
+          </div>
+        </th>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 bhjpql"
+      >
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bzvxGh StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 VweX"
+            style="height: 0px;"
+          >
+            <label
+              aria-label="select 2.1"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fFmVaU"
+            >
+              <div
+                class="StyledBox-sc-13pk1d4-0 kUMPgf StyledCheckBox-sc-1dbk5ju-6 bXiBYz"
+              >
+                <input
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 iaLOrJ"
+                  type="checkbox"
+                />
+                <div
+                  class="StyledBox-sc-13pk1d4-0 gDQNNZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 WtXtt"
+                />
+              </div>
+            </label>
+          </div>
+        </td>
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dkctaV StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bULqXT"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fkNrQP"
+            >
+              two
+            </span>
+          </div>
+        </td>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dkctaV StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+          scope="row"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bULqXT"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fDswbh"
+            >
+              2.1
+            </span>
+          </div>
+        </th>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 bhjpql"
+      >
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bzvxGh StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 VweX"
+            style="height: 0px;"
+          >
+            <label
+              aria-label="select 2.2"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fFmVaU"
+            >
+              <div
+                class="StyledBox-sc-13pk1d4-0 kUMPgf StyledCheckBox-sc-1dbk5ju-6 bXiBYz"
+              >
+                <input
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 iaLOrJ"
+                  type="checkbox"
+                />
+                <div
+                  class="StyledBox-sc-13pk1d4-0 gDQNNZ StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 WtXtt"
+                />
+              </div>
+            </label>
+          </div>
+        </td>
+        <td
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dkctaV StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bULqXT"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fkNrQP"
+            >
+              two
+            </span>
+          </div>
+        </td>
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 dkctaV StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 bCSjGy"
+          scope="row"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bULqXT"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fDswbh"
+            >
+              2.2
+            </span>
+          </div>
+        </th>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`DataTable onSort 1`] = `
 .c0 {
   font-size: 18px;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This fixes a condition to check if `groupBy` prop exists before trying to access `groupBy.onSelect` and restores `onSelect` functionality for DataTables that don't have `groupBy.onSelect`.

Our jest tests did not have a test for this, so I have added one. I confirmed that the test failed with the published code and is resolved with the fix in this PR.

#### Where should the reviewer start?
src/js/components/DataTable/Header.js

#### What testing has been done on this PR?
Tested `onSelect` storybook and added jest test.

#### How should this be manually tested?
`onSelect` storybook, click the checkbox in the header to select all, all should be selected.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

BEFORE:

<img width="949" alt="Screen Shot 2021-11-20 at 7 45 18 AM" src="https://user-images.githubusercontent.com/12522275/142691025-48d43328-b938-490b-acfd-88d628090a03.png">

<img width="386" alt="Screen Shot 2021-11-20 at 7 45 09 AM" src="https://user-images.githubusercontent.com/12522275/142691029-472a9551-0723-4b7e-9385-eb0efc4a7db5.png">

AFTER:
<img width="343" alt="Screen Shot 2021-11-20 at 8 02 23 AM" src="https://user-images.githubusercontent.com/12522275/142691256-9b643da7-f6b3-4041-b0f8-faf25c7d64fa.png">

#### Do the grommet docs need to be updated?
no.

#### Should this PR be mentioned in the release notes?
Yes. Fixed DataTable `onSelect` bug.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.