### PR TITLE
Changed DataChart to add type 'areas'

### DIFF
--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -522,7 +522,7 @@ const DataChart = forwardRef(
                     {...seriesStyles[pProp]}
                     {...chartProps[i]}
                     {...chartRest}
-                    type={type === 'areas' ? 'area' : 'bars'}
+                    type={type === 'areas' ? 'area' : 'bar'}
                     size={size}
                     pad={pad}
                   />

--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -109,10 +109,11 @@ const DataChart = forwardRef(
         charts.map(({ opacity, property, type }) => {
           if (property) {
             if (Array.isArray(property)) {
-              // A range chart or a stacked bar chart have multiple properties.
+              // A range chart or a stacked bar or area chart has multiple
+              // properties.
               // In this case, this returns an array of values,
               // one per property.
-              if (type === 'bars') {
+              if (type === 'bars' || type === 'areas') {
                 // Further down, where we render, each property is rendered
                 // using a separate Chart component and the values are stacked
                 // such that they line up appropriately.
@@ -256,11 +257,12 @@ const DataChart = forwardRef(
       } else steps[1] = 1;
 
       let chartBounds = chartValues.map((_, index) => {
-        if (charts[index].type === 'bars') {
-          // merge values for bars case
+        const { type } = charts[index];
+        if (type === 'bars' || type === 'areas') {
+          // merge values for bars and areas cases
           let mergedValues = chartValues[index][0].slice(0);
           chartValues[index]
-            .slice(1)
+            .slice(1) // skip first index as that is the x value
             .filter((values) => values) // property name isn't valid
             .forEach((values) => {
               mergedValues = mergedValues.map((__, i) => [
@@ -290,8 +292,14 @@ const DataChart = forwardRef(
       }
 
       return chartValues.map((values, index) => {
-        const calcValues = charts[index].type === 'bars' ? values[0] : values;
-        return calcs(calcValues, { bounds: chartBounds[index], steps });
+        const { thickness, type } = charts[index];
+        const calcValues =
+          type === 'bars' || type === 'areas' ? values[0] : values;
+        return calcs(calcValues, {
+          bounds: chartBounds[index],
+          steps,
+          thickness,
+        });
       });
     }, [axis, boundsProp, charts, chartValues, data, granularities]);
 
@@ -499,7 +507,7 @@ const DataChart = forwardRef(
         {guide && guide.x && <XGuide guide={guide} pad={pad} />}
         {guide && guide.y && <YGuide guide={guide} pad={pad} />}
         {charts.map(({ property: prop, type, x, y, ...chartRest }, i) => {
-          if (type === 'bars') {
+          if (type === 'bars' || type === 'areas') {
             // reverse to ensure area Charts are stacked in the right order
             return prop
               .map((cProp, j) => {
@@ -514,7 +522,7 @@ const DataChart = forwardRef(
                     {...seriesStyles[pProp]}
                     {...chartProps[i]}
                     {...chartRest}
-                    type="bar"
+                    type={type === 'areas' ? 'area' : 'bars'}
                     size={size}
                     pad={pad}
                   />

--- a/src/js/components/DataChart/__tests__/DataChart-test.js
+++ b/src/js/components/DataChart/__tests__/DataChart-test.js
@@ -263,4 +263,18 @@ describe('DataChart', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('areas', () => {
+    const { container } = render(
+      <Grommet>
+        <DataChart
+          data={data}
+          series={['a', 'c']}
+          chart={[{ property: ['a', 'c'], type: 'areas' }]}
+        />
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
+++ b/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
@@ -1,5 +1,280 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DataChart areas 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: yAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 1;
+  -ms-flex: 0 1;
+  flex: 0 1;
+  -webkit-flex-basis: 96px;
+  -ms-flex-preferred-size: 96px;
+  flex-basis: 96px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: xAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+}
+
+.c8 {
+  display: block;
+  max-width: 100%;
+  overflow: visible;
+}
+
+.c6 {
+  position: relative;
+  grid-area: charts;
+}
+
+.c7 {
+  position: relative;
+  display: block;
+}
+
+.c9 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        <div
+          class="c4"
+        >
+          240K
+        </div>
+        <div
+          class="c4"
+        >
+          0K
+        </div>
+      </div>
+      <div
+        class="c5"
+        style="height: 0px;"
+      />
+    </div>
+    <div
+      class="c2"
+    >
+      <div
+        class="c6"
+      >
+        <div
+          class="c7"
+        >
+          <svg
+            class="c8"
+            height="192"
+            preserveAspectRatio="none"
+            viewBox="0 0 384 192"
+            width="384"
+          >
+            0
+            <g
+              fill="#00873D"
+              stroke="#00873D"
+              stroke-linecap="butt"
+              stroke-linejoin="miter"
+              stroke-width="96"
+            >
+              <g>
+                <path
+                  d="M 48,99.5552 L 336,55.1104 L 336,143.9992 L 48,143.9996 Z"
+                />
+              </g>
+            </g>
+          </svg>
+        </div>
+        <div
+          class="c9"
+        >
+          <svg
+            class="c8"
+            height="192"
+            preserveAspectRatio="none"
+            viewBox="0 0 384 192"
+            width="384"
+          >
+            0
+            <g
+              fill="#6FFFB0"
+              stroke="#6FFFB0"
+              stroke-linecap="butt"
+              stroke-linejoin="miter"
+              stroke-width="96"
+            >
+              <g>
+                <path
+                  d="M 48,143.9996 L 336,143.9992 L 336,144 L 48,144 Z"
+                />
+              </g>
+            </g>
+          </svg>
+        </div>
+      </div>
+      <div
+        class="c10"
+      >
+        <div
+          class="c11"
+        >
+          0
+        </div>
+        <div
+          class="c11"
+        >
+          1
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DataChart axis 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/DataChart/index.d.ts
+++ b/src/js/components/DataChart/index.d.ts
@@ -33,7 +33,7 @@ type ChartType =
           };
       round?: ChartProps['round']; // defaults to undefined
       thickness?: ChartProps['thickness']; // defaults to auto assigned based on available space and amount of data
-      type?: ChartProps['type'] | 'bars'; // defaults to 'bar',
+      type?: ChartProps['type'] | 'bars' | 'areas'; // defaults to 'bar',
     };
 
 type SeriesType =

--- a/src/js/components/DataChart/propTypes.js
+++ b/src/js/components/DataChart/propTypes.js
@@ -71,7 +71,7 @@ const chartType = PropTypes.oneOfType([
     point: pointPropType,
     round: PropTypes.bool,
     thickness: thicknessType,
-    type: PropTypes.oneOf(['bar', 'bars', 'line', 'area', 'point']),
+    type: PropTypes.oneOf(['bar', 'bars', 'line', 'area', 'areas', 'point']),
   }),
 ]);
 

--- a/src/js/components/DataChart/stories/StackedAreas.js
+++ b/src/js/components/DataChart/stories/StackedAreas.js
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import { Box, DataChart, Text } from 'grommet';
+
+const data = [];
+for (let i = 0; i < 7; i += 1) {
+  data.push({
+    date: `2020-07-${((i % 31) + 1).toString().padStart(2, 0)}`,
+    usage: Math.floor(Math.abs(Math.sin(i / 2.0) * 100)),
+    bonus: Math.floor(Math.abs(Math.cos(i / 2.0) * 100)),
+  });
+}
+
+export const StackedAreas = () => (
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={grommet}>
+  <Box align="center" justify="start" pad="large">
+    <DataChart
+      data={data}
+      series={[
+        {
+          property: 'date',
+          render: (date) => (
+            <Text margin={{ horizontal: 'xsmall' }}>
+              {new Date(date).toLocaleDateString('en-US', {
+                month: 'numeric',
+                day: 'numeric',
+              })}
+            </Text>
+          ),
+        },
+        'usage',
+        'bonus',
+      ]}
+      chart={[
+        {
+          property: ['usage', 'bonus'],
+          type: 'areas',
+          thickness: 'hair',
+        },
+      ]}
+      axis={{ x: { property: 'date', granularity: 'fine' }, y: true }}
+      guide={{ y: true }}
+      legend
+    />
+  </Box>
+  // </Grommet>
+);
+
+StackedAreas.storyName = 'Stacked areas';
+
+export default {
+  title: 'Visualizations/DataChart/Stacked areas',
+};


### PR DESCRIPTION
#### What does this PR do?

Changed DataChart to add type 'areas'.

#### Where should the reviewer start?

DataChart.js

#### What testing has been done on this PR?

Added a story.
Tested with grommet-designer.

#### How should this be manually tested?

Stacked areas story

#### Do Jest tests follow these best practices?

not yet, following existing tests in DataChart for now

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Screenshots (if appropriate)

![Screen Shot 2022-02-04 at 5 19 41 PM](https://user-images.githubusercontent.com/11637956/152623170-b96a03ad-6627-4151-811f-764967f71ed1.png)

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
