### PR TITLE
Fix icon styling for plain buttons

### DIFF
--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -204,12 +204,19 @@ const fillStyle = (fillContainer) => {
   return undefined;
 };
 
-const plainStyle = css`
+const plainStyle = (props) => css`
   outline: none;
   border: none;
   padding: 0;
   text-align: inherit;
   color: inherit;
+  ${props.icon &&
+  `
+    > svg {
+      display: flex;
+      align-self: center;
+    }
+  `}
 `;
 
 const StyledButtonKind = styled.button.withConfig({
@@ -229,7 +236,7 @@ const StyledButtonKind = styled.button.withConfig({
   text-transform: none;
 
   ${genericStyles}
-  ${(props) => props.plain && plainStyle}
+  ${(props) => props.plain && plainStyle(props)}
   // set baseline activeStyle for all buttons including plain buttons
   // buttons with kind will have active styling overridden by kindStyle
   // if they have specific state styles


### PR DESCRIPTION
#### What does this PR do?
This PR fixes an issue with the alignment of icons in plain buttons.

#### Where should the reviewer start?

#### What testing has been done on this PR?
storybook

#### How should this be manually tested?
View the Tag/onRemove story with the hpe theme

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #5884

#### Screenshots (if appropriate)
Before:
<img width="476" alt="Screen Shot 2022-01-10 at 5 22 20 PM" src="https://user-images.githubusercontent.com/54560994/148859906-f84bd5e6-92cb-45c4-9b4e-138c43d47fb2.png">

After:
<img width="475" alt="Screen Shot 2022-01-12 at 11 38 20 AM" src="https://user-images.githubusercontent.com/54560994/149201627-39e71e9b-19ad-45b0-a5cb-54500278b1a1.png">

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible