### PR TITLE
Resolve DateInput incomplete date bug

### DIFF
--- a/src/js/components/Calendar/utils.js
+++ b/src/js/components/Calendar/utils.js
@@ -145,7 +145,7 @@ export const normalizeForTimezone = (value, timestamp) => {
   let valueOffset = 0;
   if (timestamp && typeof timestamp === 'string') {
     hourDelta = parseInt(timestamp?.split(':')[0], 10);
-    valueOffset = hourDelta * 60 * 1000; // ms
+    valueOffset = hourDelta * 60 * 60 * 1000; // ms
   }
   const localOffset = new Date().getTimezoneOffset() * 60 * 1000;
 

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -4444,8 +4444,6 @@ exports[`DateInput controlled format inline without timezone 2`] = `
 
 .c14 {
   position: relative;
-  -webkit-animation: gGnBir 0.5s forwards;
-  animation: gGnBir 0.5s forwards;
 }
 
 .c15 {
@@ -5472,28 +5470,6 @@ exports[`DateInput controlled format inline without timezone 2`] = `
                       class="c18"
                     >
                       8
-                    </div>
-                  </button>
-                </div>
-              </div>
-              <div
-                class="c15"
-                role="row"
-              >
-                <div
-                  class="c16"
-                  role="gridcell"
-                >
-                  <button
-                    aria-label="Sun Aug 09 2020"
-                    class="c17"
-                    tabindex="-1"
-                    type="button"
-                  >
-                    <div
-                      class="c18"
-                    >
-                      9
                     </div>
                   </button>
                 </div>

--- a/src/js/components/DateInput/utils.js
+++ b/src/js/components/DateInput/utils.js
@@ -176,7 +176,7 @@ export const textToValue = (text, schema, range, timestamp) => {
         // prematurely calculated.
         // ex: 2022/01/0 would reutrn 2021/12/31 in addDate()
         if (parts.d === '0') delete parts.d;
-        index += parts?.d?.length;
+        index += (parts?.d?.length || 0);
       } else if (char === 'y') {
         parts.y = pullDigits(text, index);
         index += parts.y.length;

--- a/src/js/components/DateInput/utils.js
+++ b/src/js/components/DateInput/utils.js
@@ -171,7 +171,12 @@ export const textToValue = (text, schema, range, timestamp) => {
         index += parts.m.length;
       } else if (char === 'd') {
         parts.d = pullDigits(text, index);
-        index += parts.d.length;
+        // when format is something like yyyy/mm/dd,
+        // '0' as incomplete day can cause date to be
+        // prematurely calculated.
+        // ex: 2022/01/0 would reutrn 2021/12/31 in addDate()
+        if (parts.d === '0') delete parts.d;
+        index += parts?.d?.length;
       } else if (char === 'y') {
         parts.y = pullDigits(text, index);
         index += parts.y.length;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Resolves a bug where a date with format of `yyyy-mm-dd` or `yyyy/mm/dd` (day at end) was resulting in the date prematurely being considered "complete" and miscalculating the date.

I have also resolved bug in a calculation that converts hours to ms.

Regarding the snapshot change, I believe this is fixing an existing bug in a fairly new test/snapshot (created by https://github.com/grommet/grommet/pull/5837). The date of August 9 should not have been in the snapshot. See screenshot below of the storybook rendering:
<img width="453" alt="Screen Shot 2022-01-13 at 4 55 41 PM" src="https://user-images.githubusercontent.com/12522275/149433323-932d250f-9aeb-4f38-93e6-132e810fdfaf.png">

 
#### Where should the reviewer start?

src/js/components/DateInput/utils.js

#### What testing has been done on this PR?

Tested locally with the following:

```
import React from 'react';

import { Box, DateInput } from 'grommet';

export const Format = () => {
  const [value, setValue] = React.useState('');
  const onChange = (event) => {
    const nextValue = event.value;
    console.log('onChange', nextValue);
    setValue(nextValue);
  };
  return (
    <Box align="center" pad="large">
      <Box width="medium">
        <DateInput
          id="item"
          name="item"
          format="yyyy-mm-dd"
          value={value}
          inline
          onChange={onChange}
        />
      </Box>
    </Box>
  );
};

export default {
  title: 'Input/DateInput/Format',
};
```

https://user-images.githubusercontent.com/12522275/149433374-a580bd5e-fddd-4fde-a623-8704c50865fc.mov

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

N/A tests were not touched.

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #5871 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes. Fixed DateInput bug with yyyy/mm/dd format.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.