### PR TITLE
Fix NameValueList for backwards compatibility

### DIFF
--- a/src/js/components/NameValueList/NameValueList.js
+++ b/src/js/components/NameValueList/NameValueList.js
@@ -31,7 +31,10 @@ const NameValueList = forwardRef(
         size: !Array.isArray(valueWidth) ? ['auto', valueWidth] : valueWidth,
       };
     else if (layout === 'column' && pairProps.direction === 'row')
-      columns = [nameWidth, ['auto', valueWidth]];
+      columns = [
+        nameWidth,
+        !Array.isArray(valueWidth) ? ['auto', valueWidth] : valueWidth,
+      ];
     else columns = [valueWidth];
 
     let { gap } = theme.nameValueList;

--- a/src/js/components/NameValueList/__tests__/NameValueList-test.tsx
+++ b/src/js/components/NameValueList/__tests__/NameValueList-test.tsx
@@ -83,6 +83,22 @@ describe('NameValueList', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test(`should render correct width of value when value is array`, () => {
+    const { container } = render(
+      <Grommet>
+        <NameValueList valueProps={{ width: 'xsmall' }}>
+          {Object.entries(data).map(([name, value]) => (
+            <NameValuePair key={name} name={name}>
+              {value}
+            </NameValuePair>
+          ))}
+        </NameValueList>
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test(`should render correct alignment of name`, () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/NameValueList/__tests__/NameValueList-test.tsx
+++ b/src/js/components/NameValueList/__tests__/NameValueList-test.tsx
@@ -84,7 +84,7 @@ describe('NameValueList', () => {
   });
 
   test(`should render correct width of value when value is array`, () => {
-    const { container } = render(
+    const { asFragment } = render(
       <Grommet>
         <NameValueList valueProps={{ width: 'xsmall' }}>
           {Object.entries(data).map(([name, value]) => (
@@ -96,7 +96,7 @@ describe('NameValueList', () => {
       </Grommet>,
     );
 
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test(`should render correct alignment of name`, () => {

--- a/src/js/components/NameValueList/__tests__/__snapshots__/NameValueList-test.tsx.snap
+++ b/src/js/components/NameValueList/__tests__/__snapshots__/NameValueList-test.tsx.snap
@@ -660,6 +660,116 @@ exports[`NameValueList should render correct width of value 1`] = `
 </div>
 `;
 
+exports[`NameValueList should render correct width of value when value is array 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  margin: 0px;
+  grid-template-columns: repeat( auto-fit,minmax(auto,96px) );
+  grid-gap: 24px 48px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c4 {
+  margin: 0px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #444444;
+}
+
+.c3 {
+  margin-bottom: 3px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #444444;
+  font-weight: bold;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin: 0px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <dl
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      <dt
+        class="c3"
+      >
+        name
+      </dt>
+      <dd
+        class="c4"
+      >
+        entry
+      </dd>
+    </div>
+    <div
+      class="c2"
+    >
+      <dt
+        class="c3"
+      >
+        location
+      </dt>
+      <dd
+        class="c4"
+      >
+        San Francisco
+      </dd>
+    </div>
+    <div
+      class="c2"
+    >
+      <dt
+        class="c3"
+      >
+        health
+      </dt>
+      <dd
+        class="c4"
+      >
+        80
+      </dd>
+    </div>
+  </dl>
+</div>
+`;
+
 exports[`NameValueList should render name/value as a column when pairProps = { direction: 
     'column' } 1`] = `
 .c0 {

--- a/src/js/components/NameValueList/__tests__/__snapshots__/NameValueList-test.tsx.snap
+++ b/src/js/components/NameValueList/__tests__/__snapshots__/NameValueList-test.tsx.snap
@@ -661,7 +661,8 @@ exports[`NameValueList should render correct width of value 1`] = `
 `;
 
 exports[`NameValueList should render correct width of value when value is array 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -719,55 +720,56 @@ exports[`NameValueList should render correct width of value when value is array 
 }
 
 <div
-  class="c0"
->
-  <dl
-    class="c1"
+    class="c0"
   >
-    <div
-      class="c2"
+    <dl
+      class="c1"
     >
-      <dt
-        class="c3"
+      <div
+        class="c2"
       >
-        name
-      </dt>
-      <dd
-        class="c4"
+        <dt
+          class="c3"
+        >
+          name
+        </dt>
+        <dd
+          class="c4"
+        >
+          entry
+        </dd>
+      </div>
+      <div
+        class="c2"
       >
-        entry
-      </dd>
-    </div>
-    <div
-      class="c2"
-    >
-      <dt
-        class="c3"
+        <dt
+          class="c3"
+        >
+          location
+        </dt>
+        <dd
+          class="c4"
+        >
+          San Francisco
+        </dd>
+      </div>
+      <div
+        class="c2"
       >
-        location
-      </dt>
-      <dd
-        class="c4"
-      >
-        San Francisco
-      </dd>
-    </div>
-    <div
-      class="c2"
-    >
-      <dt
-        class="c3"
-      >
-        health
-      </dt>
-      <dd
-        class="c4"
-      >
-        80
-      </dd>
-    </div>
-  </dl>
-</div>
+        <dt
+          class="c3"
+        >
+          health
+        </dt>
+        <dd
+          class="c4"
+        >
+          80
+        </dd>
+      </div>
+    </dl>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`NameValueList should render name/value as a column when pairProps = { direction: 

--- a/src/js/components/NameValueList/stories/CustomValue.js
+++ b/src/js/components/NameValueList/stories/CustomValue.js
@@ -38,7 +38,7 @@ export const CustomValue = () => (
     <Box pad="small" gap="medium">
       <>
         <Text weight="bold" size="3xl">
-          Custom Mult-Line Value
+          Custom Multi-Line Value
         </Text>
         <NameValueList>
           {Object.entries(languageData).map(([name, value]) => {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds check if caller has passed an array for `valueProps` -- resolves backwards compatibility.

#### Where should the reviewer start?
src/js/components/NameValueList/NameValueList.js

#### What testing has been done on this PR?
Added jest test, storybook.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] N/A `screen` is used for querying.
- [ ] N/A The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] N/A `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes.