### PR TITLE
Improve logic for when to normalize date in DateInput

### DIFF
--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -261,6 +261,10 @@ const Calendar = forwardRef(
       };
     }, []);
 
+    // whether or not we should normalize the date based on the timestamp.
+    // will be set to false if the initial timestamp is undefined (meaning
+    // a user did not provide a defaultValue or value). in this case, we
+    // will just rely on the UTC timestamp and don't need to normalize.
     const [normalize, setNormalize] = useState(normalizeProp);
 
     // set activeDate when caller changes it, allows us to change

--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -55,31 +55,35 @@ const activeDates = {
 
 const timeStamp = /T.*/;
 
-const formatSelectedDatesString = (date) => `Currently selected
+const formatSelectedDatesString = (date, normalize) => `Currently selected
   ${date?.map((item) => {
     let dates;
     if (!Array.isArray(item)) {
-      dates = `${formatToLocalYYYYMMDD(item)} `;
+      dates = `${formatToLocalYYYYMMDD(item, normalize)} `;
     } else {
       const start =
-        item[0] !== undefined ? formatToLocalYYYYMMDD(item[0]) : 'none';
+        item[0] !== undefined
+          ? formatToLocalYYYYMMDD(item[0], normalize)
+          : 'none';
       const end =
-        item[1] !== undefined ? formatToLocalYYYYMMDD(item[1]) : 'none';
+        item[1] !== undefined
+          ? formatToLocalYYYYMMDD(item[1], normalize)
+          : 'none';
       dates = `${start} through ${end}`;
     }
 
     return dates;
   })}`;
 
-const getAccessibilityString = (date, dates) => {
+const getAccessibilityString = (date, dates, normalize) => {
   if (date && !Array.isArray(date)) {
-    return `Currently selected ${formatToLocalYYYYMMDD(date)};`;
+    return `Currently selected ${formatToLocalYYYYMMDD(date, normalize)};`;
   }
   if (date && Array.isArray(date)) {
-    return formatSelectedDatesString(date);
+    return formatSelectedDatesString(date, normalize);
   }
   if (dates?.length) {
-    return formatSelectedDatesString(dates);
+    return formatSelectedDatesString(dates, normalize);
   }
 
   return 'No date selected';
@@ -225,6 +229,7 @@ const Calendar = forwardRef(
       header,
       locale = 'en-US',
       messages,
+      normalize,
       onReference,
       onSelect,
       range,
@@ -487,11 +492,15 @@ const Calendar = forwardRef(
         // output date with no timestamp if that's how user provided it
         let adjustedDate;
         if (!range) {
-          nextDate = formatDateToPropStructure(selectedDate, timestamp);
+          nextDate = formatDateToPropStructure(
+            selectedDate,
+            timestamp,
+            normalize,
+          );
           if (datesProp) {
             datesProp.forEach((d) => {
               if (!timeStamp.test(d)) {
-                adjustedDate = formatToLocalYYYYMMDD(nextDate);
+                adjustedDate = formatToLocalYYYYMMDD(nextDate, normalize);
                 if (d === adjustedDate) {
                   nextDate = undefined;
                 } else {
@@ -501,7 +510,7 @@ const Calendar = forwardRef(
             });
           } else if (typeof dateProp === 'string') {
             if (!timeStamp.test(dateProp)) {
-              adjustedDate = formatToLocalYYYYMMDD(selectedDate);
+              adjustedDate = formatToLocalYYYYMMDD(selectedDate, normalize);
               if (dateProp === adjustedDate) {
                 nextDate = undefined;
               } else {
@@ -511,7 +520,7 @@ const Calendar = forwardRef(
           } else if (Array.isArray(dateProp)) {
             dateProp.forEach((d) => {
               if (!timeStamp.test(d)) {
-                adjustedDate = formatToLocalYYYYMMDD(nextDate);
+                adjustedDate = formatToLocalYYYYMMDD(nextDate, normalize);
                 if (d === adjustedDate) {
                   nextDate = undefined;
                 } else {
@@ -613,12 +622,24 @@ const Calendar = forwardRef(
           ) {
             // return string for backwards compatibility
             [adjustedDates] = nextDates[0].filter((d) => d);
-            adjustedDates = formatDateToPropStructure(adjustedDates, timestamp);
+            adjustedDates = formatDateToPropStructure(
+              adjustedDates,
+              timestamp,
+              normalize,
+            );
           } else if (nextDates) {
             adjustedDates = [
               [
-                formatDateToPropStructure(nextDates[0][0], timestamp),
-                formatDateToPropStructure(nextDates[0][1], timestamp),
+                formatDateToPropStructure(
+                  nextDates[0][0],
+                  timestamp,
+                  normalize,
+                ),
+                formatDateToPropStructure(
+                  nextDates[0][1],
+                  timestamp,
+                  normalize,
+                ),
               ],
             ];
           }
@@ -632,6 +653,7 @@ const Calendar = forwardRef(
         dateProp,
         dates,
         datesProp,
+        normalize,
         onSelect,
         range,
         timestamp,
@@ -845,7 +867,7 @@ const Calendar = forwardRef(
                 onClick: () => {
                   selectDate(dateString);
                   announce(
-                    `Selected ${formatToLocalYYYYMMDD(dateString)}`,
+                    `Selected ${formatToLocalYYYYMMDD(dateString, normalize)}`,
                     'assertive',
                   );
                   // Chrome moves the focus indicator to this button. Set
@@ -879,7 +901,7 @@ const Calendar = forwardRef(
                         selectDate(dateString);
                         announce(
                           `Selected
-                          ${formatToLocalYYYYMMDD(dateString)}`,
+                          ${formatToLocalYYYYMMDD(dateString, normalize)}`,
                           'assertive',
                         );
                         // Chrome moves the focus indicator to this button. Set
@@ -1004,7 +1026,7 @@ const Calendar = forwardRef(
                   month: 'long',
                   year: 'numeric',
                 })};
-                ${getAccessibilityString(date, dates)}
+                ${getAccessibilityString(date, dates, normalize)}
               `}
               ref={daysRef}
               sizeProp={size}

--- a/src/js/components/Calendar/stories/Simple.js
+++ b/src/js/components/Calendar/stories/Simple.js
@@ -6,6 +6,7 @@ export const Simple = () => {
   const [date, setDate] = useState();
 
   const onSelect = (nextDate) => {
+    console.log(nextDate);
     setDate(nextDate !== date ? nextDate : undefined);
   };
 

--- a/src/js/components/Calendar/stories/Simple.js
+++ b/src/js/components/Calendar/stories/Simple.js
@@ -6,7 +6,6 @@ export const Simple = () => {
   const [date, setDate] = useState();
 
   const onSelect = (nextDate) => {
-    console.log(nextDate);
     setDate(nextDate !== date ? nextDate : undefined);
   };
 

--- a/src/js/components/Calendar/utils.js
+++ b/src/js/components/Calendar/utils.js
@@ -69,13 +69,14 @@ export const sameDayOrBefore = (date1, date2) =>
 export const daysApart = (date1, date2) =>
   Math.floor((date1.getTime() - date2.getTime()) / DAY_MILLISECONDS);
 
-export const formatToLocalYYYYMMDD = (date) => {
+export const formatToLocalYYYYMMDD = (date, normalize) => {
   const adjustedDate = new Date(date);
-  return new Date(
-    adjustedDate.getTime() - adjustedDate.getTimezoneOffset() * 60000,
-  )
-    .toISOString()
-    .split('T')[0];
+  const nextDate = normalize
+    ? new Date(
+        adjustedDate.getTime() - adjustedDate.getTimezoneOffset() * 60000,
+      )
+    : new Date(adjustedDate.getTime());
+  return nextDate.toISOString().split('T')[0];
 };
 // betweenDates takes an array of two elements and checks if the
 // supplied date lies between them, inclusive.
@@ -139,15 +140,18 @@ export const getTimestamp = (date) =>
 // can create undesired results. The standardizes the input value
 // for internal calculations
 // Reference: https://www.ursahealth.com/new-insights/dates-and-timezones-in-javascript
-export const normalizeForTimezone = (value, timestamp) => {
+export const normalizeForTimezone = (value, timestamp, normalize) => {
   let adjustedDate;
   let hourDelta;
   let valueOffset = 0;
-  if (timestamp && typeof timestamp === 'string') {
-    hourDelta = parseInt(timestamp?.split(':')[0], 10);
-    valueOffset = hourDelta * 60 * 60 * 1000; // ms
+  let localOffset = 0;
+  if (normalize) {
+    if (timestamp && typeof timestamp === 'string') {
+      hourDelta = parseInt(timestamp?.split(':')[0], 10);
+      valueOffset = hourDelta * 60 * 60 * 1000; // ms
+    }
+    localOffset = new Date().getTimezoneOffset() * 60 * 1000;
   }
-  const localOffset = new Date().getTimezoneOffset() * 60 * 1000;
 
   adjustedDate =
     value &&
@@ -160,15 +164,15 @@ export const normalizeForTimezone = (value, timestamp) => {
 };
 
 // format the date to align with date format caller passed in
-export const formatDateToPropStructure = (date, timestamp) => {
+export const formatDateToPropStructure = (date, timestamp, normalize) => {
   let adjustedDate;
   if (date) {
-    if (timestamp)
+    if (timestamp) {
       adjustedDate = `${
-        formatToLocalYYYYMMDD(date).split('T')[0]
+        formatToLocalYYYYMMDD(date, normalize).split('T')[0]
       }T${timestamp}`;
-    else if (timestamp === false)
-      [adjustedDate] = formatToLocalYYYYMMDD(date).split('T');
+    } else if (timestamp === false)
+      [adjustedDate] = formatToLocalYYYYMMDD(date, normalize).split('T');
     else adjustedDate = date;
   }
   return adjustedDate;

--- a/src/js/components/Calendar/utils.js
+++ b/src/js/components/Calendar/utils.js
@@ -140,7 +140,9 @@ export const getTimestamp = (date) =>
 // can create undesired results. The standardizes the input value
 // for internal calculations
 // Reference: https://www.ursahealth.com/new-insights/dates-and-timezones-in-javascript
-export const normalizeForTimezone = (value, timestamp, normalize) => {
+
+// default this to true
+export const normalizeForTimezone = (value, timestamp, normalize = true) => {
   let adjustedDate;
   let hourDelta;
   let valueOffset = 0;

--- a/src/js/components/Calendar/utils.js
+++ b/src/js/components/Calendar/utils.js
@@ -180,3 +180,40 @@ export const formatDateToPropStructure = (date, timestamp, normalize) => {
   }
   return adjustedDate;
 };
+
+export const getFormattedDate = (
+  nextDate,
+  nextDates,
+  normalize,
+  range,
+  timestamp,
+) => {
+  let adjustedDate;
+  let adjustedDates;
+
+  if (
+    nextDates &&
+    Array.isArray(nextDates[0]) &&
+    (!nextDates[0][0] || !nextDates[0][1]) &&
+    range === true
+  ) {
+    // return string for backwards compatibility
+    [adjustedDates] = nextDates[0].filter((d) => d);
+    adjustedDates = formatDateToPropStructure(
+      adjustedDates,
+      timestamp,
+      normalize,
+    );
+  } else if (nextDates) {
+    adjustedDates = [
+      [
+        formatDateToPropStructure(nextDates[0][0], timestamp, normalize),
+        formatDateToPropStructure(nextDates[0][1], timestamp, normalize),
+      ],
+    ];
+  } else {
+    adjustedDate = formatDateToPropStructure(nextDate, timestamp, normalize);
+  }
+
+  return adjustedDates || adjustedDate;
+};

--- a/src/js/components/Calendar/utils.js
+++ b/src/js/components/Calendar/utils.js
@@ -141,7 +141,8 @@ export const getTimestamp = (date) =>
 // for internal calculations
 // Reference: https://www.ursahealth.com/new-insights/dates-and-timezones-in-javascript
 
-// default this to true
+// If normalize is false just convert the value toISOString(),
+// valueOffset/localOffset will be 0.
 export const normalizeForTimezone = (value, timestamp, normalize = true) => {
   let adjustedDate;
   let hourDelta;

--- a/src/js/components/DateInput/DateInput.js
+++ b/src/js/components/DateInput/DateInput.js
@@ -79,7 +79,10 @@ const DateInput = forwardRef(
       return undefined;
     }, [defaultValue, value]);
 
-    // whether or not we should normalize the date based on the timestamp
+    // whether or not we should normalize the date based on the timestamp.
+    // will be set to false if the initial timestamp is undefined (meaning
+    // a user did not provide a defaultValue or value). in this case, we
+    // will just rely on the UTC timestamp and don't need to normalize.
     const [normalize, setNormalize] = useState(true);
 
     // normalize value based on timestamp vs user's local timezone
@@ -252,7 +255,7 @@ Use the icon prop instead.`,
 
                 let localTimestamp;
                 // get the UTC timestamp relative to the user's timezone
-                // once a date it complete
+                // once a date is complete
                 if (timestamp === undefined && Date.parse(nextTextValue))
                   [, localTimestamp] = new Date(nextTextValue)
                     .toISOString()

--- a/src/js/components/DateInput/DateInput.js
+++ b/src/js/components/DateInput/DateInput.js
@@ -153,6 +153,9 @@ const DateInput = forwardRef(
                 // clicking an edge date removes it
                 else if (range) normalizedValue = [nextValue, nextValue];
                 else normalizedValue = nextValue;
+                // timestamp will be undefined if no defaultValue or value have
+                // been passed in, indicating that we should stay local if the
+                // user first picks a date via the Calendar.
                 let nextNormalize = normalize;
                 if (timestamp === undefined) {
                   nextNormalize = false;
@@ -235,12 +238,28 @@ const DateInput = forwardRef(
               onChange={(event) => {
                 const nextTextValue = event.target.value;
                 setTextValue(nextTextValue);
+
+                let localTimestamp;
+                // get the UTC timestamp relative to the user's timezone
+                // once a date it complete
+                if (timestamp === undefined && Date.parse(nextTextValue))
+                  [, localTimestamp] = new Date(nextTextValue)
+                    .toISOString()
+                    .split('T');
+
+                // timestamp will be undefined if no defaultValue or value have
+                // been passed in, indicating that we should stay local
+                let nextNormalize = normalize;
+                if (timestamp === undefined) {
+                  nextNormalize = false;
+                  setNormalize(nextNormalize);
+                }
                 const nextValue = textToValue(
                   nextTextValue,
                   schema,
                   range,
-                  timestamp,
-                  normalize,
+                  timestamp || localTimestamp,
+                  nextNormalize,
                 );
 
                 // reset to original state

--- a/src/js/components/DateInput/__tests__/DateInput-test.tsx
+++ b/src/js/components/DateInput/__tests__/DateInput-test.tsx
@@ -895,7 +895,7 @@ describe('DateInput', () => {
   test('clicking calendar icon should open drop', () => {
     render(
       <Grommet>
-        <DateInput format="m/d/yy" defaultValue="1/1/2021" />
+        <DateInput format="m/d/yy" defaultValue="2021-01-01" />
       </Grommet>,
     );
     expect(

--- a/src/js/components/DateInput/utils.js
+++ b/src/js/components/DateInput/utils.js
@@ -117,7 +117,7 @@ const pullDigits = (text, index) => {
   return text.slice(index, end);
 };
 
-export const textToValue = (text, schema, range, timestamp) => {
+export const textToValue = (text, schema, range, timestamp, normalize) => {
   if (!text) return range ? [] : undefined;
 
   let result;
@@ -144,8 +144,10 @@ export const textToValue = (text, schema, range, timestamp) => {
     let date = new Date(parts.y, parts.m - 1, parts.d).toISOString();
     // match time and timezone of any supplied valueProp
     if (timestamp)
-      date = `${formatToLocalYYYYMMDD(date).split('T')[0]}T${timestamp}`;
-    else date = `${formatToLocalYYYYMMDD(date).split('T')[0]}`;
+      date = `${
+        formatToLocalYYYYMMDD(date, normalize).split('T')[0]
+      }T${timestamp}`;
+    else date = `${formatToLocalYYYYMMDD(date, normalize).split('T')[0]}`;
 
     if (!range) {
       if (!result) result = date;
@@ -176,7 +178,7 @@ export const textToValue = (text, schema, range, timestamp) => {
         // prematurely calculated.
         // ex: 2022/01/0 would reutrn 2021/12/31 in addDate()
         if (parts.d === '0') delete parts.d;
-        index += (parts?.d?.length || 0);
+        index += parts?.d?.length || 0;
       } else if (char === 'y') {
         parts.y = pullDigits(text, index);
         index += parts.y.length;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
When DateInput value starts as undefined, the `onChange` logic should be in UTC relative to the local timezone of the user. In these instances, we don't want to perform the subsequent normalization logic. This PR introduces a state variable in dateinput that is passed ot the normalization functions. When it is true, we proceed with normalization. When it is false, we don't normalize because the date is already in UTC with respect to the timezone.


#### Where should the reviewer start?
DateInput.js

#### What testing has been done on this PR?
Format Inline story in timezones before UTC and after (for example, pacific time and eastern european.

#### How should this be manually tested?
With FormatInline story in various timezones.

#### Do Jest tests follow these best practices?

N/A did not touch tests aside from fixing a test that did not have `defaultValue` in ISO8601 format.

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #5920 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.