### PR TITLE
Made Markdown wrapper overrideable

### DIFF
--- a/src/js/components/Markdown/Markdown.js
+++ b/src/js/components/Markdown/Markdown.js
@@ -45,11 +45,12 @@ const GrommetMarkdown = forwardRef(
     );
 
     // we use Fragment as the wrapper so we can assign the ref with the div
+    // wrapper can still be overridden with the options.
     return (
       <div ref={ref} {...rest}>
         <Markdown
           {...{ children }}
-          options={{ ...options, wrapper: Fragment, overrides }}
+          options={{ wrapper: Fragment, ...options,  overrides }}
         />
       </div>
     );

--- a/src/js/components/Markdown/__tests__/Markdown-test.js
+++ b/src/js/components/Markdown/__tests__/Markdown-test.js
@@ -4,6 +4,7 @@ import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
 import { Markdown } from '..';
+import { Box } from '../../Box';
 
 const CONTENT = `
 # H1
@@ -28,10 +29,24 @@ Markdown | Less | Pretty
 1 | 2 | 3
 `;
 
+const Wrapper = props => <Box gap="small" {...props} />;
+
 test('Markdown renders', () => {
   const { container } = render(
     <Grommet>
       <Markdown>{CONTENT}</Markdown>
+    </Grommet>,
+  );
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('wrapper', () => {
+  const { container } = render(
+    <Grommet>
+      <Markdown
+        options={{ wrapper: Wrapper }}
+      >{CONTENT}</Markdown>
     </Grommet>,
   );
 

--- a/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
+++ b/src/js/components/Markdown/__tests__/__snapshots__/Markdown-test.js.snap
@@ -294,3 +294,342 @@ exports[`Markdown renders 1`] = `
   </div>
 </div>
 `;
+
+exports[`wrapper 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  font-size: 50px;
+  line-height: 56px;
+  max-width: 1200px;
+  font-weight: 600;
+}
+
+.c5 {
+  font-size: 34px;
+  line-height: 40px;
+  max-width: 816px;
+  font-weight: 600;
+}
+
+.c6 {
+  font-size: 26px;
+  line-height: 32px;
+  max-width: 624px;
+  font-weight: 600;
+}
+
+.c7 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  font-weight: 600;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
+}
+
+.c8 {
+  box-sizing: border-box;
+  font-size: inherit;
+  line-height: inherit;
+  color: #7D4CDB;
+  font-weight: 600;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.c8:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c10 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c11 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c9 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    font-size: 34px;
+    line-height: 40px;
+    max-width: 816px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    font-size: 26px;
+    line-height: 32px;
+    max-width: 624px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    font-size: 16px;
+    line-height: 22px;
+    max-width: 384px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    height: 6px;
+  }
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c9 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div>
+    <div
+      class="c1"
+    >
+      <h1
+        class="c2"
+        id="h1"
+      >
+        H1
+      </h1>
+      <div
+        class="c3"
+      />
+      <p
+        class="c4"
+      >
+        Paragraph
+      </p>
+      <div
+        class="c3"
+      />
+      <h2
+        class="c5"
+        id="h2"
+      >
+        H2
+      </h2>
+      <div
+        class="c3"
+      />
+      <h3
+        class="c6"
+        id="h3"
+      >
+        H3
+      </h3>
+      <div
+        class="c3"
+      />
+      <h4
+        class="c7"
+        id="h4"
+      >
+        H4
+      </h4>
+      <div
+        class="c3"
+      />
+      <p
+        class="c4"
+      >
+        <a
+          class="c8"
+          href="#"
+        >
+          a link
+        </a>
+      </p>
+      <div
+        class="c3"
+      />
+      <blockquote>
+        <p
+          class="c4"
+        >
+          i carry your heart with me
+        </p>
+      </blockquote>
+      <div
+        class="c3"
+      />
+      <p
+        class="c4"
+      >
+        <img
+          alt="alt text"
+          class=""
+          src="//v2.grommet.io/assets/IMG_4245.jpg"
+          title="Markdown Image"
+        />
+      </p>
+      <div
+        class="c3"
+      />
+      <table
+        class="c9"
+      >
+        <thead
+          class="StyledTable__StyledTableHeader-sc-1m3u5g-4"
+        >
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2"
+          >
+            <td
+              class="c10"
+            >
+              <div
+                class="c1"
+              >
+                Markdown
+              </div>
+            </td>
+            <td
+              class="c10"
+            >
+              <div
+                class="c1"
+              >
+                Less
+              </div>
+            </td>
+            <td
+              class="c10"
+            >
+              <div
+                class="c1"
+              >
+                Pretty
+              </div>
+            </td>
+          </tr>
+        </thead>
+        <tbody
+          class="StyledTable__StyledTableBody-sc-1m3u5g-3"
+        >
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2"
+          >
+            <td
+              class="c11"
+            >
+              <em>
+                Still
+              </em>
+            </td>
+            <td
+              class="c11"
+            >
+              <code>
+                renders
+              </code>
+            </td>
+            <td
+              class="c11"
+            >
+              <strong>
+                nicely
+              </strong>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2"
+          >
+            <td
+              class="c11"
+            >
+              1
+            </td>
+            <td
+              class="c11"
+            >
+              2
+            </td>
+            <td
+              class="c11"
+            >
+              3
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
#### What does this PR do?

Currently any `wrapper` specified in the Markdown `options` parameter gets ignored since `Markdown` forces it to be a `Fragment`. This change will honor a `wrapper` specified in `options`, if any.

#### Where should the reviewer start?
Markdown.js

#### What testing has been done on this PR?
A custom storybook example, plus a Jest case added

#### How should this be manually tested?
```jsx
const Wrapper = props => <Box gap="small" {...props} />;
...
<Markdown
  options={{ wrapper: Wrapper }}
  components={{
    p: { 
      component: Paragraph,
      props: { margin: 'none' },
    },
  }}
>
  {'first paragraph\n\nsecond paragraph'}
</Markdown>
```

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
#5832 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
