### PR TITLE
feat(Grid): enhance theming in Grid story

### DIFF
--- a/src/js/components/Grid/stories/AreasPropAlternative.js
+++ b/src/js/components/Grid/stories/AreasPropAlternative.js
@@ -1,37 +1,37 @@
 import React from 'react';
 
-import { Grommet, Box, Grid } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, Grid } from 'grommet';
 
 export const GridAreasAlternative = () => (
-  <Grommet full theme={grommet}>
-    <Grid
-      rows={['xxsmall', 'medium', 'xsmall']}
-      columns={['1/4', '3/4']}
-      areas={[
-        ['header', 'header'],
-        ['sidebar', 'main'],
-        ['footer', 'footer'],
-      ]}
-      gap="small"
-    >
-      <Box background="brand" gridArea="header">
-        Header
-      </Box>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={...}>
+  <Grid
+    rows={['xxsmall', 'medium', 'xsmall']}
+    columns={['1/4', '3/4']}
+    areas={[
+      ['header', 'header'],
+      ['sidebar', 'main'],
+      ['footer', 'footer'],
+    ]}
+    gap="small"
+  >
+    <Box background="brand" gridArea="header">
+      Header
+    </Box>
 
-      <Box background="light-5" gridArea="sidebar">
-        Sidebar
-      </Box>
+    <Box background="light-5" gridArea="sidebar">
+      Sidebar
+    </Box>
 
-      <Box background="light-2" gridArea="main">
-        Main
-      </Box>
+    <Box background="light-2" gridArea="main">
+      Main
+    </Box>
 
-      <Box background="dark-2" gridArea="footer">
-        Footer
-      </Box>
-    </Grid>
-  </Grommet>
+    <Box background="dark-2" gridArea="footer">
+      Footer
+    </Box>
+  </Grid>
+  // </Grommet>
 );
 
 GridAreasAlternative.storyName = 'Areas prop alternatives';

--- a/src/js/components/Grid/stories/Border.js
+++ b/src/js/components/Grid/stories/Border.js
@@ -1,73 +1,73 @@
 import React from 'react';
 
-import { Box, Grid, Grommet } from 'grommet';
-import { grommet } from '../../../themes';
+import { Box, Grid } from 'grommet';
 
 export const BorderGrid = () => (
-  <Grommet theme={grommet}>
-    <Box pad="small" gap="small" align="start">
-      <Grid pad="small" border>
-        true
-      </Grid>
-      <Box direction="row-responsive" gap="small">
-        {['horizontal', 'vertical', 'left', 'top', 'right', 'bottom'].map(
-          border => (
-            <Grid key={border} pad="small" border={border}>
-              {border}
-            </Grid>
-          ),
-        )}
-      </Box>
-      <Box direction="row-responsive" gap="small" align="start">
-        <Grid
-          pad="small"
-          border={[
-            { size: 'medium', style: 'dotted', side: 'top' },
-            {
-              size: 'medium',
-              style: 'double',
-              side: 'vertical',
-            },
-          ]}
-        >
-          custom top & vertical borders
-        </Grid>
-      </Box>
-      <Grid pad="small" border={{ color: 'brand' }}>
-        color
-      </Grid>
-      <Box direction="row-responsive" gap="small" align="start">
-        {['small', 'medium', 'large'].map(size => (
-          <Grid key={size} pad="small" border={{ size }}>
-            {size}
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={...}>
+  <Box pad="small" gap="small" align="start">
+    <Grid pad="small" border>
+      true
+    </Grid>
+    <Box direction="row-responsive" gap="small">
+      {['horizontal', 'vertical', 'left', 'top', 'right', 'bottom'].map(
+        (border) => (
+          <Grid key={border} pad="small" border={border}>
+            {border}
           </Grid>
-        ))}
-      </Box>
-      <Box direction="row-responsive" gap="small" align="start">
-        {['small', 'medium', 'large'].map(size => (
-          <Grid key={size} pad="small" responsive={false} border={{ size }}>
-            {size}
-          </Grid>
-        ))}
-      </Box>
-      <Box direction="row-responsive" gap="small" align="start">
-        {[
-          'solid',
-          'dashed',
-          'dotted',
-          'double',
-          'groove',
-          'ridge',
-          'inset',
-          'outset',
-        ].map(type => (
-          <Grid key={type} pad="small" border={{ size: 'medium', style: type }}>
-            {type}
-          </Grid>
-        ))}
-      </Box>
+        ),
+      )}
     </Box>
-  </Grommet>
+    <Box direction="row-responsive" gap="small" align="start">
+      <Grid
+        pad="small"
+        border={[
+          { size: 'medium', style: 'dotted', side: 'top' },
+          {
+            size: 'medium',
+            style: 'double',
+            side: 'vertical',
+          },
+        ]}
+      >
+        custom top & vertical borders
+      </Grid>
+    </Box>
+    <Grid pad="small" border={{ color: 'brand' }}>
+      color
+    </Grid>
+    <Box direction="row-responsive" gap="small" align="start">
+      {['small', 'medium', 'large'].map((size) => (
+        <Grid key={size} pad="small" border={{ size }}>
+          {size}
+        </Grid>
+      ))}
+    </Box>
+    <Box direction="row-responsive" gap="small" align="start">
+      {['small', 'medium', 'large'].map((size) => (
+        <Grid key={size} pad="small" responsive={false} border={{ size }}>
+          {size}
+        </Grid>
+      ))}
+    </Box>
+    <Box direction="row-responsive" gap="small" align="start">
+      {[
+        'solid',
+        'dashed',
+        'dotted',
+        'double',
+        'groove',
+        'ridge',
+        'inset',
+        'outset',
+      ].map((type) => (
+        <Grid key={type} pad="small" border={{ size: 'medium', style: type }}>
+          {type}
+        </Grid>
+      ))}
+    </Box>
+  </Box>
+  // </Grommet>
 );
 
 BorderGrid.storyName = 'Border';

--- a/src/js/components/Grid/stories/CustomThemed/Responsive.js
+++ b/src/js/components/Grid/stories/CustomThemed/Responsive.js
@@ -89,7 +89,7 @@ const animals = [
 ];
 
 // Create box for each animal
-const listAnimalsBoxes = animals.map(animalName => (
+const listAnimalsBoxes = animals.map((animalName) => (
   <Box
     elevation="large"
     key={animalName}
@@ -110,7 +110,7 @@ const Responsive = ({
   ...props
 }) => (
   <ResponsiveContext.Consumer>
-    {size => {
+    {(size) => {
       // Take into consideration if not array is sent but a simple string
       let columnsVal = columns;
       if (columns) {
@@ -191,5 +191,5 @@ export const ResponsiveGrid = () => (
 ResponsiveGrid.storyName = 'Responsive grid';
 
 export default {
-  title: 'Layout/Grid/Responsive grid',
+  title: 'Layout/Grid/Custom Themed/Responsive grid',
 };

--- a/src/js/components/Grid/stories/NColumn.js
+++ b/src/js/components/Grid/stories/NColumn.js
@@ -1,25 +1,25 @@
 import React from 'react';
 
-import { Grommet, Box, Grid } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, Grid } from 'grommet';
 
 export const NColumnGrid = () => (
-  <Grommet theme={grommet} full>
-    <Grid
-      columns={{
-        count: 6,
-        size: 'auto',
-      }}
-      gap="small"
-    >
-      <Box background="brand">Item 1</Box>
-      <Box background="brand">Item 2</Box>
-      <Box background="brand">Item 3</Box>
-      <Box background="brand">Item 4</Box>
-      <Box background="brand">Item 5</Box>
-      <Box background="brand">Item 6</Box>
-    </Grid>
-  </Grommet>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={...}>
+  <Grid
+    columns={{
+      count: 6,
+      size: 'auto',
+    }}
+    gap="small"
+  >
+    <Box background="brand">Item 1</Box>
+    <Box background="brand">Item 2</Box>
+    <Box background="brand">Item 3</Box>
+    <Box background="brand">Item 4</Box>
+    <Box background="brand">Item 5</Box>
+    <Box background="brand">Item 6</Box>
+  </Grid>
+  // </Grommet>
 );
 
 NColumnGrid.storyName = 'N-column layout';

--- a/src/js/components/Grid/stories/Percentages.js
+++ b/src/js/components/Grid/stories/Percentages.js
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import { Grommet, Box, Grid } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, Grid } from 'grommet';
 
 export const Percentages = () => (
-  <Grommet theme={grommet} full>
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={...}>
+  <Box height="medium">
     <Grid
       fill
       areas={[
@@ -18,7 +19,8 @@ export const Percentages = () => (
       <Box gridArea="nav" background="brand" />
       <Box gridArea="main" background="brand" />
     </Grid>
-  </Grommet>
+  </Box>
+  // </Grommet>
 );
 
 export default {

--- a/src/js/components/Grid/stories/ResponsiveCards.js
+++ b/src/js/components/Grid/stories/ResponsiveCards.js
@@ -1,14 +1,6 @@
 import React, { useContext } from 'react';
 
-import {
-  grommet,
-  Box,
-  Card,
-  Grid,
-  Grommet,
-  ResponsiveContext,
-  Text,
-} from 'grommet';
+import { Box, Card, Grid, ResponsiveContext, Text } from 'grommet';
 
 const cards = Array(20)
   .fill()
@@ -18,18 +10,19 @@ const cards = Array(20)
 export const Example = () => {
   const size = useContext(ResponsiveContext);
   return (
-    <Grommet theme={grommet}>
-      <Box pad="large">
-        <Grid columns={size !== 'small' ? 'small' : '100%'} gap="small">
-          {cards.map((card, index) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <Card pad="large" key={index}>
-              {card}
-            </Card>
-          ))}
-        </Grid>
-      </Box>
-    </Grommet>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={...}>
+    <Box pad="large">
+      <Grid columns={size !== 'small' ? 'small' : '100%'} gap="small">
+        {cards.map((card, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Card pad="large" key={index}>
+            {card}
+          </Card>
+        ))}
+      </Grid>
+    </Box>
+    // </Grommet>
   );
 };
 

--- a/src/js/components/Grid/stories/typescript/App.tsx
+++ b/src/js/components/Grid/stories/typescript/App.tsx
@@ -1,13 +1,14 @@
 import React, { useState } from 'react';
 
-import { Grommet, Box, Button, Grid, Text } from 'grommet';
-import { grommet } from 'grommet/themes';
+import { Box, Button, Grid, Text } from 'grommet';
 
 export const AppGrid = () => {
   const [sidebar, setSidebar] = useState(true);
 
   return (
-    <Grommet full theme={grommet}>
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={...}>
+    <Box>
       {Grid.available ? (
         <Grid
           fill
@@ -58,7 +59,8 @@ export const AppGrid = () => {
       ) : (
         <Text>Grid is not supported by your browser</Text>
       )}
-    </Grommet>
+    </Box>
+    // </Grommet>
   );
 };
 


### PR DESCRIPTION
What does this PR do?
Working on #5735, theming support for following components is added:

- [x] Grid

The theme can now be switched between the currently available themes: base, grommet, hpe.

Where should the reviewer start?
Start in src/js/components and look at the changes made to the following folders:

- [x] Grid

What testing has been done on this PR?
Passed the existing tests ran through jest and manually verified the changes on storybook.

How should this be manually tested?
Run storybook and navigate to the following stories: Grid. Themes can now be switched for these stories using the Theme button.

What are the relevant issues?
https://github.com/grommet/grommet/issues/5735

Do the grommet docs need to be updated?
No.

Should this PR be mentioned in the release notes?
No.

Is this change backwards compatible or is it a breaking change?
Not a breaking change.