### PR TITLE
Fix: Clock not handling period when no hour is assigned

### DIFF
--- a/src/js/components/Clock/Clock.js
+++ b/src/js/components/Clock/Clock.js
@@ -13,7 +13,7 @@ const parseTime = (time, hourLimit) => {
   if (time) {
     let match = DURATION_REGEXP.exec(time);
     if (match) {
-      result.hours = parseFloat(match[2]);
+      result.hours = parseFloat(match[2]) || 0;
       if (hourLimit === 12) {
         result.hours12 = result.hours > 12 ? result.hours - 12 : result.hours;
       }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- This PR aims to fix `NaN` being displayed when using Clock with the iso8601 format and not providing an hour (ex. PT30M10S)

#### Where should the reviewer start?
- `Clock.js` line 16 where the hours are parsed

#### What testing has been done on this PR?
- Trying `time` prop with no hour and making sure it displays 00

#### How should this be manually tested?
- In any clock storybook, add a Clock component with a time given to it with no hours specified

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
- Resolves #5804

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
- No
#### Should this PR be mentioned in the release notes?
- No
#### Is this change backwards compatible or is it a breaking change?
- Backwards compatible