### PR TITLE
Fix storybook deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "test-watch": "jest --watchAll",
     "test-bundlesize": "bundlesize",
     "pack": "babel-node ./tools/pack",
-    "storybook": "cross-env NODE_ENV=development start-storybook -p 9001 -c storybook -s ./storybook/public",
-    "build-storybook": "build-storybook -c storybook -o storybook-static -s ./storybook/public",
+    "storybook": "cross-env NODE_ENV=development start-storybook -p 9001 -c storybook",
+    "build-storybook": "build-storybook -c storybook -o storybook-static",
     "prettier": "pretty-quick --staged",
     "chromatic": "chromatic -t 9q99in2ygnh"
   },

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -21,4 +21,8 @@ module.exports = {
     '../src/js/all/**/stories/*.@(ts|tsx|js|jsx)',
     '../src/js/all/stories/typescript/*.tsx',
   ],
+  features: {
+    postcss: false,
+  },
+  staticDirs: ['./public'],
 };


### PR DESCRIPTION
#### What does this PR do?
Fixes deprecation warnings on storybook.

For the first warning `--static-dir CLI flag is deprecated` I removed the -s flag from the storybook commands in package.json and added `staticDirs: ['./public']` to `storybook/main.js`. (More info here: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated---static-dir-cli-flag)

For the second warning, `Default PostCSS plugins are deprecated` I added `features: { postcss: false }` to `storybook/main.js` since we are not using the postcss-loader in storybook. (More info here: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-implicit-postcss-loader)

#### Where should the reviewer start?

#### What testing has been done on this PR?
Ran `yarn storybook` and `yarn build-storybook`  and checked that warnings were no longer showing up and storybook is working as expected

#### How should this be manually tested?
See above ^

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #5829 

#### Screenshots (if appropriate)
Deprecation warnings that were showing up on `yarn storybook`
<img width="568" alt="Screen Shot 2022-01-11 at 12 26 39 PM" src="https://user-images.githubusercontent.com/54560994/149008327-453a2a3f-dfda-408a-8858-914f092b690f.png">

<img width="572" alt="Screen Shot 2022-01-11 at 12 27 04 PM" src="https://user-images.githubusercontent.com/54560994/149008364-2eec875e-505f-4571-be48-a108a0fe086b.png">

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible