### PR TITLE
Fix TextInput scroll issue

### DIFF
--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -151,6 +151,13 @@ const TextInput = forwardRef(
       if (onSuggestionsClose) onSuggestionsClose();
     }, [onSuggestionsClose, suggestions]);
 
+    const clickOutside = useCallback(
+      (event) => {
+        if (event.target !== inputRef.current) closeDrop();
+      },
+      [inputRef, closeDrop],
+    );
+
     // Handle scenarios where we have focus, the drop isn't showing,
     // and the suggestions change. We don't want to open the drop if
     // the drop has been closed by onEsc and the suggestions haven't
@@ -315,11 +322,7 @@ const TextInput = forwardRef(
           align={dropAlign}
           responsive={false}
           target={dropTarget || inputRef.current}
-          onClickOutside={({ target }) => {
-            if (target !== inputRef.current) {
-              closeDrop();
-            }
-          }}
+          onClickOutside={clickOutside}
           onEsc={closeDrop}
           {...dropProps}
         >


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where TextInput would jump back up to the most recent hovered option when scrolling.
The fix moves the content in `onClickOutside` to a callback function. Using an arrow function was causing unnecessary re-renders which resulted in the jumping scroll behavior. `useCallback` ensures the component only re-renders when necessary.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with TextInput Default suggestion and Custom suggestion stories.

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #4098 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Maybe

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible