### PR TITLE
Fix: TextInput cursor jumping to end

### DIFF
--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -116,6 +116,7 @@ const TextInput = forwardRef(
 
     const [focus, setFocus] = useState();
     const [showDrop, setShowDrop] = useState(false);
+    const [cursor, setCursor] = useState(null);
 
     const handleSuggestionSelect = useMemo(
       () => (onSelect && !onSuggestionSelect ? onSelect : onSuggestionSelect),
@@ -176,6 +177,12 @@ const TextInput = forwardRef(
         closeDrop();
       }
     }, [closeDrop, showDrop, suggestions]);
+
+    useEffect(() => {
+      // log inputRef's input type to console
+      if (inputRef.current?.type === 'text')
+        inputRef.current.setSelectionRange(cursor, cursor);
+    }, [inputRef, cursor, value]);
 
     const valueSuggestionIndex = useMemo(
       () =>
@@ -485,6 +492,7 @@ const TextInput = forwardRef(
                     if (suggestions && focus && !showDrop) {
                       openDrop();
                     }
+                    setCursor(event.target.selectionStart);
                     setValue(event.target.value);
                     setActiveSuggestionIndex(resetSuggestionIndex);
                     if (onChange) onChange(event);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR aims to solve the issue of TextInput's cursor jumping to the end when the cursor was not positioned there.

#### Where should the reviewer start?
Changes made in `TextInput.js`

#### What testing has been done on this PR?
In issue #5682, I made a new story using the submitter's example. With the new changes in place the behavior described in the issue is no longer prevalent (cursor jumping to end of the text)

#### How should this be manually tested?
- Make a new storybook using the submitter's codesandbox (https://codesandbox.io/s/grommet-v2-template-forked-zssn2?file=/index.js)
- Type into TextInput
- Move cursor around what you typed and then try typing again
- The cursor should no longer jump to the end of the string you typed

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Resolves #5682

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Possibly as small bug fix to TextInput

#### Is this change backwards compatible or is it a breaking change?
Backwards Compatible