### PR TITLE
Fix double focus for Select with search in FormField

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
   "bundlesize": [
     {
       "path": "./dist/grommet.min.js",
-      "maxSize": "124 kB"
+      "maxSize": "125 kB"
     }
   ],
   "keywords": [

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -458,8 +458,11 @@ const FormField = forwardRef(
         {...outerProps}
         style={outerStyle}
         onFocus={(event) => {
-          setFocus(containsFocus(formFieldRef.current));
-          if (isDateInputComponent) {
+          if (!isDateInputComponent) {
+            setFocus(containsFocus(formFieldRef.current));
+          } else {
+            // if FormField contains a DateInput component check if the calendar
+            // button is in focus before assigning focus to the FormField
             const formDescendants =
               formFieldRef.current.getElementsByTagName('*');
             let buttonChild;
@@ -468,6 +471,7 @@ const FormField = forwardRef(
               if (child.tagName.toLowerCase() === 'button') buttonChild = child;
             }
             if (buttonChild === document.activeElement) setFocus(false);
+            else setFocus(containsFocus(formFieldRef.current));
           }
           if (onFocus) onFocus(event);
         }}

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -8,7 +8,7 @@ import React, {
 import styled, { ThemeContext } from 'styled-components';
 import { defaultProps } from '../../default-props';
 
-import { shouldKeepFocus } from '../../utils/DOM';
+import { containsFocus } from '../../utils/DOM';
 import { focusStyle } from '../../utils/styles';
 import { parseMetricToNum } from '../../utils/mixins';
 import { useForwardedRef } from '../../utils/refs';
@@ -262,6 +262,7 @@ const FormField = forwardRef(
     // fileinput handle
     // use fileinput plain use formfield to drive the border
     let isFileInputComponent;
+    let isDateInputComponent;
     if (
       children &&
       Children.forEach(children, (child) => {
@@ -271,6 +272,12 @@ const FormField = forwardRef(
           'FileInput'.indexOf(child.type.displayName) !== -1
         )
           isFileInputComponent = true;
+        if (
+          child &&
+          child.type &&
+          'DateInput'.indexOf(child.type.displayName) !== -1
+        )
+          isDateInputComponent = true;
       })
     );
 
@@ -451,7 +458,17 @@ const FormField = forwardRef(
         {...outerProps}
         style={outerStyle}
         onFocus={(event) => {
-          setFocus(shouldKeepFocus());
+          setFocus(containsFocus(formFieldRef.current));
+          if (isDateInputComponent) {
+            const formDescendants =
+              formFieldRef.current.getElementsByTagName('*');
+            let buttonChild;
+            for (let i = 0; i < formDescendants.length; i += 1) {
+              const child = formDescendants[i];
+              if (child.tagName.toLowerCase() === 'button') buttonChild = child;
+            }
+            if (buttonChild === document.activeElement) setFocus(false);
+          }
           if (onFocus) onFocus(event);
         }}
         onBlur={(event) => {

--- a/src/js/utils/DOM.js
+++ b/src/js/utils/DOM.js
@@ -82,12 +82,6 @@ export const getFirstFocusableDescendant = (element) => {
   return undefined;
 };
 
-export const shouldKeepFocus = () => {
-  const element = document.activeElement;
-  if (isFocusable(element)) return true;
-  return !!getFirstFocusableDescendant(element);
-};
-
 export const getNewContainer = (
   target = document.body,
   targetChildPosition,


### PR DESCRIPTION
#### What does this PR do?
This fixes an issue where Select would receive double focus when it had search capability and was contained in a Form. This issue was introduced in https://github.com/grommet/grommet/pull/5862 in an effort to fix a double focus issue on DateInput. I changed FormField back to the way it was handling focus before #5826 and added a case to handle DateInput focus separately. 

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with the following story:
```javascript
import React, { useState } from 'react';
import { FileInput, Form, FormField, Select, DateInput } from 'grommet'

const defaultOptions = ['EMEA', 'Asia/Pacific', 'Americas', 'Polar Regions'];
// Escaping regular expression special characters: [ \ ^ $ . | ? * + ( )
const getEscapedText = (text) => text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
// Create the regular expression with escaped special characters.
const formatSearchExpression = (text) => new RegExp(getEscapedText(text), 'i');

export const Test = () => {
  const [options, setOptions] = useState(defaultOptions);
  const [selected, setSelected] = useState('');

  const onSearch = (text) => {
    const exp = formatSearchExpression(text);
    setOptions(defaultOptions.filter((option) => exp.test(option)));
  };

  return (
      <Form>
        <FormField
          htmlFor="select-with-search__input"
          name="select-with-search"
          label="Location"
          help="Type to filter the location options"
        >
          <Select
            id="select-with-search"
            name="select-with-search"
            placeholder="Select location"
            searchPlaceholder="Search locations"
            options={options}
            value={selected}
            onChange={({ option }) => setSelected(option)}
            onSearch={(text) => onSearch(text)}
            clear
          />
        </FormField>
        <FormField>
          <DateInput format="mm/dd/yyyy" />
        </FormField>
      </Form>
  );
};

export default {
  title: 'Input/Select/Test',
};
```

#### How should this be manually tested?
Ensure focus is working correctly with Select + search in a Form and that DateInput focus in a Form is also working correctly

#### Any background context you want to provide?

#### What are the relevant issues?
#5887 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes (Fixed an issue where Select with search in a FormField had double focus)

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible