### PR TITLE
Fix Select's infinitescroll accessibility issues

### DIFF
--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -753,6 +753,8 @@ exports[`Form accessibility Select in Form should have no accessibility violatio
         class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
       >
         <button
+          aria-expanded="false"
+          aria-haspopup="listbox"
           aria-label="test"
           class="c3 "
           type="button"
@@ -3119,6 +3121,8 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
         class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
       >
         <button
+          aria-expanded="false"
+          aria-haspopup="listbox"
           aria-label="Open Drop"
           class="c4 "
           id="test-select"
@@ -3355,6 +3359,8 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
         class="StyledBox-sc-13pk1d4-0 ctACHi FormField__FormFieldContentBox-sc-m9hood-1"
       >
         <button
+          aria-expanded="false"
+          aria-haspopup="listbox"
           aria-label="Open Drop"
           class="StyledButton-sc-323bzc-0 fhAZId Select__StyledSelectDropButton-sc-17idtfo-2 fJfYtd"
           id="test-select"

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -2261,6 +2261,8 @@ exports[`Layer invokes onEsc when modal={false} 1`] = `
       tabindex="-1"
     />
     <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
       aria-label="Open Drop"
       class="c3 c4"
       type="button"

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -291,7 +291,7 @@ const Select = forwardRef(
         <StyledSelectDropButton
           ref={ref}
           a11yTitle={ariaLabel || a11yTitle}
-          aria-expanded={Boolean(open)}
+          aria-expanded={open}
           aria-haspopup="listbox"
           id={id}
           disabled={disabled === true || undefined}

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -291,6 +291,8 @@ const Select = forwardRef(
         <StyledSelectDropButton
           ref={ref}
           a11yTitle={ariaLabel || a11yTitle}
+          aria-expanded={Boolean(open)}
+          aria-haspopup="listbox"
           id={id}
           disabled={disabled === true || undefined}
           dropAlign={dropAlign}

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -291,7 +291,7 @@ const Select = forwardRef(
         <StyledSelectDropButton
           ref={ref}
           a11yTitle={ariaLabel || a11yTitle}
-          aria-expanded={open}
+          aria-expanded={Boolean(open)}
           aria-haspopup="listbox"
           id={id}
           disabled={disabled === true || undefined}

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -362,7 +362,7 @@ const SelectContainer = forwardRef(
               setFocus={setFocus}
             />
           )}
-          <OptionsBox role="menubar" tabIndex="-1" ref={optionsRef}>
+          <OptionsBox role="listbox" tabIndex="-1" ref={optionsRef}>
             {options.length > 0 ? (
               <InfiniteScroll
                 items={options}
@@ -410,8 +410,11 @@ const SelectContainer = forwardRef(
                       // eslint-disable-next-line react/no-array-index-key
                       key={index}
                       ref={optionRef}
-                      tabIndex="-1"
-                      role="menuitem"
+                      tabIndex={optionSelected ? '0' : '-1'}
+                      role="option"
+                      aria-setsize={options.length}
+                      aria-posinset={index}
+                      aria-selected={optionSelected}
                       plain={!child ? undefined : true}
                       align="start"
                       kind={!child ? 'option' : undefined}

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -219,6 +219,8 @@ exports[`Select 0 value 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -488,12 +490,15 @@ exports[`Select Clear option renders - bottom 1`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -508,8 +513,11 @@ exports[`Select Clear option renders - bottom 1`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -772,12 +780,15 @@ exports[`Select Clear option renders correct label when wrapped in FormField 1`]
     
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -792,8 +803,11 @@ exports[`Select Clear option renders correct label when wrapped in FormField 1`]
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -1047,12 +1061,15 @@ exports[`Select Clear option renders custom label 1`] = `
     
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -1067,8 +1084,11 @@ exports[`Select Clear option renders custom label 1`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -1322,12 +1342,15 @@ exports[`Select Clear option renders- top 1`] = `
     
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -1342,8 +1365,11 @@ exports[`Select Clear option renders- top 1`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -1623,6 +1649,8 @@ exports[`Select Search timeout 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="true"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     data-g-tabindex="none"
@@ -1999,6 +2027,8 @@ exports[`Select applies custom global.hover theme to options 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="applies-custom-hover-style-id"
@@ -2163,8 +2193,11 @@ exports[`Select applies custom global.hover theme to options 2`] = `
 }
 
 <button
+  aria-posinset="1"
+  aria-selected="false"
+  aria-setsize="3"
   class="c0 c1"
-  role="menuitem"
+  role="option"
   tabindex="-1"
   type="button"
 >
@@ -2399,6 +2432,8 @@ exports[`Select basic 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Select"
   class="c0 c1"
   id="test-select"
@@ -2665,6 +2700,8 @@ exports[`Select complex options and children 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -2714,6 +2751,8 @@ exports[`Select complex options and children 1`] = `
 
 exports[`Select complex options and children 2`] = `
 <button
+  aria-expanded="true"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="StyledButton-sc-323bzc-0 eiEooU Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
   id="test-select"
@@ -2952,12 +2991,15 @@ exports[`Select complex options and children 3`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -2966,8 +3008,11 @@ exports[`Select complex options and children 3`] = `
         </span>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -3253,6 +3298,8 @@ exports[`Select dark 1`] = `
     class="c1"
   >
     <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
       aria-label="Open Drop"
       class="c2 c3"
       type="button"
@@ -3532,6 +3579,8 @@ exports[`Select default value 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-select"
@@ -3971,12 +4020,15 @@ exports[`Select default value clear 1`] = `
     </button>
     <div
       class="c7"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c8 c9"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -3991,9 +4043,12 @@ exports[`Select default value clear 1`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="true"
+        aria-setsize="2"
         class="c12 c13"
-        role="menuitem"
-        tabindex="-1"
+        role="option"
+        tabindex="0"
         type="button"
       >
         <div
@@ -4255,6 +4310,8 @@ exports[`Select default value object options 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-select"
@@ -4524,6 +4581,8 @@ exports[`Select disabled 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   disabled=""
@@ -4574,6 +4633,8 @@ exports[`Select disabled 1`] = `
 
 exports[`Select disabled 2`] = `
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="StyledButton-sc-323bzc-0 ijdOBy Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
   disabled=""
@@ -4854,6 +4915,8 @@ exports[`Select disabled key 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-select"
@@ -5184,13 +5247,16 @@ exports[`Select disabled key 2`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
         disabled=""
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -5205,8 +5271,11 @@ exports[`Select disabled key 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c9 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -5519,13 +5588,16 @@ exports[`Select disabled option value 1`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
         disabled=""
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -5540,8 +5612,11 @@ exports[`Select disabled option value 1`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c9 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -5910,6 +5985,8 @@ exports[`Select keyboard navigation timeout 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="true"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     data-g-tabindex="none"
@@ -6183,12 +6260,15 @@ exports[`Select large drop container height 1`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -6203,8 +6283,11 @@ exports[`Select large drop container height 1`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -6448,12 +6531,15 @@ exports[`Select medium drop container height 1`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -6468,8 +6554,11 @@ exports[`Select medium drop container height 1`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -6724,6 +6813,8 @@ exports[`Select modifies select control style on open 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-open-id"
@@ -7005,6 +7096,8 @@ exports[`Select onChange with valueKey string 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-select"
@@ -7275,12 +7368,15 @@ exports[`Select onChange with valueKey string 2`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -7295,8 +7391,11 @@ exports[`Select onChange with valueKey string 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -7510,6 +7609,8 @@ exports[`Select onChange with valueLabel 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-select"
@@ -7776,12 +7877,15 @@ exports[`Select onChange with valueLabel 2`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -7796,8 +7900,11 @@ exports[`Select onChange with valueLabel 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -8060,6 +8167,8 @@ exports[`Select onChange without valueKey 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-select"
@@ -8330,12 +8439,15 @@ exports[`Select onChange without valueKey 2`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -8350,8 +8462,11 @@ exports[`Select onChange without valueKey 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -8613,6 +8728,8 @@ exports[`Select prop: onClose 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -8894,6 +9011,8 @@ exports[`Select prop: onClose 2`] = `
   <div />
   <div>
     <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
       aria-label="Open Drop"
       class="c0 c1"
       id="test-select"
@@ -9162,6 +9281,8 @@ exports[`Select prop: onOpen 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -9211,6 +9332,8 @@ exports[`Select prop: onOpen 1`] = `
 
 exports[`Select prop: onOpen 2`] = `
 <button
+  aria-expanded="true"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="StyledButton-sc-323bzc-0 eiEooU Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
   id="test-select"
@@ -9480,12 +9603,15 @@ exports[`Select prop: onOpen 3`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -9500,8 +9626,11 @@ exports[`Select prop: onOpen 3`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -9535,12 +9664,15 @@ exports[`Select prop: onOpen 4`] = `
 exports[`Select prop: onOpen 5`] = `
 <div
   class="SelectContainer__OptionsBox-sc-1wi0ul8-0 jviAPV"
-  role="menubar"
+  role="listbox"
   tabindex="-1"
 >
   <button
+    aria-posinset="0"
+    aria-selected="false"
+    aria-setsize="2"
     class="StyledButton-sc-323bzc-0 cmzBhQ SelectContainer__SelectOption-sc-1wi0ul8-1 jRnsyM"
-    role="menuitem"
+    role="option"
     tabindex="-1"
     type="button"
   >
@@ -9555,8 +9687,11 @@ exports[`Select prop: onOpen 5`] = `
     </div>
   </button>
   <button
+    aria-posinset="1"
+    aria-selected="false"
+    aria-setsize="2"
     class="StyledButton-sc-323bzc-0 cmzBhQ SelectContainer__SelectOption-sc-1wi0ul8-1 jRnsyM"
-    role="menuitem"
+    role="option"
     tabindex="-1"
     type="button"
   >
@@ -9795,6 +9930,8 @@ exports[`Select renders custom icon 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -10073,6 +10210,8 @@ exports[`Select renders custom up and down icons 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     type="button"
@@ -10124,6 +10263,8 @@ exports[`Select renders custom up and down icons 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bUiuPe"
 >
   <button
+    aria-expanded="true"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="StyledButton-sc-323bzc-0 eiEooU Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
     type="button"
@@ -10439,6 +10580,8 @@ exports[`Select renders default icon 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -10718,6 +10861,8 @@ exports[`Select renders styled select options backwards compatible with legacy
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-options-style-id"
@@ -11001,6 +11146,8 @@ exports[`Select renders styled select options combining select.options.box &&
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-options-style-id"
@@ -11282,6 +11429,8 @@ exports[`Select renders styled select options using select.options.container 1`]
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-options-style-id"
@@ -11490,6 +11639,8 @@ exports[`Select renders without icon 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -11738,6 +11889,8 @@ exports[`Select search 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -12179,12 +12332,15 @@ exports[`Select search 2`] = `
     </div>
     <div
       class="c7"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c8 c9"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -12199,9 +12355,12 @@ exports[`Select search 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="true"
+        aria-setsize="2"
         class="c12 c13"
-        role="menuitem"
-        tabindex="-1"
+        role="option"
+        tabindex="0"
         type="button"
       >
         <div
@@ -12468,6 +12627,8 @@ exports[`Select search and select 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -12844,12 +13005,15 @@ exports[`Select search and select 2`] = `
     </div>
     <div
       class="c7"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c8 c9"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -12864,8 +13028,11 @@ exports[`Select search and select 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c8 c9"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -13133,6 +13300,8 @@ exports[`Select select an object with label key specific with keypress 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -13399,6 +13568,8 @@ exports[`Select select an option 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -13611,6 +13782,8 @@ exports[`Select select an option with complex options 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 "
   id="test-select"
@@ -13873,6 +14046,8 @@ exports[`Select select an option with enter 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -14139,6 +14314,8 @@ exports[`Select select an option with keypress 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -14405,6 +14582,8 @@ exports[`Select select on multiple keydown always picks first enabled option 1`]
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -14684,6 +14863,8 @@ exports[`Select select option by typing should not break if caller passes JSX 1`
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-select"
@@ -14737,6 +14918,8 @@ exports[`Select select option by typing should not break if caller passes JSX 2`
   class="StyledGrommet-sc-19lkkz7-0 bUiuPe"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="StyledButton-sc-323bzc-0 eiEooU Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
     id="test-select"
@@ -15017,6 +15200,8 @@ exports[`Select selected 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-select"
@@ -15297,6 +15482,8 @@ exports[`Select should apply a11yTitle or aria-label 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="test"
     class="c1 c2"
     type="button"
@@ -15341,6 +15528,8 @@ exports[`Select should apply a11yTitle or aria-label 1`] = `
     </div>
   </button>
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="test-select"
     class="c1 c2"
     type="button"
@@ -15619,6 +15808,8 @@ exports[`Select should not have accessibility violations 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="test"
     class="c1 c2"
     type="button"
@@ -15886,6 +16077,8 @@ exports[`Select size 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -16154,12 +16347,15 @@ exports[`Select small drop container height 1`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -16174,8 +16370,11 @@ exports[`Select small drop container height 1`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -219,6 +219,8 @@ exports[`Select Controlled deselect an option 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -485,6 +487,8 @@ exports[`Select Controlled multiple 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -763,6 +767,8 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-select"
@@ -1098,13 +1104,16 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="true"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
-        tabindex="-1"
+        role="option"
+        tabindex="0"
         type="button"
       >
         <div
@@ -1118,8 +1127,11 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c9 c10"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -1382,6 +1394,8 @@ exports[`Select Controlled multiple onChange with valueKey reduce 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-select"
@@ -1652,12 +1666,15 @@ exports[`Select Controlled multiple onChange with valueKey reduce 2`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -1672,8 +1689,11 @@ exports[`Select Controlled multiple onChange with valueKey reduce 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -1936,6 +1956,8 @@ exports[`Select Controlled multiple onChange with valueKey string 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-select"
@@ -2206,12 +2228,15 @@ exports[`Select Controlled multiple onChange with valueKey string 2`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -2226,8 +2251,11 @@ exports[`Select Controlled multiple onChange with valueKey string 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -2490,6 +2518,8 @@ exports[`Select Controlled multiple onChange without valueKey 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-select"
@@ -2760,12 +2790,15 @@ exports[`Select Controlled multiple onChange without valueKey 2`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -2780,8 +2813,11 @@ exports[`Select Controlled multiple onChange without valueKey 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -2826,12 +2862,14 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
   >
     <div
       class="SelectContainer__OptionsBox-sc-1wi0ul8-0 jviAPV"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-setsize="2"
         class="StyledButton-sc-323bzc-0 cmzBhQ SelectContainer__SelectOption-sc-1wi0ul8-1 jRnsyM"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -2846,8 +2884,10 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-setsize="2"
         class="StyledButton-sc-323bzc-0 cmzBhQ SelectContainer__SelectOption-sc-1wi0ul8-1 jRnsyM"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -3097,6 +3137,8 @@ exports[`Select Controlled multiple values 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -3146,6 +3188,8 @@ exports[`Select Controlled multiple values 1`] = `
 
 exports[`Select Controlled multiple values 2`] = `
 <button
+  aria-expanded="true"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="StyledButton-sc-323bzc-0 eiEooU Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
   id="test-select"
@@ -3412,13 +3456,16 @@ exports[`Select Controlled multiple values 3`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="true"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
-        tabindex="-1"
+        role="option"
+        tabindex="0"
         type="button"
       >
         <div
@@ -3432,9 +3479,12 @@ exports[`Select Controlled multiple values 3`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="true"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
-        tabindex="-1"
+        role="option"
+        tabindex="0"
         type="button"
       >
         <div
@@ -3696,6 +3746,8 @@ exports[`Select Controlled multiple with empty results 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="Open Drop"
     class="c1 c2"
     id="test-select"
@@ -3966,12 +4018,15 @@ exports[`Select Controlled multiple with empty results 2`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="0"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -3986,8 +4041,11 @@ exports[`Select Controlled multiple with empty results 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -4237,6 +4295,8 @@ exports[`Select Controlled select another option 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Open Drop"
   class="c0 c1"
   id="test-select"
@@ -4516,6 +4576,8 @@ exports[`Select Controlled should not have accessibility violations 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="test"
     class="c1 c2"
     type="button"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Add [aria state attributes](https://www.w3.org/TR/wai-aria-1.1/#aria-setsize) to Select component to better identify active options, the position of each item, and the total amount of options available regardless of how many items are on the DOM (for instance, when using infinite scroll)

#### Where should the reviewer start?
`src/js/components/Select/Select.js`

#### What testing has been done on this PR?
`yarn test`

#### How should this be manually tested?
`yarn storybook`, choose a select story and turn on your screen reader

#### Any background context you want to provide?

#### What are the relevant issues?
Related to #5898 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backwards compatible