### PR TITLE
Fix icon alignment issue in Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
   "bundlesize": [
     {
       "path": "./dist/grommet.min.js",
-      "maxSize": "124 kB"
+      "maxSize": "125 kB"
     }
   ],
   "keywords": [

--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -78,10 +78,11 @@ const basicStyle = (props) => css`
 
   ${props.icon &&
   `
-  > svg {
-    display: flex;
-    align-self: center;
-  }
+    > svg {
+      display: flex;
+      align-self: center;
+      vertical-align: middle;
+    }
   `}
 `;
 
@@ -215,6 +216,7 @@ const plainStyle = (props) => css`
     > svg {
       display: flex;
       align-self: center;
+  vertical-align: middle;
     }
   `}
 `;

--- a/src/js/components/Button/__tests__/Button-kind-test.js
+++ b/src/js/components/Button/__tests__/Button-kind-test.js
@@ -619,4 +619,17 @@ describe('Button kind', () => {
     fireEvent.mouseOver(getByText('Button'));
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test(`plain with icon`, () => {
+    const { asFragment } = render(
+      <Grommet
+        theme={{
+          button: { default: {} },
+        }}
+      >
+        <Button plain icon={<Add />} />
+      </Grommet>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -3040,6 +3040,145 @@ exports[`Button kind padding on default button 1`] = `
 </div>
 `;
 
+exports[`Button kind plain with icon 1`] = `
+<DocumentFragment>
+  .c2 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c2 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c2 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c2 *[stroke*="#"],
+.c2 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c2 *[fill-rule],
+.c2 *[FILL-RULE],
+.c2 *[fill*="#"],
+.c2 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  color: inherit;
+}
+
+.c1 > svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus > circle,
+.c1:focus > ellipse,
+.c1:focus > line,
+.c1:focus > path,
+.c1:focus > polygon,
+.c1:focus > polyline,
+.c1:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c1:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible) > circle,
+.c1:focus:not(:focus-visible) > ellipse,
+.c1:focus:not(:focus-visible) > line,
+.c1:focus:not(:focus-visible) > path,
+.c1:focus:not(:focus-visible) > polygon,
+.c1:focus:not(:focus-visible) > polyline,
+.c1:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+    class="c0"
+  >
+    <button
+      class="c1"
+      type="button"
+    >
+      <svg
+        aria-label="Add"
+        class="c2"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 22V2M2 12h20"
+          fill="none"
+          stroke="#000"
+          stroke-width="2"
+        />
+      </svg>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Button kind primary button 1`] = `
 .c1 {
   display: inline-block;

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -978,6 +978,7 @@ exports[`Button kind badge should render relative to contents when button has no
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c1:focus {
@@ -1238,6 +1239,7 @@ exports[`Button kind button icon colors 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c1:focus {
@@ -1381,6 +1383,7 @@ exports[`Button kind button with icon and align 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c1:focus {
@@ -2562,6 +2565,7 @@ exports[`Button kind mouseOver and mouseOut events 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c1:focus {
@@ -2650,7 +2654,7 @@ exports[`Button kind mouseOver and mouseOut events 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bUiuPe"
 >
   <button
-    class="StyledButtonKind-sc-1vhfpnt-0 fxEFiO"
+    class="StyledButtonKind-sc-1vhfpnt-0 evKzRa"
     type="button"
   >
     <div

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -20899,6 +20899,7 @@ exports[`DataTable should apply pagination styling 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c16:focus {
@@ -21136,6 +21137,7 @@ exports[`DataTable should apply pagination styling 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c22:hover {
@@ -23683,6 +23685,7 @@ exports[`DataTable should paginate 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c16:focus {
@@ -23920,6 +23923,7 @@ exports[`DataTable should paginate 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c22:hover {
@@ -26025,6 +26029,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c16:focus {
@@ -26262,6 +26267,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c22:hover {
@@ -27321,6 +27327,7 @@ exports[`DataTable should render new data when page changes 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c16:focus {
@@ -27558,6 +27565,7 @@ exports[`DataTable should render new data when page changes 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c22:hover {
@@ -30877,7 +30885,7 @@ exports[`DataTable should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to previous page"
-              class="StyledButtonKind-sc-1vhfpnt-0 fhaBsw StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKykNU"
+              class="StyledButtonKind-sc-1vhfpnt-0 iiMYzM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKykNU"
               type="button"
             >
               <svg
@@ -30932,7 +30940,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="StyledButtonKind-sc-1vhfpnt-0 kwkGFQ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKykNU"
+              class="StyledButtonKind-sc-1vhfpnt-0 lgFhec StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKykNU"
               disabled=""
               type="button"
             >
@@ -31211,6 +31219,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c16:focus {
@@ -31448,6 +31457,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c22:hover {
@@ -33552,6 +33562,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c16:hover {
@@ -33794,6 +33805,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c22:focus {

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -2524,6 +2524,7 @@ exports[`List events should apply pagination styling 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c11:focus {
@@ -2761,6 +2762,7 @@ exports[`List events should apply pagination styling 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c17:hover {
@@ -3678,6 +3680,7 @@ exports[`List events should paginate 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c11:focus {
@@ -3915,6 +3918,7 @@ exports[`List events should paginate 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c17:hover {
@@ -4675,6 +4679,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c11:focus {
@@ -4912,6 +4917,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c17:hover {
@@ -5562,6 +5568,7 @@ exports[`List events should render new data when page changes 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c11:focus {
@@ -5799,6 +5806,7 @@ exports[`List events should render new data when page changes 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c17:hover {
@@ -9893,7 +9901,7 @@ exports[`List events should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to previous page"
-              class="StyledButtonKind-sc-1vhfpnt-0 fhaBsw StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKykNU"
+              class="StyledButtonKind-sc-1vhfpnt-0 iiMYzM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKykNU"
               type="button"
             >
               <svg
@@ -9948,7 +9956,7 @@ exports[`List events should render new data when page changes 2`] = `
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="StyledButtonKind-sc-1vhfpnt-0 kwkGFQ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKykNU"
+              class="StyledButtonKind-sc-1vhfpnt-0 lgFhec StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKykNU"
               disabled=""
               type="button"
             >
@@ -10226,6 +10234,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c11:focus {
@@ -10463,6 +10472,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c17:hover {
@@ -11222,6 +11232,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c11:hover {
@@ -11464,6 +11475,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c17:focus {

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -1577,6 +1577,7 @@ exports[`Menu custom theme with default button 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c1:focus {

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
@@ -307,6 +307,7 @@ exports[`Pagination should allow user to control page via state with page +
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:hover {
@@ -753,6 +754,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:focus {
@@ -990,6 +992,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c13:hover {
@@ -1569,6 +1572,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:focus {
@@ -1813,6 +1817,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c13:focus {
@@ -2250,6 +2255,7 @@ exports[`Pagination should apply custom theme 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c6:focus {
@@ -2487,6 +2493,7 @@ exports[`Pagination should apply custom theme 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c14:hover {
@@ -2949,6 +2956,7 @@ exports[`Pagination should apply size 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:focus {
@@ -3186,6 +3194,7 @@ exports[`Pagination should apply size 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c13:hover {
@@ -3273,6 +3282,7 @@ exports[`Pagination should apply size 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c16:focus {
@@ -3510,6 +3520,7 @@ exports[`Pagination should apply size 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c22:hover {
@@ -3597,6 +3608,7 @@ exports[`Pagination should apply size 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c24:focus {
@@ -3834,6 +3846,7 @@ exports[`Pagination should apply size 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c30:hover {
@@ -4786,6 +4799,7 @@ exports[`Pagination should change the page on prop change 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:hover {
@@ -5231,6 +5245,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:hover {
@@ -5473,6 +5488,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c13:focus {
@@ -5879,6 +5895,7 @@ exports[`Pagination should disable previous and next controls when numberItems
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:focus {
@@ -6278,6 +6295,7 @@ exports[`Pagination should disable previous and next controls when numberItems
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:focus {
@@ -6582,6 +6600,7 @@ exports[`Pagination should disable previous and next controls when numberItems
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:focus {
@@ -7019,6 +7038,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:focus {
@@ -7256,6 +7276,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c13:hover {
@@ -7825,6 +7846,7 @@ exports[`Pagination should display next page of results when "next" is
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:hover {
@@ -8105,7 +8127,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 fhaBsw StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKykNU"
+            class="StyledButtonKind-sc-1vhfpnt-0 iiMYzM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKykNU"
             type="button"
           >
             <svg
@@ -8227,7 +8249,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 fhaBsw StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKykNU"
+            class="StyledButtonKind-sc-1vhfpnt-0 iiMYzM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKykNU"
             type="button"
           >
             <svg
@@ -8557,6 +8579,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:hover {
@@ -8969,6 +8992,7 @@ exports[`Pagination should display previous page of results when "previous" is
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:hover {
@@ -9404,7 +9428,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 fhaBsw StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKykNU"
+            class="StyledButtonKind-sc-1vhfpnt-0 iiMYzM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKykNU"
             type="button"
           >
             <svg
@@ -9526,7 +9550,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 fhaBsw StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKykNU"
+            class="StyledButtonKind-sc-1vhfpnt-0 iiMYzM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKykNU"
             type="button"
           >
             <svg
@@ -9736,6 +9760,7 @@ exports[`Pagination should display the correct last page based on items length
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:focus {
@@ -9973,6 +9998,7 @@ exports[`Pagination should display the correct last page based on items length
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c13:hover {
@@ -10386,6 +10412,7 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:hover {
@@ -11006,6 +11033,7 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:hover {
@@ -11584,6 +11612,7 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:hover {
@@ -12211,6 +12240,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:focus {
@@ -12448,6 +12478,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c13:hover {
@@ -12868,6 +12899,7 @@ exports[`Pagination should set page to last page if page prop > total possible
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c5:hover {
@@ -13110,6 +13142,7 @@ exports[`Pagination should set page to last page if page prop > total possible
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  vertical-align: middle;
 }
 
 .c13:focus {


### PR DESCRIPTION
#### What does this PR do?
Fixes Button icons alignment in Safari.
This is a follow up PR to https://github.com/grommet/grommet/pull/5885, which fixed button icon alignment for plain buttons but didn't fix the alignment on safari.

I also added a jest test for a plain kind Button with an icon and increased the bundle size since we were at our limit.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with storybook across multiple browsers

#### How should this be manually tested?
See above

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #5884 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible