### PR TITLE
Restored arrow key functionality to Menu component

### DIFF
--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -28,6 +28,10 @@ const ContainerBox = styled(Box)`
     width: 100%;
   }
 
+  :focus {
+    outline: none;
+  }
+
   ${(props) => props.theme.menu.extend};
 `;
 
@@ -288,7 +292,6 @@ const Menu = forwardRef((props, ref) => {
     <Keyboard
       onDown={onDropOpen}
       onUp={onDropOpen}
-      onEnter={onSelectMenuItem}
       onSpace={onSelectMenuItem}
       onEsc={onDropClose}
       onTab={onDropClose}

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -28,6 +28,7 @@ const ContainerBox = styled(Box)`
     width: 100%;
   }
 
+  /* remove the browser default focus outline */
   :focus {
     outline: none;
   }

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -560,6 +560,10 @@ exports[`Menu close by clicking outside 2`] = `
   max-height: inherit;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c6 {
     padding: 6px;
@@ -3277,6 +3281,10 @@ exports[`Menu open and close on click 3`] = `
   max-height: inherit;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c6 {
     padding: 6px;
@@ -4021,6 +4029,10 @@ exports[`Menu open on up close on esc 2`] = `
 
 .c3 {
   max-height: inherit;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -5709,6 +5721,10 @@ exports[`Menu with dropAlign bottom renders 2`] = `
   max-height: inherit;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c8 {
     padding: 6px;
@@ -6249,6 +6265,10 @@ exports[`Menu with dropAlign top renders 2`] = `
 
 .c3 {
   max-height: inherit;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -606,6 +606,7 @@ exports[`Menu close by clicking outside 2`] = `
 >
   <div
     class="c2 c3"
+    tabindex="-1"
   >
     <div
       class="c4"
@@ -3322,6 +3323,7 @@ exports[`Menu open and close on click 3`] = `
 >
   <div
     class="c2 c3"
+    tabindex="-1"
   >
     <div
       class="c4"
@@ -4067,6 +4069,7 @@ exports[`Menu open on up close on esc 2`] = `
 >
   <div
     class="c2 c3"
+    tabindex="-1"
   >
     <div
       class="c4"
@@ -5752,6 +5755,7 @@ exports[`Menu with dropAlign bottom renders 2`] = `
 >
   <div
     class="c2 c3"
+    tabindex="-1"
   >
     <div
       class="c4"
@@ -6293,6 +6297,7 @@ exports[`Menu with dropAlign top renders 2`] = `
 >
   <div
     class="c2 c3"
+    tabindex="-1"
   >
     <div
       class="c4"


### PR DESCRIPTION
#### What does this PR do?
Restores arrow key navigation to the Menu component

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with existing Menu stories

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #5935

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible