### PR TITLE
Allow theming for Collapsible, DataTable stories - Issue 5735

### DIFF
--- a/src/js/components/Collapsible/stories/Horizontal.js
+++ b/src/js/components/Collapsible/stories/Horizontal.js
@@ -50,6 +50,10 @@ export const Horizontal = () => {
   );
 };
 
+Horizontal.args = {
+  full: true,
+};
+
 Horizontal.parameters = {
   chromatic: { disable: true },
 };

--- a/src/js/components/Collapsible/stories/Horizontal.js
+++ b/src/js/components/Collapsible/stories/Horizontal.js
@@ -2,51 +2,51 @@ import React from 'react';
 
 import { Notification } from 'grommet-icons';
 
-import { Box, Button, Collapsible, Heading, Grommet, Text } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, Button, Collapsible, Heading, Text } from 'grommet';
 
 export const Horizontal = () => {
   const [openNotification, setOpenNotification] = React.useState();
 
   return (
-    <Grommet full theme={grommet}>
-      <Box fill>
-        <Box
-          as="header"
-          direction="row"
-          align="center"
-          pad={{ vertical: 'small', horizontal: 'medium' }}
-          justify="between"
-          background="neutral-3"
-          elevation="large"
-          style={{ zIndex: '1000' }}
-        >
-          <Heading level={3} margin="none" color="white">
-            <strong>My App</strong>
-          </Heading>
-          <Button
-            onClick={() => setOpenNotification(!openNotification)}
-            icon={<Notification color="white" />}
-          />
-        </Box>
-        <Box flex direction="row">
-          <Box flex align="center" justify="center">
-            Dashboard content goes here, click on the notification icon
-          </Box>
-          <Collapsible direction="horizontal" open={openNotification}>
-            <Box
-              flex
-              width="medium"
-              background="light-2"
-              pad="small"
-              elevation="small"
-            >
-              <Text size="xlarge">Sidebar</Text>
-            </Box>
-          </Collapsible>
-        </Box>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet full theme={grommet}>
+    <Box fill>
+      <Box
+        as="header"
+        direction="row"
+        align="center"
+        pad={{ vertical: 'small', horizontal: 'medium' }}
+        justify="between"
+        background="brand"
+        elevation="large"
+        style={{ zIndex: '1000' }}
+      >
+        <Heading level={3} margin="none" color="white">
+          <strong>My App</strong>
+        </Heading>
+        <Button
+          onClick={() => setOpenNotification(!openNotification)}
+          icon={<Notification color="white" />}
+        />
       </Box>
-    </Grommet>
+      <Box flex direction="row">
+        <Box flex align="center" justify="center">
+          Dashboard content goes here, click on the notification icon
+        </Box>
+        <Collapsible direction="horizontal" open={openNotification}>
+          <Box
+            flex
+            width="medium"
+            background="light-2"
+            pad="small"
+            elevation="small"
+          >
+            <Text size="xlarge">Sidebar</Text>
+          </Box>
+        </Collapsible>
+      </Box>
+    </Box>
+    // </Grommet>
   );
 };
 

--- a/src/js/components/Collapsible/stories/Nested.js
+++ b/src/js/components/Collapsible/stories/Nested.js
@@ -2,8 +2,7 @@ import React from 'react';
 
 import { FormDown, FormNext } from 'grommet-icons';
 
-import { Box, Button, Collapsible, Grommet, Text } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, Button, Collapsible, Text } from 'grommet';
 
 const MenuButton = ({ label, open, submenu, ...rest }) => {
   const Icon = open ? FormDown : FormNext;
@@ -28,61 +27,26 @@ export const Nested = () => {
   const [openMenu2, setOpenMenu2] = React.useState(false);
 
   return (
-    <Grommet theme={grommet}>
-      <Box width="small">
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={grommet}>
+    <Box width="small">
+      <MenuButton
+        open={openMenu1}
+        label="Accordion"
+        onClick={() => {
+          const newOpenMenu1 = !openMenu1;
+          setOpenMenu1(newOpenMenu1);
+          setOpenSubmenu1(!newOpenMenu1 ? false : openSubmenu1);
+        }}
+      />
+      <Collapsible open={openMenu1}>
         <MenuButton
-          open={openMenu1}
-          label="Accordion"
-          onClick={() => {
-            const newOpenMenu1 = !openMenu1;
-            setOpenMenu1(newOpenMenu1);
-            setOpenSubmenu1(!newOpenMenu1 ? false : openSubmenu1);
-          }}
+          submenu
+          open={openSubmenu1}
+          label="Accordion Basics"
+          onClick={() => setOpenSubmenu1(!openSubmenu1)}
         />
-        <Collapsible open={openMenu1}>
-          <MenuButton
-            submenu
-            open={openSubmenu1}
-            label="Accordion Basics"
-            onClick={() => setOpenSubmenu1(!openSubmenu1)}
-          />
-          <Collapsible open={openSubmenu1}>
-            {/* eslint-disable no-alert */}
-            <Button
-              hoverIndicator="background"
-              onClick={() => alert('Submenu item 1 selected')}
-            >
-              <Box
-                margin={{ left: 'medium' }}
-                direction="row"
-                align="center"
-                pad="xsmall"
-              >
-                <Text size="small">Submenu item 1</Text>
-              </Box>
-            </Button>
-            <Button
-              hoverIndicator="background"
-              onClick={() => alert('Submenu item 2 selected')}
-            >
-              <Box
-                margin={{ left: 'medium' }}
-                direction="row"
-                align="center"
-                pad="xsmall"
-              >
-                <Text size="small">Submenu item 2</Text>
-              </Box>
-            </Button>
-            {/* eslint-enable no-alert */}
-          </Collapsible>
-        </Collapsible>
-        <MenuButton
-          open={openMenu2}
-          label="Button"
-          onClick={() => setOpenMenu2(!openMenu2)}
-        />
-        <Collapsible open={openMenu2}>
+        <Collapsible open={openSubmenu1}>
           {/* eslint-disable no-alert */}
           <Button
             hoverIndicator="background"
@@ -97,10 +61,46 @@ export const Nested = () => {
               <Text size="small">Submenu item 1</Text>
             </Box>
           </Button>
+          <Button
+            hoverIndicator="background"
+            onClick={() => alert('Submenu item 2 selected')}
+          >
+            <Box
+              margin={{ left: 'medium' }}
+              direction="row"
+              align="center"
+              pad="xsmall"
+            >
+              <Text size="small">Submenu item 2</Text>
+            </Box>
+          </Button>
           {/* eslint-enable no-alert */}
         </Collapsible>
-      </Box>
-    </Grommet>
+      </Collapsible>
+      <MenuButton
+        open={openMenu2}
+        label="Button"
+        onClick={() => setOpenMenu2(!openMenu2)}
+      />
+      <Collapsible open={openMenu2}>
+        {/* eslint-disable no-alert */}
+        <Button
+          hoverIndicator="background"
+          onClick={() => alert('Submenu item 1 selected')}
+        >
+          <Box
+            margin={{ left: 'medium' }}
+            direction="row"
+            align="center"
+            pad="xsmall"
+          >
+            <Text size="small">Submenu item 1</Text>
+          </Box>
+        </Button>
+        {/* eslint-enable no-alert */}
+      </Collapsible>
+    </Box>
+    // </Grommet>
   );
 };
 

--- a/src/js/components/Collapsible/stories/Simple.js
+++ b/src/js/components/Collapsible/stories/Simple.js
@@ -1,29 +1,29 @@
 import React from 'react';
 
-import { Box, Button, Collapsible, Grommet, Text } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, Button, Collapsible, Text } from 'grommet';
 
-export const Default = props => {
+export const Default = (props) => {
   const [open, setOpen] = React.useState(false);
 
   return (
-    <Grommet theme={grommet}>
-      <Box align="start" gap="small">
-        <Button primary onClick={() => setOpen(!open)} label="Toggle" />
-        <Collapsible open={open} {...props}>
-          <Box
-            background="light-2"
-            round="medium"
-            pad="medium"
-            align="center"
-            justify="center"
-          >
-            <Text>This is a box inside a Collapsible component</Text>
-          </Box>
-        </Collapsible>
-        <Text>This is other content outside the Collapsible box</Text>
-      </Box>
-    </Grommet>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={grommet}>
+    <Box align="start" gap="small">
+      <Button primary onClick={() => setOpen(!open)} label="Toggle" />
+      <Collapsible open={open} {...props}>
+        <Box
+          background="light-2"
+          round="medium"
+          pad="medium"
+          align="center"
+          justify="center"
+        >
+          <Text>This is a box inside a Collapsible component</Text>
+        </Box>
+      </Collapsible>
+      <Text>This is other content outside the Collapsible box</Text>
+    </Box>
+    // </Grommet>
   );
 };
 

--- a/src/js/components/DataTable/stories/ColumnSize.js
+++ b/src/js/components/DataTable/stories/ColumnSize.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable, Heading } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable, Heading } from 'grommet';
 
 const DATA = [
   {
@@ -93,7 +92,9 @@ const columnsDefault = [
 ];
 
 export const ColumnSize = () => (
-  <Grommet theme={grommet}>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={grommet}>
+  <Box>
     <Box fill="horizontal" pad="medium">
       <Heading level="3"> Default DataTable</Heading>
       <DataTable
@@ -149,7 +150,8 @@ export const ColumnSize = () => (
         }}
       />
     </Box>
-  </Grommet>
+  </Box>
+  // </Grommet>
 );
 
 ColumnSize.storyName = 'Column sizes';

--- a/src/js/components/DataTable/stories/Controlled.js
+++ b/src/js/components/DataTable/stories/Controlled.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable, CheckBox } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable, CheckBox } from 'grommet';
 
 // Source code for the data can be found here
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
@@ -28,38 +27,39 @@ export const ControlledDataTable = () => {
     setChecked(event.target.checked ? DATA.map((datum) => datum.name) : []);
 
   return (
-    <Grommet theme={grommet}>
-      <Box align="center" pad="medium">
-        <DataTable
-          columns={[
-            {
-              property: 'checkbox',
-              render: ({ name }) => (
-                <CheckBox
-                  key={name}
-                  checked={checked.indexOf(name) !== -1}
-                  onChange={(e) => onCheck(e, name)}
-                />
-              ),
-              header: (
-                <CheckBox
-                  checked={checked.length === DATA.length}
-                  indeterminate={
-                    checked.length > 0 && checked.length < DATA.length
-                  }
-                  onChange={onCheckAll}
-                />
-              ),
-              sortable: false,
-            },
-            ...controlledColumns,
-          ].map((col) => ({ ...col }))}
-          data={DATA}
-          sortable
-          size="medium"
-        />
-      </Box>
-    </Grommet>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={grommet}>
+    <Box align="center" pad="medium">
+      <DataTable
+        columns={[
+          {
+            property: 'checkbox',
+            render: ({ name }) => (
+              <CheckBox
+                key={name}
+                checked={checked.indexOf(name) !== -1}
+                onChange={(e) => onCheck(e, name)}
+              />
+            ),
+            header: (
+              <CheckBox
+                checked={checked.length === DATA.length}
+                indeterminate={
+                  checked.length > 0 && checked.length < DATA.length
+                }
+                onChange={onCheckAll}
+              />
+            ),
+            sortable: false,
+          },
+          ...controlledColumns,
+        ].map((col) => ({ ...col }))}
+        data={DATA}
+        sortable
+        size="medium"
+      />
+    </Box>
+    // </Grommet>
   );
 };
 

--- a/src/js/components/DataTable/stories/ControlledGrouped.js
+++ b/src/js/components/DataTable/stories/ControlledGrouped.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 
-import { Grommet, DataTable } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { DataTable } from 'grommet';
 
 // Source code for the data can be found here
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
@@ -18,18 +17,19 @@ export const ControlledGroupedDataTable = () => {
   const [expandedGroups, setExpandedGroups] = useState([DATA[2].location]);
 
   return (
-    <Grommet theme={grommet}>
-      <DataTable
-        columns={groupColumns}
-        data={DATA}
-        groupBy={{
-          property: 'location',
-          expand: expandedGroups,
-          onExpand: setExpandedGroups,
-        }}
-        sortable
-      />
-    </Grommet>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={grommet}>
+    <DataTable
+      columns={groupColumns}
+      data={DATA}
+      groupBy={{
+        property: 'location',
+        expand: expandedGroups,
+        onExpand: setExpandedGroups,
+      }}
+      sortable
+    />
+    // </Grommet>
   );
 };
 

--- a/src/js/components/DataTable/stories/CustomThemed/Fill.js
+++ b/src/js/components/DataTable/stories/CustomThemed/Fill.js
@@ -5,9 +5,9 @@ import { deepMerge } from 'grommet/utils';
 
 // Source code for the data can be found here
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
-import { columns, data } from './data';
+import { columns, data } from '../data';
 
-const pinnedColumns = columns.map(c => ({ ...c }));
+const pinnedColumns = columns.map((c) => ({ ...c }));
 pinnedColumns[0].pin = true;
 
 const myTheme = deepMerge(grommet, {
@@ -53,5 +53,5 @@ export const Fill = () => (
 Fill.storyName = 'Fill and pin';
 
 export default {
-  title: 'Visualizations/DataTable/Fill and pin',
+  title: 'Visualizations/DataTable/Custom Themed/Fill and pin',
 };

--- a/src/js/components/DataTable/stories/Grouped.js
+++ b/src/js/components/DataTable/stories/Grouped.js
@@ -1,23 +1,18 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable } from 'grommet';
 
 // Source code for the data can be found here
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
 import { groupColumns, DATA } from './data';
 
 export const GroupedDataTable = () => (
-  <Grommet theme={grommet}>
-    <Box align="center" pad="large">
-      <DataTable
-        columns={groupColumns}
-        data={DATA}
-        groupBy="location"
-        sortable
-      />
-    </Box>
-  </Grommet>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={grommet}>
+  <Box align="center" pad="large">
+    <DataTable columns={groupColumns} data={DATA} groupBy="location" sortable />
+  </Box>
+  // </Grommet>
 );
 
 GroupedDataTable.storyName = 'Grouped';

--- a/src/js/components/DataTable/stories/GroupedOnSelect.js
+++ b/src/js/components/DataTable/stories/GroupedOnSelect.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable } from 'grommet';
 // Source code for the data can be found here
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
 import { columns, DATA } from './data';
@@ -14,17 +13,18 @@ groupColumns[0].footer = groupColumns[1].footer;
 delete groupColumns[1].footer;
 
 export const GroupedOnSelectDataTable = () => (
-  <Grommet theme={grommet}>
-    <Box align="center" pad="large">
-      <DataTable
-        columns={groupColumns}
-        data={DATA}
-        groupBy="location"
-        onSelect={() => {}}
-        sortable
-      />
-    </Box>
-  </Grommet>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={grommet}>
+  <Box align="center" pad="large">
+    <DataTable
+      columns={groupColumns}
+      data={DATA}
+      groupBy="location"
+      onSelect={() => {}}
+      sortable
+    />
+  </Box>
+  // </Grommet>
 );
 
 GroupedOnSelectDataTable.storyName = 'Grouped and onSelect';

--- a/src/js/components/DataTable/stories/InfiniteScrollDataTable.js
+++ b/src/js/components/DataTable/stories/InfiniteScrollDataTable.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable, Heading, Meter, Text } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable, Heading, Meter, Text } from 'grommet';
 
 const amountFormatter = new Intl.NumberFormat('en-US', {
   style: 'currency',
@@ -39,7 +38,7 @@ const columns = [
     render: ({ key, percent }) => (
       <Box pad={{ vertical: 'xsmall' }} alignSelf="center">
         <Meter
-          values={[{ value: percent, color: `accent-${(key % 4) + 1}` }]}
+          values={[{ value: percent, color: `graph-${(key % 4) + 1}` }]}
           thickness="small"
           size="xxsmall"
           type="circle"
@@ -308,24 +307,25 @@ export const InfiniteScrollDataTable = () => {
   };
 
   return (
-    <Grommet theme={grommet}>
-      <Box align="center" pad="large">
-        <Heading level={3}>
-          <Box gap="small">
-            <strong>InfiniteScroll embedded in DataTable</strong>
-            <Text>
-              Scroll down to load more data, open console to see loading info
-            </Text>
-          </Box>
-        </Heading>
-        <DataTable
-          columns={columns}
-          data={DATA}
-          step={step}
-          onMore={() => load()}
-        />
-      </Box>
-    </Grommet>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={grommet}>
+    <Box align="center" pad="large">
+      <Heading level={3}>
+        <Box gap="small">
+          <strong>InfiniteScroll embedded in DataTable</strong>
+          <Text>
+            Scroll down to load more data, open console to see loading info
+          </Text>
+        </Box>
+      </Heading>
+      <DataTable
+        columns={columns}
+        data={DATA}
+        step={step}
+        onMore={() => load()}
+      />
+    </Box>
+    // </Grommet>
   );
 };
 

--- a/src/js/components/DataTable/stories/MultiplePin.js
+++ b/src/js/components/DataTable/stories/MultiplePin.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, DataTable, Grommet, grommet, Meter, Text } from 'grommet';
+import { Box, DataTable, Meter, Text } from 'grommet';
 
 const data = [
   {
@@ -269,43 +269,44 @@ const handleClickRow = (obj) => {
 };
 
 export const MultiplePins = () => (
-  <Grommet theme={grommet}>
-    <Box align="center">
-      <Box height="medium" width="600px" overflow="auto">
-        <DataTable
-          background={{ pinned: 'pink' }}
-          data={data}
-          columns={[
-            {
-              property: 'id',
-              header: 'Id',
-              primary: true,
-              render: (datum) => datum.id.slice(datum.id.length - 5),
-              pin: true,
-            },
-            {
-              property: 'poolName',
-              header: 'Pool Name',
-              render: ({ poolName }) => <Text truncate>{poolName}</Text>,
-              primary: true,
-              pin: true,
-            },
-            {
-              property: 'groupName',
-              header: 'Group Name',
-              pin: true,
-            },
-            ...columns,
-          ]}
-          fill
-          onClickRow={({ datum }) => handleClickRow(datum)}
-          pin
-          onSelect={() => {}}
-          sortable
-        />
-      </Box>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={grommet}>
+  <Box align="center">
+    <Box height="medium" width="600px" overflow="auto">
+      <DataTable
+        background={{ pinned: 'pink' }}
+        data={data}
+        columns={[
+          {
+            property: 'id',
+            header: 'Id',
+            primary: true,
+            render: (datum) => datum.id.slice(datum.id.length - 5),
+            pin: true,
+          },
+          {
+            property: 'poolName',
+            header: 'Pool Name',
+            render: ({ poolName }) => <Text truncate>{poolName}</Text>,
+            primary: true,
+            pin: true,
+          },
+          {
+            property: 'groupName',
+            header: 'Group Name',
+            pin: true,
+          },
+          ...columns,
+        ]}
+        fill
+        onClickRow={({ datum }) => handleClickRow(datum)}
+        pin
+        onSelect={() => {}}
+        sortable
+      />
     </Box>
-  </Grommet>
+  </Box>
+  // </Grommet>
 );
 
 MultiplePins.storyName = 'Multiple pins';

--- a/src/js/components/DataTable/stories/NoPrimary.js
+++ b/src/js/components/DataTable/stories/NoPrimary.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable } from 'grommet';
 
 // Source code for the data can be found here
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
@@ -13,11 +12,12 @@ const columns = [
 ];
 
 export const NoPrimaryKeyDataTable = () => (
-  <Grommet theme={grommet}>
-    <Box align="center" pad="large">
-      <DataTable columns={columns} data={DATA} step={10} primaryKey={false} />
-    </Box>
-  </Grommet>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={grommet}>
+  <Box align="center" pad="large">
+    <DataTable columns={columns} data={DATA} step={10} primaryKey={false} />
+  </Box>
+  // </Grommet>
 );
 
 NoPrimaryKeyDataTable.storyName = 'No primary';

--- a/src/js/components/DataTable/stories/OnUpdate.js
+++ b/src/js/components/DataTable/stories/OnUpdate.js
@@ -1,8 +1,7 @@
 /* eslint-disable no-param-reassign */
 import React, { useCallback, useMemo, useState } from 'react';
 
-import { Grommet, Box, DataTable } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable } from 'grommet';
 
 // Source code for the data can be found here
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
@@ -233,25 +232,26 @@ export const OnUpdateDataTable = () => {
   );
 
   return (
-    <Grommet theme={grommet}>
-      <Box align="center" pad="large">
-        <DataTable
-          primaryKey="id"
-          columns={columns}
-          data={data}
-          sortable
-          replace
-          groupBy={groupBy}
-          onSelect={onSelect}
-          onUpdate={(opts) => {
-            setExpand(opts.expanded);
-            setData(getData(opts));
-          }}
-          select={select}
-          step={step}
-        />
-      </Box>
-    </Grommet>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={grommet}>
+    <Box align="center" pad="large">
+      <DataTable
+        primaryKey="id"
+        columns={columns}
+        data={data}
+        sortable
+        replace
+        groupBy={groupBy}
+        onSelect={onSelect}
+        onUpdate={(opts) => {
+          setExpand(opts.expanded);
+          setData(getData(opts));
+        }}
+        select={select}
+        step={step}
+      />
+    </Box>
+    // </Grommet>
   );
 };
 

--- a/src/js/components/DataTable/stories/Placeholder.js
+++ b/src/js/components/DataTable/stories/Placeholder.js
@@ -1,36 +1,36 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable, Spinner, Text } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable, Spinner, Text } from 'grommet';
 
 // Source code for the data can be found here
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
 import { columns, DATA } from './data';
 
 export const Placeholder = () => (
-  <Grommet theme={grommet}>
-    <Box align="center" pad="large">
-      <DataTable
-        columns={columns}
-        data={DATA}
-        placeholder={
-          <Box
-            fill
-            align="center"
-            justify="center"
-            direction="row"
-            pad="large"
-            gap="small"
-            background={{ color: 'background-front', opacity: 'strong' }}
-          >
-            <Spinner />
-            <Text weight="bold">Loading ...</Text>
-          </Box>
-        }
-        step={10}
-      />
-    </Box>
-  </Grommet>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={grommet}>
+  <Box align="center" pad="large">
+    <DataTable
+      columns={columns}
+      data={DATA}
+      placeholder={
+        <Box
+          fill
+          align="center"
+          justify="center"
+          direction="row"
+          pad="large"
+          gap="small"
+          background={{ color: 'background-front', opacity: 'strong' }}
+        >
+          <Spinner />
+          <Text weight="bold">Loading ...</Text>
+        </Box>
+      }
+      step={10}
+    />
+  </Box>
+  // </Grommet>
 );
 
 export default {

--- a/src/js/components/DataTable/stories/ResizableColumns.js
+++ b/src/js/components/DataTable/stories/ResizableColumns.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable, Heading } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable, Heading } from 'grommet';
 
 const DATA = [
   {
@@ -62,17 +61,18 @@ const columnsResize = [
 ];
 
 export const ResizableDataTable = () => (
-  <Grommet theme={grommet}>
-    <Box align="center" pad="large">
-      <Heading level="3">Table with resizable & column sizes</Heading>
-      <DataTable
-        columns={columnsResize}
-        data={DATA}
-        primaryKey={false}
-        resizeable
-      />
-    </Box>
-  </Grommet>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={grommet}>
+  <Box align="center" pad="large">
+    <Heading level="3">Table with resizable & column sizes</Heading>
+    <DataTable
+      columns={columnsResize}
+      data={DATA}
+      primaryKey={false}
+      resizeable
+    />
+  </Box>
+  // </Grommet>
 );
 
 ResizableDataTable.storyName = 'Resizable columns';

--- a/src/js/components/DataTable/stories/Served.js
+++ b/src/js/components/DataTable/stories/Served.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable } from 'grommet';
 
 // Source code for the data can be found here
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
@@ -34,19 +33,19 @@ export const ServedDataTable = () => {
   };
 
   return (
-    <Grommet theme={grommet}>
-      <Box align="center" pad="large">
-        <DataTable
-          columns={columns.map((column) => ({
-            ...column,
-            search:
-              column.property === 'name' || column.property === 'location',
-          }))}
-          data={data2}
-          onSearch={onSearch}
-        />
-      </Box>
-    </Grommet>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={grommet}>
+    <Box align="center" pad="large">
+      <DataTable
+        columns={columns.map((column) => ({
+          ...column,
+          search: column.property === 'name' || column.property === 'location',
+        }))}
+        data={data2}
+        onSearch={onSearch}
+      />
+    </Box>
+    // </Grommet>
   );
 };
 

--- a/src/js/components/DataTable/stories/Show.js
+++ b/src/js/components/DataTable/stories/Show.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable, Heading, Meter, Text } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable, Heading, Meter, Text } from 'grommet';
 
 const amountFormatter = new Intl.NumberFormat('en-US', {
   style: 'currency',
@@ -39,7 +38,7 @@ const columns = [
     render: ({ key, percent }) => (
       <Box pad={{ vertical: 'xsmall' }} alignSelf="center">
         <Meter
-          values={[{ value: percent, color: `accent-${(key % 4) + 1}` }]}
+          values={[{ value: percent, color: `graph-${(key % 4) + 1}` }]}
           thickness="small"
           size="xxsmall"
           type="circle"
@@ -304,21 +303,28 @@ export const Show = () => {
   const step = 10;
 
   return (
-    <Grommet theme={grommet}>
-      <Box align="center" pad="large">
-        <Heading level={3}>
-          <Box gap="small">
-            <strong>DataTable with show</strong>
-          </Box>
-        </Heading>
-        <DataTable
-          columns={columns}
-          data={DATA}
-          step={step}
-          show={30}
-          onMore={() => console.log('loading more data')}
-        />
-      </Box>
-    </Grommet>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={grommet}>
+    <Box align="center" pad="large">
+      <Heading level={3}>
+        <Box gap="small">
+          <strong>DataTable with show</strong>
+        </Box>
+      </Heading>
+      <DataTable
+        columns={columns}
+        data={DATA}
+        step={step}
+        show={20}
+        onMore={() => console.log('loading more data')}
+      />
+    </Box>
+    // </Grommet>
   );
+};
+
+Show.storyName = 'Show';
+
+export default {
+  title: 'Visualizations/DataTable/Show',
 };

--- a/src/js/components/DataTable/stories/Show.js
+++ b/src/js/components/DataTable/stories/Show.js
@@ -323,8 +323,6 @@ export const Show = () => {
   );
 };
 
-Show.storyName = 'Show';
-
 export default {
   title: 'Visualizations/DataTable/Show',
 };

--- a/src/js/components/DataTable/stories/Simple.js
+++ b/src/js/components/DataTable/stories/Simple.js
@@ -1,18 +1,18 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable } from 'grommet';
 
 // Source code for the data can be found here
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
 import { columns, DATA } from './data';
 
 export const Simple = () => (
-  <Grommet theme={grommet}>
-    <Box align="center" pad="large">
-      <DataTable columns={columns} data={DATA} step={10} />
-    </Box>
-  </Grommet>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={grommet}>
+  <Box align="center" pad="large">
+    <DataTable columns={columns} data={DATA} step={10} />
+  </Box>
+  // </Grommet>
 );
 
 export default {

--- a/src/js/components/DataTable/stories/Sized.js
+++ b/src/js/components/DataTable/stories/Sized.js
@@ -1,18 +1,18 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable } from 'grommet';
 
 // Source code for the data can be found here
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
 import { columns, data } from './data';
 
 export const SizedDataTable = () => (
-  <Grommet theme={grommet}>
-    <Box align="center" pad="large">
-      <DataTable columns={columns} data={data} size="medium" />
-    </Box>
-  </Grommet>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={grommet}>
+  <Box align="center" pad="large">
+    <DataTable columns={columns} data={data} size="medium" />
+  </Box>
+  // </Grommet>
 );
 
 SizedDataTable.storyName = 'Sized';

--- a/src/js/components/DataTable/stories/Sort.js
+++ b/src/js/components/DataTable/stories/Sort.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable } from 'grommet';
 
 import { columns } from './data';
 
@@ -93,20 +92,21 @@ export const Sort = () => {
     direction: 'desc',
   });
   return (
-    <Grommet theme={grommet}>
-      <Box align="center" pad="large">
-        <DataTable
-          columns={columns.map((c) => ({
-            ...c,
-            search: c.property === 'name' || c.property === 'location',
-          }))}
-          data={DATA}
-          sort={sort}
-          onSort={setSort}
-          resizeable
-        />
-      </Box>
-    </Grommet>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={grommet}>
+    <Box align="center" pad="large">
+      <DataTable
+        columns={columns.map((c) => ({
+          ...c,
+          search: c.property === 'name' || c.property === 'location',
+        }))}
+        data={DATA}
+        sort={sort}
+        onSort={setSort}
+        resizeable
+      />
+    </Box>
+    // </Grommet>
   );
 };
 

--- a/src/js/components/DataTable/stories/SpaceX.js
+++ b/src/js/components/DataTable/stories/SpaceX.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 
-import { Grommet, Box, DataTable, Text, Tip } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable, Text, Tip } from 'grommet';
 import { StatusCritical } from 'grommet-icons';
 
 const columns = [
@@ -181,28 +180,29 @@ export const SpaceX = () => {
   }, [expanded, groups, limit, sort]);
 
   return (
-    <Grommet theme={grommet}>
-      <Box align="center" pad="large">
-        <DataTable
-          primaryKey="id"
-          columns={columns}
-          data={data}
-          sortable
-          replace
-          groupBy={{
-            expandable,
-            expand: expanded,
-            property: 'rocketId',
-          }}
-          onUpdate={(opts) => {
-            setExpanded(opts.expanded);
-            setLimit(opts.count);
-            if (opts.sort) setSort(opts.sort);
-          }}
-          step={20}
-        />
-      </Box>
-    </Grommet>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={grommet}>
+    <Box align="center" pad="large">
+      <DataTable
+        primaryKey="id"
+        columns={columns}
+        data={data}
+        sortable
+        replace
+        groupBy={{
+          expandable,
+          expand: expanded,
+          property: 'rocketId',
+        }}
+        onUpdate={(opts) => {
+          setExpanded(opts.expanded);
+          setLimit(opts.count);
+          if (opts.sort) setSort(opts.sort);
+        }}
+        step={20}
+      />
+    </Box>
+    // </Grommet>
   );
 };
 

--- a/src/js/components/DataTable/stories/SpaceXUngrouped.js
+++ b/src/js/components/DataTable/stories/SpaceXUngrouped.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { Grommet, Box, DataTable, Text, Tip } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable, Text, Tip } from 'grommet';
 import { StatusCritical } from 'grommet-icons';
 
 const columns = [
@@ -90,23 +89,24 @@ export const SpaceXUngrouped = () => {
   }, [limit, sort]);
 
   return (
-    <Grommet theme={grommet}>
-      <Box align="center" pad="large">
-        <DataTable
-          primaryKey="id"
-          columns={columns}
-          data={data}
-          sortable
-          replace
-          onUpdate={(opts) => {
-            console.log('onUpdate', opts);
-            setLimit(opts.count);
-            if (opts.sort) setSort(opts.sort);
-          }}
-          step={20}
-        />
-      </Box>
-    </Grommet>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={grommet}>
+    <Box align="center" pad="large">
+      <DataTable
+        primaryKey="id"
+        columns={columns}
+        data={data}
+        sortable
+        replace
+        onUpdate={(opts) => {
+          console.log('onUpdate', opts);
+          setLimit(opts.count);
+          if (opts.sort) setSort(opts.sort);
+        }}
+        step={20}
+      />
+    </Box>
+    // </Grommet>
   );
 };
 

--- a/src/js/components/DataTable/stories/Styled.js
+++ b/src/js/components/DataTable/stories/Styled.js
@@ -1,34 +1,34 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable } from 'grommet';
 
 // Source code for the data can be found here
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
 import { groupColumns, DATA } from './data';
 
 export const StyledDataTable = () => (
-  <Grommet theme={grommet}>
-    <Box align="center" pad="large">
-      <DataTable
-        columns={groupColumns}
-        data={DATA}
-        step={10}
-        pad={{ horizontal: 'small', vertical: 'xsmall' }}
-        background={{
-          header: { color: 'dark-3', opacity: 'strong' },
-          body: ['light-1', 'light-3'],
-          footer: { color: 'dark-3', opacity: 'strong' },
-        }}
-        border={{ body: 'bottom' }}
-        groupBy={{ property: 'location', expand: ['Palo Alto'] }}
-        rowProps={{
-          Eric: { background: ['accent-2', 'accent-3'], pad: 'small' },
-          Jet: { background: ['accent-2', 'accent-3'], pad: 'small' },
-        }}
-      />
-    </Box>
-  </Grommet>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={grommet}>
+  <Box align="center" pad="large">
+    <DataTable
+      columns={groupColumns}
+      data={DATA}
+      step={10}
+      pad={{ horizontal: 'small', vertical: 'xsmall' }}
+      background={{
+        header: { color: 'dark-3', opacity: 'strong' },
+        body: ['light-1', 'light-3'],
+        footer: { color: 'dark-3', opacity: 'strong' },
+      }}
+      border={{ body: 'bottom' }}
+      groupBy={{ property: 'location', expand: ['Palo Alto'] }}
+      rowProps={{
+        Eric: { background: ['graph-2', 'graph-3'], pad: 'small' },
+        Jet: { background: ['graph-2', 'graph-3'], pad: 'small' },
+      }}
+    />
+  </Box>
+  // </Grommet>
 );
 
 StyledDataTable.storyName = 'Styled';

--- a/src/js/components/DataTable/stories/Tunable.js
+++ b/src/js/components/DataTable/stories/Tunable.js
@@ -1,26 +1,25 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable } from 'grommet';
-import { grommet } from 'grommet/themes';
-
+import { Box, DataTable } from 'grommet';
 // Source code for the data can be found here
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
 import { columns, DATA } from './data';
 
 export const TunableDataTable = () => (
-  <Grommet theme={grommet}>
-    <Box align="center" pad="large">
-      <DataTable
-        columns={columns.map(c => ({
-          ...c,
-          search: c.property === 'name' || c.property === 'location',
-        }))}
-        data={DATA}
-        sortable
-        resizeable
-      />
-    </Box>
-  </Grommet>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={grommet}>
+  <Box align="center" pad="large">
+    <DataTable
+      columns={columns.map((c) => ({
+        ...c,
+        search: c.property === 'name' || c.property === 'location',
+      }))}
+      data={DATA}
+      sortable
+      resizeable
+    />
+  </Box>
+  // </Grommet>
 );
 
 TunableDataTable.storyName = 'Tunable';

--- a/src/js/components/DataTable/stories/Units.js
+++ b/src/js/components/DataTable/stories/Units.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable, Heading } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable, Heading } from 'grommet';
 
 const DATA = [
   {
@@ -40,12 +39,13 @@ const columns = [
 ];
 
 export const UnitsDataTable = () => (
-  <Grommet theme={grommet}>
-    <Box align="center" pad="large">
-      <Heading level="3">Table with units in the heading</Heading>
-      <DataTable columns={columns} data={DATA} primaryKey={false} />
-    </Box>
-  </Grommet>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={grommet}>
+  <Box align="center" pad="large">
+    <Heading level="3">Table with units in the heading</Heading>
+    <DataTable columns={columns} data={DATA} primaryKey={false} />
+  </Box>
+  // </Grommet>
 );
 
 UnitsDataTable.storyName = 'Units';

--- a/src/js/components/DataTable/stories/rowDetails.js
+++ b/src/js/components/DataTable/stories/rowDetails.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Grommet, Box, DataTable, CheckBox } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable, CheckBox } from 'grommet';
 
 // Source code for the data can be found here
 // https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
@@ -28,44 +27,45 @@ export const ControlledDataTable = () => {
     setChecked(event.target.checked ? DATA.map((datum) => datum.name) : []);
 
   return (
-    <Grommet theme={grommet}>
-      <Box align="center" pad="medium">
-        <DataTable
-          columns={[
-            {
-              property: 'checkbox',
-              render: ({ name }) => (
-                <CheckBox
-                  key={name}
-                  checked={checked.indexOf(name) !== -1}
-                  onChange={(e) => onCheck(e, name)}
-                />
-              ),
-              header: (
-                <CheckBox
-                  checked={checked.length === DATA.length}
-                  indeterminate={
-                    checked.length > 0 && checked.length < DATA.length
-                  }
-                  onChange={onCheckAll}
-                />
-              ),
-              sortable: false,
-            },
-            ...controlledColumns,
-          ].map((col) => ({ ...col }))}
-          data={DATA}
-          sortable
-          rowDetails={(row) => {
-            if (row.name === 'Alan') {
-              return <Box> {row.name} </Box>;
-            }
-            return <Box>Blah {row.name} </Box>;
-          }}
-          size="medium"
-        />
-      </Box>
-    </Grommet>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={grommet}>
+    <Box align="center" pad="medium">
+      <DataTable
+        columns={[
+          {
+            property: 'checkbox',
+            render: ({ name }) => (
+              <CheckBox
+                key={name}
+                checked={checked.indexOf(name) !== -1}
+                onChange={(e) => onCheck(e, name)}
+              />
+            ),
+            header: (
+              <CheckBox
+                checked={checked.length === DATA.length}
+                indeterminate={
+                  checked.length > 0 && checked.length < DATA.length
+                }
+                onChange={onCheckAll}
+              />
+            ),
+            sortable: false,
+          },
+          ...controlledColumns,
+        ].map((col) => ({ ...col }))}
+        data={DATA}
+        sortable
+        rowDetails={(row) => {
+          if (row.name === 'Alan') {
+            return <Box> {row.name} </Box>;
+          }
+          return <Box>Blah {row.name} </Box>;
+        }}
+        size="medium"
+      />
+    </Box>
+    // </Grommet>
   );
 };
 

--- a/src/js/components/DataTable/stories/typescript/Clickable.tsx
+++ b/src/js/components/DataTable/stories/typescript/Clickable.tsx
@@ -145,35 +145,36 @@ export const ClickableDataTable = () => {
   const [clicked, setClicked] = React.useState({});
 
   return (
-    <Grommet theme={grommet}>
-      <Box align="center" pad="large">
-        <DataTable
-          columns={columns}
-          data={DATA}
-          step={10}
-          onClickRow={(event) => {
-            setShow(true);
-            setClicked(event.datum);
-          }}
-        />
-        {show && (
-          <Layer
-            position="center"
-            onEsc={() => setShow(false)}
-            onClickOutside={() => setShow(false)}
-          >
-            <Box margin="medium">
-              <Text>{clicked && JSON.stringify(clicked, null, 2)}</Text>
-              <Button
-                margin={{ top: 'medium' }}
-                label="close"
-                onClick={() => setShow(false)}
-              />
-            </Box>
-          </Layer>
-        )}
-      </Box>
-    </Grommet>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={grommet}>
+    <Box align="center" pad="large">
+      <DataTable
+        columns={columns}
+        data={DATA}
+        step={10}
+        onClickRow={(event) => {
+          setShow(true);
+          setClicked(event.datum);
+        }}
+      />
+      {show && (
+        <Layer
+          position="center"
+          onEsc={() => setShow(false)}
+          onClickOutside={() => setShow(false)}
+        >
+          <Box margin="medium">
+            <Text>{clicked && JSON.stringify(clicked, null, 2)}</Text>
+            <Button
+              margin={{ top: 'medium' }}
+              label="close"
+              onClick={() => setShow(false)}
+            />
+          </Box>
+        </Layer>
+      )}
+    </Box>
+    // </Grommet>
   );
 };
 

--- a/src/js/components/DataTable/stories/typescript/OnSelect.tsx
+++ b/src/js/components/DataTable/stories/typescript/OnSelect.tsx
@@ -1,7 +1,6 @@
 import React, { ReactText, useState } from 'react';
 
-import { Grommet, Box, DataTable, Meter, Text } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable, Meter, Text } from 'grommet';
 
 import { ColumnConfig } from '../..';
 
@@ -160,17 +159,18 @@ export const OnSelectDataTable = () => {
   const [select, setSelect] = useState<ReactText[]>([]);
 
   return (
-    <Grommet theme={grommet}>
-      <Box align="center" pad="large">
-        <DataTable
-          columns={columns}
-          data={DATA}
-          step={10}
-          select={select}
-          onSelect={setSelect}
-        />
-      </Box>
-    </Grommet>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={grommet}>
+    <Box align="center" pad="large">
+      <DataTable
+        columns={columns}
+        data={DATA}
+        step={10}
+        select={select}
+        onSelect={setSelect}
+      />
+    </Box>
+    // </Grommet>
   );
 };
 

--- a/src/js/components/DataTable/stories/typescript/Paginated.tsx
+++ b/src/js/components/DataTable/stories/typescript/Paginated.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Box, Grommet, DataTable, Meter, Text } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, DataTable, Meter, Text } from 'grommet';
 
 import { ColumnConfig } from '../..';
 
@@ -143,19 +142,20 @@ const DATA: RowType[] = [
 export const Paginated = () => {
   const [select, setSelect] = React.useState([]);
   return (
-    <Grommet theme={grommet} full>
-      <Box pad="large">
-        <DataTable
-          columns={columns}
-          data={DATA}
-          onSelect={setSelect}
-          select={select}
-          sortable
-          step={3}
-          paginate
-        />
-      </Box>
-    </Grommet>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={grommet} full>
+    <Box pad="large">
+      <DataTable
+        columns={columns}
+        data={DATA}
+        onSelect={setSelect}
+        select={select}
+        sortable
+        step={3}
+        paginate
+      />
+    </Box>
+    // </Grommet>
   );
 };
 


### PR DESCRIPTION
What does this PR do?
Working on #5735, theming support for following components is added:


- [x] Collapsible
- [x] DataTable

The theme can now be switched between the currently available themes: base, grommet, hpe.

Where should the reviewer start?
Start in src/js/components and look at the changes made to the following folders:

- [x] Collapsible
- [x] DataTable

What testing has been done on this PR?
Passed the existing tests ran through jest and manually verified the changes on storybook.

How should this be manually tested?
Run storybook and navigate to the following stories: Collapsible, DataTable. Themes can now be switched for these stories using the Theme button.

What are the relevant issues?
https://github.com/grommet/grommet/issues/5735

Do the grommet docs need to be updated?
No.

Should this PR be mentioned in the release notes?
No.

Is this change backwards compatible or is it a breaking change?
Not a breaking change.