### PR TITLE
Improve Select screenreader and keyboard navigation experience

### DIFF
--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -753,6 +753,8 @@ exports[`Form accessibility Select in Form should have no accessibility violatio
         class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
       >
         <button
+          aria-expanded="false"
+          aria-haspopup="listbox"
           aria-label="test"
           class="c3 "
           type="button"
@@ -3119,7 +3121,9 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
         class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
       >
         <button
-          aria-label="Open Drop"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-label="test select; Selected: small"
           class="c4 "
           id="test-select"
           type="button"
@@ -3355,7 +3359,9 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
         class="StyledBox-sc-13pk1d4-0 ctACHi FormField__FormFieldContentBox-sc-m9hood-1"
       >
         <button
-          aria-label="Open Drop"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-label="test select"
           class="StyledButton-sc-323bzc-0 fhAZId Select__StyledSelectDropButton-sc-17idtfo-2 fJfYtd"
           id="test-select"
           type="button"

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -101,6 +101,9 @@ const Select = forwardRef(
     const formContext = useContext(FormContext);
     const { format } = useContext(MessageContext);
 
+    // Determine if the Select is opened with the keyboard. If so,
+    // focus should be set on the first option when the drop opens
+    // see set initial focus code in SelectContainer.js
     const [usingKeyboard, setUsingKeyboard] = useState();
 
     const onMouseDown = () => setUsingKeyboard(false);

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -100,6 +100,20 @@ const Select = forwardRef(
     const inputRef = useRef();
     const formContext = useContext(FormContext);
     const { format } = useContext(MessageContext);
+
+    const [usingKeyboard, setUsingKeyboard] = useState();
+
+    const onMouseDown = () => setUsingKeyboard(false);
+    const onKeyPress = () => setUsingKeyboard(true);
+    useEffect(() => {
+      document.addEventListener('mousedown', onMouseDown);
+      document.addEventListener('keydown', onKeyPress);
+      return () => {
+        document.removeEventListener('mousedown', onMouseDown);
+        document.removeEventListener('keydown', onKeyPress);
+      };
+    }, []);
+
     // value is used for what we receive in valueProp and the basis for
     // what we send with onChange
     // When 'valueKey' sets 'reduce', the value(s) here should match
@@ -338,6 +352,7 @@ const Select = forwardRef(
               search={search}
               setSearch={setSearch}
               selected={selected}
+              usingKeyboard={usingKeyboard}
               value={value}
               valueKey={valueKey}
             >

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -291,7 +291,8 @@ const Select = forwardRef(
         <StyledSelectDropButton
           ref={ref}
           a11yTitle={
-            `${placeholder}${
+            // let title = ariaLabel || a11yTitle || placeholder || undefined;
+            `${ariaLabel || a11yTitle || placeholder || undefined}${
               value
                 ? format({
                     id: 'select.selected',
@@ -299,10 +300,10 @@ const Select = forwardRef(
                     values: { currentSelectedValue: value },
                   })
                 : ''
-            }` ||
-            ariaLabel ||
-            a11yTitle
+            }`
           }
+          aria-expanded={Boolean(open)}
+          aria-haspopup="listbox"
           id={id}
           disabled={disabled === true || undefined}
           dropAlign={dropAlign}
@@ -317,8 +318,6 @@ const Select = forwardRef(
           onOpen={onRequestOpen}
           onClose={onRequestClose}
           onClick={onClick}
-          aria-haspopup="listbox"
-          aria-expanded={open}
           dropContent={
             <SelectContainer
               clear={clear}

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -290,7 +290,19 @@ const Select = forwardRef(
       <Keyboard onDown={onRequestOpen} onUp={onRequestOpen}>
         <StyledSelectDropButton
           ref={ref}
-          a11yTitle={ariaLabel || a11yTitle}
+          a11yTitle={
+            `${placeholder}${
+              value
+                ? format({
+                    id: 'select.selected',
+                    messages,
+                    values: { currentSelectedValue: value },
+                  })
+                : ''
+            }` ||
+            ariaLabel ||
+            a11yTitle
+          }
           id={id}
           disabled={disabled === true || undefined}
           dropAlign={dropAlign}
@@ -305,6 +317,8 @@ const Select = forwardRef(
           onOpen={onRequestOpen}
           onClose={onRequestClose}
           onClick={onClick}
+          aria-haspopup="listbox"
+          aria-expanded={open}
           dropContent={
             <SelectContainer
               clear={clear}

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -77,6 +77,7 @@ const SelectContainer = forwardRef(
       search,
       setSearch,
       selected,
+      usingKeyboard,
       value = '',
       valueKey,
       replace = true,
@@ -113,12 +114,17 @@ const SelectContainer = forwardRef(
           if (searchInput && searchInput.focus) {
             setFocusWithoutScroll(searchInput);
           }
+        } else if (optionsNode && optionsNode.children && usingKeyboard) {
+          // if the user is navigating with the keyboard set the
+          // first child as the active index when the drop opens
+          setFocusWithoutScroll(optionsNode.children[0]);
+          setActiveIndex(0);
         } else if (optionsNode) {
           setFocusWithoutScroll(optionsNode);
         }
       }, 100);
       return () => clearTimeout(timer);
-    }, [onSearch]);
+    }, [onSearch, usingKeyboard]);
 
     // clear keyboardNavigation after a while
     useEffect(() => {

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -94,7 +94,6 @@ const SelectContainer = forwardRef(
       const optionsNode = optionsRef.current;
       if (optionsNode.children && optionsNode.children[activeIndex])
         optionsNode.children[activeIndex].focus();
-      console.log(optionsNode.children[activeIndex]);
     }, [activeIndex]);
 
     // adjust activeIndex when options change

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -232,9 +232,6 @@ const SelectContainer = forwardRef(
             value: nextValue,
             selected: nextSelected,
           });
-          const optionsNode = optionsRef.current;
-          if (optionsNode.children && optionsNode.children[activeIndex])
-            optionsNode.children[activeIndex].focus();
         }
       },
       [multiple, onChange, optionIndexesInValue, options, allOptions, valueKey],
@@ -336,114 +333,7 @@ const SelectContainer = forwardRef(
         }
       : {};
 
-    const itemsTest = options.map((option, index) => {
-      const optionDisabled = isDisabled(index);
-      const optionSelected = isSelected(index);
-      const optionActive = activeIndex === index;
-      // Determine whether the label is done as a child or
-      // as an option Button kind property.
-      let child;
-      let textComponent = false;
-      if (children) {
-        child = children(option, index, options, {
-          active: optionActive,
-          disabled: optionDisabled,
-          selected: optionSelected,
-        });
-        if (
-          typeof child === 'string' ||
-          (child.props &&
-            child.props.children &&
-            typeof child.props.children === 'string')
-        )
-          textComponent = true;
-      } else if (theme.select.options) {
-        child = (
-          <Box {...selectOptionsStyle}>
-            <Text {...theme.select.options.text}>{optionLabel(index)}</Text>
-          </Box>
-        );
-        textComponent = true;
-      }
-
-      return (
-        <SelectOption
-          // focusIndicator={false}
-          // eslint-disable-next-line react/no-array-index-key
-          key={index}
-          // ref={optionRef}
-          tabIndex="-1"
-          role="option"
-          plain={!child ? undefined : true}
-          align="start"
-          kind={!child ? 'option' : undefined}
-          hoverIndicator={!child ? undefined : 'background'}
-          label={!child ? optionLabel(index) : undefined}
-          disabled={optionDisabled || undefined}
-          aria-disabled={optionDisabled || undefined}
-          active={optionActive}
-          selected={optionSelected}
-          option={option}
-          aria-selected={optionSelected}
-          // aria-activedescendant={optionActive}
-          focus={optionActive}
-          onMouseOver={!optionDisabled ? onActiveOption(index) : undefined}
-          onClick={!optionDisabled ? selectOption(index) : undefined}
-          textComponent={textComponent}
-        >
-          {child}
-        </SelectOption>
-      );
-    });
-
     return (
-      // <Keyboard
-      //   onEnter={onSelectOption}
-      //   onUp={onPreviousOption}
-      //   onDown={onNextOption}
-      //   onKeyDown={onKeyDownOption}
-      // >
-      //   <StyledContainer
-      //     ref={ref}
-      //     as={Box}
-      //     id={id ? `${id}__select-drop` : undefined}
-      //     dropHeight={dropHeight}
-      //   >
-      //     {onSearch && (
-      //       <Box pad={!customSearchInput ? 'xsmall' : undefined} flex={false}>
-      //         <SelectTextInput
-      //           focusIndicator={!customSearchInput}
-      //           size="small"
-      //           ref={searchRef}
-      //           type="search"
-      //           value={search || ''}
-      //           placeholder={searchPlaceholder}
-      //           onChange={(event) => {
-      //             const nextSearch = event.target.value;
-      //             setSearch(nextSearch);
-      //             setActiveIndex(-1);
-      //             onSearch(nextSearch);
-      //           }}
-      //         />
-      //       </Box>
-      //     )}
-      //     {clear && clear.position !== 'bottom' && value && (
-      //       <ClearButton
-      //         clear={clear}
-      //         name={name}
-      //         onClear={onClear}
-      //         theme={theme}
-      //         setFocus={setFocus}
-      //       />
-      //     )}
-      //     <OptionsBox
-      //       role="listbox"
-      //       id="listbox1"
-      //       // tabIndex="-1"
-      //       ref={optionsRef}
-      //     >
-      //       {itemsTest}
-
       <Keyboard
         onEnter={onSelectOption}
         onUp={onPreviousOption}
@@ -485,12 +375,9 @@ const SelectContainer = forwardRef(
           )}
           <OptionsBox
             role="listbox"
-            // role="combobox"
             tabIndex="-1"
             ref={optionsRef}
-            // aria-activedescendant={optionActive}
             aria-multiselectable={multiple}
-            // id="listbox1"
           >
             {options.length > 0 ? (
               <InfiniteScroll
@@ -531,33 +418,29 @@ const SelectContainer = forwardRef(
                     );
                     textComponent = true;
                   }
-                  // console.log(optionSelected);
-                  // if we have a child, turn on plain, and hoverIndicator
 
+                  // if we have a child, turn on plain, and hoverIndicator
                   return (
                     <SelectOption
-                      // focusIndicator={false}
                       // eslint-disable-next-line react/no-array-index-key
                       key={index}
                       ref={optionRef}
-                      tabIndex="-1"
-                      // tabIndex={optionSelected ? '0' : '-1'}
-                      aria-setsize={options.length}
-                      aria-posinset={index}
+                      tabIndex={optionSelected ? '0' : '-1'}
                       role="option"
+                      aria-setsize={options.length}
+                      aria-posinset={index + 1}
+                      aria-selected={optionSelected}
+                      focusIndicator={false}
+                      aria-disabled={optionDisabled || undefined}
                       plain={!child ? undefined : true}
                       align="start"
                       kind={!child ? 'option' : undefined}
                       hoverIndicator={!child ? undefined : 'background'}
                       label={!child ? optionLabel(index) : undefined}
                       disabled={optionDisabled || undefined}
-                      aria-disabled={optionDisabled || undefined}
                       active={optionActive}
                       selected={optionSelected}
                       option={option}
-                      aria-selected={optionSelected}
-                      // aria-activedescendant={optionActive}
-                      // focus={optionActive}
                       onMouseOver={
                         !optionDisabled ? onActiveOption(index) : undefined
                       }
@@ -565,27 +448,6 @@ const SelectContainer = forwardRef(
                         !optionDisabled ? selectOption(index) : undefined
                       }
                       textComponent={textComponent}
-                      // eslint-disable-next-line react/no-array-index-key
-                      // key={index}
-                      // ref={optionRef}
-                      // tabIndex="-1"
-                      // role="menuitem"
-                      // plain={!child ? undefined : true}
-                      // align="start"
-                      // kind={!child ? 'option' : undefined}
-                      // hoverIndicator={!child ? undefined : 'background'}
-                      // label={!child ? optionLabel(index) : undefined}
-                      // disabled={optionDisabled || undefined}
-                      // active={optionActive}
-                      // selected={optionSelected}
-                      // option={option}
-                      // onMouseOver={
-                      //   !optionDisabled ? onActiveOption(index) : undefined
-                      // }
-                      // onClick={
-                      //   !optionDisabled ? selectOption(index) : undefined
-                      // }
-                      // textComponent={textComponent}
                     >
                       {child}
                     </SelectOption>

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -89,6 +89,14 @@ const SelectContainer = forwardRef(
     const [focus, setFocus] = useState(false);
     const searchRef = useRef();
     const optionsRef = useRef();
+
+    useEffect(() => {
+      const optionsNode = optionsRef.current;
+      if (optionsNode.children && optionsNode.children[activeIndex])
+        optionsNode.children[activeIndex].focus();
+      console.log(optionsNode.children[activeIndex]);
+    }, [activeIndex]);
+
     // adjust activeIndex when options change
     useEffect(() => {
       if (activeIndex === -1 && search && optionIndexesInValue.length) {
@@ -106,6 +114,9 @@ const SelectContainer = forwardRef(
           if (searchInput && searchInput.focus) {
             setFocusWithoutScroll(searchInput);
           }
+        } else if (optionsNode && optionsNode.children) {
+          setFocusWithoutScroll(optionsNode.children[0]);
+          setActiveIndex(0);
         } else if (optionsNode) {
           setFocusWithoutScroll(optionsNode);
         }
@@ -221,6 +232,9 @@ const SelectContainer = forwardRef(
             value: nextValue,
             selected: nextSelected,
           });
+          const optionsNode = optionsRef.current;
+          if (optionsNode.children && optionsNode.children[activeIndex])
+            optionsNode.children[activeIndex].focus();
         }
       },
       [multiple, onChange, optionIndexesInValue, options, allOptions, valueKey],
@@ -322,7 +336,114 @@ const SelectContainer = forwardRef(
         }
       : {};
 
+    const itemsTest = options.map((option, index) => {
+      const optionDisabled = isDisabled(index);
+      const optionSelected = isSelected(index);
+      const optionActive = activeIndex === index;
+      // Determine whether the label is done as a child or
+      // as an option Button kind property.
+      let child;
+      let textComponent = false;
+      if (children) {
+        child = children(option, index, options, {
+          active: optionActive,
+          disabled: optionDisabled,
+          selected: optionSelected,
+        });
+        if (
+          typeof child === 'string' ||
+          (child.props &&
+            child.props.children &&
+            typeof child.props.children === 'string')
+        )
+          textComponent = true;
+      } else if (theme.select.options) {
+        child = (
+          <Box {...selectOptionsStyle}>
+            <Text {...theme.select.options.text}>{optionLabel(index)}</Text>
+          </Box>
+        );
+        textComponent = true;
+      }
+
+      return (
+        <SelectOption
+          // focusIndicator={false}
+          // eslint-disable-next-line react/no-array-index-key
+          key={index}
+          // ref={optionRef}
+          tabIndex="-1"
+          role="option"
+          plain={!child ? undefined : true}
+          align="start"
+          kind={!child ? 'option' : undefined}
+          hoverIndicator={!child ? undefined : 'background'}
+          label={!child ? optionLabel(index) : undefined}
+          disabled={optionDisabled || undefined}
+          aria-disabled={optionDisabled || undefined}
+          active={optionActive}
+          selected={optionSelected}
+          option={option}
+          aria-selected={optionSelected}
+          // aria-activedescendant={optionActive}
+          focus={optionActive}
+          onMouseOver={!optionDisabled ? onActiveOption(index) : undefined}
+          onClick={!optionDisabled ? selectOption(index) : undefined}
+          textComponent={textComponent}
+        >
+          {child}
+        </SelectOption>
+      );
+    });
+
     return (
+      // <Keyboard
+      //   onEnter={onSelectOption}
+      //   onUp={onPreviousOption}
+      //   onDown={onNextOption}
+      //   onKeyDown={onKeyDownOption}
+      // >
+      //   <StyledContainer
+      //     ref={ref}
+      //     as={Box}
+      //     id={id ? `${id}__select-drop` : undefined}
+      //     dropHeight={dropHeight}
+      //   >
+      //     {onSearch && (
+      //       <Box pad={!customSearchInput ? 'xsmall' : undefined} flex={false}>
+      //         <SelectTextInput
+      //           focusIndicator={!customSearchInput}
+      //           size="small"
+      //           ref={searchRef}
+      //           type="search"
+      //           value={search || ''}
+      //           placeholder={searchPlaceholder}
+      //           onChange={(event) => {
+      //             const nextSearch = event.target.value;
+      //             setSearch(nextSearch);
+      //             setActiveIndex(-1);
+      //             onSearch(nextSearch);
+      //           }}
+      //         />
+      //       </Box>
+      //     )}
+      //     {clear && clear.position !== 'bottom' && value && (
+      //       <ClearButton
+      //         clear={clear}
+      //         name={name}
+      //         onClear={onClear}
+      //         theme={theme}
+      //         setFocus={setFocus}
+      //       />
+      //     )}
+      //     <OptionsBox
+      //       role="listbox"
+      //       id="listbox1"
+      //       // tabIndex="-1"
+      //       ref={optionsRef}
+      //     >
+      //       {itemsTest}
+
       <Keyboard
         onEnter={onSelectOption}
         onUp={onPreviousOption}
@@ -362,7 +483,15 @@ const SelectContainer = forwardRef(
               setFocus={setFocus}
             />
           )}
-          <OptionsBox role="menubar" tabIndex="-1" ref={optionsRef}>
+          <OptionsBox
+            role="listbox"
+            // role="combobox"
+            tabIndex="-1"
+            ref={optionsRef}
+            // aria-activedescendant={optionActive}
+            aria-multiselectable={multiple}
+            // id="listbox1"
+          >
             {options.length > 0 ? (
               <InfiniteScroll
                 items={options}
@@ -402,25 +531,33 @@ const SelectContainer = forwardRef(
                     );
                     textComponent = true;
                   }
-
+                  // console.log(optionSelected);
                   // if we have a child, turn on plain, and hoverIndicator
 
                   return (
                     <SelectOption
+                      // focusIndicator={false}
                       // eslint-disable-next-line react/no-array-index-key
                       key={index}
                       ref={optionRef}
                       tabIndex="-1"
-                      role="menuitem"
+                      // tabIndex={optionSelected ? '0' : '-1'}
+                      aria-setsize={options.length}
+                      aria-posinset={index}
+                      role="option"
                       plain={!child ? undefined : true}
                       align="start"
                       kind={!child ? 'option' : undefined}
                       hoverIndicator={!child ? undefined : 'background'}
                       label={!child ? optionLabel(index) : undefined}
                       disabled={optionDisabled || undefined}
+                      aria-disabled={optionDisabled || undefined}
                       active={optionActive}
                       selected={optionSelected}
                       option={option}
+                      aria-selected={optionSelected}
+                      // aria-activedescendant={optionActive}
+                      // focus={optionActive}
                       onMouseOver={
                         !optionDisabled ? onActiveOption(index) : undefined
                       }
@@ -428,6 +565,27 @@ const SelectContainer = forwardRef(
                         !optionDisabled ? selectOption(index) : undefined
                       }
                       textComponent={textComponent}
+                      // eslint-disable-next-line react/no-array-index-key
+                      // key={index}
+                      // ref={optionRef}
+                      // tabIndex="-1"
+                      // role="menuitem"
+                      // plain={!child ? undefined : true}
+                      // align="start"
+                      // kind={!child ? 'option' : undefined}
+                      // hoverIndicator={!child ? undefined : 'background'}
+                      // label={!child ? optionLabel(index) : undefined}
+                      // disabled={optionDisabled || undefined}
+                      // active={optionActive}
+                      // selected={optionSelected}
+                      // option={option}
+                      // onMouseOver={
+                      //   !optionDisabled ? onActiveOption(index) : undefined
+                      // }
+                      // onClick={
+                      //   !optionDisabled ? selectOption(index) : undefined
+                      // }
+                      // textComponent={textComponent}
                     >
                       {child}
                     </SelectOption>

--- a/src/js/components/Select/__tests__/Select-test.js
+++ b/src/js/components/Select/__tests__/Select-test.js
@@ -104,7 +104,7 @@ describe('Select', () => {
     expect(container.firstChild).toMatchSnapshot();
     expect(document.getElementById('test-select__drop')).toBeNull();
     // advance timers so the select closes
-    jest.advanceTimersByTime(100);
+    act(() => jest.advanceTimersByTime(100));
     // verify that select was closed
     expect(document.activeElement).toMatchSnapshot();
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -376,7 +376,7 @@ describe('Select', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
     fireEvent.click(getByPlaceholderText('test select'));
-    jest.advanceTimersByTime(200);
+    act(() => jest.advanceTimersByTime(200));
     expectPortal('test-select__drop').toMatchSnapshot();
   });
 

--- a/src/js/components/Select/__tests__/Select-test.js
+++ b/src/js/components/Select/__tests__/Select-test.js
@@ -104,7 +104,7 @@ describe('Select', () => {
     expect(container.firstChild).toMatchSnapshot();
     expect(document.getElementById('test-select__drop')).toBeNull();
     // advance timers so the select closes
-    act(() => jest.advanceTimersByTime(100));
+    jest.advanceTimersByTime(100);
     // verify that select was closed
     expect(document.activeElement).toMatchSnapshot();
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -376,7 +376,7 @@ describe('Select', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
     fireEvent.click(getByPlaceholderText('test select'));
-    act(() => jest.advanceTimersByTime(200));
+    jest.advanceTimersByTime(200);
     expectPortal('test-select__drop').toMatchSnapshot();
   });
 

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -219,7 +219,9 @@ exports[`Select 0 value 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -387,26 +389,6 @@ exports[`Select Clear option renders - bottom 1`] = `
   color: #000000;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -488,12 +470,15 @@ exports[`Select Clear option renders - bottom 1`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -508,8 +493,11 @@ exports[`Select Clear option renders - bottom 1`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -662,26 +650,6 @@ exports[`Select Clear option renders correct label when wrapped in FormField 1`]
   color: #000000;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -772,12 +740,15 @@ exports[`Select Clear option renders correct label when wrapped in FormField 1`]
     
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -792,8 +763,11 @@ exports[`Select Clear option renders correct label when wrapped in FormField 1`]
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -945,26 +919,6 @@ exports[`Select Clear option renders custom label 1`] = `
   color: #000000;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -1047,12 +1001,15 @@ exports[`Select Clear option renders custom label 1`] = `
     
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -1067,8 +1024,11 @@ exports[`Select Clear option renders custom label 1`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -1220,26 +1180,6 @@ exports[`Select Clear option renders- top 1`] = `
   color: #000000;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -1322,12 +1262,15 @@ exports[`Select Clear option renders- top 1`] = `
     
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -1342,8 +1285,11 @@ exports[`Select Clear option renders- top 1`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -1623,7 +1569,9 @@ exports[`Select Search timeout 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="true"
+    aria-haspopup="listbox"
+    aria-label="test select"
     class="c1 c2"
     data-g-tabindex="none"
     id="test-select"
@@ -1999,7 +1947,9 @@ exports[`Select applies custom global.hover theme to options 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="Select..."
     class="c1 c2"
     id="applies-custom-hover-style-id"
     type="button"
@@ -2094,31 +2044,6 @@ exports[`Select applies custom global.hover theme to options 2`] = `
   color: #000000;
 }
 
-.c0:hover {
-  background-color: lightgreen;
-  color: #7D4CDB;
-}
-
-.c0:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c0:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c0:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -2163,8 +2088,11 @@ exports[`Select applies custom global.hover theme to options 2`] = `
 }
 
 <button
+  aria-posinset="2"
+  aria-selected="false"
+  aria-setsize="3"
   class="c0 c1"
-  role="menuitem"
+  role="option"
   tabindex="-1"
   type="button"
 >
@@ -2399,6 +2327,8 @@ exports[`Select basic 1`] = `
 }
 
 <button
+  aria-expanded="false"
+  aria-haspopup="listbox"
   aria-label="Select"
   class="c0 c1"
   id="test-select"
@@ -2665,7 +2595,9 @@ exports[`Select complex options and children 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -2714,7 +2646,9 @@ exports[`Select complex options and children 1`] = `
 
 exports[`Select complex options and children 2`] = `
 <button
-  aria-label="Open Drop"
+  aria-expanded="true"
+  aria-haspopup="listbox"
+  aria-label="test select"
   class="StyledButton-sc-323bzc-0 eiEooU Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
   id="test-select"
   type="button"
@@ -2857,26 +2791,6 @@ exports[`Select complex options and children 3`] = `
   color: #000000;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -2952,12 +2866,15 @@ exports[`Select complex options and children 3`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -2966,8 +2883,11 @@ exports[`Select complex options and children 3`] = `
         </span>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -3253,7 +3173,9 @@ exports[`Select dark 1`] = `
     class="c1"
   >
     <button
-      aria-label="Open Drop"
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-label="Select"
       class="c2 c3"
       type="button"
     >
@@ -3532,7 +3454,9 @@ exports[`Select default value 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="test select; Selected: two"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -3785,26 +3709,6 @@ exports[`Select default value clear 1`] = `
   color: #000000;
 }
 
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -3841,26 +3745,6 @@ exports[`Select default value clear 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
-}
-
-.c12:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c12:focus::-moz-focus-inner {
-  border: 0;
 }
 
 .c12:focus:not(:focus-visible) {
@@ -3971,12 +3855,15 @@ exports[`Select default value clear 1`] = `
     </button>
     <div
       class="c7"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c8 c9"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -3991,9 +3878,12 @@ exports[`Select default value clear 1`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="true"
+        aria-setsize="2"
         class="c12 c13"
-        role="menuitem"
-        tabindex="-1"
+        role="option"
+        tabindex="0"
         type="button"
       >
         <div
@@ -4255,7 +4145,9 @@ exports[`Select default value object options 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="test select; Selected: 2"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -4524,7 +4416,9 @@ exports[`Select disabled 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select"
   class="c0 c1"
   disabled=""
   id="test-select"
@@ -4574,7 +4468,9 @@ exports[`Select disabled 1`] = `
 
 exports[`Select disabled 2`] = `
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select"
   class="StyledButton-sc-323bzc-0 ijdOBy Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
   disabled=""
   id="test-select"
@@ -4854,7 +4750,9 @@ exports[`Select disabled key 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="test select"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -5355,26 +5253,6 @@ exports[`Select disabled option value 1`] = `
   cursor: default;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -5416,26 +5294,6 @@ exports[`Select disabled option value 1`] = `
 .c9:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus::-moz-focus-inner {
-  border: 0;
 }
 
 .c9:focus:not(:focus-visible) {
@@ -5519,13 +5377,17 @@ exports[`Select disabled option value 1`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-disabled="true"
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
         disabled=""
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -5540,8 +5402,11 @@ exports[`Select disabled option value 1`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c9 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -5910,7 +5775,9 @@ exports[`Select keyboard navigation timeout 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="true"
+    aria-haspopup="listbox"
+    aria-label="test select"
     class="c1 c2"
     data-g-tabindex="none"
     id="test-select"
@@ -6082,26 +5949,6 @@ exports[`Select large drop container height 1`] = `
   color: #000000;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -6183,12 +6030,15 @@ exports[`Select large drop container height 1`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -6203,8 +6053,11 @@ exports[`Select large drop container height 1`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -6347,26 +6200,6 @@ exports[`Select medium drop container height 1`] = `
   color: #000000;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -6448,12 +6281,15 @@ exports[`Select medium drop container height 1`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -6468,8 +6304,11 @@ exports[`Select medium drop container height 1`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -6724,7 +6563,9 @@ exports[`Select modifies select control style on open 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="Select..."
     class="c1 c2"
     id="test-open-id"
     type="button"
@@ -7005,7 +6846,9 @@ exports[`Select onChange with valueKey string 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="test select"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -7174,26 +7017,6 @@ exports[`Select onChange with valueKey string 2`] = `
   color: #000000;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -7275,12 +7098,15 @@ exports[`Select onChange with valueKey string 2`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -7295,8 +7121,11 @@ exports[`Select onChange with valueKey string 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -7510,7 +7339,9 @@ exports[`Select onChange with valueLabel 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="undefined"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -7675,26 +7506,6 @@ exports[`Select onChange with valueLabel 2`] = `
   color: #000000;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -7776,12 +7587,15 @@ exports[`Select onChange with valueLabel 2`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -7796,8 +7610,11 @@ exports[`Select onChange with valueLabel 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -8060,7 +7877,9 @@ exports[`Select onChange without valueKey 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="test select"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -8229,26 +8048,6 @@ exports[`Select onChange without valueKey 2`] = `
   color: #000000;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -8330,12 +8129,15 @@ exports[`Select onChange without valueKey 2`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -8350,8 +8152,11 @@ exports[`Select onChange without valueKey 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -8613,7 +8418,9 @@ exports[`Select prop: onClose 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -8894,7 +8701,9 @@ exports[`Select prop: onClose 2`] = `
   <div />
   <div>
     <button
-      aria-label="Open Drop"
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-label="test select"
       class="c0 c1"
       id="test-select"
       type="button"
@@ -9162,7 +8971,9 @@ exports[`Select prop: onOpen 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -9211,7 +9022,9 @@ exports[`Select prop: onOpen 1`] = `
 
 exports[`Select prop: onOpen 2`] = `
 <button
-  aria-label="Open Drop"
+  aria-expanded="true"
+  aria-haspopup="listbox"
+  aria-label="test select"
   class="StyledButton-sc-323bzc-0 eiEooU Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
   id="test-select"
   type="button"
@@ -9379,26 +9192,6 @@ exports[`Select prop: onOpen 3`] = `
   color: #000000;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -9480,12 +9273,15 @@ exports[`Select prop: onOpen 3`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -9500,8 +9296,11 @@ exports[`Select prop: onOpen 3`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -9795,7 +9594,9 @@ exports[`Select renders custom icon 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="undefined"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -10073,7 +9874,9 @@ exports[`Select renders custom up and down icons 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="Select..."
     class="c1 c2"
     type="button"
   >
@@ -10124,7 +9927,9 @@ exports[`Select renders custom up and down icons 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bUiuPe"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="true"
+    aria-haspopup="listbox"
+    aria-label="Select..."
     class="StyledButton-sc-323bzc-0 eiEooU Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
     type="button"
   >
@@ -10439,7 +10244,9 @@ exports[`Select renders default icon 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="undefined"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -10718,7 +10525,9 @@ exports[`Select renders styled select options backwards compatible with legacy
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="Select..."
     class="c1 c2"
     id="test-options-style-id"
     type="button"
@@ -11001,7 +10810,9 @@ exports[`Select renders styled select options combining select.options.box &&
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="Select..."
     class="c1 c2"
     id="test-options-style-id"
     type="button"
@@ -11282,7 +11093,9 @@ exports[`Select renders styled select options using select.options.container 1`]
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="Select..."
     class="c1 c2"
     id="test-options-style-id"
     type="button"
@@ -11490,7 +11303,9 @@ exports[`Select renders without icon 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="undefined"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -11738,7 +11553,9 @@ exports[`Select search 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select; Selected: two"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -11924,26 +11741,6 @@ exports[`Select search 2`] = `
   color: #000000;
 }
 
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -11980,26 +11777,6 @@ exports[`Select search 2`] = `
   border: none;
   padding: 0;
   text-align: inherit;
-}
-
-.c12:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c12:focus::-moz-focus-inner {
-  border: 0;
 }
 
 .c12:focus:not(:focus-visible) {
@@ -12179,12 +11956,15 @@ exports[`Select search 2`] = `
     </div>
     <div
       class="c7"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c8 c9"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -12199,9 +11979,12 @@ exports[`Select search 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="true"
+        aria-setsize="2"
         class="c12 c13"
-        role="menuitem"
-        tabindex="-1"
+        role="option"
+        tabindex="0"
         type="button"
       >
         <div
@@ -12241,12 +12024,25 @@ exports[`Select search 4`] = `
 `;
 
 exports[`Select search 5`] = `
-<input
-  autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 vgBsu"
-  type="search"
-  value="o"
-/>
+<button
+  aria-posinset="2"
+  aria-selected="true"
+  aria-setsize="2"
+  class="StyledButton-sc-323bzc-0 jXGGBG SelectContainer__SelectOption-sc-1wi0ul8-1 fFhDhl"
+  role="option"
+  tabindex="0"
+  type="button"
+>
+  <div
+    class="StyledBox-sc-13pk1d4-0 gZcrCV"
+  >
+    <span
+      class="StyledText-sc-1sadyjn-0 grcvBZ"
+    >
+      two
+    </span>
+  </div>
+</button>
 `;
 
 exports[`Select search and select 1`] = `
@@ -12468,7 +12264,9 @@ exports[`Select search and select 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -12654,26 +12452,6 @@ exports[`Select search and select 2`] = `
   color: #000000;
 }
 
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -12844,12 +12622,15 @@ exports[`Select search and select 2`] = `
     </div>
     <div
       class="c7"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c8 c9"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -12864,8 +12645,11 @@ exports[`Select search and select 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c8 c9"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -13133,7 +12917,9 @@ exports[`Select select an object with label key specific with keypress 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -13399,7 +13185,9 @@ exports[`Select select an option 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -13611,7 +13399,9 @@ exports[`Select select an option with complex options 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="undefined; Selected: [object Object]"
   class="c0 "
   id="test-select"
   type="button"
@@ -13873,7 +13663,9 @@ exports[`Select select an option with enter 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -14139,7 +13931,9 @@ exports[`Select select an option with keypress 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -14405,7 +14199,9 @@ exports[`Select select on multiple keydown always picks first enabled option 1`]
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -14684,7 +14480,9 @@ exports[`Select select option by typing should not break if caller passes JSX 1`
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="test select"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -14737,7 +14535,9 @@ exports[`Select select option by typing should not break if caller passes JSX 2`
   class="StyledGrommet-sc-19lkkz7-0 bUiuPe"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="test select; Selected: two"
     class="StyledButton-sc-323bzc-0 eiEooU Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
     id="test-select"
     type="button"
@@ -15017,7 +14817,9 @@ exports[`Select selected 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="test select"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -15297,6 +15099,8 @@ exports[`Select should apply a11yTitle or aria-label 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="test"
     class="c1 c2"
     type="button"
@@ -15341,6 +15145,8 @@ exports[`Select should apply a11yTitle or aria-label 1`] = `
     </div>
   </button>
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="test-select"
     class="c1 c2"
     type="button"
@@ -15619,6 +15425,8 @@ exports[`Select should not have accessibility violations 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="test"
     class="c1 c2"
     type="button"
@@ -15886,7 +15694,9 @@ exports[`Select size 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="undefined; Selected: "
   class="c0 c1"
   id="test-select"
   type="button"
@@ -16053,26 +15863,6 @@ exports[`Select small drop container height 1`] = `
   color: #000000;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -16154,12 +15944,15 @@ exports[`Select small drop container height 1`] = `
   >
     <div
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -16174,8 +15967,11 @@ exports[`Select small drop container height 1`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -219,7 +219,9 @@ exports[`Select Controlled deselect an option 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select; Selected: one"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -485,7 +487,9 @@ exports[`Select Controlled multiple 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="undefined; Selected: "
   class="c0 c1"
   id="test-select"
   type="button"
@@ -763,7 +767,9 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="test select; Selected: 1"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -927,26 +933,6 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
   text-align: inherit;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -988,26 +974,6 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
 .c9:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus::-moz-focus-inner {
-  border: 0;
 }
 
 .c9:focus:not(:focus-visible) {
@@ -1097,14 +1063,18 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
     id="test-select__select-drop"
   >
     <div
+      aria-multiselectable="true"
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="true"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
-        tabindex="-1"
+        role="option"
+        tabindex="0"
         type="button"
       >
         <div
@@ -1118,8 +1088,11 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c9 c10"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -1382,7 +1355,9 @@ exports[`Select Controlled multiple onChange with valueKey reduce 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="test select"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -1551,26 +1526,6 @@ exports[`Select Controlled multiple onChange with valueKey reduce 2`] = `
   color: #000000;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -1651,13 +1606,17 @@ exports[`Select Controlled multiple onChange with valueKey reduce 2`] = `
     id="test-select__select-drop"
   >
     <div
+      aria-multiselectable="true"
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -1672,8 +1631,11 @@ exports[`Select Controlled multiple onChange with valueKey reduce 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -1936,7 +1898,9 @@ exports[`Select Controlled multiple onChange with valueKey string 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="test select"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -2105,26 +2069,6 @@ exports[`Select Controlled multiple onChange with valueKey string 2`] = `
   color: #000000;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -2205,13 +2149,17 @@ exports[`Select Controlled multiple onChange with valueKey string 2`] = `
     id="test-select__select-drop"
   >
     <div
+      aria-multiselectable="true"
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -2226,8 +2174,11 @@ exports[`Select Controlled multiple onChange with valueKey string 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -2490,7 +2441,9 @@ exports[`Select Controlled multiple onChange without valueKey 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="test select"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -2659,26 +2612,6 @@ exports[`Select Controlled multiple onChange without valueKey 2`] = `
   color: #000000;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -2759,13 +2692,17 @@ exports[`Select Controlled multiple onChange without valueKey 2`] = `
     id="test-select__select-drop"
   >
     <div
+      aria-multiselectable="true"
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -2780,8 +2717,11 @@ exports[`Select Controlled multiple onChange without valueKey 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -2825,13 +2765,16 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
     id="test-select__select-drop"
   >
     <div
+      aria-multiselectable="true"
       class="SelectContainer__OptionsBox-sc-1wi0ul8-0 jviAPV"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
-        class="StyledButton-sc-323bzc-0 cmzBhQ SelectContainer__SelectOption-sc-1wi0ul8-1 jRnsyM"
-        role="menuitem"
+        aria-posinset="1"
+        aria-setsize="2"
+        class="StyledButton-sc-323bzc-0 cOvmzN SelectContainer__SelectOption-sc-1wi0ul8-1 jRnsyM"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -2846,8 +2789,10 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
         </div>
       </button>
       <button
-        class="StyledButton-sc-323bzc-0 cmzBhQ SelectContainer__SelectOption-sc-1wi0ul8-1 jRnsyM"
-        role="menuitem"
+        aria-posinset="2"
+        aria-setsize="2"
+        class="StyledButton-sc-323bzc-0 cOvmzN SelectContainer__SelectOption-sc-1wi0ul8-1 jRnsyM"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -3097,7 +3042,9 @@ exports[`Select Controlled multiple values 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select; Selected: one,two"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -3146,7 +3093,9 @@ exports[`Select Controlled multiple values 1`] = `
 
 exports[`Select Controlled multiple values 2`] = `
 <button
-  aria-label="Open Drop"
+  aria-expanded="true"
+  aria-haspopup="listbox"
+  aria-label="test select; Selected: one,two"
   class="StyledButton-sc-323bzc-0 eiEooU Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
   id="test-select"
   type="button"
@@ -3309,26 +3258,6 @@ exports[`Select Controlled multiple values 3`] = `
   text-align: inherit;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -3411,14 +3340,18 @@ exports[`Select Controlled multiple values 3`] = `
     id="test-select__select-drop"
   >
     <div
+      aria-multiselectable="true"
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="true"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
-        tabindex="-1"
+        role="option"
+        tabindex="0"
         type="button"
       >
         <div
@@ -3432,9 +3365,12 @@ exports[`Select Controlled multiple values 3`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="true"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
-        tabindex="-1"
+        role="option"
+        tabindex="0"
         type="button"
       >
         <div
@@ -3696,7 +3632,9 @@ exports[`Select Controlled multiple with empty results 1`] = `
   class="c0"
 >
   <button
-    aria-label="Open Drop"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-label="test select; Selected: "
     class="c1 c2"
     id="test-select"
     type="button"
@@ -3865,26 +3803,6 @@ exports[`Select Controlled multiple with empty results 2`] = `
   color: #000000;
 }
 
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
 .c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -3965,13 +3883,17 @@ exports[`Select Controlled multiple with empty results 2`] = `
     id="test-select__select-drop"
   >
     <div
+      aria-multiselectable="true"
       class="c4"
-      role="menubar"
+      role="listbox"
       tabindex="-1"
     >
       <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -3986,8 +3908,11 @@ exports[`Select Controlled multiple with empty results 2`] = `
         </div>
       </button>
       <button
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="2"
         class="c5 c6"
-        role="menuitem"
+        role="option"
         tabindex="-1"
         type="button"
       >
@@ -4237,7 +4162,9 @@ exports[`Select Controlled select another option 1`] = `
 }
 
 <button
-  aria-label="Open Drop"
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select; Selected: two"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -4516,6 +4443,8 @@ exports[`Select Controlled should not have accessibility violations 1`] = `
   class="c0"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="listbox"
     aria-label="test"
     class="c1 c2"
     type="button"

--- a/src/js/languages/default.json
+++ b/src/js/languages/default.json
@@ -42,7 +42,8 @@
     "upper": "Upper Bounds"
   },
   "select": {
-    "multiple": "multiple"
+    "multiple": "multiple",
+    "selected": "; Selected: {currentSelectedValue}"
   },
   "skipLinks": {
     "skipTo": "Skip To:"


### PR DESCRIPTION
#### What does this PR do?
Improves how the screenreader reads and interacts with the Select component. 
- Options can now be selected with either 'Enter' or 'Space' (previously only 'Enter' worked)
- Options are read when navigating with up and down arrows (previously they were not read out)
- The user is notified when an option is selected and when revisiting a selected option.
- When an option is selected and the drop is closed and the select has focus the aria-label, a11yTitle, or placeholder is read along with the selected option.

Notes: 
- There is an issue in Chrome with voice over where once an option is selected, when navigating to other options the screen reader reads out the selected option. This issue is present in other Select components when using a screenreader (see https://mui.com/components/selects/). Firefox and Safari do not have this issue.
- The 'Clear' button is not currently accessible. I am planning to open a separate issue for this.

Snapshot Changes:
- This following section is being removed from snapshots because I am setting the `focusIndicator={false}` in SelectOption (line435 of SelectContainer.js). Previously we were not setting focus on the options which is why they were not being read out by the screenreader. Now that we are setting focus I removed the focusIndicator to stay consistent with how options were displayed before. Visually the Select looks the same as it did before.
```
.c5:focus {
  outline: none;
  box-shadow: 0 0 2px 2px #6FFFB0;
}
.c5:focus > circle,
.c5:focus > ellipse,
.c5:focus > line,
.c5:focus > path,
.c5:focus > polygon,
.c5:focus > polyline,
.c5:focus > rect {
  outline: none;
  box-shadow: 0 0 2px 2px #6FFFB0;
}
.c5:focus::-moz-focus-inner {
  border: 0;
}
```

- Some of the aria-labels are changing. See [languages/default.json](https://github.com/grommet/grommet/pull/5934/files#diff-ecd05461ba0fd4b2a00e66e9708f8d8a59bf3dde54716424f8aadaa0a4750430) and [Select.js line 307](https://github.com/grommet/grommet/pull/5934/files#diff-cdd95f77ccbcbeefc239c0ad1f72eec210c2e09b16719e18af4a75e71e68e73bR307) for relevant code. The aria label change was made so that the screenreader will notify the user what the aria-label or placeholder for the select is in addition to the currently selected item or items when the Select gets focus.

- `aria-posinset` is increasing by one in the snapshots. Previously the indexing was starting at 0 so when there was two options the screenreader would read "option name (0 of 2)" for the first and "option name (1 of 2)" for the second. Now it reads "option name (1 of 2)" for the first and "option name (2 of 2)".

#### Where should the reviewer start?
See how the current Select is working with a screenreader & keyboard navigation.

#### What testing has been done on this PR?
Tested on Chrome, Firefox, and Safari with voice over

#### How should this be manually tested?
Test with a screenreader on the Select storybook stories

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #5918 
Closes #5917 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible