### PR TITLE
Calendar component chevron aria label not informative enough 

### DIFF
--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -669,10 +669,23 @@ const Calendar = forwardRef(
           </Box>
           <Box flex={false} direction="row" align="center">
             <Button
-              a11yTitle={previousMonth.toLocaleDateString(locale, {
-                month: 'long',
-                year: 'numeric',
-              })}
+              a11yTitle={
+                messages?.previous
+                  ? format({
+                      id: 'calendar.previous',
+                      messages,
+                      values: {
+                        date: previousMonth.toLocaleDateString(locale, {
+                          month: 'long',
+                          year: 'numeric',
+                        }),
+                      },
+                    })
+                  : previousMonth.toLocaleDateString(locale, {
+                      month: 'long',
+                      year: 'numeric',
+                    })
+              }
               icon={<PreviousIcon size={size !== 'small' ? size : undefined} />}
               disabled={!betweenDates(previousMonth, bounds)}
               onClick={() => {
@@ -692,10 +705,23 @@ const Calendar = forwardRef(
               }}
             />
             <Button
-              a11yTitle={nextMonth.toLocaleDateString(locale, {
-                month: 'long',
-                year: 'numeric',
-              })}
+              a11yTitle={
+                messages?.next
+                  ? format({
+                      id: 'calendar.next',
+                      messages,
+                      values: {
+                        date: nextMonth.toLocaleDateString(locale, {
+                          month: 'long',
+                          year: 'numeric',
+                        }),
+                      },
+                    })
+                  : nextMonth.toLocaleDateString(locale, {
+                      month: 'long',
+                      year: 'numeric',
+                    })
+              }
               icon={<NextIcon size={size !== 'small' ? size : undefined} />}
               disabled={!betweenDates(nextMonth, bounds)}
               onClick={() => {
@@ -864,7 +890,7 @@ const Calendar = forwardRef(
                       onClick: () => {
                         selectDate(dateString);
                         announce(
-                          `Selected 
+                          `Selected
                           ${formatToLocalYYYYMMDD(dateString)}`,
                           'assertive',
                         );

--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -55,7 +55,7 @@ const activeDates = {
 
 const timeStamp = /T.*/;
 
-const formatSelectedDatesString = (date) => `Currently selected
+const formatSelectedDatesString = (date) => `Currently selected 
   ${date?.map((item) => {
     let dates;
     if (!Array.isArray(item)) {

--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -55,7 +55,7 @@ const activeDates = {
 
 const timeStamp = /T.*/;
 
-const formatSelectedDatesString = (date) => `Currently selected 
+const formatSelectedDatesString = (date) => `Currently selected
   ${date?.map((item) => {
     let dates;
     if (!Array.isArray(item)) {
@@ -685,7 +685,7 @@ const Calendar = forwardRef(
                 changeReference(previousMonth);
                 announce(
                   format({
-                    id: 'calendar.previous',
+                    id: 'calendar.previousMove',
                     messages,
                     values: {
                       date: previousMonth.toLocaleDateString(locale, {
@@ -714,7 +714,7 @@ const Calendar = forwardRef(
                 changeReference(nextMonth);
                 announce(
                   format({
-                    id: 'calendar.next',
+                    id: 'calendar.nextMove',
                     messages,
                     values: {
                       date: nextMonth.toLocaleDateString(locale, {

--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -55,7 +55,7 @@ const activeDates = {
 
 const timeStamp = /T.*/;
 
-const formatSelectedDatesString = (date) => `Currently selected 
+const formatSelectedDatesString = (date) => `Currently selected
   ${date?.map((item) => {
     let dates;
     if (!Array.isArray(item)) {
@@ -669,23 +669,16 @@ const Calendar = forwardRef(
           </Box>
           <Box flex={false} direction="row" align="center">
             <Button
-              a11yTitle={
-                messages?.previous
-                  ? format({
-                      id: 'calendar.previous',
-                      messages,
-                      values: {
-                        date: previousMonth.toLocaleDateString(locale, {
-                          month: 'long',
-                          year: 'numeric',
-                        }),
-                      },
-                    })
-                  : previousMonth.toLocaleDateString(locale, {
-                      month: 'long',
-                      year: 'numeric',
-                    })
-              }
+              a11yTitle={format({
+                id: 'calendar.previous',
+                messages,
+                values: {
+                  date: previousMonth.toLocaleDateString(locale, {
+                    month: 'long',
+                    year: 'numeric',
+                  }),
+                },
+              })}
               icon={<PreviousIcon size={size !== 'small' ? size : undefined} />}
               disabled={!betweenDates(previousMonth, bounds)}
               onClick={() => {
@@ -705,23 +698,16 @@ const Calendar = forwardRef(
               }}
             />
             <Button
-              a11yTitle={
-                messages?.next
-                  ? format({
-                      id: 'calendar.next',
-                      messages,
-                      values: {
-                        date: nextMonth.toLocaleDateString(locale, {
-                          month: 'long',
-                          year: 'numeric',
-                        }),
-                      },
-                    })
-                  : nextMonth.toLocaleDateString(locale, {
-                      month: 'long',
-                      year: 'numeric',
-                    })
-              }
+              a11yTitle={format({
+                id: 'calendar.next',
+                messages,
+                values: {
+                  date: nextMonth.toLocaleDateString(locale, {
+                    month: 'long',
+                    year: 'numeric',
+                  }),
+                },
+              })}
               icon={<NextIcon size={size !== 'small' ? size : undefined} />}
               disabled={!betweenDates(nextMonth, bounds)}
               onClick={() => {

--- a/src/js/components/Calendar/__tests__/Calendar-test.tsx
+++ b/src/js/components/Calendar/__tests__/Calendar-test.tsx
@@ -248,13 +248,13 @@ describe('Calendar', () => {
       </Grommet>,
     );
     // Change the Calendar from January to December
-    fireEvent.click(getByLabelText('Moved to December 2019'));
+    fireEvent.click(getByLabelText('Go to December 2019'));
     act(() => {
       jest.runAllTimers();
     });
     expect(container.firstChild).toMatchSnapshot();
     // Change the Calendar back to January
-    fireEvent.click(getByLabelText('Moved to January 2020'));
+    fireEvent.click(getByLabelText('Go to January 2020'));
     act(() => {
       jest.runAllTimers();
     });

--- a/src/js/components/Calendar/__tests__/Calendar-test.tsx
+++ b/src/js/components/Calendar/__tests__/Calendar-test.tsx
@@ -248,13 +248,13 @@ describe('Calendar', () => {
       </Grommet>,
     );
     // Change the Calendar from January to December
-    fireEvent.click(getByLabelText('December 2019'));
+    fireEvent.click(getByLabelText('Moved to December 2019'));
     act(() => {
       jest.runAllTimers();
     });
     expect(container.firstChild).toMatchSnapshot();
     // Change the Calendar back to January
-    fireEvent.click(getByLabelText('January 2020'));
+    fireEvent.click(getByLabelText('Moved to January 2020'));
     act(() => {
       jest.runAllTimers();
     });

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
@@ -360,7 +360,7 @@ exports[`Calendar change months 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to November 2019"
+            aria-label="Go to November 2019"
             class="c7"
             type="button"
           >
@@ -378,7 +378,7 @@ exports[`Calendar change months 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to January 2020"
+            aria-label="Go to January 2020"
             class="c7"
             type="button"
           >
@@ -1186,7 +1186,7 @@ exports[`Calendar change months 2`] = `
           class="StyledBox-sc-13pk1d4-0 ellHmk"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="StyledButton-sc-323bzc-0 bpsTzm"
             type="button"
           >
@@ -1204,7 +1204,7 @@ exports[`Calendar change months 2`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="StyledButton-sc-323bzc-0 bpsTzm"
             type="button"
           >
@@ -2737,7 +2737,7 @@ exports[`Calendar children 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="c7"
             type="button"
           >
@@ -2755,7 +2755,7 @@ exports[`Calendar children 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >
@@ -3623,7 +3623,7 @@ exports[`Calendar date 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="c7"
             type="button"
           >
@@ -3641,7 +3641,7 @@ exports[`Calendar date 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >
@@ -4821,7 +4821,7 @@ exports[`Calendar dates 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="c7"
             type="button"
           >
@@ -4839,7 +4839,7 @@ exports[`Calendar dates 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >
@@ -4861,7 +4861,7 @@ exports[`Calendar dates 1`] = `
       <div
         aria-label="
                 January 2020;
-                Currently selected 
+                Currently selected
   2020-01-12 ,2020-01-08 through 2020-01-10
               "
         class="c9"
@@ -6020,7 +6020,7 @@ exports[`Calendar daysOfWeek 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="c7"
             type="button"
           >
@@ -6038,7 +6038,7 @@ exports[`Calendar daysOfWeek 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >
@@ -6135,7 +6135,7 @@ exports[`Calendar daysOfWeek 1`] = `
       <div
         aria-label="
                 January 2020;
-                Currently selected 
+                Currently selected
   2020-01-12 ,2020-01-08 through 2020-01-10
               "
         class="c12"
@@ -7337,7 +7337,7 @@ exports[`Calendar disabled 1`] = `
             class="c6"
           >
             <button
-              aria-label="Moved to December 2019"
+              aria-label="Go to December 2019"
               class="c7"
               type="button"
             >
@@ -7355,7 +7355,7 @@ exports[`Calendar disabled 1`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to February 2020"
+              aria-label="Go to February 2020"
               class="c7"
               type="button"
             >
@@ -8540,7 +8540,7 @@ exports[`Calendar fill 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="c7"
             type="button"
           >
@@ -8558,7 +8558,7 @@ exports[`Calendar fill 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >
@@ -9720,7 +9720,7 @@ exports[`Calendar first day sunday week monday 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >
@@ -9738,7 +9738,7 @@ exports[`Calendar first day sunday week monday 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to April 2020"
+            aria-label="Go to April 2020"
             class="c7"
             type="button"
           >
@@ -10900,7 +10900,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="c7"
             type="button"
           >
@@ -10918,7 +10918,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >
@@ -11719,7 +11719,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="c7"
             type="button"
           >
@@ -11737,7 +11737,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >
@@ -14037,7 +14037,7 @@ exports[`Calendar reference 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="c7"
             type="button"
           >
@@ -14055,7 +14055,7 @@ exports[`Calendar reference 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >
@@ -15217,7 +15217,7 @@ exports[`Calendar select date 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="c7"
             type="button"
           >
@@ -15235,7 +15235,7 @@ exports[`Calendar select date 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >
@@ -16043,7 +16043,7 @@ exports[`Calendar select date 2`] = `
           class="StyledBox-sc-13pk1d4-0 ellHmk"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="StyledButton-sc-323bzc-0 bpsTzm"
             type="button"
           >
@@ -16061,7 +16061,7 @@ exports[`Calendar select date 2`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="StyledButton-sc-323bzc-0 bpsTzm"
             type="button"
           >
@@ -17241,7 +17241,7 @@ exports[`Calendar select dates 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="c7"
             type="button"
           >
@@ -17259,7 +17259,7 @@ exports[`Calendar select dates 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >
@@ -17281,7 +17281,7 @@ exports[`Calendar select dates 1`] = `
       <div
         aria-label="
                 January 2020;
-                Currently selected 
+                Currently selected
   2020-01-12 ,2020-01-08 through 2020-01-10
               "
         class="c9"
@@ -18068,7 +18068,7 @@ exports[`Calendar select dates 2`] = `
           class="StyledBox-sc-13pk1d4-0 ellHmk"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="StyledButton-sc-323bzc-0 bpsTzm"
             type="button"
           >
@@ -18086,7 +18086,7 @@ exports[`Calendar select dates 2`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="StyledButton-sc-323bzc-0 bpsTzm"
             type="button"
           >
@@ -19248,7 +19248,7 @@ exports[`Calendar showAdjacentDays 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="c7"
             type="button"
           >
@@ -19266,7 +19266,7 @@ exports[`Calendar showAdjacentDays 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >
@@ -20067,7 +20067,7 @@ exports[`Calendar showAdjacentDays 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="c7"
             type="button"
           >
@@ -20085,7 +20085,7 @@ exports[`Calendar showAdjacentDays 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >
@@ -20775,7 +20775,7 @@ exports[`Calendar showAdjacentDays 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="c7"
             type="button"
           >
@@ -20793,7 +20793,7 @@ exports[`Calendar showAdjacentDays 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >
@@ -22146,7 +22146,7 @@ exports[`Calendar size 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="c7"
             type="button"
           >
@@ -22164,7 +22164,7 @@ exports[`Calendar size 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >
@@ -22965,7 +22965,7 @@ exports[`Calendar size 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="c7"
             type="button"
           >
@@ -22983,7 +22983,7 @@ exports[`Calendar size 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >
@@ -23784,7 +23784,7 @@ exports[`Calendar size 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to December 2019"
+            aria-label="Go to December 2019"
             class="c7"
             type="button"
           >
@@ -23802,7 +23802,7 @@ exports[`Calendar size 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to February 2020"
+            aria-label="Go to February 2020"
             class="c7"
             type="button"
           >

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
@@ -4861,7 +4861,7 @@ exports[`Calendar dates 1`] = `
       <div
         aria-label="
                 January 2020;
-                Currently selected
+                Currently selected 
   2020-01-12 ,2020-01-08 through 2020-01-10
               "
         class="c9"
@@ -6135,7 +6135,7 @@ exports[`Calendar daysOfWeek 1`] = `
       <div
         aria-label="
                 January 2020;
-                Currently selected
+                Currently selected 
   2020-01-12 ,2020-01-08 through 2020-01-10
               "
         class="c12"
@@ -17281,7 +17281,7 @@ exports[`Calendar select dates 1`] = `
       <div
         aria-label="
                 January 2020;
-                Currently selected
+                Currently selected 
   2020-01-12 ,2020-01-08 through 2020-01-10
               "
         class="c9"

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
@@ -360,7 +360,7 @@ exports[`Calendar change months 1`] = `
           class="c6"
         >
           <button
-            aria-label="November 2019"
+            aria-label="Moved to November 2019"
             class="c7"
             type="button"
           >
@@ -378,7 +378,7 @@ exports[`Calendar change months 1`] = `
             </svg>
           </button>
           <button
-            aria-label="January 2020"
+            aria-label="Moved to January 2020"
             class="c7"
             type="button"
           >
@@ -1186,7 +1186,7 @@ exports[`Calendar change months 2`] = `
           class="StyledBox-sc-13pk1d4-0 ellHmk"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="StyledButton-sc-323bzc-0 bpsTzm"
             type="button"
           >
@@ -1204,7 +1204,7 @@ exports[`Calendar change months 2`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="StyledButton-sc-323bzc-0 bpsTzm"
             type="button"
           >
@@ -2737,7 +2737,7 @@ exports[`Calendar children 1`] = `
           class="c6"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="c7"
             type="button"
           >
@@ -2755,7 +2755,7 @@ exports[`Calendar children 1`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >
@@ -3623,7 +3623,7 @@ exports[`Calendar date 1`] = `
           class="c6"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="c7"
             type="button"
           >
@@ -3641,7 +3641,7 @@ exports[`Calendar date 1`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >
@@ -4821,7 +4821,7 @@ exports[`Calendar dates 1`] = `
           class="c6"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="c7"
             type="button"
           >
@@ -4839,7 +4839,7 @@ exports[`Calendar dates 1`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >
@@ -4861,7 +4861,7 @@ exports[`Calendar dates 1`] = `
       <div
         aria-label="
                 January 2020;
-                Currently selected 
+                Currently selected
   2020-01-12 ,2020-01-08 through 2020-01-10
               "
         class="c9"
@@ -6020,7 +6020,7 @@ exports[`Calendar daysOfWeek 1`] = `
           class="c6"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="c7"
             type="button"
           >
@@ -6038,7 +6038,7 @@ exports[`Calendar daysOfWeek 1`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >
@@ -6135,7 +6135,7 @@ exports[`Calendar daysOfWeek 1`] = `
       <div
         aria-label="
                 January 2020;
-                Currently selected 
+                Currently selected
   2020-01-12 ,2020-01-08 through 2020-01-10
               "
         class="c12"
@@ -7337,7 +7337,7 @@ exports[`Calendar disabled 1`] = `
             class="c6"
           >
             <button
-              aria-label="December 2019"
+              aria-label="Moved to December 2019"
               class="c7"
               type="button"
             >
@@ -7355,7 +7355,7 @@ exports[`Calendar disabled 1`] = `
               </svg>
             </button>
             <button
-              aria-label="February 2020"
+              aria-label="Moved to February 2020"
               class="c7"
               type="button"
             >
@@ -8540,7 +8540,7 @@ exports[`Calendar fill 1`] = `
           class="c6"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="c7"
             type="button"
           >
@@ -8558,7 +8558,7 @@ exports[`Calendar fill 1`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >
@@ -9720,7 +9720,7 @@ exports[`Calendar first day sunday week monday 1`] = `
           class="c6"
         >
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >
@@ -9738,7 +9738,7 @@ exports[`Calendar first day sunday week monday 1`] = `
             </svg>
           </button>
           <button
-            aria-label="April 2020"
+            aria-label="Moved to April 2020"
             class="c7"
             type="button"
           >
@@ -10900,7 +10900,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
           class="c6"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="c7"
             type="button"
           >
@@ -10918,7 +10918,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >
@@ -11719,7 +11719,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
           class="c6"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="c7"
             type="button"
           >
@@ -11737,7 +11737,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >
@@ -14037,7 +14037,7 @@ exports[`Calendar reference 1`] = `
           class="c6"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="c7"
             type="button"
           >
@@ -14055,7 +14055,7 @@ exports[`Calendar reference 1`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >
@@ -15217,7 +15217,7 @@ exports[`Calendar select date 1`] = `
           class="c6"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="c7"
             type="button"
           >
@@ -15235,7 +15235,7 @@ exports[`Calendar select date 1`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >
@@ -16043,7 +16043,7 @@ exports[`Calendar select date 2`] = `
           class="StyledBox-sc-13pk1d4-0 ellHmk"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="StyledButton-sc-323bzc-0 bpsTzm"
             type="button"
           >
@@ -16061,7 +16061,7 @@ exports[`Calendar select date 2`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="StyledButton-sc-323bzc-0 bpsTzm"
             type="button"
           >
@@ -17241,7 +17241,7 @@ exports[`Calendar select dates 1`] = `
           class="c6"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="c7"
             type="button"
           >
@@ -17259,7 +17259,7 @@ exports[`Calendar select dates 1`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >
@@ -17281,7 +17281,7 @@ exports[`Calendar select dates 1`] = `
       <div
         aria-label="
                 January 2020;
-                Currently selected 
+                Currently selected
   2020-01-12 ,2020-01-08 through 2020-01-10
               "
         class="c9"
@@ -18068,7 +18068,7 @@ exports[`Calendar select dates 2`] = `
           class="StyledBox-sc-13pk1d4-0 ellHmk"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="StyledButton-sc-323bzc-0 bpsTzm"
             type="button"
           >
@@ -18086,7 +18086,7 @@ exports[`Calendar select dates 2`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="StyledButton-sc-323bzc-0 bpsTzm"
             type="button"
           >
@@ -19248,7 +19248,7 @@ exports[`Calendar showAdjacentDays 1`] = `
           class="c6"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="c7"
             type="button"
           >
@@ -19266,7 +19266,7 @@ exports[`Calendar showAdjacentDays 1`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >
@@ -20067,7 +20067,7 @@ exports[`Calendar showAdjacentDays 1`] = `
           class="c6"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="c7"
             type="button"
           >
@@ -20085,7 +20085,7 @@ exports[`Calendar showAdjacentDays 1`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >
@@ -20775,7 +20775,7 @@ exports[`Calendar showAdjacentDays 1`] = `
           class="c6"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="c7"
             type="button"
           >
@@ -20793,7 +20793,7 @@ exports[`Calendar showAdjacentDays 1`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >
@@ -22146,7 +22146,7 @@ exports[`Calendar size 1`] = `
           class="c6"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="c7"
             type="button"
           >
@@ -22164,7 +22164,7 @@ exports[`Calendar size 1`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >
@@ -22965,7 +22965,7 @@ exports[`Calendar size 1`] = `
           class="c6"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="c7"
             type="button"
           >
@@ -22983,7 +22983,7 @@ exports[`Calendar size 1`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >
@@ -23784,7 +23784,7 @@ exports[`Calendar size 1`] = `
           class="c6"
         >
           <button
-            aria-label="December 2019"
+            aria-label="Moved to December 2019"
             class="c7"
             type="button"
           >
@@ -23802,7 +23802,7 @@ exports[`Calendar size 1`] = `
             </svg>
           </button>
           <button
-            aria-label="February 2020"
+            aria-label="Moved to February 2020"
             class="c7"
             type="button"
           >

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -907,7 +907,7 @@ exports[`DateInput controlled format inline 1`] = `
             class="c11"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="c12"
               type="button"
             >
@@ -925,7 +925,7 @@ exports[`DateInput controlled format inline 1`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="c12"
               type="button"
             >
@@ -1776,7 +1776,7 @@ exports[`DateInput controlled format inline 2`] = `
             class="StyledBox-sc-13pk1d4-0 ellHmk"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -1794,7 +1794,7 @@ exports[`DateInput controlled format inline 2`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -3228,7 +3228,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
               class="c11"
             >
               <button
-                aria-label="June 2020"
+                aria-label="Moved to June 2020"
                 class="c12"
                 type="button"
               >
@@ -3246,7 +3246,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                 </svg>
               </button>
               <button
-                aria-label="August 2020"
+                aria-label="Moved to August 2020"
                 class="c12"
                 type="button"
               >
@@ -4683,7 +4683,7 @@ exports[`DateInput controlled format inline without timezone 2`] = `
               class="c11"
             >
               <button
-                aria-label="June 2020"
+                aria-label="Moved to June 2020"
                 class="c12"
                 type="button"
               >
@@ -4701,7 +4701,7 @@ exports[`DateInput controlled format inline without timezone 2`] = `
                 </svg>
               </button>
               <button
-                aria-label="August 2020"
+                aria-label="Moved to August 2020"
                 class="c12"
                 type="button"
               >
@@ -7191,7 +7191,7 @@ exports[`DateInput format inline 1`] = `
             class="c11"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="c12"
               type="button"
             >
@@ -7209,7 +7209,7 @@ exports[`DateInput format inline 1`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="c12"
               type="button"
             >
@@ -8373,7 +8373,7 @@ exports[`DateInput inline 1`] = `
           class="c6"
         >
           <button
-            aria-label="June 2020"
+            aria-label="Moved to June 2020"
             class="c7"
             type="button"
           >
@@ -8391,7 +8391,7 @@ exports[`DateInput inline 1`] = `
             </svg>
           </button>
           <button
-            aria-label="August 2020"
+            aria-label="Moved to August 2020"
             class="c7"
             type="button"
           >
@@ -10139,7 +10139,7 @@ exports[`DateInput range format inline 1`] = `
             class="c11"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="c12"
               type="button"
             >
@@ -10157,7 +10157,7 @@ exports[`DateInput range format inline 1`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="c12"
               type="button"
             >
@@ -10179,7 +10179,7 @@ exports[`DateInput range format inline 1`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-02 through 2020-07-07
               "
           class="c13"
@@ -11340,7 +11340,7 @@ exports[`DateInput range inline 1`] = `
           class="c6"
         >
           <button
-            aria-label="June 2020"
+            aria-label="Moved to June 2020"
             class="c7"
             type="button"
           >
@@ -11358,7 +11358,7 @@ exports[`DateInput range inline 1`] = `
             </svg>
           </button>
           <button
-            aria-label="August 2020"
+            aria-label="Moved to August 2020"
             class="c7"
             type="button"
           >
@@ -11380,7 +11380,7 @@ exports[`DateInput range inline 1`] = `
       <div
         aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-02 through 2020-07-07
               "
         class="c9"
@@ -13301,7 +13301,7 @@ exports[`DateInput select format 3`] = `
           class="c7"
         >
           <button
-            aria-label="June 2020"
+            aria-label="Moved to June 2020"
             class="c8"
             type="button"
           >
@@ -13319,7 +13319,7 @@ exports[`DateInput select format 3`] = `
             </svg>
           </button>
           <button
-            aria-label="August 2020"
+            aria-label="Moved to August 2020"
             class="c8"
             type="button"
           >
@@ -14707,7 +14707,7 @@ exports[`DateInput select format inline 1`] = `
             class="c11"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="c12"
               type="button"
             >
@@ -14725,7 +14725,7 @@ exports[`DateInput select format inline 1`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="c12"
               type="button"
             >
@@ -15570,7 +15570,7 @@ exports[`DateInput select format inline 2`] = `
             class="StyledBox-sc-13pk1d4-0 ellHmk"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -15588,7 +15588,7 @@ exports[`DateInput select format inline 2`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -16947,7 +16947,7 @@ exports[`DateInput select format inline 3`] = `
               class="c11"
             >
               <button
-                aria-label="June 2020"
+                aria-label="Moved to June 2020"
                 class="c12"
                 type="button"
               >
@@ -16965,7 +16965,7 @@ exports[`DateInput select format inline 3`] = `
                 </svg>
               </button>
               <button
-                aria-label="August 2020"
+                aria-label="Moved to August 2020"
                 class="c12"
                 type="button"
               >
@@ -18402,7 +18402,7 @@ exports[`DateInput select format inline 4`] = `
               class="c11"
             >
               <button
-                aria-label="June 2020"
+                aria-label="Moved to June 2020"
                 class="c12"
                 type="button"
               >
@@ -18420,7 +18420,7 @@ exports[`DateInput select format inline 4`] = `
                 </svg>
               </button>
               <button
-                aria-label="August 2020"
+                aria-label="Moved to August 2020"
                 class="c12"
                 type="button"
               >
@@ -19797,7 +19797,7 @@ exports[`DateInput select format inline range 1`] = `
             class="c11"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="c12"
               type="button"
             >
@@ -19815,7 +19815,7 @@ exports[`DateInput select format inline range 1`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="c12"
               type="button"
             >
@@ -19837,7 +19837,7 @@ exports[`DateInput select format inline range 1`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-02 through 2020-07-07
               "
           class="c13"
@@ -20661,7 +20661,7 @@ exports[`DateInput select format inline range 2`] = `
             class="StyledBox-sc-13pk1d4-0 ellHmk"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -20679,7 +20679,7 @@ exports[`DateInput select format inline range 2`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -20701,7 +20701,7 @@ exports[`DateInput select format inline range 2`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-10 through 2020-07-10
               "
           class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 bqRhn"
@@ -22057,7 +22057,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
               class="c11"
             >
               <button
-                aria-label="June 2020"
+                aria-label="Moved to June 2020"
                 class="c12"
                 type="button"
               >
@@ -22075,7 +22075,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                 </svg>
               </button>
               <button
-                aria-label="August 2020"
+                aria-label="Moved to August 2020"
                 class="c12"
                 type="button"
               >
@@ -22097,7 +22097,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-02 through 2020-07-07
               "
             class="c13"
@@ -23513,7 +23513,7 @@ exports[`DateInput select format inline range without timezone 2`] = `
               class="c11"
             >
               <button
-                aria-label="June 2020"
+                aria-label="Moved to June 2020"
                 class="c12"
                 type="button"
               >
@@ -23531,7 +23531,7 @@ exports[`DateInput select format inline range without timezone 2`] = `
                 </svg>
               </button>
               <button
-                aria-label="August 2020"
+                aria-label="Moved to August 2020"
                 class="c12"
                 type="button"
               >
@@ -23553,7 +23553,7 @@ exports[`DateInput select format inline range without timezone 2`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-10 through 2020-07-10
               "
             class="c13"
@@ -25318,7 +25318,7 @@ exports[`DateInput select format no timezone 3`] = `
           class="c7"
         >
           <button
-            aria-label="June 2020"
+            aria-label="Moved to June 2020"
             class="c8"
             type="button"
           >
@@ -25336,7 +25336,7 @@ exports[`DateInput select format no timezone 3`] = `
             </svg>
           </button>
           <button
-            aria-label="August 2020"
+            aria-label="Moved to August 2020"
             class="c8"
             type="button"
           >
@@ -26530,7 +26530,7 @@ exports[`DateInput select inline 1`] = `
           class="c6"
         >
           <button
-            aria-label="June 2020"
+            aria-label="Moved to June 2020"
             class="c7"
             type="button"
           >
@@ -26548,7 +26548,7 @@ exports[`DateInput select inline 1`] = `
             </svg>
           </button>
           <button
-            aria-label="August 2020"
+            aria-label="Moved to August 2020"
             class="c7"
             type="button"
           >
@@ -27711,7 +27711,7 @@ exports[`DateInput select inline without timezone 1`] = `
           class="c6"
         >
           <button
-            aria-label="June 2020"
+            aria-label="Moved to June 2020"
             class="c7"
             type="button"
           >
@@ -27729,7 +27729,7 @@ exports[`DateInput select inline without timezone 1`] = `
             </svg>
           </button>
           <button
-            aria-label="August 2020"
+            aria-label="Moved to August 2020"
             class="c7"
             type="button"
           >
@@ -29086,7 +29086,7 @@ exports[`DateInput type format inline 1`] = `
             class="c11"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="c12"
               type="button"
             >
@@ -29104,7 +29104,7 @@ exports[`DateInput type format inline 1`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="c12"
               type="button"
             >
@@ -29949,7 +29949,7 @@ exports[`DateInput type format inline 2`] = `
             class="StyledBox-sc-13pk1d4-0 ellHmk"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -29967,7 +29967,7 @@ exports[`DateInput type format inline 2`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -31325,7 +31325,7 @@ exports[`DateInput type format inline partial 1`] = `
             class="c11"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="c12"
               type="button"
             >
@@ -31343,7 +31343,7 @@ exports[`DateInput type format inline partial 1`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="c12"
               type="button"
             >
@@ -32702,7 +32702,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
               class="c11"
             >
               <button
-                aria-label="June 2020"
+                aria-label="Moved to June 2020"
                 class="c12"
                 type="button"
               >
@@ -32720,7 +32720,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                 </svg>
               </button>
               <button
-                aria-label="August 2020"
+                aria-label="Moved to August 2020"
                 class="c12"
                 type="button"
               >
@@ -34097,7 +34097,7 @@ exports[`DateInput type format inline range 1`] = `
             class="c11"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="c12"
               type="button"
             >
@@ -34115,7 +34115,7 @@ exports[`DateInput type format inline range 1`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="c12"
               type="button"
             >
@@ -34137,7 +34137,7 @@ exports[`DateInput type format inline range 1`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-02 through 2020-07-07
               "
           class="c13"
@@ -34961,7 +34961,7 @@ exports[`DateInput type format inline range 2`] = `
             class="StyledBox-sc-13pk1d4-0 ellHmk"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -34979,7 +34979,7 @@ exports[`DateInput type format inline range 2`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -35001,7 +35001,7 @@ exports[`DateInput type format inline range 2`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-21 through 2020-07-23
               "
           class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 goAAKK"
@@ -36356,7 +36356,7 @@ exports[`DateInput type format inline range partial 1`] = `
             class="c11"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="c12"
               type="button"
             >
@@ -36374,7 +36374,7 @@ exports[`DateInput type format inline range partial 1`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="c12"
               type="button"
             >
@@ -36396,7 +36396,7 @@ exports[`DateInput type format inline range partial 1`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-02 through 2020-07-07
               "
           class="c13"
@@ -37220,7 +37220,7 @@ exports[`DateInput type format inline range partial 2`] = `
             class="StyledBox-sc-13pk1d4-0 ellHmk"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -37238,7 +37238,7 @@ exports[`DateInput type format inline range partial 2`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -37260,7 +37260,7 @@ exports[`DateInput type format inline range partial 2`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-21 through none
               "
           class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 goAAKK"
@@ -38084,7 +38084,7 @@ exports[`DateInput type format inline range partial 3`] = `
             class="StyledBox-sc-13pk1d4-0 ellHmk"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -38102,7 +38102,7 @@ exports[`DateInput type format inline range partial 3`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -38124,7 +38124,7 @@ exports[`DateInput type format inline range partial 3`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-21 through none
               "
           class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 goAAKK"
@@ -39480,7 +39480,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
               class="c11"
             >
               <button
-                aria-label="June 2020"
+                aria-label="Moved to June 2020"
                 class="c12"
                 type="button"
               >
@@ -39498,7 +39498,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                 </svg>
               </button>
               <button
-                aria-label="August 2020"
+                aria-label="Moved to August 2020"
                 class="c12"
                 type="button"
               >
@@ -39520,7 +39520,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-02 through 2020-07-07
               "
             class="c13"
@@ -40859,7 +40859,7 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
               class="c11"
             >
               <button
-                aria-label="June 2020"
+                aria-label="Moved to June 2020"
                 class="c12"
                 type="button"
               >
@@ -40877,7 +40877,7 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
                 </svg>
               </button>
               <button
-                aria-label="August 2020"
+                aria-label="Moved to August 2020"
                 class="c12"
                 type="button"
               >
@@ -40899,7 +40899,7 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-21 through none
               "
             class="c13"
@@ -42238,7 +42238,7 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
               class="c11"
             >
               <button
-                aria-label="June 2020"
+                aria-label="Moved to June 2020"
                 class="c12"
                 type="button"
               >
@@ -42256,7 +42256,7 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
                 </svg>
               </button>
               <button
-                aria-label="August 2020"
+                aria-label="Moved to August 2020"
                 class="c12"
                 type="button"
               >
@@ -42278,7 +42278,7 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-21 through none
               "
             class="c13"
@@ -43635,7 +43635,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
               class="c11"
             >
               <button
-                aria-label="June 2020"
+                aria-label="Moved to June 2020"
                 class="c12"
                 type="button"
               >
@@ -43653,7 +43653,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                 </svg>
               </button>
               <button
-                aria-label="August 2020"
+                aria-label="Moved to August 2020"
                 class="c12"
                 type="button"
               >
@@ -43675,7 +43675,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-02 through 2020-07-07
               "
             class="c13"
@@ -45032,7 +45032,7 @@ exports[`DateInput type format inline range without timezone 2`] = `
               class="c11"
             >
               <button
-                aria-label="June 2020"
+                aria-label="Moved to June 2020"
                 class="c12"
                 type="button"
               >
@@ -45050,7 +45050,7 @@ exports[`DateInput type format inline range without timezone 2`] = `
                 </svg>
               </button>
               <button
-                aria-label="August 2020"
+                aria-label="Moved to August 2020"
                 class="c12"
                 type="button"
               >
@@ -45072,7 +45072,7 @@ exports[`DateInput type format inline range without timezone 2`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-21 through 2020-07-23
               "
             class="c13"
@@ -46410,7 +46410,7 @@ exports[`DateInput type format inline short 1`] = `
             class="c11"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="c12"
               type="button"
             >
@@ -46428,7 +46428,7 @@ exports[`DateInput type format inline short 1`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="c12"
               type="button"
             >
@@ -47273,7 +47273,7 @@ exports[`DateInput type format inline short 2`] = `
             class="StyledBox-sc-13pk1d4-0 ellHmk"
           >
             <button
-              aria-label="June 2020"
+              aria-label="Moved to June 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -47291,7 +47291,7 @@ exports[`DateInput type format inline short 2`] = `
               </svg>
             </button>
             <button
-              aria-label="August 2020"
+              aria-label="Moved to August 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -48650,7 +48650,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
               class="c11"
             >
               <button
-                aria-label="June 2020"
+                aria-label="Moved to June 2020"
                 class="c12"
                 type="button"
               >
@@ -48668,7 +48668,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                 </svg>
               </button>
               <button
-                aria-label="August 2020"
+                aria-label="Moved to August 2020"
                 class="c12"
                 type="button"
               >
@@ -50028,7 +50028,7 @@ exports[`DateInput type format inline short without timezone 2`] = `
               class="c11"
             >
               <button
-                aria-label="June 2020"
+                aria-label="Moved to June 2020"
                 class="c12"
                 type="button"
               >
@@ -50046,7 +50046,7 @@ exports[`DateInput type format inline short without timezone 2`] = `
                 </svg>
               </button>
               <button
-                aria-label="August 2020"
+                aria-label="Moved to August 2020"
                 class="c12"
                 type="button"
               >
@@ -51406,7 +51406,7 @@ exports[`DateInput type format inline without timezone 1`] = `
               class="c11"
             >
               <button
-                aria-label="June 2020"
+                aria-label="Moved to June 2020"
                 class="c12"
                 type="button"
               >
@@ -51424,7 +51424,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                 </svg>
               </button>
               <button
-                aria-label="August 2020"
+                aria-label="Moved to August 2020"
                 class="c12"
                 type="button"
               >
@@ -52784,7 +52784,7 @@ exports[`DateInput type format inline without timezone 2`] = `
               class="c11"
             >
               <button
-                aria-label="June 2020"
+                aria-label="Moved to June 2020"
                 class="c12"
                 type="button"
               >
@@ -52802,7 +52802,7 @@ exports[`DateInput type format inline without timezone 2`] = `
                 </svg>
               </button>
               <button
-                aria-label="August 2020"
+                aria-label="Moved to August 2020"
                 class="c12"
                 type="button"
               >

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -10179,7 +10179,7 @@ exports[`DateInput range format inline 1`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected
+                Currently selected 
   2020-07-02 through 2020-07-07
               "
           class="c13"
@@ -11380,7 +11380,7 @@ exports[`DateInput range inline 1`] = `
       <div
         aria-label="
                 July 2020;
-                Currently selected
+                Currently selected 
   2020-07-02 through 2020-07-07
               "
         class="c9"
@@ -19837,7 +19837,7 @@ exports[`DateInput select format inline range 1`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected
+                Currently selected 
   2020-07-02 through 2020-07-07
               "
           class="c13"
@@ -20701,7 +20701,7 @@ exports[`DateInput select format inline range 2`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected
+                Currently selected 
   2020-07-10 through 2020-07-10
               "
           class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 bqRhn"
@@ -22097,7 +22097,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected
+                Currently selected 
   2020-07-02 through 2020-07-07
               "
             class="c13"
@@ -23553,7 +23553,7 @@ exports[`DateInput select format inline range without timezone 2`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected
+                Currently selected 
   2020-07-10 through 2020-07-10
               "
             class="c13"
@@ -34137,7 +34137,7 @@ exports[`DateInput type format inline range 1`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected
+                Currently selected 
   2020-07-02 through 2020-07-07
               "
           class="c13"
@@ -35001,7 +35001,7 @@ exports[`DateInput type format inline range 2`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected
+                Currently selected 
   2020-07-21 through 2020-07-23
               "
           class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 goAAKK"
@@ -36396,7 +36396,7 @@ exports[`DateInput type format inline range partial 1`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected
+                Currently selected 
   2020-07-02 through 2020-07-07
               "
           class="c13"
@@ -37260,7 +37260,7 @@ exports[`DateInput type format inline range partial 2`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected
+                Currently selected 
   2020-07-21 through none
               "
           class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 goAAKK"
@@ -38124,7 +38124,7 @@ exports[`DateInput type format inline range partial 3`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected
+                Currently selected 
   2020-07-21 through none
               "
           class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 goAAKK"
@@ -39520,7 +39520,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected
+                Currently selected 
   2020-07-02 through 2020-07-07
               "
             class="c13"
@@ -40899,7 +40899,7 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected
+                Currently selected 
   2020-07-21 through none
               "
             class="c13"
@@ -42278,7 +42278,7 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected
+                Currently selected 
   2020-07-21 through none
               "
             class="c13"
@@ -43675,7 +43675,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected
+                Currently selected 
   2020-07-02 through 2020-07-07
               "
             class="c13"
@@ -45072,7 +45072,7 @@ exports[`DateInput type format inline range without timezone 2`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected
+                Currently selected 
   2020-07-21 through 2020-07-23
               "
             class="c13"

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -907,7 +907,7 @@ exports[`DateInput controlled format inline 1`] = `
             class="c11"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="c12"
               type="button"
             >
@@ -925,7 +925,7 @@ exports[`DateInput controlled format inline 1`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="c12"
               type="button"
             >
@@ -1776,7 +1776,7 @@ exports[`DateInput controlled format inline 2`] = `
             class="StyledBox-sc-13pk1d4-0 ellHmk"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -1794,7 +1794,7 @@ exports[`DateInput controlled format inline 2`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -3228,7 +3228,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
               class="c11"
             >
               <button
-                aria-label="Moved to June 2020"
+                aria-label="Go to June 2020"
                 class="c12"
                 type="button"
               >
@@ -3246,7 +3246,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                 </svg>
               </button>
               <button
-                aria-label="Moved to August 2020"
+                aria-label="Go to August 2020"
                 class="c12"
                 type="button"
               >
@@ -4683,7 +4683,7 @@ exports[`DateInput controlled format inline without timezone 2`] = `
               class="c11"
             >
               <button
-                aria-label="Moved to June 2020"
+                aria-label="Go to June 2020"
                 class="c12"
                 type="button"
               >
@@ -4701,7 +4701,7 @@ exports[`DateInput controlled format inline without timezone 2`] = `
                 </svg>
               </button>
               <button
-                aria-label="Moved to August 2020"
+                aria-label="Go to August 2020"
                 class="c12"
                 type="button"
               >
@@ -7191,7 +7191,7 @@ exports[`DateInput format inline 1`] = `
             class="c11"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="c12"
               type="button"
             >
@@ -7209,7 +7209,7 @@ exports[`DateInput format inline 1`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="c12"
               type="button"
             >
@@ -8373,7 +8373,7 @@ exports[`DateInput inline 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to June 2020"
+            aria-label="Go to June 2020"
             class="c7"
             type="button"
           >
@@ -8391,7 +8391,7 @@ exports[`DateInput inline 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to August 2020"
+            aria-label="Go to August 2020"
             class="c7"
             type="button"
           >
@@ -10139,7 +10139,7 @@ exports[`DateInput range format inline 1`] = `
             class="c11"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="c12"
               type="button"
             >
@@ -10157,7 +10157,7 @@ exports[`DateInput range format inline 1`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="c12"
               type="button"
             >
@@ -10179,7 +10179,7 @@ exports[`DateInput range format inline 1`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-02 through 2020-07-07
               "
           class="c13"
@@ -11340,7 +11340,7 @@ exports[`DateInput range inline 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to June 2020"
+            aria-label="Go to June 2020"
             class="c7"
             type="button"
           >
@@ -11358,7 +11358,7 @@ exports[`DateInput range inline 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to August 2020"
+            aria-label="Go to August 2020"
             class="c7"
             type="button"
           >
@@ -11380,7 +11380,7 @@ exports[`DateInput range inline 1`] = `
       <div
         aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-02 through 2020-07-07
               "
         class="c9"
@@ -13301,7 +13301,7 @@ exports[`DateInput select format 3`] = `
           class="c7"
         >
           <button
-            aria-label="Moved to June 2020"
+            aria-label="Go to June 2020"
             class="c8"
             type="button"
           >
@@ -13319,7 +13319,7 @@ exports[`DateInput select format 3`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to August 2020"
+            aria-label="Go to August 2020"
             class="c8"
             type="button"
           >
@@ -14707,7 +14707,7 @@ exports[`DateInput select format inline 1`] = `
             class="c11"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="c12"
               type="button"
             >
@@ -14725,7 +14725,7 @@ exports[`DateInput select format inline 1`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="c12"
               type="button"
             >
@@ -15570,7 +15570,7 @@ exports[`DateInput select format inline 2`] = `
             class="StyledBox-sc-13pk1d4-0 ellHmk"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -15588,7 +15588,7 @@ exports[`DateInput select format inline 2`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -16947,7 +16947,7 @@ exports[`DateInput select format inline 3`] = `
               class="c11"
             >
               <button
-                aria-label="Moved to June 2020"
+                aria-label="Go to June 2020"
                 class="c12"
                 type="button"
               >
@@ -16965,7 +16965,7 @@ exports[`DateInput select format inline 3`] = `
                 </svg>
               </button>
               <button
-                aria-label="Moved to August 2020"
+                aria-label="Go to August 2020"
                 class="c12"
                 type="button"
               >
@@ -18402,7 +18402,7 @@ exports[`DateInput select format inline 4`] = `
               class="c11"
             >
               <button
-                aria-label="Moved to June 2020"
+                aria-label="Go to June 2020"
                 class="c12"
                 type="button"
               >
@@ -18420,7 +18420,7 @@ exports[`DateInput select format inline 4`] = `
                 </svg>
               </button>
               <button
-                aria-label="Moved to August 2020"
+                aria-label="Go to August 2020"
                 class="c12"
                 type="button"
               >
@@ -19797,7 +19797,7 @@ exports[`DateInput select format inline range 1`] = `
             class="c11"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="c12"
               type="button"
             >
@@ -19815,7 +19815,7 @@ exports[`DateInput select format inline range 1`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="c12"
               type="button"
             >
@@ -19837,7 +19837,7 @@ exports[`DateInput select format inline range 1`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-02 through 2020-07-07
               "
           class="c13"
@@ -20661,7 +20661,7 @@ exports[`DateInput select format inline range 2`] = `
             class="StyledBox-sc-13pk1d4-0 ellHmk"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -20679,7 +20679,7 @@ exports[`DateInput select format inline range 2`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -20701,7 +20701,7 @@ exports[`DateInput select format inline range 2`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-10 through 2020-07-10
               "
           class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 bqRhn"
@@ -22057,7 +22057,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
               class="c11"
             >
               <button
-                aria-label="Moved to June 2020"
+                aria-label="Go to June 2020"
                 class="c12"
                 type="button"
               >
@@ -22075,7 +22075,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                 </svg>
               </button>
               <button
-                aria-label="Moved to August 2020"
+                aria-label="Go to August 2020"
                 class="c12"
                 type="button"
               >
@@ -22097,7 +22097,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-02 through 2020-07-07
               "
             class="c13"
@@ -23513,7 +23513,7 @@ exports[`DateInput select format inline range without timezone 2`] = `
               class="c11"
             >
               <button
-                aria-label="Moved to June 2020"
+                aria-label="Go to June 2020"
                 class="c12"
                 type="button"
               >
@@ -23531,7 +23531,7 @@ exports[`DateInput select format inline range without timezone 2`] = `
                 </svg>
               </button>
               <button
-                aria-label="Moved to August 2020"
+                aria-label="Go to August 2020"
                 class="c12"
                 type="button"
               >
@@ -23553,7 +23553,7 @@ exports[`DateInput select format inline range without timezone 2`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-10 through 2020-07-10
               "
             class="c13"
@@ -25318,7 +25318,7 @@ exports[`DateInput select format no timezone 3`] = `
           class="c7"
         >
           <button
-            aria-label="Moved to June 2020"
+            aria-label="Go to June 2020"
             class="c8"
             type="button"
           >
@@ -25336,7 +25336,7 @@ exports[`DateInput select format no timezone 3`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to August 2020"
+            aria-label="Go to August 2020"
             class="c8"
             type="button"
           >
@@ -26530,7 +26530,7 @@ exports[`DateInput select inline 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to June 2020"
+            aria-label="Go to June 2020"
             class="c7"
             type="button"
           >
@@ -26548,7 +26548,7 @@ exports[`DateInput select inline 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to August 2020"
+            aria-label="Go to August 2020"
             class="c7"
             type="button"
           >
@@ -27711,7 +27711,7 @@ exports[`DateInput select inline without timezone 1`] = `
           class="c6"
         >
           <button
-            aria-label="Moved to June 2020"
+            aria-label="Go to June 2020"
             class="c7"
             type="button"
           >
@@ -27729,7 +27729,7 @@ exports[`DateInput select inline without timezone 1`] = `
             </svg>
           </button>
           <button
-            aria-label="Moved to August 2020"
+            aria-label="Go to August 2020"
             class="c7"
             type="button"
           >
@@ -29086,7 +29086,7 @@ exports[`DateInput type format inline 1`] = `
             class="c11"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="c12"
               type="button"
             >
@@ -29104,7 +29104,7 @@ exports[`DateInput type format inline 1`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="c12"
               type="button"
             >
@@ -29949,7 +29949,7 @@ exports[`DateInput type format inline 2`] = `
             class="StyledBox-sc-13pk1d4-0 ellHmk"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -29967,7 +29967,7 @@ exports[`DateInput type format inline 2`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -31325,7 +31325,7 @@ exports[`DateInput type format inline partial 1`] = `
             class="c11"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="c12"
               type="button"
             >
@@ -31343,7 +31343,7 @@ exports[`DateInput type format inline partial 1`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="c12"
               type="button"
             >
@@ -32702,7 +32702,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
               class="c11"
             >
               <button
-                aria-label="Moved to June 2020"
+                aria-label="Go to June 2020"
                 class="c12"
                 type="button"
               >
@@ -32720,7 +32720,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                 </svg>
               </button>
               <button
-                aria-label="Moved to August 2020"
+                aria-label="Go to August 2020"
                 class="c12"
                 type="button"
               >
@@ -34097,7 +34097,7 @@ exports[`DateInput type format inline range 1`] = `
             class="c11"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="c12"
               type="button"
             >
@@ -34115,7 +34115,7 @@ exports[`DateInput type format inline range 1`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="c12"
               type="button"
             >
@@ -34137,7 +34137,7 @@ exports[`DateInput type format inline range 1`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-02 through 2020-07-07
               "
           class="c13"
@@ -34961,7 +34961,7 @@ exports[`DateInput type format inline range 2`] = `
             class="StyledBox-sc-13pk1d4-0 ellHmk"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -34979,7 +34979,7 @@ exports[`DateInput type format inline range 2`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -35001,7 +35001,7 @@ exports[`DateInput type format inline range 2`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-21 through 2020-07-23
               "
           class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 goAAKK"
@@ -36356,7 +36356,7 @@ exports[`DateInput type format inline range partial 1`] = `
             class="c11"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="c12"
               type="button"
             >
@@ -36374,7 +36374,7 @@ exports[`DateInput type format inline range partial 1`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="c12"
               type="button"
             >
@@ -36396,7 +36396,7 @@ exports[`DateInput type format inline range partial 1`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-02 through 2020-07-07
               "
           class="c13"
@@ -37220,7 +37220,7 @@ exports[`DateInput type format inline range partial 2`] = `
             class="StyledBox-sc-13pk1d4-0 ellHmk"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -37238,7 +37238,7 @@ exports[`DateInput type format inline range partial 2`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -37260,7 +37260,7 @@ exports[`DateInput type format inline range partial 2`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-21 through none
               "
           class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 goAAKK"
@@ -38084,7 +38084,7 @@ exports[`DateInput type format inline range partial 3`] = `
             class="StyledBox-sc-13pk1d4-0 ellHmk"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -38102,7 +38102,7 @@ exports[`DateInput type format inline range partial 3`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -38124,7 +38124,7 @@ exports[`DateInput type format inline range partial 3`] = `
         <div
           aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-21 through none
               "
           class="StyledCalendar__StyledWeeksContainer-sc-1y4xhmp-1 goAAKK"
@@ -39480,7 +39480,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
               class="c11"
             >
               <button
-                aria-label="Moved to June 2020"
+                aria-label="Go to June 2020"
                 class="c12"
                 type="button"
               >
@@ -39498,7 +39498,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                 </svg>
               </button>
               <button
-                aria-label="Moved to August 2020"
+                aria-label="Go to August 2020"
                 class="c12"
                 type="button"
               >
@@ -39520,7 +39520,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-02 through 2020-07-07
               "
             class="c13"
@@ -40859,7 +40859,7 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
               class="c11"
             >
               <button
-                aria-label="Moved to June 2020"
+                aria-label="Go to June 2020"
                 class="c12"
                 type="button"
               >
@@ -40877,7 +40877,7 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
                 </svg>
               </button>
               <button
-                aria-label="Moved to August 2020"
+                aria-label="Go to August 2020"
                 class="c12"
                 type="button"
               >
@@ -40899,7 +40899,7 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-21 through none
               "
             class="c13"
@@ -42238,7 +42238,7 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
               class="c11"
             >
               <button
-                aria-label="Moved to June 2020"
+                aria-label="Go to June 2020"
                 class="c12"
                 type="button"
               >
@@ -42256,7 +42256,7 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
                 </svg>
               </button>
               <button
-                aria-label="Moved to August 2020"
+                aria-label="Go to August 2020"
                 class="c12"
                 type="button"
               >
@@ -42278,7 +42278,7 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-21 through none
               "
             class="c13"
@@ -43635,7 +43635,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
               class="c11"
             >
               <button
-                aria-label="Moved to June 2020"
+                aria-label="Go to June 2020"
                 class="c12"
                 type="button"
               >
@@ -43653,7 +43653,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                 </svg>
               </button>
               <button
-                aria-label="Moved to August 2020"
+                aria-label="Go to August 2020"
                 class="c12"
                 type="button"
               >
@@ -43675,7 +43675,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-02 through 2020-07-07
               "
             class="c13"
@@ -45032,7 +45032,7 @@ exports[`DateInput type format inline range without timezone 2`] = `
               class="c11"
             >
               <button
-                aria-label="Moved to June 2020"
+                aria-label="Go to June 2020"
                 class="c12"
                 type="button"
               >
@@ -45050,7 +45050,7 @@ exports[`DateInput type format inline range without timezone 2`] = `
                 </svg>
               </button>
               <button
-                aria-label="Moved to August 2020"
+                aria-label="Go to August 2020"
                 class="c12"
                 type="button"
               >
@@ -45072,7 +45072,7 @@ exports[`DateInput type format inline range without timezone 2`] = `
           <div
             aria-label="
                 July 2020;
-                Currently selected 
+                Currently selected
   2020-07-21 through 2020-07-23
               "
             class="c13"
@@ -46410,7 +46410,7 @@ exports[`DateInput type format inline short 1`] = `
             class="c11"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="c12"
               type="button"
             >
@@ -46428,7 +46428,7 @@ exports[`DateInput type format inline short 1`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="c12"
               type="button"
             >
@@ -47273,7 +47273,7 @@ exports[`DateInput type format inline short 2`] = `
             class="StyledBox-sc-13pk1d4-0 ellHmk"
           >
             <button
-              aria-label="Moved to June 2020"
+              aria-label="Go to June 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -47291,7 +47291,7 @@ exports[`DateInput type format inline short 2`] = `
               </svg>
             </button>
             <button
-              aria-label="Moved to August 2020"
+              aria-label="Go to August 2020"
               class="StyledButton-sc-323bzc-0 bpsTzm"
               type="button"
             >
@@ -48650,7 +48650,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
               class="c11"
             >
               <button
-                aria-label="Moved to June 2020"
+                aria-label="Go to June 2020"
                 class="c12"
                 type="button"
               >
@@ -48668,7 +48668,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                 </svg>
               </button>
               <button
-                aria-label="Moved to August 2020"
+                aria-label="Go to August 2020"
                 class="c12"
                 type="button"
               >
@@ -50028,7 +50028,7 @@ exports[`DateInput type format inline short without timezone 2`] = `
               class="c11"
             >
               <button
-                aria-label="Moved to June 2020"
+                aria-label="Go to June 2020"
                 class="c12"
                 type="button"
               >
@@ -50046,7 +50046,7 @@ exports[`DateInput type format inline short without timezone 2`] = `
                 </svg>
               </button>
               <button
-                aria-label="Moved to August 2020"
+                aria-label="Go to August 2020"
                 class="c12"
                 type="button"
               >
@@ -51406,7 +51406,7 @@ exports[`DateInput type format inline without timezone 1`] = `
               class="c11"
             >
               <button
-                aria-label="Moved to June 2020"
+                aria-label="Go to June 2020"
                 class="c12"
                 type="button"
               >
@@ -51424,7 +51424,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                 </svg>
               </button>
               <button
-                aria-label="Moved to August 2020"
+                aria-label="Go to August 2020"
                 class="c12"
                 type="button"
               >
@@ -52784,7 +52784,7 @@ exports[`DateInput type format inline without timezone 2`] = `
               class="c11"
             >
               <button
-                aria-label="Moved to June 2020"
+                aria-label="Go to June 2020"
                 class="c12"
                 type="button"
               >
@@ -52802,7 +52802,7 @@ exports[`DateInput type format inline without timezone 2`] = `
                 </svg>
               </button>
               <button
-                aria-label="Moved to August 2020"
+                aria-label="Go to August 2020"
                 class="c12"
                 type="button"
               >

--- a/src/js/languages/default.json
+++ b/src/js/languages/default.json
@@ -1,7 +1,9 @@
 {
   "calendar": {
-    "previous": "Moved to {date}",
-    "next": "Moved to {date}"
+    "previousMove": "Moved to {date}",
+    "previous": "Go to {date}",
+    "nextMove": "Moved to {date}",
+    "next": "Go to {date}"
   },
   "dateInput": {
     "openCalendar": "Press space to open calendar",


### PR DESCRIPTION
#### What does this PR do?
It add aria-label in chevrons when messages is given 

#### Where should the reviewer start?
Starts by Calendar

#### What testing has been done on this PR?
#### How should this be manually tested?
Add messages in Calendar on storybook 
`messages={{ next: 'go to {date}', previous: 'go to {date}', }}`
and run `yarn storybook`
turn on voice over and focus in chevrons to listen the message

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/5844

#### Is this change backwards compatible or is it a breaking change?
Yes, it is