### PR TITLE
fix when empty string in Calendar

### DIFF
--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -271,7 +271,9 @@ const Calendar = forwardRef(
         if (Array.isArray(dateProp[0])) {
           timestamp = getTimestamp(dateProp[0][0]);
         } else timestamp = getTimestamp(dateProp[0]);
-      } else if (typeof dateProp === 'string') {
+        // check to see if value is not an empty string
+        // empty string should behave like undefined
+      } else if (typeof dateProp === 'string' && dateProp.length) {
         timestamp = getTimestamp(dateProp);
       } else if (Array.isArray(datesProp) && datesProp.length) {
         if (Array.isArray(datesProp[0])) {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR checks for if someone is passing an empty string for value in `date` in Calendar
#### Where should the reviewer start?
Calendar.js
#### What testing has been done on this PR?
dropdown calendar story
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
The `timeStamp` function was checking if a string was provided however if a user passed in an empty string then the `timeStamp` should be `undefined` 
#### What are the relevant issues?
This was blocking the release currently the simple story was showing the wrong date when clicked 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible