### PR TITLE
types(theme): fixes disabled opacity type

### DIFF
--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1462,7 +1462,7 @@ export interface ThemeType {
   };
   textInput?: {
     extend?: ExtendType;
-    disabled?: OpacityType;
+    disabled?: OpacityType | { opacity: OpacityType };
     container?: {
       extend?: ExtendType;
     };


### PR DESCRIPTION
#### What does this PR do?

According to [this line](https://github.com/grommet/grommet/blob/31456ab4f9dbcf314030dc4f1984d7a8e40cba53/src/js/components/TextInput/StyledTextInput.js?_pjax=%23js-repo-pjax-container%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%2C%20%5Bdata-pjax-container%5D#L32) in the StyledTextInput definition and the [TextInput docs](https://v2.grommet.io/textinput#:~:text=textInput.disabled.opacity), the type for `theme.textInput.disabled` should include something with a property of `opacity`.

This PR updates that type in the ThemeType to align with the usage and documentation.  Since I don't know if the existing type is also acceptable, I left it in place.

#### Where should the reviewer start?

N/A

#### What testing has been done on this PR?

N/A

#### How should this be manually tested?

Assign a theme object that uses the `theme.textInput.disabled.opacity` to a variable with the type: `ThemeType`.

Alternatively, you can do the following:

```ts
const Foo: ThemeType["textInput"] = { disabled: { opacity: 1 } };
```

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

I was updating our theme and noticed this issue and jumped straight to a PR.  I did not submit an issue and don't know if there is one already open - sorry!

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible