### PR TITLE
Fix: TextInput suggestions closing incorrectly

### DIFF
--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -172,7 +172,9 @@ const TextInput = forwardRef(
 
     // if we have no suggestions, close drop if it's open
     useEffect(() => {
-      if (showDrop && (!suggestions || !suggestions.length)) closeDrop();
+      if (showDrop && (!suggestions || !suggestions.length)) {
+        closeDrop();
+      }
     }, [closeDrop, showDrop, suggestions]);
 
     const valueSuggestionIndex = useMemo(
@@ -476,6 +478,9 @@ const TextInput = forwardRef(
                     // will come from this onChange and remove the placeholder
                     // so we need to update state to ensure the styled
                     // placeholder only appears when there is no value
+                    if (suggestions && focus && !showDrop) {
+                      openDrop();
+                    }
                     setValue(event.target.value);
                     setActiveSuggestionIndex(resetSuggestionIndex);
                     if (onChange) onChange(event);

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -106,7 +106,6 @@ const TextInput = forwardRef(
     const formContext = useContext(FormContext);
     const inputRef = useForwardedRef(ref);
     const dropRef = useRef();
-    const containerRef = useRef();
     const suggestionsRef = useRef();
     // if this is a readOnly property, don't set a name with the form context
     // this allows Select to control the form context for the name.
@@ -317,10 +316,7 @@ const TextInput = forwardRef(
           responsive={false}
           target={dropTarget || inputRef.current}
           onClickOutside={({ target }) => {
-            if (
-              target !== containerRef.current &&
-              !containerRef.current.contains(target)
-            ) {
+            if (target !== inputRef.current) {
               closeDrop();
             }
           }}
@@ -417,7 +413,7 @@ const TextInput = forwardRef(
     // primarily for tests.
 
     return (
-      <StyledTextInputContainer ref={containerRef} plain={plain}>
+      <StyledTextInputContainer plain={plain}>
         {showStyledPlaceholder && (
           <StyledPlaceholder>{placeholder}</StyledPlaceholder>
         )}

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -106,6 +106,7 @@ const TextInput = forwardRef(
     const formContext = useContext(FormContext);
     const inputRef = useForwardedRef(ref);
     const dropRef = useRef();
+    const containerRef = useRef();
     const suggestionsRef = useRef();
     // if this is a readOnly property, don't set a name with the form context
     // this allows Select to control the form context for the name.
@@ -315,7 +316,14 @@ const TextInput = forwardRef(
           align={dropAlign}
           responsive={false}
           target={dropTarget || inputRef.current}
-          onClickOutside={closeDrop}
+          onClickOutside={({ target }) => {
+            if (
+              target !== containerRef.current &&
+              !containerRef.current.contains(target)
+            ) {
+              closeDrop();
+            }
+          }}
           onEsc={closeDrop}
           {...dropProps}
         >
@@ -409,7 +417,7 @@ const TextInput = forwardRef(
     // primarily for tests.
 
     return (
-      <StyledTextInputContainer plain={plain}>
+      <StyledTextInputContainer ref={containerRef} plain={plain}>
         {showStyledPlaceholder && (
           <StyledPlaceholder>{placeholder}</StyledPlaceholder>
         )}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR addresses issues with the TextInput suggestion dropdown closing and suggestions not reappearing upon further user input or after regaining focus.

#### Where should the reviewer start?
- Changes made in `TextInput.js`

#### What testing has been done on this PR?
Manual testing with a focus on TextInput suggestion behavior after losing / regaining focus through various methods

#### How should this be manually tested?
- Example given with the `TextInput/Default suggestion` story

Part 1:
- Type in sug, the dropdown is open
- Double click inside and delete
- Type again sug --> dropdown remains open after deletion and is ready to scan for new suggestions

Part 2:
- Type in sug, dropdown opens
- Click on the TextInput box --> dropdown remains open after the click and is still actively listening for suggestions

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
- Resolves #5426
- Resolves #5440
- Resolves #5790 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Can be included for TextInput fixes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible