### PR TITLE
add or for ts in theme for pagination

### DIFF
--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -177,12 +177,13 @@ interface ButtonType {
   primary?: ButtonKindType;
   secondary?: ButtonKindType;
   option?: ButtonKindType;
-  active?: ButtonKindType & {
-    default?: ButtonKindType;
-    primary?: ButtonKindType;
-    secondary?: ButtonKindType;
-    [key: string]: ButtonKindType;
-  };
+  active?:
+    | (ButtonKindType & {
+        default?: ButtonKindType;
+        primary?: ButtonKindType;
+        secondary?: ButtonKindType;
+      })
+    | { [key: string]: ButtonKindType };
   disabled?: ButtonKindType & { opacity?: OpacityType };
   hover?: ButtonKindType & {
     default?: ButtonKindType;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -178,7 +178,7 @@ interface ButtonType {
   secondary?: ButtonKindType;
   option?: ButtonKindType;
   active?:
-    | (ButtonKindType & {
+    (ButtonKindType & {
         default?: ButtonKindType;
         primary?: ButtonKindType;
         secondary?: ButtonKindType;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -185,11 +185,12 @@ interface ButtonType {
       })
     | { [key: string]: ButtonKindType };
   disabled?: ButtonKindType & { opacity?: OpacityType };
-  hover?: ButtonKindType & {
+  hover?: (ButtonKindType & {
     default?: ButtonKindType;
     primary?: ButtonKindType;
     secondary?: ButtonKindType;
-  };
+  })
+  | { [key: string]: ButtonKindType };
   size?: {
     small?: {
       border?: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes a TS error that was with `pagination` 
#### Where should the reviewer start?
base.d.ts
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
The error was 
```
{ background: { color: string; }; color: string; }' is not assignable to type 'ButtonKindType & { [key: string]:
```
It seemed that since there was a & with the `{ [key: string]: ButtonKindType }` it was flagging that it should of been included but we do not always want this so I added an OR option

https://stackoverflow.com/questions/57145172/how-to-create-an-optional-object-key-string-in-typescript/57145386
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible