### PR TITLE
Fix fill on TextInput suggestions

### DIFF
--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -362,7 +362,7 @@ const TextInput = forwardRef(
                     >
                       <Button
                         active={activeSuggestionIndex === index}
-                        fill
+                        fill="horizontal"
                         plain={!child ? undefined : true}
                         align="start"
                         kind={!child ? 'option' : undefined}

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -374,11 +374,6 @@ exports[`TextInput calls onSuggestionsClose 2`] = `
   padding: 0;
   text-align: inherit;
   width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
 }
 
 .c5:focus {
@@ -613,11 +608,6 @@ exports[`TextInput calls onSuggestionsOpen 1`] = `
   padding: 0;
   text-align: inherit;
   width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
 }
 
 .c5:focus {
@@ -929,11 +919,6 @@ exports[`TextInput close suggestion drop 2`] = `
   padding: 0;
   text-align: inherit;
   width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
 }
 
 .c5:focus {
@@ -1264,11 +1249,6 @@ exports[`TextInput complex suggestions 2`] = `
   padding: 0;
   text-align: inherit;
   width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
 }
 
 .c5:focus {
@@ -2073,11 +2053,6 @@ exports[`TextInput large drop height 1`] = `
   padding: 0;
   text-align: inherit;
   width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
 }
 
 .c5:focus {
@@ -2293,11 +2268,6 @@ exports[`TextInput medium drop height 1`] = `
   padding: 0;
   text-align: inherit;
   width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
 }
 
 .c5:focus {
@@ -3784,11 +3754,6 @@ exports[`TextInput select suggestion 2`] = `
   padding: 0;
   text-align: inherit;
   width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
 }
 
 .c5:focus {
@@ -4752,11 +4717,6 @@ exports[`TextInput small drop height 1`] = `
   padding: 0;
   text-align: inherit;
   width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
 }
 
 .c5:focus {
@@ -5054,11 +5014,6 @@ exports[`TextInput suggestions 2`] = `
   padding: 0;
   text-align: inherit;
   width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
 }
 
 .c5:focus {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adjusts "fill" on the Button within TextInput suggestions to be `fill="horizontal"` as opposed to `fill`, which was causing the suggestion to take the full height on the drop in some environments.

#### Where should the reviewer start?
src/js/components/TextInput/TextInput.js

#### What testing has been done on this PR?
Updated snapshots and the changes are expected.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

N/A did not touch tests.

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

The exact scenario causing this issue was on Windows Firefox where a Grommet app was inside an existing application. The team had isolated that the "height: 100%" on the suggestion "Button" in the DOM (coming from the `fill`) was causing this issue. Removing it caused no changes to the UI on any browser.

The plan would be to release this fix on stable and allow the team to test in their environment and confirm this resolves the issue.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes. Fixed TextInput suggestions styling.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.